### PR TITLE
Fix the $JAVA environment variable.

### DIFF
--- a/k-distribution/src/main/scripts/lib/checkJava
+++ b/k-distribution/src/main/scripts/lib/checkJava
@@ -39,7 +39,7 @@ else
       TIERED=-XX:+TieredCompilation
     fi
     export K_OPTS="-Xms64m -Xmx4096m -Xss32m $TIERED $K_OPTS"
-    JAVA="java -Dfile.encoding=UTF-8 -Djava.awt.headless=true $K_OPTS -ea -cp \"$(dirname "$0")/java/*\""
+    JAVA="java -Dfile.encoding=UTF-8 -Djava.awt.headless=true $K_OPTS -ea -cp \"$(dirname "$BASH_SOURCE")/java/*\""
   fi
 fi
 


### PR DESCRIPTION
When running a script in the bin directory that sources checkJava (e.g. k-bin-to-text, which sources setenv, which sources checkJava), $0 is in the bin directory, making checkJava set the classpath to bin/java instead of lib/java.