### PR TITLE
fix top-constraint issue

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -167,6 +167,13 @@ public class ConstrainedTerm extends JavaSymbolicObject {
         return data.constraint.addAndSimplify(constraint, context);
     }
 
+    public ConstrainedTerm evaluateUnderCurrentConstraint() {
+        context.setTopConstraint(data.constraint);
+        Term term = data.term.evaluate(context);
+        context.setTopConstraint(null);
+        return new ConstrainedTerm(term, data.constraint, context);
+    }
+
     public Term term() {
         return data.term;
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -586,6 +586,7 @@ public class SymbolicRewriter {
         List<ConstrainedTerm> nextQueue = new ArrayList<>();
 
         initialTerm = initialTerm.expandPatterns(true);
+        initialTerm = initialTerm.evaluateUnderCurrentConstraint();
 
         visited.add(initialTerm);
         queue.add(initialTerm);


### PR DESCRIPTION
@andreistefanescu This is a fix for another problem that a function is not evaluated in the initial term where it should be using the current constraint.

Can you think a better fix?  I mean, it could be fixed by adding `context.setTopConstraint(data.constraint);` in a proper place that you might miss last time.
For example, can we make `initialTerm.expandPatterns(true);` resolve such a function?
