### PR TITLE
Fix a bug introduced in constraint simplification

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -658,7 +658,7 @@ public class SymbolicRewriter {
                             cterm.constraint().removeBindings(
                                     Sets.difference(
                                             cterm.constraint().substitution().keySet(),
-                                            initialTerm.variableSet())),
+                                            Sets.union(initialTerm.variableSet(), cterm.term().variableSet()))),
                             cterm.termContext());
                     if (visited.add(result)) {
                         nextQueue.add(result);


### PR DESCRIPTION
I found a bug when prover was simplifying the ConstrainedTerm. 

Here is the initialConfig:
```
<k>... </k>
<balance> BAL </balance>
requires 0<=Int BAL andBool BAL <Int pow256
```

After several steps, it becomes the intermediateConfig :
```
<k> ... </k>
<balance> R_BAL </balance>
requires BAL ==K R_BAL andBool 0<=Int R_BAL andBool R_BAL <Int pow256
```

When the intermediateConfig matches and applies the following rule:
```
rule <k> #transferFunds ACCT ACCT VALUE => . ... </k>
         <account>
           <acctID> ACCT </acctID>
           <balance> ORIGFROM </balance>
           ...
         </account>
      requires VALUE <=Int ORIGFROM
```

the finalConfig becomes:
```
<k> ... </k>
<balance> R_BAL </balance>
requires BAL ==K R_ORIGINFROM andBool R_BAL ==K R_ORIGINFROM andBool 0<=Int R_ORIGINFROM andBool R_ORIGINFROM <Int pow256
```
which is OK. 
However, in SymbolicRewriter.java (L656 - L662), the kprover tries to simplify the constraint further by removing the bindings of `Sets.difference(cterm.constraint().substitution().keySet(), initialTerm.variableSet()))`. The substitution contains `R_BAL -> R_ORIGINFROM` and `BAL -> R_ORIGINFROM` and the initialTerm contains `BAL`. Thus, `R_BAL ==K R_ORIGINFROM` is removed from the constraint. As a result, `R_BAL` still appears in the term but there is no constraint regarding this variable.
After discussing with Daejun, we came up with a fix which will still keep the constraint. 
Another thing that came to my mind is  why in the finalConfig, `R_BAL` is not substituted by `R_ORIGINFROM`.