### PR TITLE
evaluate spec rules with requires constraints when initializing

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -322,8 +322,8 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
                         .map(r -> converter.convert(Optional.<Module>empty(), r))
                         .map(r -> new org.kframework.backend.java.kil.Rule(
                                 r.label(),
-                                r.leftHandSide().evaluate(termContext),
-                                r.rightHandSide().evaluate(termContext),
+                                evaluate(r.leftHandSide(), r.getRequires(), termContext),
+                                evaluate(r.rightHandSide(), r.getRequires(), termContext),
                                 r.requires(),
                                 r.ensures(),
                                 r.freshConstants(),
@@ -333,6 +333,13 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
                                 termContext.global()))
                         .collect(Collectors.toList());
                 return this;
+            }
+
+            private Term evaluate(Term term, ConjunctiveFormula constraint, TermContext context) {
+                context.setTopConstraint(constraint);
+                Term newTerm = term.evaluate(context);
+                context.setTopConstraint(null);
+                return newTerm;
             }
         }
     }


### PR DESCRIPTION
Fix the initial evaluation of spec rules.

For example,

when we have the following spec rule:
```
module A-SPEC
  rule a(f(X)) => b
    requires X >Int 0
endmodule
```
now, the functional term `f(X)` is evaluated under the constraint `X >Int 0`.

This is needed when this spec rule is used to prove another spec rule.

