### PR TITLE
add [proj] attribute

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -155,6 +155,24 @@ public class ConstrainedTerm extends JavaSymbolicObject {
             }
         }
 
+        // evaluate/simplify equalities
+        context.setTopConstraint(data.constraint);
+        for (Equality equality : constraint.equalities()) {
+            Term equalityTerm = equality.toK();
+            Term evaluatedTerm = equalityTerm.evaluate(context);
+            if (!evaluatedTerm.equals(equalityTerm)) {
+                constraint = constraint.addAll(Collections.singletonList(evaluatedTerm));
+                if (constraint == null || constraint.isFalse()) {
+                    return null;
+                }
+            }
+        }
+        context.setTopConstraint(null);
+        constraint = constraint.simplifyModuloPatternFolding(context);
+        if (constraint.isFalse()) {
+            return null;
+        }
+
         context.setTopConstraint(data.constraint);
         constraint = (ConjunctiveFormula) constraint.evaluate(context);
 

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -135,6 +135,11 @@ public class ConstrainedTerm extends JavaSymbolicObject {
             return null;
         }
 
+        constraint = constraint.applyProjectionLemma();
+        if (constraint.isFalse()) {
+            return null;
+        }
+
         /* apply pattern folding */
         constraint = constraint.simplifyModuloPatternFolding(context)
                 .add(constrainedTerm.data.constraint)

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KLabel.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KLabel.java
@@ -50,6 +50,7 @@ public abstract class KLabel extends Term {
      */
     public abstract boolean isFunction();
 
+    public abstract boolean isProjection();
 
     /**
      * Checks if this {@code KLabel} represents a pattern. A {@code KLabel}

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KLabelConstant.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KLabelConstant.java
@@ -58,6 +58,8 @@ public class KLabelConstant extends KLabel implements org.kframework.kore.KLabel
      */
     private final boolean isFunction;
 
+    private final boolean isProjection;
+
     /*
      * boolean flag set iff a production tagged with "pattern" generates
      * this {@code KLabelConstant}
@@ -86,12 +88,14 @@ public class KLabelConstant extends KLabel implements org.kframework.kore.KLabel
         // TODO(YilongL): urgent; how to detect KLabel clash?
 
         boolean isFunction;
+        boolean isProjection = false;
         boolean isPattern = false;
         String smtlib = null;
         // there are labels which are just predicates, but are not obligated to be sort membership predicates
         if (!productionAttributes.contains(Attribute.PREDICATE_KEY, org.kframework.kore.Sort.class)) {
             predicateSort = null;
             isFunction = productionAttributes.contains(Attribute.FUNCTION_KEY);
+            isProjection = productionAttributes.contains(Attribute.PROJECTION_KEY);
             isPattern = productionAttributes.contains(Attribute.PATTERN_KEY);
             smtlib = productionAttributes.getOptional(Attribute.SMTLIB_KEY).orElse(null);
         } else {
@@ -101,6 +105,7 @@ public class KLabelConstant extends KLabel implements org.kframework.kore.KLabel
         }
         this.isSortPredicate = predicateSort != null;
         this.isFunction = isFunction;
+        this.isProjection = isProjection;
         this.isPattern = isPattern;
         this.smtlib = smtlib;
     }
@@ -140,6 +145,11 @@ public class KLabelConstant extends KLabel implements org.kframework.kore.KLabel
     @Override
     public boolean isFunction() {
         return isFunction;
+    }
+
+    @Override
+    public boolean isProjection() {
+        return isProjection;
     }
 
     /**

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KLabelInjection.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KLabelInjection.java
@@ -65,6 +65,11 @@ public class KLabelInjection extends KLabel {
     }
 
     @Override
+    public final boolean isProjection() {
+        return false;
+    }
+
+    @Override
     public final boolean isPattern() {
         return false;
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -8,6 +8,7 @@ import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.kframework.backend.java.builtins.BoolToken;
+import org.kframework.backend.java.builtins.IntToken;
 import org.kframework.backend.java.kil.*;
 import org.kframework.backend.java.util.Constants;
 import org.kframework.backend.java.util.RewriteEngineUtils;
@@ -502,6 +503,66 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                 TruthValue.FALSE,
                 equality,
                 global);
+    }
+
+    /**
+     * Apply projection lemmas over equalities:
+     *     proj(X,0,N) == proj(Y,0,N) /\ ... /\ proj(X,N-1,N) == proj(Y,N-1,N)
+     *   iff
+     *     X == Y
+     */
+    public ConjunctiveFormula applyProjectionLemma() {
+        // Map: (X,Y) ==> N ==> {0,1,...,N-1}
+        Map<Equality, Map<Integer, Set<Integer>>> projEqualitiesMap = new HashMap<>();
+        for (Equality equality : this.equalities) {
+            if (equality.leftHandSide() instanceof KItem && equality.rightHandSide() instanceof KItem) {
+                KLabelConstant lKLabel = (KLabelConstant) ((KItem) equality.leftHandSide()).kLabel(); // proj
+                KLabelConstant rKLabel = (KLabelConstant) ((KItem) equality.rightHandSide()).klabel(); // proj
+
+                KList lKList = (KList) ((KItem) equality.leftHandSide()).kList(); // X, I, N
+                KList rKList = (KList) ((KItem) equality.rightHandSide()).kList(); // Y, I, N
+
+                if (lKLabel.isProjection() && lKLabel.equals(rKLabel)) {
+                    // TODO: extract from [proj] attribute
+                    int sizeKList = 3;
+                    int idxVector = 0; // X
+                    int idxElem = 1; // I
+                    int idxSize = 2; // N
+                    if (lKList.size() == sizeKList && rKList.size() == sizeKList) {
+                        if (lKList.get(idxElem) instanceof IntToken && rKList.get(idxElem) instanceof IntToken
+                                && lKList.get(idxSize) instanceof IntToken && rKList.get(idxSize) instanceof IntToken) {
+                            int lElem = ((IntToken) lKList.get(idxElem)).intValue(); // I
+                            int rElem = ((IntToken) rKList.get(idxElem)).intValue(); // I
+                            int lSize = ((IntToken) lKList.get(idxSize)).intValue(); // N
+                            int rSize = ((IntToken) rKList.get(idxSize)).intValue(); // N
+                            if (lElem == rElem && lSize == rSize) {
+                                Equality newEquality = new Equality(lKList.get(idxVector), rKList.get(idxVector), global); // X == Y
+                                Map<Integer, Set<Integer>> projEqualities = projEqualitiesMap.get(newEquality); // N ==> {...,I,...}
+                                if (projEqualities == null) {
+                                    projEqualities = new HashMap<>();
+                                    Set<Integer> elemSet = new HashSet<>(); // {0,1,...,N-1}
+                                    for (int i = 0; i < lSize; i++) { elemSet.add(i); }
+                                    projEqualities.put(lSize, elemSet);
+                                    projEqualitiesMap.put(newEquality, projEqualities);
+                                }
+                                projEqualities.get(lSize).remove(lElem); // N ==> {...}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        PersistentUniqueList<Equality> equalities = this.equalities;
+        for (Equality equality : projEqualitiesMap.keySet()) {
+            for (int size :projEqualitiesMap.get(equality).keySet()) {
+                if (projEqualitiesMap.get(equality).get(size).isEmpty()) {
+                    equalities = equalities.plus(equality);
+                }
+            }
+        }
+
+        return new ConjunctiveFormula(substitution, equalities, disjunctions, truthValue, falsifyingEquality, global);
     }
 
     public ImmutableMapSubstitution<Variable, Term> getSubstitution(Variable variable, Term term) {

--- a/kernel/src/main/java/org/kframework/kil/Attribute.java
+++ b/kernel/src/main/java/org/kframework/kil/Attribute.java
@@ -21,6 +21,7 @@ public class Attribute<T> extends ASTNode {
     public static final String ASSOCIATIVE_KEY = "assoc";
     public static final String COMMUTATIVE_KEY = "comm";
     public static final String IDEMPOTENT_KEY = "idem";
+    public static final String PROJECTION_KEY = "proj";
     public static final String UNIT_KEY = "unit";
     public static final String PREDICATE_KEY = "predicate";
     public static final String ANYWHERE_KEY = Constants.ANYWHERE;


### PR DESCRIPTION
Add `[proj]` attribute, which will implicitly insert the projection lemma, that is, for all `f` with the `[proj]` attribute, we have:
```
f(X,0,N) == f(Y,0,N) /\ ... /\ f(X,N-1,N) == f(Y,N-1,N)
  iff
X == Y
```

Example.

Spec:
```
module D-SPEC
imports D

rule <k> call(X) => X ... </k>
     <calldata> _ => _ </calldata>
     <flag> 0 => 1 </flag>

rule <k> run => X ... </k>
     <calldata> bytes2(nth(X,0,2), nth(X,1,2)) </calldata>
     <flag> 0 => 1 </flag>
     [trusted]

endmodule
```

Semantics:
```
requires "domains.k"

module D
imports INT

configuration <T>
  <k> $PGM:Cmd </k>
  <calldata> bytes2(0,0) </calldata>
  <flag> 0 </flag>
</T>

// commands

syntax Cmd ::= call(Int)
             | "run"

rule <k> call(X) => run ... </k>
     <calldata> _ => split(X) </calldata>

rule <k> run => merge(CD) ... </k>
     <calldata> CD </calldata>

// utility functions

syntax Bytes ::= bytes2(Int, Int)

syntax Bytes ::= split(Int) [function]

syntax Int ::= merge(Bytes) [function]


// abstractions

syntax Int ::= nth(Int, Int, Int) [function, proj]

rule split(X) => bytes2(nth(X,0,2), nth(X,1,2))
     
rule merge(bytes2(nth(X,0,2), nth(X,1,2))) => X

endmodule
```
