### PR TITLE
Fix compilation errors with Java 9

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -9,6 +9,7 @@ import org.kframework.backend.Backends;
 import org.kframework.builtin.KLabels;
 import org.kframework.compile.*;
 import org.kframework.definition.*;
+import org.kframework.definition.Module;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.Kompile;
 import org.kframework.kompile.KompileOptions;

--- a/kernel/src/main/java/org/kframework/Parser.java
+++ b/kernel/src/main/java/org/kframework/Parser.java
@@ -3,6 +3,7 @@ package org.kframework;
 
 import org.kframework.attributes.Source;
 import org.kframework.definition.*;
+import org.kframework.definition.Module;
 import org.kframework.kore.K;
 import org.kframework.kore.Sort;
 import org.kframework.parser.concrete2kore.ParseInModule;

--- a/kernel/src/main/java/org/kframework/compile/AddImplicitComputationCell.java
+++ b/kernel/src/main/java/org/kframework/compile/AddImplicitComputationCell.java
@@ -6,6 +6,7 @@ import org.kframework.compile.ConfigurationInfoFromModule;
 import org.kframework.compile.LabelInfo;
 import org.kframework.compile.LabelInfoFromModule;
 import org.kframework.definition.*;
+import org.kframework.definition.Module;
 import org.kframework.kil.Attribute;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;

--- a/kernel/src/main/java/org/kframework/compile/ConcretizeCells.java
+++ b/kernel/src/main/java/org/kframework/compile/ConcretizeCells.java
@@ -6,6 +6,7 @@ import org.kframework.compile.ConfigurationInfoFromModule;
 import org.kframework.compile.LabelInfo;
 import org.kframework.compile.LabelInfoFromModule;
 import org.kframework.definition.*;
+import org.kframework.definition.Module;
 
 /**
  * Apply the configuration concretization process.

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -15,6 +15,7 @@ import org.kframework.compile.checks.CheckRewrite;
 import org.kframework.compile.checks.CheckSortTopUniqueness;
 import org.kframework.compile.checks.CheckStreams;
 import org.kframework.definition.*;
+import org.kframework.definition.Module;
 import org.kframework.kore.Sort;
 import org.kframework.main.GlobalOptions;
 import org.kframework.parser.concrete2kore.ParserUtils;

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -6,6 +6,7 @@ import org.apache.commons.io.FilenameUtils;
 import org.kframework.attributes.Att;
 import org.kframework.compile.*;
 import org.kframework.definition.*;
+import org.kframework.definition.Module;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.Kompile;
 import org.kframework.kore.K;

--- a/kernel/src/test/java/org/kframework/ParserTest.java
+++ b/kernel/src/test/java/org/kframework/ParserTest.java
@@ -5,6 +5,7 @@ import static org.junit.Assert.*;
 
 import org.junit.Test;
 import org.kframework.definition.*;
+import org.kframework.definition.Module;
 import org.kframework.kore.K;
 import org.kframework.kore.Sort;
 import scala.Option;


### PR DESCRIPTION
While reviewing PR #64, I tried to build k5 (which I hadn't done since I reinstalled the OS).  But the Java I had installed was Java 9.

Now, apparently Java 9 introduces a `java.lang.Module`, which makes our `Module`s ambiguous, so compilation fails.

Fortunately, adding some imports dedicated to our `Module` seems to solve the problem. 