### PR TITLE
Improve performance of coverage tool

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -757,16 +757,7 @@ module K-IO
   syntax KItem ::= #system ( String ) [function, hook(IO.system), impure]
                  | "#systemResult" "(" Int /* exit code */ "," String /* stdout */ "," String /* stderr */ ")"
 
-  syntax K ::= #appendToFile(String, String) [function]
-             | #lockOpenFileThenAppendAndClose(Int, String) [function]
-             | #appendToOpenFileThenClose(K, Int, String) [function]
-             | #thenUnlockAndClose(K, Int, String) [function]
-             | #thenClose(K, Int) [function]
-  rule #appendToFile(Path:String, Text:String) => #lockOpenFileThenAppendAndClose(#open(Path, "a"), Text)
-  rule #lockOpenFileThenAppendAndClose(FD:Int, Text:String) => #appendToOpenFileThenClose(#lock(FD, 0), FD, Text)
-  rule #appendToOpenFileThenClose(.K, FD:Int, Text:String) => #thenUnlockAndClose(#write(FD, Text), FD, Text)
-  rule #thenUnlockAndClose(.K, FD:Int, Text:String) => #thenClose(#unlock(FD, 0 -Int lengthString(Text)), FD)
-  rule #thenClose(.K, FD) => #close(FD)
+  syntax K ::= #logToFile(String, String) [function, hook(IO.log), impure]
 
 endmodule
 

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -757,7 +757,7 @@ module K-IO
   syntax KItem ::= #system ( String ) [function, hook(IO.system), impure]
                  | "#systemResult" "(" Int /* exit code */ "," String /* stdout */ "," String /* stderr */ ")"
 
-  syntax K ::= #logToFile(String, String) [function, hook(IO.log), impure]
+  syntax K ::= #logToFile(String, String) [function, hook(IO.log), impure, returnsUnit]
 
 endmodule
 

--- a/k-distribution/include/ocaml/prelude.ml
+++ b/k-distribution/include/ocaml/prelude.ml
@@ -601,6 +601,32 @@ struct
       [Int fd], [Int len] -> unix_error (fun () -> Unix.lockf (Hashtbl.find file_descriptors fd) Unix.F_ULOCK (Z.to_int len); [])
     | _ -> raise Not_implemented
 
+  let log_files = Hashtbl.create 2
+
+  let hook_log c _ _ _ _ = match c with
+      [String path], [String txt] -> 
+      let log = try
+        Hashtbl.find log_files path
+      with Not_found -> 
+        let empty = Buffer.create 16 in
+        Hashtbl.add log_files path empty;
+        empty
+      in
+      Buffer.add_string log txt;
+      []
+    | _ -> raise Not_implemented
+  
+  let flush_log path txt =
+    let flags = [Open_wronly; Open_append; Open_creat; Open_text] in
+    let out_chan = open_out_gen flags 0o666 path in
+    let fd = Unix.descr_of_out_channel out_chan in
+    Unix.lockf fd Unix.F_LOCK 0;
+    output_string out_chan (Buffer.contents txt);
+    close_out out_chan
+
+  let flush_logs () =
+    Hashtbl.iter flush_log log_files 
+
   let hook_stat _ _ _ _ _ = raise Not_implemented
   let hook_lstat _ _ _ _ _ = raise Not_implemented
   let hook_opendir _ _ _ _ _ = raise Not_implemented

--- a/k-distribution/include/ocaml/prelude.ml
+++ b/k-distribution/include/ocaml/prelude.ml
@@ -617,8 +617,12 @@ struct
     | _ -> raise Not_implemented
   
   let flush_log path txt =
+    let dir = Filename.dirname path in
+    let base = Filename.basename path in
+    let pid = string_of_int (Unix.getpid ()) in
+    let new_path = Filename.concat dir (pid ^ "_" ^ base) in
     let flags = [Open_wronly; Open_append; Open_creat; Open_text] in
-    let out_chan = open_out_gen flags 0o666 path in
+    let out_chan = open_out_gen flags 0o666 new_path in
     let fd = Unix.descr_of_out_channel out_chan in
     Unix.lockf fd Unix.F_LOCK 0;
     output_string out_chan (Buffer.contents txt);

--- a/k-distribution/include/ocaml/run.ml
+++ b/k-distribution/include/ocaml/run.ml
@@ -96,7 +96,9 @@ let rec strat_run (module Def: Plugin.Definition) (config: k) (depth: int) (n: i
 
 let run (config: k) (depth: int) : k * int =
   let module Def = (val Plugin.get () : Plugin.Definition) in
-  strat_run (module Def) config depth 0
+  let result = strat_run (module Def) config depth 0 in
+  Prelude.IO.flush_logs ();
+  result
 
 let rec strat_run_no_thread_opt (module Def: Plugin.Definition) (config: k) (depth: int) (n: int) : k * int =
   let c1,n1 = take_steps_no_thread (module Def) Def.step config depth n in
@@ -105,7 +107,9 @@ let rec strat_run_no_thread_opt (module Def: Plugin.Definition) (config: k) (dep
 
 let run_no_thread_opt (config: k) (depth: int) : k * int =
   let module Def = (val Plugin.get () : Plugin.Definition) in
-  strat_run_no_thread_opt (module Def) config depth 0
+  let result = strat_run_no_thread_opt (module Def) config depth 0 in
+  Prelude.IO.flush_logs ();
+  result
 
 module Makeconfig =
 struct

--- a/k-distribution/src/main/scripts/bin/kcovr
+++ b/k-distribution/src/main/scripts/bin/kcovr
@@ -1,4 +1,5 @@
 #!/usr/bin/python3
+import glob
 import os
 import sys
 import time
@@ -7,7 +8,14 @@ if len(sys.argv) < 4:
   print("usage: " + sys.argv[0] + " <kompiled-dir>... -- <files>...")
   exit(1)
 allRules = set()
-coverage = []
+coverMap = {}
+
+def addCover(rule):
+  rule = rule.strip()
+  if not rule in coverMap:
+    coverMap[rule] = 0
+  coverMap[rule] += 1
+
 for idx, dir in enumerate(sys.argv[1:], start=1):
   if dir == "--":
     fileIdx = idx + 1
@@ -17,9 +25,12 @@ for idx, dir in enumerate(sys.argv[1:], start=1):
     allRules.update(f.readlines())
   filename = dir + "/coverage.txt"
   with open(filename) as f:
-    coverage.extend(f.readlines())
-  
-coverage = [rule.strip() for rule in coverage]
+    for line in f:
+      addCover(line)
+  for filename in glob.glob(dir + "/*_coverage.txt"):
+    with open(filename) as f:
+      for line in f:
+        addCover(line)
 
 sources = [os.path.abspath(path) for path in  sys.argv[fileIdx:]]
 
@@ -45,14 +56,12 @@ def linesCovered(coverageOfComponent):
   return len(coveredLines)
 
 def rulesCovered(coverageOfComponent):
-  coveredRules = set()
-  coveredRules.update(coverageOfComponent)
-  return len(coveredRules)
+  return len(coverageOfComponent)
 
 numRulesGlobal = len(allRules)
 numLines = len(allLines)
-lineRateGlobal = float(linesCovered(coverage)) / numLines
-ruleRateGlobal = float(rulesCovered(coverage)) / numRulesGlobal
+lineRateGlobal = float(linesCovered(coverMap)) / numLines
+ruleRateGlobal = float(rulesCovered(coverMap)) / numRulesGlobal
 timestamp = int(time.time())
 
 template = """
@@ -115,7 +124,7 @@ for filename in sources:
     else:
       ruleMapByLine[value[0]].append(key)
 
-  fileCoverage = [rule for rule in coverage if rule in allRules]
+  fileCoverage = {rule: num for rule, num in coverMap.items() if rule in allRules}
 
   numRulesFile = len(allRules)
   numLines = len(allLines)
@@ -125,9 +134,9 @@ for filename in sources:
   lines = []
 
   for lineNum,rules in ruleMapByLine.items():
-    lineCoverage = [rule for rule in fileCoverage if rule in rules]
-    hits = len(lineCoverage)
-    numCovered = len(set(lineCoverage))
+    lineCoverage = {rule: num for rule, num in fileCoverage.items() if rule in rules}
+    hits = sum(lineCoverage.values())
+    numCovered = len(lineCoverage)
     numRulesLine = len(rules)
     ruleRateLine = float(numCovered) / numRulesLine
     if numRulesLine == 1:

--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k+fp/4.03.0+k+fp.comp
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k+fp/4.03.0+k+fp.comp
@@ -1,0 +1,18 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["mkdir" "-p" "%{lib}%/ocaml/"]
+  ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
+  ["patch" "-p1" "-i" "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k/4.06.1+k.comp
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k/4.06.1+k.comp
@@ -1,0 +1,16 @@
+opam-version: "1"
+version: "4.06.1"
+src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+build: [
+  ["patch" "-p1" "-i" "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch"]
+  ["./configure" "-prefix" prefix "-with-debug-runtime"]
+  [make "world"]
+  [make "world.opt"]
+  [make "install"]
+]
+packages: [
+  "base-unix"
+  "base-bigarray"
+  "base-threads"
+]
+env: [[CAML_LD_LIBRARY_PATH = "%{lib}%/stublibs"]]

--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch
@@ -1,0 +1,155 @@
+diff --git a/bytecomp/matching.ml b/bytecomp/matching.ml
+index 32e8043..6dc9f26 100644
+--- a/bytecomp/matching.ml
++++ b/bytecomp/matching.ml
+@@ -95,7 +95,7 @@ let rec small_enough n = function
+       else small_enough (n-1) rem
+ 
+ let ctx_lshift ctx =
+-  if small_enough 31 ctx then
++  if small_enough (!Clflags.match_context_rows - 1) ctx then
+     List.map lshift ctx
+   else (* Context pruning *) begin
+     get_mins le_ctx (List.map lforget ctx)
+@@ -2183,7 +2183,7 @@ let mk_failaction_pos partial seen ctx defs  =
+       | _  -> scan_def ((List.map fst now,idef)::env) later rem in
+ 
+   let fail_pats = complete_pats_constrs seen in
+-  if List.length fail_pats < 32 then begin
++  if List.length fail_pats < !Clflags.match_context_rows then begin
+     let fail,jmps =
+       scan_def
+         []
+diff --git a/driver/main.ml b/driver/main.ml
+index 110ea3c..45d2161 100644
+--- a/driver/main.ml
++++ b/driver/main.ml
+@@ -111,6 +111,7 @@ module Options = Main_args.Make_bytecomp_options (struct
+   let _where = print_standard_library
+   let _verbose = set verbose
+   let _nopervasives = set nopervasives
++  let _match_context_rows n = match_context_rows := n
+   let _dsource = set dump_source
+   let _dparsetree = set dump_parsetree
+   let _dtypedtree = set dump_typedtree
+diff --git a/driver/main_args.ml b/driver/main_args.ml
+index 757c7ac..c3b8989 100644
+--- a/driver/main_args.ml
++++ b/driver/main_args.ml
+@@ -597,6 +597,10 @@ let mk_nopervasives f =
+   "-nopervasives", Arg.Unit f, " (undocumented)"
+ ;;
+ 
++let mk_match_context_rows f =
++  "-match-context-rows", Arg.Int f, "<n> (undocumented)"
++;;
++
+ let mk_use_prims f =
+   "-use-prims", Arg.String f, "<file>  (undocumented)"
+ ;;
+@@ -859,6 +863,7 @@ module type Compiler_options = sig
+   val _color : string -> unit
+ 
+   val _nopervasives : unit -> unit
++  val _match_context_rows : int -> unit
+   val _dtimings : unit -> unit
+   val _dprofile : unit -> unit
+ 
+@@ -1081,6 +1086,7 @@ struct
+     mk__ F.anonymous;
+ 
+     mk_nopervasives F._nopervasives;
++    mk_match_context_rows F._match_context_rows;
+     mk_use_prims F._use_prims;
+     mk_dsource F._dsource;
+     mk_dparsetree F._dparsetree;
+@@ -1254,6 +1260,7 @@ struct
+     mk__ F.anonymous;
+ 
+     mk_nopervasives F._nopervasives;
++    mk_match_context_rows F._match_context_rows;
+     mk_dsource F._dsource;
+     mk_dparsetree F._dparsetree;
+     mk_dtypedtree F._dtypedtree;
+diff --git a/driver/main_args.mli b/driver/main_args.mli
+index 3d6db53..e72e404 100644
+--- a/driver/main_args.mli
++++ b/driver/main_args.mli
+@@ -99,6 +99,7 @@ module type Compiler_options = sig
+   val _color : string -> unit
+ 
+   val _nopervasives : unit -> unit
++  val _match_context_rows : int -> unit
+   val _dtimings : unit -> unit
+   val _dprofile : unit -> unit
+ 
+diff --git a/driver/optmain.ml b/driver/optmain.ml
+index 33fc848..5d43442 100644
+--- a/driver/optmain.ml
++++ b/driver/optmain.ml
+@@ -195,6 +195,7 @@ module Options = Main_args.Make_optcomp_options (struct
+   let _where () = print_standard_library ()
+ 
+   let _nopervasives = set nopervasives
++  let _match_context_rows n = match_context_rows := n
+   let _dsource = set dump_source
+   let _dparsetree = set dump_parsetree
+   let _dtypedtree = set dump_typedtree
+diff --git a/tools/ocamlcp.ml b/tools/ocamlcp.ml
+index 0aeaf2c..b8f7b85 100644
+--- a/tools/ocamlcp.ml
++++ b/tools/ocamlcp.ml
+@@ -23,6 +23,9 @@ let option opt () = compargs := opt :: !compargs
+ let option_with_arg opt arg =
+   compargs := (Filename.quote arg) :: opt :: !compargs
+ ;;
++let option_with_int opt arg =
++  compargs := (string_of_int arg) :: opt :: !compargs
++;;
+ 
+ let make_archive = ref false;;
+ let with_impl = ref false;;
+@@ -118,6 +121,7 @@ module Options = Main_args.Make_bytecomp_options (struct
+   let _color s = option_with_arg "-color" s
+   let _where = option "-where"
+   let _nopervasives = option "-nopervasives"
++  let _match_context_rows n = option_with_int "-match-context-rows" n
+   let _dsource = option "-dsource"
+   let _dparsetree = option "-dparsetree"
+   let _dtypedtree = option "-dtypedtree"
+diff --git a/tools/ocamloptp.ml b/tools/ocamloptp.ml
+index 4683cc0..004514a 100644
+--- a/tools/ocamloptp.ml
++++ b/tools/ocamloptp.ml
+@@ -146,6 +146,7 @@ module Options = Main_args.Make_optcomp_options (struct
+ 
+   let _linscan = option "-linscan"
+   let _nopervasives = option "-nopervasives"
++  let _match_context_rows n = option_with_int "-match-context-rows" n
+   let _dsource = option "-dsource"
+   let _dparsetree = option "-dparsetree"
+   let _dtypedtree = option "-dtypedtree"
+diff --git a/utils/clflags.ml b/utils/clflags.ml
+index c502c41..cec0908 100644
+--- a/utils/clflags.ml
++++ b/utils/clflags.ml
+@@ -60,6 +60,7 @@ and output_complete_object = ref false  (* -output-complete-obj *)
+ and all_ccopts = ref ([] : string list)     (* -ccopt *)
+ and classic = ref false                 (* -nolabels *)
+ and nopervasives = ref false            (* -nopervasives *)
++and match_context_rows = ref 32         (* -match-context-rows *)
+ and preprocessor = ref(None : string option) (* -pp *)
+ and all_ppx = ref ([] : string list)        (* -ppx *)
+ let annotations = ref false             (* -annot *)
+diff --git a/utils/clflags.mli b/utils/clflags.mli
+index 9a15649..439ea07 100644
+--- a/utils/clflags.mli
++++ b/utils/clflags.mli
+@@ -87,6 +87,7 @@ val output_complete_object : bool ref
+ val all_ccopts : string list ref
+ val classic : bool ref
+ val nopervasives : bool ref
++val match_context_rows : int ref
+ val open_modules : string list ref
+ val preprocessor : string option ref
+ val all_ppx : string list ref

--- a/k-distribution/src/main/scripts/lib/opam/packages/mlgmp/mlgmp.20150824/files/patch
+++ b/k-distribution/src/main/scripts/lib/opam/packages/mlgmp/mlgmp.20150824/files/patch
@@ -1,6 +1,6 @@
-diff -ruN mlgmp_ref/mlgmp/config.h mlgmp/config.h
---- mlgmp_ref/mlgmp/config.h	2002-07-29 20:31:12.000000000 -0500
-+++ mlgmp/config.h	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/config.h mlgmp/config.h
+--- mlgmp_ref/config.h	2002-07-29 20:31:12.000000000 -0500
++++ mlgmp/config.h	2018-05-18 16:35:43.518092957 -0500
 @@ -3,6 +3,7 @@
  #define NDEBUG
  #undef TRACE
@@ -30,9 +30,9 @@ diff -ruN mlgmp_ref/mlgmp/config.h mlgmp/config.h
  extern void deserialize_block_1(void * data, long len);
  
  #endif /* SERIALIZE */
-diff -ruN mlgmp_ref/mlgmp/gmp.ml mlgmp/gmp.ml
---- mlgmp_ref/mlgmp/gmp.ml	2012-02-24 01:48:47.000000000 -0600
-+++ mlgmp/gmp.ml	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/gmp.ml mlgmp/gmp.ml
+--- mlgmp_ref/gmp.ml	2012-02-24 01:48:47.000000000 -0600
++++ mlgmp/gmp.ml	2018-05-18 16:35:43.530093046 -0500
 @@ -1,7 +1,8 @@
  (*
   * ML GMP - Interface between Objective Caml and GNU MP
@@ -52,6 +52,23 @@ diff -ruN mlgmp_ref/mlgmp/gmp.ml mlgmp/gmp.ml
    external urandomb: state: RNG.randstate_t->nbits: int->t =
      "_mlgmp_z_urandomb";;
    external urandomm: state: RNG.randstate_t->n: t->t =
+@@ -415,11 +418,11 @@
+        ((if sign < 0 then "-" else "")
+        ^ (let lm=String.length mantissa
+         in if lm > 1
+-           then let tmp = String.create (succ lm)
+-                in String.blit mantissa 0 tmp 0 1;
+-                   String.blit mantissa 1 tmp 2 (pred lm);
+-                   String.set tmp 1 '.';
+-                   tmp
++           then let tmp = Bytes.create (succ lm)
++                in Bytes.blit_string mantissa 0 tmp 0 1;
++                   Bytes.blit_string mantissa 1 tmp 2 (pred lm);
++                   Bytes.set tmp 1 '.';
++                   Bytes.to_string tmp
+            else mantissa)
+        ^ (if base <= 10 then "E" else "@")
+        ^ (string_of_int (pred exponent)));;
 @@ -512,6 +515,14 @@
        = "_mlgmp_fr_exp";;
    external exp2_prec : prec: int -> mode: rounding_mode -> t->t
@@ -114,6 +131,23 @@ diff -ruN mlgmp_ref/mlgmp/gmp.ml mlgmp/gmp.ml
    let to_string_base_digits ~mode: mode
       ~base: base ~digits: digits x =
     let mantissa, exponent =
+@@ -608,11 +636,11 @@
+           then "Inf"
+           else (let lm=String.length mantissa
+         in if lm > 1
+-           then let tmp = String.create (succ lm)
+-                in String.blit mantissa 0 tmp 0 (1+i);
+-                   String.blit mantissa (1+i) tmp (2+i) ((pred lm)-i);
+-                   String.set tmp (1+i) '.';
+-                   tmp
++           then let tmp = Bytes.create (succ lm)
++                in Bytes.blit_string mantissa 0 tmp 0 (1+i);
++                   Bytes.blit_string mantissa (1+i) tmp (2+i) ((pred lm)-i);
++                   Bytes.set tmp (1+i) '.';
++                   Bytes.to_string tmp
+            else mantissa)
+        ^ (if base <= 10 then "E" else "@")
+        ^ (string_of_int (pred exponent)));;
 @@ -626,10 +654,7 @@
     if sign = 0
     then Z.zero
@@ -126,9 +160,9 @@ diff -ruN mlgmp_ref/mlgmp/gmp.ml mlgmp/gmp.ml
       if exponent < 0
       then division mantissa (- exponent)
       else Z.mul_2exp mantissa exponent;;
-diff -ruN mlgmp_ref/mlgmp/gmp.mli mlgmp/gmp.mli
---- mlgmp_ref/mlgmp/gmp.mli	2012-02-24 01:48:02.000000000 -0600
-+++ mlgmp/gmp.mli	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/gmp.mli mlgmp/gmp.mli
+--- mlgmp_ref/gmp.mli	2012-02-24 01:48:02.000000000 -0600
++++ mlgmp/gmp.mli	2018-05-18 16:35:43.518092957 -0500
 @@ -128,6 +128,8 @@
      external hamdist : t -> t -> int = "_mlgmp_z_hamdist"
      external scan0 : t -> int -> int = "_mlgmp_z_scan0"
@@ -194,9 +228,9 @@ diff -ruN mlgmp_ref/mlgmp/gmp.mli mlgmp/gmp.mli
      val to_string_base_digits :
        mode:rounding_mode -> base:int -> digits:int -> t -> string
      val to_string : t -> string
-diff -ruN mlgmp_ref/mlgmp/Makefile mlgmp/Makefile
---- mlgmp_ref/mlgmp/Makefile	2012-02-24 02:17:29.000000000 -0600
-+++ mlgmp/Makefile	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/Makefile mlgmp/Makefile
+--- mlgmp_ref/Makefile	2012-02-24 02:17:29.000000000 -0600
++++ mlgmp/Makefile	2018-05-18 16:35:43.518092957 -0500
 @@ -15,7 +15,7 @@
  	-cclib -lmpfr -cclib -lgmp -cclib -L$(DESTDIR)
  
@@ -235,9 +269,9 @@ diff -ruN mlgmp_ref/mlgmp/Makefile mlgmp/Makefile
  
  test_suite.opt:	gmp.cmxa test_suite.cmx
  	$(OCAMLOPT) $+ -o $@
-diff -ruN mlgmp_ref/mlgmp/META mlgmp/META
---- mlgmp_ref/mlgmp/META	1969-12-31 18:00:00.000000000 -0600
-+++ mlgmp/META	2016-03-10 08:53:26.330509447 -0600
+diff -ruN mlgmp_ref/META mlgmp/META
+--- mlgmp_ref/META	1969-12-31 18:00:00.000000000 -0600
++++ mlgmp/META	2018-05-18 16:35:43.518092957 -0500
 @@ -0,0 +1,11 @@
 +version = "20150824"
 +description = "GMP"
@@ -250,9 +284,9 @@ diff -ruN mlgmp_ref/mlgmp/META mlgmp/META
 +
 +
 +
-diff -ruN mlgmp_ref/mlgmp/mlgmp_f.c mlgmp/mlgmp_f.c
---- mlgmp_ref/mlgmp/mlgmp_f.c	2012-02-24 02:10:11.000000000 -0600
-+++ mlgmp/mlgmp_f.c	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/mlgmp_f.c mlgmp/mlgmp_f.c
+--- mlgmp_ref/mlgmp_f.c	2012-02-24 02:10:11.000000000 -0600
++++ mlgmp/mlgmp_f.c	2018-05-18 16:35:43.518092957 -0500
 @@ -228,8 +228,7 @@
  
  int _mlgmp_f_custom_compare(value a, value b)
@@ -280,9 +314,9 @@ diff -ruN mlgmp_ref/mlgmp/mlgmp_f.c mlgmp/mlgmp_f.c
  }
  
  unsigned long _mlgmp_f_deserialize(void * dst)
-diff -ruN mlgmp_ref/mlgmp/mlgmp_fr.c mlgmp/mlgmp_fr.c
---- mlgmp_ref/mlgmp/mlgmp_fr.c	2012-02-24 02:13:11.000000000 -0600
-+++ mlgmp/mlgmp_fr.c	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/mlgmp_fr.c mlgmp/mlgmp_fr.c
+--- mlgmp_ref/mlgmp_fr.c	2012-02-24 02:13:11.000000000 -0600
++++ mlgmp/mlgmp_fr.c	2018-05-18 16:35:43.518092957 -0500
 @@ -35,7 +35,7 @@
  
  struct custom_operations _mlgmp_custom_fr =
@@ -527,9 +561,9 @@ diff -ruN mlgmp_ref/mlgmp/mlgmp_fr.c mlgmp/mlgmp_fr.c
  }
  
  unsigned long _mlgmp_fr_deserialize(void * dst)
-diff -ruN mlgmp_ref/mlgmp/mlgmp_q.c mlgmp/mlgmp_q.c
---- mlgmp_ref/mlgmp/mlgmp_q.c	2012-02-24 02:16:14.000000000 -0600
-+++ mlgmp/mlgmp_q.c	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/mlgmp_q.c mlgmp/mlgmp_q.c
+--- mlgmp_ref/mlgmp_q.c	2012-02-24 02:16:14.000000000 -0600
++++ mlgmp/mlgmp_q.c	2018-05-18 16:35:43.518092957 -0500
 @@ -156,8 +156,7 @@
  
  int _mlgmp_q_custom_compare(value a, value b)
@@ -572,9 +606,9 @@ diff -ruN mlgmp_ref/mlgmp/mlgmp_q.c mlgmp/mlgmp_q.c
 -  CAMLreturn(r);
 +  return r;
  }
-diff -ruN mlgmp_ref/mlgmp/mlgmp_z.c mlgmp/mlgmp_z.c
---- mlgmp_ref/mlgmp/mlgmp_z.c	2012-02-24 02:15:29.000000000 -0600
-+++ mlgmp/mlgmp_z.c	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/mlgmp_z.c mlgmp/mlgmp_z.c
+--- mlgmp_ref/mlgmp_z.c	2012-02-24 02:15:29.000000000 -0600
++++ mlgmp/mlgmp_z.c	2018-05-18 16:35:43.518092957 -0500
 @@ -571,8 +571,7 @@
  
  int _mlgmp_z_custom_compare(value a, value b)
@@ -630,9 +664,9 @@ diff -ruN mlgmp_ref/mlgmp/mlgmp_z.c mlgmp/mlgmp_z.c
 -  CAMLreturn(r);
 +  return r;
  }
-diff -ruN mlgmp_ref/mlgmp/test_suite.ml mlgmp/test_suite.ml
---- mlgmp_ref/mlgmp/test_suite.ml	2012-02-24 02:32:36.000000000 -0600
-+++ mlgmp/test_suite.ml	2016-03-10 08:50:24.938515505 -0600
+diff -ruN mlgmp_ref/test_suite.ml mlgmp/test_suite.ml
+--- mlgmp_ref/test_suite.ml	2012-02-24 02:32:36.000000000 -0600
++++ mlgmp/test_suite.ml	2018-05-18 16:35:43.522092987 -0500
 @@ -82,6 +82,7 @@
  
  begin

--- a/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
@@ -56,7 +56,7 @@ public class GenerateCoverage implements AutoCloseable {
             //handled by macro expander
             return body;
         }
-        return KRewrite(left, KSequence(right, KApply(KLabel("#appendToFile"),
+        return KRewrite(left, KSequence(right, KApply(KLabel("#logToFile"),
             KToken(StringUtil.enquoteKString(files.resolveKompiled("coverage.txt").getAbsolutePath()), Sorts.String()),
             KToken(StringUtil.enquoteKString(id + '\n'), Sorts.String()))));
     }

--- a/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
@@ -56,9 +56,9 @@ public class GenerateCoverage implements AutoCloseable {
             //handled by macro expander
             return body;
         }
-        return KRewrite(left, KSequence(right, KApply(KLabel("#logToFile"),
+        return KRewrite(left, KSequence(KApply(KLabel("#logToFile"),
             KToken(StringUtil.enquoteKString(files.resolveKompiled("coverage.txt").getAbsolutePath()), Sorts.String()),
-            KToken(StringUtil.enquoteKString(id + '\n'), Sorts.String()))));
+            KToken(StringUtil.enquoteKString(id + '\n'), Sorts.String())), right));
     }
 
     @Override

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
@@ -3071,15 +3071,22 @@ public class DefinitionToOcaml implements Serializable {
             for (int i = 0; i < items.size(); i++) {
                 K item = items.get(i);
                 boolean stack = topAnywherePre;
+                if (isUnit(item, klist, rhs, vars, stack)) {
+                    sb.append("let _ = ");
+                }
                 apply(item);
                 if (i != items.size() - 1) {
-                    if (isList(item, klist, rhs, vars, stack)) {
+                    if (isUnit(item, klist, rhs, vars, stack)) {
+                        sb.append(" in ");
+                    } else if (isList(item, klist, rhs, vars, stack)) {
                         sb.append(" @ ");
                     } else {
                         sb.append(" :: ");
                     }
                 } else {
-                    if (!isList(item, klist, rhs, vars, stack)) {
+                    if (isUnit(item, klist, rhs, vars, stack)) {
+                        sb.append(" in []");
+                    } else if (!isList(item, klist, rhs, vars, stack)) {
                         sb.append(" :: []");
                     }
                 }
@@ -3116,6 +3123,10 @@ public class DefinitionToOcaml implements Serializable {
             }
         }
         return k.att().<String>getOptional(Attribute.SORT_KEY).orElse("K");
+    }
+
+    private boolean isUnit(K item, boolean klist, boolean rhs, VarInfo vars, boolean anywhereRule) {
+        return isList(item, klist, rhs, vars, anywhereRule) && item instanceof KApply && mainModule.attributesFor().apply(((KApply)item).klabel()).contains("returnsUnit");
     }
 
     private boolean isList(K item, boolean klist, boolean rhs, VarInfo vars, boolean anywhereRule) {

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
@@ -3126,7 +3126,7 @@ public class DefinitionToOcaml implements Serializable {
     }
 
     private boolean isUnit(K item, boolean klist, boolean rhs, VarInfo vars, boolean anywhereRule) {
-        return isList(item, klist, rhs, vars, anywhereRule) && item instanceof KApply && mainModule.attributesFor().apply(((KApply)item).klabel()).contains("returnsUnit");
+        return isList(item, klist, rhs, vars, anywhereRule) && item instanceof KApply && !(((KApply)item).klabel() instanceof KVariable) && mainModule.attributesFor().apply(((KApply)item).klabel()).contains("returnsUnit");
     }
 
     private boolean isList(K item, boolean klist, boolean rhs, VarInfo vars, boolean anywhereRule) {


### PR DESCRIPTION
As it turns out, the overhead on complex programs of the prior mechanism for measuring coverage was too substantial for me to be able to efficiently compute the coverage of the EVM semantics, which I am trying to do so I can get that data to IOHK.

In order to solve this, I rename #appendToFile to #logToFile and give it a hook IO.log which maintains a mapping from paths to string buffers and appends to the files only after rewriting ends.

Furthermore, it was discovered that the rule instrumentation used previously made it so that tail recursive K functions did not compile down to tailcalls in OCAML, which led to stack overflows occurring. Here we introduce a minor change to the OCAML backend in the form of a new attribute indicating a function that always returns .K, which is compiled down to a let statement instead of a list append statement, preserving the tailcall.

Finally, in the course of testing this PR I was required to test the behavior of a program on the latest version of OCAML. The bug was still present in that version, so I worked around it, which is why I am not updating the ocaml versions at this time, but in the interests of saving time if we do end up upgrading at some point in the future, I am checking in the changes to OPAM switches and patches required for OCAML 4.06.1 compatibility with K.