### PR TITLE
backport fix for latest gcc into 4.03.0+k switch

### DIFF
--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.03.0/4.03.0+k/files/opam-compiler.patch
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.03.0/4.03.0+k/files/opam-compiler.patch
@@ -1,5 +1,5 @@
 diff --git a/bytecomp/matching.ml b/bytecomp/matching.ml
-index 8159cc5..d4530de 100644
+index 7d54160..5a51708 100644
 --- a/bytecomp/matching.ml
 +++ b/bytecomp/matching.ml
 @@ -82,7 +82,7 @@ let rec small_enough n = function
@@ -11,7 +11,7 @@ index 8159cc5..d4530de 100644
      List.map lshift ctx
    else (* Context pruning *) begin
      get_mins le_ctx (List.map lforget ctx)
-@@ -2205,7 +2205,7 @@ let mk_failaction_pos partial seen ctx defs  =
+@@ -2194,7 +2194,7 @@ let mk_failaction_pos partial seen ctx defs  =
        | _  -> scan_def ((List.map fst now,idef)::env) later rem in
  
    let fail_pats = complete_pats_constrs seen in
@@ -20,11 +20,32 @@ index 8159cc5..d4530de 100644
      let fail,jmps =
        scan_def
          []
+diff --git a/byterun/signals.c b/byterun/signals.c
+index 5c4e261..085f5f0 100644
+--- a/byterun/signals.c
++++ b/byterun/signals.c
+@@ -134,12 +134,12 @@ void caml_execute_signal(int signal_number, int in_signal_handler)
+ {
+   value res;
+ #ifdef POSIX_SIGNALS
+-  sigset_t sigs;
++  sigset_t nsigs, sigs;
+   /* Block the signal before executing the handler, and record in sigs
+      the original signal mask */
+-  sigemptyset(&sigs);
+-  sigaddset(&sigs, signal_number);
+-  sigprocmask(SIG_BLOCK, &sigs, &sigs);
++  sigemptyset(&nsigs);
++  sigaddset(&nsigs, signal_number);
++  sigprocmask(SIG_BLOCK, &nsigs, &sigs);
+ #endif
+   res = caml_callback_exn(
+            Field(caml_signal_handlers, signal_number),
 diff --git a/driver/main.ml b/driver/main.ml
-index 7b918be..256a0e2 100644
+index 3bfd8f3..182a609 100644
 --- a/driver/main.ml
 +++ b/driver/main.ml
-@@ -111,6 +111,7 @@ module Options = Main_args.Make_bytecomp_options (struct
+@@ -155,6 +155,7 @@ module Options = Main_args.Make_bytecomp_options (struct
    let _where = print_standard_library
    let _verbose = set verbose
    let _nopervasives = set nopervasives
@@ -33,10 +54,10 @@ index 7b918be..256a0e2 100644
    let _dparsetree = set dump_parsetree
    let _dtypedtree = set dump_typedtree
 diff --git a/driver/main_args.ml b/driver/main_args.ml
-index bf1fb8e..2216dd7 100644
+index ea89daf..bfcecae 100644
 --- a/driver/main_args.ml
 +++ b/driver/main_args.ml
-@@ -586,6 +586,10 @@ let mk_nopervasives f =
+@@ -558,6 +558,10 @@ let mk_nopervasives f =
    "-nopervasives", Arg.Unit f, " (undocumented)"
  ;;
  
@@ -47,15 +68,15 @@ index bf1fb8e..2216dd7 100644
  let mk_use_prims f =
    "-use-prims", Arg.String f, "<file>  (undocumented)"
  ;;
-@@ -834,6 +838,7 @@ module type Compiler_options = sig
+@@ -781,6 +785,7 @@ module type Compiler_options = sig
    val _color : string -> unit
  
    val _nopervasives : unit -> unit
 +  val _match_context_rows : int -> unit
    val _dtimings : unit -> unit
- 
-   val _args: string -> string array
-@@ -1052,6 +1057,7 @@ struct
+ end
+ ;;
+@@ -986,6 +991,7 @@ struct
      mk__ F.anonymous;
  
      mk_nopervasives F._nopervasives;
@@ -63,7 +84,7 @@ index bf1fb8e..2216dd7 100644
      mk_use_prims F._use_prims;
      mk_dsource F._dsource;
      mk_dparsetree F._dparsetree;
-@@ -1224,6 +1230,7 @@ struct
+@@ -1143,6 +1149,7 @@ struct
      mk__ F.anonymous;
  
      mk_nopervasives F._nopervasives;
@@ -72,22 +93,22 @@ index bf1fb8e..2216dd7 100644
      mk_dparsetree F._dparsetree;
      mk_dtypedtree F._dtypedtree;
 diff --git a/driver/main_args.mli b/driver/main_args.mli
-index dfe90c0..5910ca5 100644
+index 49de50d..f5b889a 100644
 --- a/driver/main_args.mli
 +++ b/driver/main_args.mli
-@@ -99,6 +99,7 @@ module type Compiler_options = sig
+@@ -96,6 +96,7 @@ module type Compiler_options = sig
    val _color : string -> unit
  
    val _nopervasives : unit -> unit
 +  val _match_context_rows : int -> unit
    val _dtimings : unit -> unit
- 
-   val _args: string -> string array
+ end
+ ;;
 diff --git a/driver/optmain.ml b/driver/optmain.ml
-index be262f8..b05aafc 100644
+index 8d1d3dd..ed859e7 100644
 --- a/driver/optmain.ml
 +++ b/driver/optmain.ml
-@@ -194,6 +194,7 @@ module Options = Main_args.Make_optcomp_options (struct
+@@ -231,6 +231,7 @@ module Options = Main_args.Make_optcomp_options (struct
    let _where () = print_standard_library ()
  
    let _nopervasives = set nopervasives
@@ -96,7 +117,7 @@ index be262f8..b05aafc 100644
    let _dparsetree = set dump_parsetree
    let _dtypedtree = set dump_typedtree
 diff --git a/tools/ocamlcp.ml b/tools/ocamlcp.ml
-index 278952f..53e8a3f 100644
+index 5508b17..30e2e98 100644
 --- a/tools/ocamlcp.ml
 +++ b/tools/ocamlcp.ml
 @@ -23,6 +23,9 @@ let option opt () = compargs := opt :: !compargs
@@ -109,7 +130,7 @@ index 278952f..53e8a3f 100644
  
  let make_archive = ref false;;
  let with_impl = ref false;;
-@@ -118,6 +121,7 @@ module Options = Main_args.Make_bytecomp_options (struct
+@@ -115,6 +118,7 @@ module Options = Main_args.Make_bytecomp_options (struct
    let _color s = option_with_arg "-color" s
    let _where = option "-where"
    let _nopervasives = option "-nopervasives"
@@ -118,10 +139,10 @@ index 278952f..53e8a3f 100644
    let _dparsetree = option "-dparsetree"
    let _dtypedtree = option "-dtypedtree"
 diff --git a/tools/ocamloptp.ml b/tools/ocamloptp.ml
-index 33147ea..8e1fa8a 100644
+index b96d283..7ebcc70 100644
 --- a/tools/ocamloptp.ml
 +++ b/tools/ocamloptp.ml
-@@ -145,6 +145,7 @@ module Options = Main_args.Make_optcomp_options (struct
+@@ -140,6 +140,7 @@ module Options = Main_args.Make_optcomp_options (struct
    let _where = option "-where"
  
    let _nopervasives = option "-nopervasives"
@@ -130,7 +151,7 @@ index 33147ea..8e1fa8a 100644
    let _dparsetree = option "-dparsetree"
    let _dtypedtree = option "-dtypedtree"
 diff --git a/typing/parmatch.ml b/typing/parmatch.ml
-index e5e7bd6..5477f4c 100644
+index cc2a780..96258f4 100644
 --- a/typing/parmatch.ml
 +++ b/typing/parmatch.ml
 @@ -92,7 +92,7 @@ let rec compat p q =
@@ -141,8 +162,8 @@ index e5e7bd6..5477f4c 100644
 +      Types.equal_tag c1.cstr_tag c2.cstr_tag && compats ps1 ps2
    | Tpat_variant(l1,Some p1, r1), Tpat_variant(l2,Some p2,_) ->
        l1=l2 && compat p1 p2
-   | Tpat_variant (l1,None, r1), Tpat_variant(l2,None,_) ->
-@@ -283,7 +283,7 @@ let pretty_matrix (pss : matrix) =
+   | Tpat_variant (l1,None,r1), Tpat_variant(l2,None,_) ->
+@@ -273,7 +273,7 @@ let pretty_matrix (pss : matrix) =
  let simple_match p1 p2 =
    match p1.pat_desc, p2.pat_desc with
    | Tpat_construct(_, c1, _), Tpat_construct(_, c2, _) ->
@@ -151,9 +172,9 @@ index e5e7bd6..5477f4c 100644
    | Tpat_variant(l1, _, _), Tpat_variant(l2, _, _) ->
        l1 = l2
    | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
-@@ -680,6 +680,15 @@ let should_extend ext env = match ext with
-       end
- end
+@@ -671,6 +671,15 @@ let should_extend ext env = match ext with
+       Path.same path ext
+   | _ -> false
  
 +module ConstructorTag =
 +  struct
@@ -167,7 +188,7 @@ index e5e7bd6..5477f4c 100644
  (* complement constructor tags *)
  let complete_tags nconsts nconstrs tags =
    let seen_const = Array.make nconsts false
-@@ -690,16 +699,16 @@ let complete_tags nconsts nconstrs tags =
+@@ -681,16 +690,16 @@ let complete_tags nconsts nconstrs tags =
        | Cstr_block i -> seen_constr.(i) <- true
        | _  -> assert false)
      tags ;
@@ -188,7 +209,7 @@ index e5e7bd6..5477f4c 100644
  
  (* build a pattern from a constructor list *)
  let pat_of_constr ex_pat cstr =
-@@ -764,7 +773,9 @@ let complete_constrs p all_tags =
+@@ -763,7 +772,9 @@ let complete_constrs p all_tags =
    let not_tags = complete_tags c.cstr_consts c.cstr_nonconsts all_tags in
    let constrs = get_variant_constructors p.pat_env c.cstr_res in
    let others =
@@ -199,7 +220,7 @@ index e5e7bd6..5477f4c 100644
    let const, nonconst =
      List.partition (fun cnstr -> cnstr.cstr_arity = 0) others in
    const @ nonconst
-@@ -1500,7 +1511,7 @@ let rec le_pat p q =
+@@ -1497,7 +1508,7 @@ let rec le_pat p q =
    | _, Tpat_alias(q,_,_) -> le_pat p q
    | Tpat_constant(c1), Tpat_constant(c2) -> const_compare c1 c2 = 0
    | Tpat_construct(_,c1,ps), Tpat_construct(_,c2,qs) ->
@@ -207,8 +228,8 @@ index e5e7bd6..5477f4c 100644
 +      Types.equal_tag c1.cstr_tag c2.cstr_tag && le_pats ps qs
    | Tpat_variant(l1,Some p1,_), Tpat_variant(l2,Some p2,_) ->
        (l1 = l2 && le_pat p1 p2)
-   | Tpat_variant(l1,None,_r1), Tpat_variant(l2,None,_) ->
-@@ -1550,7 +1561,7 @@ let rec lub p q = match p.pat_desc,q.pat_desc with
+   | Tpat_variant(l1,None,r1), Tpat_variant(l2,None,_) ->
+@@ -1547,7 +1558,7 @@ let rec lub p q = match p.pat_desc,q.pat_desc with
      let r = lub p q in
      make_pat (Tpat_lazy r) p.pat_type p.pat_env
  | Tpat_construct (lid, c1,ps1), Tpat_construct (_,c2,ps2)
@@ -218,10 +239,10 @@ index e5e7bd6..5477f4c 100644
          make_pat (Tpat_construct (lid, c1,rs))
            p.pat_type p.pat_env
 diff --git a/typing/types.ml b/typing/types.ml
-index 0e85644..1eadd38 100644
+index c908381..9db9727 100644
 --- a/typing/types.ml
 +++ b/typing/types.ml
-@@ -322,6 +322,14 @@ and constructor_tag =
+@@ -304,6 +304,14 @@ and constructor_tag =
    | Cstr_extension of Path.t * bool     (* Extension constructor
                                             true if a constant false if a block*)
  
@@ -237,10 +258,10 @@ index 0e85644..1eadd38 100644
    { lbl_name: string;                   (* Short name *)
      lbl_res: type_expr;                 (* Type of the result *)
 diff --git a/typing/types.mli b/typing/types.mli
-index 2dc1481..a154a75 100644
+index 45c9ddc..c826afb 100644
 --- a/typing/types.mli
 +++ b/typing/types.mli
-@@ -473,6 +473,8 @@ and constructor_tag =
+@@ -452,6 +452,8 @@ and constructor_tag =
    | Cstr_extension of Path.t * bool     (* Extension constructor
                                             true if a constant false if a block*)
  
@@ -250,7 +271,7 @@ index 2dc1481..a154a75 100644
    { lbl_name: string;                   (* Short name *)
      lbl_res: type_expr;                 (* Type of the result *)
 diff --git a/utils/clflags.ml b/utils/clflags.ml
-index 0d185b0..6feeaf2 100644
+index b8ce959..2f29487 100644
 --- a/utils/clflags.ml
 +++ b/utils/clflags.ml
 @@ -59,6 +59,7 @@ and output_complete_object = ref false  (* -output-complete-obj *)
@@ -262,7 +283,7 @@ index 0d185b0..6feeaf2 100644
  and all_ppx = ref ([] : string list)        (* -ppx *)
  let annotations = ref false             (* -annot *)
 diff --git a/utils/clflags.mli b/utils/clflags.mli
-index 6535360..35d3f0f 100644
+index a5c9ec9..e694cbe 100644
 --- a/utils/clflags.mli
 +++ b/utils/clflags.mli
 @@ -84,6 +84,7 @@ val output_complete_object : bool ref


### PR DESCRIPTION
Tested by uninstalling my opam switch, running k-configure-opam followed by mvn verify.

Part of a fix for kframework/evm-semantics#220

Ready for review.