### PR TITLE
Json output and kprint

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -55,6 +55,11 @@
       <version>3.0.0</version>
     </dependency>
     <dependency>
+      <groupId>org.glassfish</groupId>
+      <artifactId>javax.json</artifactId>
+      <version>1.0.4</version>
+    </dependency>
+    <dependency>
       <groupId>net.sf.jung</groupId>
       <artifactId>jung-api</artifactId>
       <version>2.0.1</version>

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -42,13 +42,15 @@ public class KProve {
     private final Stopwatch sw;
     private final FileUtil files;
     private TTYInfo tty;
+    private KPrint kprint;
 
     @Inject
-    public KProve(KExceptionManager kem, Stopwatch sw, FileUtil files, TTYInfo tty) {
+    public KProve(KExceptionManager kem, Stopwatch sw, FileUtil files, TTYInfo tty, KPrint kprint) {
         this.kem = kem;
         this.sw = sw;
         this.files = files;
         this.tty = tty;
+        this.kprint = kprint;
     }
 
     public int run(KProveOptions options, CompiledDefinition compiledDefinition, Backend backend, Function<Module, Rewriter> rewriterGenerator) {
@@ -63,7 +65,7 @@ public class KProve {
         } else {
             exit = 1;
         }
-        KPrint.prettyPrint(compiled._1().getModule("LANGUAGE-PARSING").get(), options.print.output, s -> KPrint.outputFile(s, options.print, files), results, options.print.color(tty.stdout, files.getEnv()));
+        kprint.prettyPrint(compiled._1().getModule("LANGUAGE-PARSING").get(), s -> kprint.outputFile(s), results);
         return exit;
     }
 

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -19,6 +19,7 @@ import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.TTYInfo;
+import org.kframework.unparser.KPrint;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.Set;
@@ -62,7 +63,7 @@ public class KProve {
         } else {
             exit = 1;
         }
-        KRun.prettyPrint(compiled._1().getModule("LANGUAGE-PARSING").get(), options.prettyPrint.output, s -> KRun.outputFile(s, options.prettyPrint, files), results, options.prettyPrint.color(tty.stdout, files.getEnv()));
+        KPrint.prettyPrint(compiled._1().getModule("LANGUAGE-PARSING").get(), options.print.output, s -> KPrint.outputFile(s, options.print, files), results, options.print.color(tty.stdout, files.getEnv()));
         return exit;
     }
 

--- a/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
@@ -1,3 +1,4 @@
+// Copyright (c) 2015-2018 K Team. All Rights Reserved.
 package org.kframework.kprove;
 
 import com.google.common.collect.ImmutableList;

--- a/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
@@ -15,6 +15,7 @@ import org.kframework.krun.modes.ExecutionMode;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.rewriter.Rewriter;
+import org.kframework.unparser.KPrint;
 import org.kframework.utils.Stopwatch;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -91,7 +92,8 @@ public class KProveFrontEnd extends FrontEnd {
                 throw KEMException.criticalError("Definition file doesn't exist: " +
                         kproveOptions.specFile(files).getAbsolutePath());
             }
-            return new KProve(kem, sw, files, tty).run(kproveOptions, compiledDef.get(), backend.get(), initializeRewriter.get());
+            KPrint kprint = new KPrint(kem, files, tty, kproveOptions.print);
+            return new KProve(kem, sw, files, tty, kprint).run(kproveOptions, compiledDef.get(), backend.get(), initializeRewriter.get());
         } finally {
             scope.exit();
         }

--- a/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
@@ -5,7 +5,7 @@ package org.kframework.kprove;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import com.google.inject.Inject;
-import org.kframework.krun.PrettyPrintOptions;
+import org.kframework.unparser.PrintOptions;
 import org.kframework.main.GlobalOptions;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.file.FileUtil;
@@ -45,7 +45,7 @@ public class KProveOptions {
     public SMTOptions smt = new SMTOptions();
 
     @ParametersDelegate
-    public PrettyPrintOptions prettyPrint = new PrettyPrintOptions();
+    public PrintOptions print = new PrintOptions();
 
     @Parameter(names={"--spec-module", "-sm"}, description="Name of module containing specification to prove")
     public String specModule;

--- a/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
@@ -1,3 +1,5 @@
+// Copyright (c) 2015-2018 K Team. All Rights Reserved.
+
 package org.kframework.kprove;
 
 import com.beust.jcommander.Parameter;

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -31,6 +31,7 @@ import org.kframework.unparser.Formatter;
 import org.kframework.unparser.KOREToTreeNodes;
 import org.kframework.unparser.OutputModes;
 import org.kframework.unparser.ToBinary;
+import org.kframework.unparser.ToJson;
 import org.kframework.unparser.ToKast;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KException;
@@ -194,6 +195,9 @@ public class KRun {
             break;
         case BINARY:
             print.accept(ToBinary.apply(result));
+            break;
+        case JSON:
+            print.accept(ToJson.apply(result));
             break;
         default:
             throw KEMException.criticalError("Unsupported output mode: " + output);

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -26,13 +26,8 @@ import org.kframework.parser.binary.BinaryParser;
 import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
 import org.kframework.parser.kore.KoreParser;
 import org.kframework.rewriter.Rewriter;
-import org.kframework.unparser.AddBrackets;
-import org.kframework.unparser.Formatter;
-import org.kframework.unparser.KOREToTreeNodes;
-import org.kframework.unparser.OutputModes;
-import org.kframework.unparser.ToBinary;
-import org.kframework.unparser.ToJson;
-import org.kframework.unparser.ToKast;
+import org.kframework.unparser.KPrint;
+import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -68,11 +63,13 @@ import static org.kframework.kore.KORE.*;
 public class KRun {
 
     private final KExceptionManager kem;
+    private final KPrint kprint;
     private final FileUtil files;
     private final TTYInfo tty;
 
-    public KRun(KExceptionManager kem, FileUtil files, TTYInfo tty) {
+    public KRun(KExceptionManager kem, KPrint kprint, FileUtil files, TTYInfo tty) {
         this.kem = kem;
+        this.kprint = kprint;
         this.files = files;
         this.tty = tty;
     }
@@ -104,7 +101,7 @@ public class KRun {
 
 
         if (result != null) {
-            prettyPrint(compiledDef.languageParsingModule(), options.prettyPrint.output, s -> outputFile(s, options.prettyPrint, files), result._1(), options.prettyPrint.color(tty.stdout, files.getEnv()));
+            kprint.prettyPrint(compiledDef.languageParsingModule(), options.print.output, s -> kprint.outputFile(s, options.print, files), result._1(), options.print.color(tty.stdout, files.getEnv()));
             return result._2();
         }
         return 0;
@@ -142,23 +139,6 @@ public class KRun {
         return vars.iterator().next();
     }
 
-    //TODO(dwightguth): use Writer
-    public static void outputFile(String output, PrettyPrintOptions options, FileUtil files) {
-        outputFile(output.getBytes(), options, files);
-    }
-
-    public static void outputFile(byte[] output, PrettyPrintOptions options, FileUtil files) {
-        if (options.outputFile == null) {
-            try {
-                System.out.write(output);
-            } catch (IOException e) {
-                throw KEMException.internalError(e.getMessage(), e);
-            }
-        } else {
-            files.saveToWorkingDirectory(options.outputFile, output);
-        }
-    }
-
     /**
      * Function to compile the String Pattern, if the pattern is not present in the cache. Note the difference between
      * compilation and parsing. Compilation is the result of resolving anonymous variables, semantic casts, and concretizing
@@ -182,104 +162,6 @@ public class KRun {
      */
     public static Rule parsePattern(FileUtil files, KExceptionManager kem, String pattern, CompiledDefinition compiledDef, Source source) {
         return compiledDef.parsePatternIfAbsent(files, kem, pattern, source);
-    }
-
-    public static void prettyPrint(Module module, OutputModes output, Consumer<byte[]> print, K result, ColorSetting colorize) {
-        print.accept(prettyPrint(module, output, result, colorize));
-    }
-
-    public static byte[] prettyPrint(Module module, OutputModes output, K result, ColorSetting colorize) {
-        switch (output) {
-        case KAST:
-            return (ToKast.apply(result) + "\n").getBytes();
-        case NONE:
-            return "".getBytes();
-        case PRETTY:
-            Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(module, false).getExtensionModule();
-            return (unparseTerm(result, unparsingModule, colorize) + "\n").getBytes();
-        case BINARY:
-            return ToBinary.apply(result);
-        case JSON:
-            return ToJson.apply(result);
-        default:
-            throw KEMException.criticalError("Unsupported output mode: " + output);
-        }
-    }
-
-    /**
-     * Methods `{omit,tokenize,flatten}KLabels` allows the user to specify some KLabels below which they do not care for accurate term representation.
-     * For example, a user-interface level tool (eg. state explorer) may not need accurate term representation to work, but handling huge Json terms may be a hindrance.
-     */
-    public static K omitTerm(Module module, K k) {
-        if (! (k instanceof KApply)) return k;
-        KApply kapp           = (KApply) k;
-        Sort   finalSort      = Sorts.K();
-        Option<Sort> termSort = module.sortFor().get(kapp.klabel());
-        if (! termSort.isEmpty()) {
-            finalSort = termSort.get();
-        }
-        return KToken(kapp.klabel().name(), finalSort);
-    }
-
-    public static K omitKLabels(Module module, K result, Set<String> omittedKLabels) {
-        return new TransformK() {
-            @Override
-            public K apply(KApply k) {
-                if (omittedKLabels.contains(k.klabel().name())) {
-                    List<K> newArgs = k.klist().items().stream().map(arg -> omitTerm(module, arg)).collect(Collectors.toList());
-                    return KApply(k.klabel(), KList(newArgs), k.att());
-                } else {
-                    return super.apply(k);
-                }
-            }
-        }.apply(result);
-    }
-
-    public static K tokenizeTerm(Module module, K k) {
-        if (! (k instanceof KApply)) return k;
-        KApply kapp            = (KApply) k;
-        Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(module, false).getExtensionModule();
-        String tokenizedTerm   = unparseTerm(kapp, unparsingModule, ColorSetting.OFF);
-        Sort   finalSort       = Sorts.K();
-        Option<Sort> termSort  = module.sortFor().get(kapp.klabel());
-        if (! termSort.isEmpty()) {
-            finalSort = termSort.get();
-        }
-        return KToken(tokenizedTerm, finalSort);
-    }
-
-    public static K tokenizeKLabels(Module module, K result, Set<String> tokenizedKLabels) {
-        return new TransformK() {
-            @Override
-            public K apply(KApply k) {
-                if (tokenizedKLabels.contains(k.klabel().name())) {
-                    List<K> newArgs = k.klist().items().stream().map(arg -> KRun.tokenizeTerm(module, arg)).collect(Collectors.toList());
-                    return KApply(k.klabel(), KList(newArgs), k.att());
-                } else {
-                    return super.apply(k);
-                }
-            }
-        }.apply(result);
-    }
-
-    public static K flattenKLabels(Module module, K result, Set<String> flattenedKLabels) {
-        return new TransformK() {
-            @Override
-            public K apply(KApply k) {
-                if (flattenedKLabels.contains(k.klabel().name())) {
-                    List<K> items = new ArrayList<>();
-                    Att att = module.attributesFor().apply(KLabel(k.klabel().name()));
-                    if (att.contains("assoc") && att.contains("unit")) {
-                        items = Assoc.flatten(k.klabel(), k.klist().items(), KLabel(att.get("unit")));
-                    } else {
-                        items = k.klist().items();
-                    }
-                    return KApply(k.klabel(), KList(items), k.att());
-                } else {
-                    return super.apply(k);
-                }
-            }
-        }.apply(result);
     }
 
     private K parseConfigVars(KRunOptions options, CompiledDefinition compiledDef) {
@@ -351,44 +233,6 @@ public class KRun {
 
     public KApply plugConfigVars(CompiledDefinition compiledDef, Map<KToken, K> output) {
         return KApply(compiledDef.topCellInitializer, output.entrySet().stream().map(e -> KApply(KLabel("_|->_"), e.getKey(), e.getValue())).reduce(KApply(KLabel(".Map")), (a, b) -> KApply(KLabel("_Map_"), a, b)));
-    }
-
-    private static String unparseTerm(K input, Module test, ColorSetting colorize) {
-        K sortedComm = new TransformK() {
-            @Override
-            public K apply(KApply k) {
-                if (k.klabel() instanceof KVariable) {
-                    return super.apply(k);
-                }
-                Att att = test.attributesFor().apply(KLabel(k.klabel().name()));
-                if (att.contains("comm") && att.contains("assoc") && att.contains("unit")) {
-                    List<K> items = new ArrayList<>(Assoc.flatten(k.klabel(), k.klist().items(), KLabel(att.get("unit"))));
-                    List<Tuple2<String, K>> printed = new ArrayList<>();
-                    for (K item : items) {
-                        String s = Formatter.format(new AddBrackets(test).addBrackets(KOREToTreeNodes.apply(KOREToTreeNodes.up(test, apply(item)), test)), ColorSetting.OFF);
-                        printed.add(Tuple2.apply(s, item));
-                    }
-                    printed.sort(Comparator.comparing(Tuple2::_1, new AlphanumComparator()));
-                    items = printed.stream().map(Tuple2::_2).map(this::apply).collect(Collectors.toList());
-                    return items.stream().reduce((k1, k2) -> KApply(k.klabel(), k1, k2)).orElse(KApply(KLabel(att.get("unit"))));
-                }
-                return super.apply(k);
-            }
-        }.apply(input);
-        K alphaRenamed = new TransformK() {
-            Map<KVariable, KVariable> renames = new HashMap<>();
-            int newCount = 0;
-
-            @Override
-            public K apply(KVariable k) {
-                if (k.att().contains("anonymous")) {
-                    return renames.computeIfAbsent(k, k2 -> KVariable("V" + newCount++, k.att()));
-                }
-                return k;
-            }
-        }.apply(sortedComm);
-        return Formatter.format(
-                new AddBrackets(test).addBrackets(KOREToTreeNodes.apply(KOREToTreeNodes.up(test, alphaRenamed), test)), colorize);
     }
 
     public K externalParse(String parser, String value, Sort startSymbol, Source source, CompiledDefinition compiledDef) {

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -185,23 +185,22 @@ public class KRun {
     }
 
     public static void prettyPrint(Module module, OutputModes output, Consumer<byte[]> print, K result, ColorSetting colorize) {
+        print.accept(prettyPrint(module, output, result, colorize));
+    }
+
+    public static byte[] prettyPrint(Module module, OutputModes output, K result, ColorSetting colorize) {
         switch (output) {
         case KAST:
-            print.accept((ToKast.apply(result) + "\n").getBytes());
-            break;
+            return (ToKast.apply(result) + "\n").getBytes();
         case NONE:
-            print.accept("".getBytes());
-            break;
+            return "".getBytes();
         case PRETTY:
             Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(module, false).getExtensionModule();
-            print.accept((unparseTerm(result, unparsingModule, colorize) + "\n").getBytes());
-            break;
+            return (unparseTerm(result, unparsingModule, colorize) + "\n").getBytes();
         case BINARY:
-            print.accept(ToBinary.apply(result));
-            break;
+            return ToBinary.apply(result);
         case JSON:
-            print.accept(ToJson.apply(result));
-            break;
+            return ToJson.apply(result);
         default:
             throw KEMException.criticalError("Unsupported output mode: " + output);
         }

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -101,7 +101,7 @@ public class KRun {
 
 
         if (result != null) {
-            kprint.prettyPrint(compiledDef.languageParsingModule(), options.print.output, s -> kprint.outputFile(s, options.print, files), result._1(), options.print.color(tty.stdout, files.getEnv()));
+            kprint.prettyPrint(compiledDef.languageParsingModule(), s -> kprint.outputFile(s), result._1());
             return result._2();
         }
         return 0;

--- a/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
@@ -81,7 +81,7 @@ public class KRunFrontEnd extends FrontEnd {
      */
     public int run() {
         scope.enter(kompiledDir.get());
-        KPrint kprint = new KPrint(kem, files, tty);
+        KPrint kprint = new KPrint(kem, files, tty, krunOptions.print);
         try {
             for (int i = 0; i < krunOptions.experimental.profile - 1; i++) {
                 new KRun(kem, kprint, files, tty).run(compiledDef.get(),

--- a/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
@@ -10,6 +10,7 @@ import org.kframework.krun.modes.ExecutionMode;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.rewriter.Rewriter;
+import org.kframework.unparser.KPrint;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.JarInfo;
@@ -80,14 +81,15 @@ public class KRunFrontEnd extends FrontEnd {
      */
     public int run() {
         scope.enter(kompiledDir.get());
+        KPrint kprint = new KPrint(kem, files, tty);
         try {
             for (int i = 0; i < krunOptions.experimental.profile - 1; i++) {
-                new KRun(kem, files, tty).run(compiledDef.get(),
+                new KRun(kem, kprint, files, tty).run(compiledDef.get(),
                         krunOptions,
                         initializeRewriter.get(),
                         executionMode.get());
             }
-            return new KRun(kem, files, tty).run(compiledDef.get(),
+            return new KRun(kem, kprint, files, tty).run(compiledDef.get(),
                     krunOptions,
                     initializeRewriter.get(),
                     executionMode.get());

--- a/kernel/src/main/java/org/kframework/krun/KRunModule.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunModule.java
@@ -22,6 +22,7 @@ import org.kframework.main.GlobalOptions;
 import org.kframework.main.Tool;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.unparser.OutputModes;
+import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
@@ -59,12 +60,12 @@ public class KRunModule extends AbstractModule {
     }
 
     @Provides
-    PrettyPrintOptions prettyPrintOptions(KRunOptions options) {
-        return options.prettyPrint;
+    PrintOptions printOptions(KRunOptions options) {
+        return options.print;
     }
 
     @Provides
-    OutputModes outputModes(PrettyPrintOptions options) {
+    OutputModes outputModes(PrintOptions options) {
         return options.output;
     }
 

--- a/kernel/src/main/java/org/kframework/krun/KRunOptions.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunOptions.java
@@ -10,6 +10,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.kframework.main.GlobalOptions;
 import org.kframework.rewriter.SearchType;
 import org.kframework.unparser.OutputModes;
+import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.OS;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.file.FileUtil;
@@ -154,7 +155,7 @@ public final class KRunOptions {
     }
 
     @ParametersDelegate
-    public PrettyPrintOptions prettyPrint = new PrettyPrintOptions();
+    public PrintOptions print = new PrintOptions();
 
     @Parameter(names="--search", description="In conjunction with it you can specify 3 options that are optional: pattern (the pattern used for search), bound (the number of desired solutions) and depth (the maximum depth of the search).")
     public boolean search = false;

--- a/kernel/src/main/java/org/kframework/krun/PrettyPrintOptions.java
+++ b/kernel/src/main/java/org/kframework/krun/PrettyPrintOptions.java
@@ -56,7 +56,7 @@ public class PrettyPrintOptions {
     public String outputFile;
 
     @Parameter(names={"--output", "-o"}, converter=OutputModeConverter.class,
-            description="How to display krun results. <mode> is either [pretty|sound|kast|binary|none|no-wrap].")
+            description="How to display krun results. <mode> is either [pretty|sound|kast|binary|json|none|no-wrap].")
     public OutputModes output = OutputModes.PRETTY;
 
     public static class OutputModeConverter extends BaseEnumConverter<OutputModes> {

--- a/kernel/src/main/java/org/kframework/krun/PrettyPrintOptions.java
+++ b/kernel/src/main/java/org/kframework/krun/PrettyPrintOptions.java
@@ -3,10 +3,13 @@ package org.kframework.krun;
 
 import com.beust.jcommander.Parameter;
 import com.google.inject.Inject;
+
 import org.kframework.unparser.OutputModes;
 import org.kframework.utils.options.BaseEnumConverter;
 
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 public class PrettyPrintOptions {
 
@@ -71,4 +74,12 @@ public class PrettyPrintOptions {
         }
     }
 
+    @Parameter(names={"--output-omit"}, description="KLabels to omit from the output.")
+    public List<String> omittedKLabels = new ArrayList<String>();
+
+    @Parameter(names={"--output-flatten"}, description="Assoc KLabels to flatten arguments for (reducing output size).")
+    public List<String> flattenedKLabels = new ArrayList<String>();
+
+    @Parameter(names={"--output-tokenize"}, description="KLabels to tokenize underneath (reducing output size).")
+    public List<String> tokenizedKLabels = new ArrayList<String>();
 }

--- a/kernel/src/main/java/org/kframework/krun/modes/DebugMode/Commands.java
+++ b/kernel/src/main/java/org/kframework/krun/modes/DebugMode/Commands.java
@@ -83,7 +83,7 @@ public class Commands {
             CommandUtils utils = new CommandUtils(isSource);
             DebuggerState requestedState = session.getActiveState();
             if (requestedState != null) {
-                KPrint.prettyPrint(compiledDefinition.languageParsingModule(), OutputModes.PRETTY, s -> utils.print(s), requestedState.getCurrentK(), ColorSetting.ON);
+                KPrint.prettyPrint(compiledDefinition.languageParsingModule(), s -> utils.print(s), requestedState.getCurrentK());
             } else {
                 throw KEMException.debuggerError("\"Requested State/Configuration Unreachable\",");
             }
@@ -306,7 +306,7 @@ public class Commands {
             if (disableOutput) {
                 return;
             }
-            KPrint.prettyPrint(compiledDefinition.languageParsingModule(), OutputModes.PRETTY, s -> System.out.println(s), result.getSubstitutions(), ColorSetting.ON);
+            KPrint.prettyPrint(compiledDefinition.languageParsingModule(), s -> System.out.println(s), result.getSubstitutions());
         }
 
         private void print(byte[] bytes){

--- a/kernel/src/main/java/org/kframework/krun/modes/DebugMode/Commands.java
+++ b/kernel/src/main/java/org/kframework/krun/modes/DebugMode/Commands.java
@@ -6,8 +6,10 @@ import org.kframework.debugger.DebuggerState;
 import org.kframework.debugger.KDebug;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.krun.KRun;
-import org.kframework.krun.ColorSetting;
+import org.kframework.unparser.ColorSetting;
 import org.kframework.unparser.OutputModes;
+import org.kframework.unparser.PrintOptions;
+import org.kframework.unparser.KPrint;
 import org.kframework.utils.errorsystem.KEMException;
 
 import java.io.IOException;
@@ -81,7 +83,7 @@ public class Commands {
             CommandUtils utils = new CommandUtils(isSource);
             DebuggerState requestedState = session.getActiveState();
             if (requestedState != null) {
-                prettyPrint(compiledDefinition.languageParsingModule(), OutputModes.PRETTY, s -> utils.print(s), requestedState.getCurrentK(), ColorSetting.ON);
+                KPrint.prettyPrint(compiledDefinition.languageParsingModule(), OutputModes.PRETTY, s -> utils.print(s), requestedState.getCurrentK(), ColorSetting.ON);
             } else {
                 throw KEMException.debuggerError("\"Requested State/Configuration Unreachable\",");
             }
@@ -304,7 +306,7 @@ public class Commands {
             if (disableOutput) {
                 return;
             }
-            KRun.prettyPrint(compiledDefinition.languageParsingModule(), OutputModes.PRETTY, s -> System.out.println(s), result.getSubstitutions(), ColorSetting.ON);
+            KPrint.prettyPrint(compiledDefinition.languageParsingModule(), OutputModes.PRETTY, s -> System.out.println(s), result.getSubstitutions(), ColorSetting.ON);
         }
 
         private void print(byte[] bytes){

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -1,0 +1,91 @@
+// Copyright (c) 2018 K Team. All Rights Reserved.
+package org.kframework.parser.json;
+
+import org.kframework.kore.K;
+import static org.kframework.kore.KORE.KLabel;
+import org.kframework.kore.mini.InjectedKLabel;
+import org.kframework.kore.mini.KApply;
+import org.kframework.kore.mini.KRewrite;
+import org.kframework.kore.mini.KSequence;
+import org.kframework.kore.mini.KToken;
+import org.kframework.kore.mini.KVariable;
+import org.kframework.parser.outer.Outer;
+import org.kframework.utils.errorsystem.KEMException;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+import javax.json.Json;
+import javax.json.JsonObject;
+import javax.json.JsonArray;
+
+/**
+ * Parses a Json term into the KORE data structures.
+ */
+public class JsonParser {
+
+    public static final String KTOKEN         = "KToken"
+                             , KAPPLY         = "KApply"
+                             , KSEQUENCE      = "KSequence"
+                             , KVARIABLE      = "KVariable"
+                             , KREWRITE       = "KRewrite"
+                             , INJECTEDKLABEL = "InjectedKLabel"
+                             ;
+
+    public static K parseJson(JsonObject data) {
+        try {
+            if (! (data.containsKey("format") && data.containsKey("version") && data.containsKey("term"))) {
+                throw KEMException.criticalError("Must have `format`, `version`, and `term` fields in serialized Json!");
+            }
+            if (data.getString("format") != "KAST") {
+                throw KEMException.criticalError("Only can deserialize 'KAST' format Json! Found: " + data.getString("format"));
+            }
+            if (data.getInt("version") != 1) {
+                throw KEMException.criticalError("Only can deserialize KAST version '1'! Found: " + data.getInt("version"));
+            }
+            return toK(data.getJsonObject("term"));
+        } catch (IOException e) {
+            throw KEMException.criticalError("Could not read K term from json", e);
+        }
+    }
+
+    private static K toK(JsonObject data) throws IOException {
+        switch (data.getString("node")) {
+
+            case KTOKEN:
+                return new KToken(data.getString("name"), Outer.parseSort(data.getString("sort")));
+
+            case KAPPLY:
+                int arity = data.getInt("arity");
+                K[] args  = toKs(arity, data.getJsonArray("args"));
+                return KApply.of(KLabel(data.getString("label")), args);
+
+            case KSEQUENCE:
+                int seqLen = data.getInt("arity");
+                K[] items  = toKs(seqLen, data.getJsonArray("items"));
+                return new KSequence(items);
+
+            case KVARIABLE:
+                return new KVariable(data.getString("name"));
+
+            case KREWRITE:
+                K lhs = toK(data.getJsonObject("lhs"));
+                K rhs = toK(data.getJsonObject("rhs"));
+                return new KRewrite(lhs, rhs);
+
+            case INJECTEDKLABEL:
+                return new InjectedKLabel(KLabel(data.getString("name")));
+
+            default:
+                throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
+        }
+    }
+
+    private static K[] toKs(int arity, JsonArray data) throws IOException {
+        K[] items = new K[arity];
+        for (int i = 0; i < arity; i++) {
+            items[i] = toK(data.getValuesAs(JsonObject.class).get(i));
+        }
+        return items;
+    }
+}

--- a/kernel/src/main/java/org/kframework/unparser/ColorSetting.java
+++ b/kernel/src/main/java/org/kframework/unparser/ColorSetting.java
@@ -1,5 +1,5 @@
 // Copyright (c) 2014-2018 K Team. All Rights Reserved.
-package org.kframework.krun;
+package org.kframework.unparser;
 
 /**
  * @author Denis Bogdanas

--- a/kernel/src/main/java/org/kframework/unparser/Formatter.java
+++ b/kernel/src/main/java/org/kframework/unparser/Formatter.java
@@ -6,7 +6,6 @@ import org.kframework.definition.NonTerminal;
 import org.kframework.definition.Production;
 import org.kframework.definition.ProductionItem;
 import org.kframework.definition.Terminal;
-import org.kframework.krun.ColorSetting;
 import org.kframework.parser.Constant;
 import org.kframework.parser.Term;
 import org.kframework.parser.TermCons;

--- a/kernel/src/main/java/org/kframework/unparser/Formatter.java
+++ b/kernel/src/main/java/org/kframework/unparser/Formatter.java
@@ -1,3 +1,5 @@
+// Copyright (c) 2018 K Team. All Rights Reserved.
+
 package org.kframework.unparser;
 
 import org.kframework.definition.NonTerminal;

--- a/kernel/src/main/java/org/kframework/unparser/Indenter.java
+++ b/kernel/src/main/java/org/kframework/unparser/Indenter.java
@@ -1,3 +1,5 @@
+// Copyright (c) 2018 K Team. All Rights Reserved.
+
 package org.kframework.unparser;
 
 public class Indenter implements Appendable {

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -96,10 +96,11 @@ public class KPrint {
     }
 
     private static K abstractionPass(Module unparsingModule, K contents) {
-        K omitted   = KPrint.omitKLabels    (unparsingModule, contents);
-        K flattened = KPrint.flattenKLabels (unparsingModule, omitted);
-        K tokenized = KPrint.tokenizeKLabels(unparsingModule, flattened);
-        return tokenized;
+        K omitted    = KPrint.omitKLabels    (unparsingModule, contents);
+        K flattened  = KPrint.flattenKLabels (unparsingModule, omitted);
+        K tokenized  = KPrint.tokenizeKLabels(unparsingModule, flattened);
+        K tostringed = KPrint.tostringKLabels(unparsingModule, tokenized);
+        return tostringed;
     }
 
     /**
@@ -150,6 +151,32 @@ public class KPrint {
             public K apply(KApply k) {
                 if (options.tokenizedKLabels.contains(k.klabel().name())) {
                     List<K> newArgs = k.klist().items().stream().map(arg -> tokenizeTerm(module, arg)).collect(Collectors.toList());
+                    return KApply(k.klabel(), KList(newArgs), k.att());
+                } else {
+                    return super.apply(k);
+                }
+            }
+        }.apply(result);
+    }
+
+    public static K tostringTerm(Module module, K k) {
+        if (! (k instanceof KApply)) return k;
+        KApply       kapp         = (KApply) k;
+        String       tostringTerm = kapp.toString();
+        Sort         finalSort    = Sorts.K();
+        Option<Sort> termSort     = module.sortFor().get(kapp.klabel());
+        if (! termSort.isEmpty()) {
+            finalSort = termSort.get();
+        }
+        return KToken(tostringTerm, finalSort);
+    }
+
+    public static K tostringKLabels(Module module, K result) {
+        return new TransformK() {
+            @Override
+            public K apply(KApply k) {
+                if (options.tostringKLabels.contains(k.klabel().name())) {
+                    List<K> newArgs = k.klist().items().stream().map(arg -> tostringTerm(module, arg)).collect(Collectors.toList());
                     return KApply(k.klabel(), KList(newArgs), k.att());
                 } else {
                     return super.apply(k);

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -1,0 +1,209 @@
+// Copyright (c) 2018 K Team. All Rights Reserved.
+package org.kframework.unparser;
+
+import com.davekoelle.AlphanumComparator;
+import org.apache.commons.lang3.tuple.Pair;
+import org.kframework.attributes.Att;
+import org.kframework.builtin.Sorts;
+import org.kframework.definition.Module;
+import org.kframework.kore.Assoc;
+import org.kframework.kore.K;
+import org.kframework.kore.KApply;
+import org.kframework.kore.KVariable;
+import org.kframework.kore.Sort;
+import org.kframework.kore.TransformK;
+import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
+import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.errorsystem.KException;
+import org.kframework.utils.errorsystem.KExceptionManager;
+import org.kframework.utils.file.FileUtil;
+import org.kframework.utils.file.TTYInfo;
+import scala.Tuple2;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+
+import scala.Option;
+
+import static org.kframework.Collections.*;
+import static org.kframework.kore.KORE.*;
+
+/**
+ * Class for printing information and outputting to files using various serializers.
+ */
+public class KPrint {
+
+    private final KExceptionManager kem;
+    private final FileUtil          files;
+    private final TTYInfo           tty;
+
+    public KPrint(KExceptionManager kem, FileUtil files, TTYInfo tty) {
+        this.kem   = kem;
+        this.files = files;
+        this.tty   = tty;
+    }
+
+    //TODO(dwightguth): use Writer
+    public static void outputFile(String output, PrintOptions options, FileUtil files) {
+        outputFile(output.getBytes(), options, files);
+    }
+
+    public static void outputFile(byte[] output, PrintOptions options, FileUtil files) {
+        if (options.outputFile == null) {
+            try {
+                System.out.write(output);
+            } catch (IOException e) {
+                throw KEMException.internalError(e.getMessage(), e);
+            }
+        } else {
+            files.saveToWorkingDirectory(options.outputFile, output);
+        }
+    }
+
+    // TODO: prettyPrint should take advantage of the `PrintOptions`
+    public static void prettyPrint(Module module, OutputModes output, Consumer<byte[]> print, K result, ColorSetting colorize) {
+        print.accept(prettyPrint(module, output, result, colorize));
+    }
+
+    public static byte[] prettyPrint(Module module, OutputModes output, K result, ColorSetting colorize) {
+        switch (output) {
+        case KAST:
+            return (ToKast.apply(result) + "\n").getBytes();
+        case NONE:
+            return "".getBytes();
+        case PRETTY:
+            Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(module, false).getExtensionModule();
+            return (unparseTerm(result, unparsingModule, colorize) + "\n").getBytes();
+        case BINARY:
+            return ToBinary.apply(result);
+        case JSON:
+            return ToJson.apply(result);
+        default:
+            throw KEMException.criticalError("Unsupported output mode: " + output);
+        }
+    }
+
+    /**
+     * Methods `{omit,tokenize,flatten}KLabels` allows the user to specify some KLabels below which they do not care for accurate term representation.
+     * For example, a user-interface level tool (eg. state explorer) may not need accurate term representation to work, but handling huge Json terms may be a hindrance.
+     */
+    // TODO: find a better place for this
+    public static K omitTerm(Module module, K k) {
+        if (! (k instanceof KApply)) return k;
+        KApply kapp           = (KApply) k;
+        Sort   finalSort      = Sorts.K();
+        Option<Sort> termSort = module.sortFor().get(kapp.klabel());
+        if (! termSort.isEmpty()) {
+            finalSort = termSort.get();
+        }
+        return KToken(kapp.klabel().name(), finalSort);
+    }
+
+    public static K omitKLabels(Module module, K result, Set<String> omittedKLabels) {
+        return new TransformK() {
+            @Override
+            public K apply(KApply k) {
+                if (omittedKLabels.contains(k.klabel().name())) {
+                    List<K> newArgs = k.klist().items().stream().map(arg -> omitTerm(module, arg)).collect(Collectors.toList());
+                    return KApply(k.klabel(), KList(newArgs), k.att());
+                } else {
+                    return super.apply(k);
+                }
+            }
+        }.apply(result);
+    }
+
+    public static K tokenizeTerm(Module module, K k) {
+        if (! (k instanceof KApply)) return k;
+        KApply kapp            = (KApply) k;
+        Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(module, false).getExtensionModule();
+        String tokenizedTerm   = unparseTerm(kapp, unparsingModule, ColorSetting.OFF);
+        Sort   finalSort       = Sorts.K();
+        Option<Sort> termSort  = module.sortFor().get(kapp.klabel());
+        if (! termSort.isEmpty()) {
+            finalSort = termSort.get();
+        }
+        return KToken(tokenizedTerm, finalSort);
+    }
+
+    public static K tokenizeKLabels(Module module, K result, Set<String> tokenizedKLabels) {
+        return new TransformK() {
+            @Override
+            public K apply(KApply k) {
+                if (tokenizedKLabels.contains(k.klabel().name())) {
+                    List<K> newArgs = k.klist().items().stream().map(arg -> tokenizeTerm(module, arg)).collect(Collectors.toList());
+                    return KApply(k.klabel(), KList(newArgs), k.att());
+                } else {
+                    return super.apply(k);
+                }
+            }
+        }.apply(result);
+    }
+
+    public static K flattenKLabels(Module module, K result, Set<String> flattenedKLabels) {
+        return new TransformK() {
+            @Override
+            public K apply(KApply k) {
+                if (flattenedKLabels.contains(k.klabel().name())) {
+                    List<K> items = new ArrayList<>();
+                    Att att = module.attributesFor().apply(KLabel(k.klabel().name()));
+                    if (att.contains("assoc") && att.contains("unit")) {
+                        items = Assoc.flatten(k.klabel(), k.klist().items(), KLabel(att.get("unit")));
+                    } else {
+                        items = k.klist().items();
+                    }
+                    return KApply(k.klabel(), KList(items), k.att());
+                } else {
+                    return super.apply(k);
+                }
+            }
+        }.apply(result);
+    }
+
+    private static String unparseTerm(K input, Module test, ColorSetting colorize) {
+        K sortedComm = new TransformK() {
+            @Override
+            public K apply(KApply k) {
+                if (k.klabel() instanceof KVariable) {
+                    return super.apply(k);
+                }
+                Att att = test.attributesFor().apply(KLabel(k.klabel().name()));
+                if (att.contains("comm") && att.contains("assoc") && att.contains("unit")) {
+                    List<K> items = new ArrayList<>(Assoc.flatten(k.klabel(), k.klist().items(), KLabel(att.get("unit"))));
+                    List<Tuple2<String, K>> printed = new ArrayList<>();
+                    for (K item : items) {
+                        String s = Formatter.format(new AddBrackets(test).addBrackets(KOREToTreeNodes.apply(KOREToTreeNodes.up(test, apply(item)), test)), ColorSetting.OFF);
+                        printed.add(Tuple2.apply(s, item));
+                    }
+                    printed.sort(Comparator.comparing(Tuple2::_1, new AlphanumComparator()));
+                    items = printed.stream().map(Tuple2::_2).map(this::apply).collect(Collectors.toList());
+                    return items.stream().reduce((k1, k2) -> KApply(k.klabel(), k1, k2)).orElse(KApply(KLabel(att.get("unit"))));
+                }
+                return super.apply(k);
+            }
+        }.apply(input);
+        K alphaRenamed = new TransformK() {
+            Map<KVariable, KVariable> renames = new HashMap<>();
+            int newCount = 0;
+
+            @Override
+            public K apply(KVariable k) {
+                if (k.att().contains("anonymous")) {
+                    return renames.computeIfAbsent(k, k2 -> KVariable("V" + newCount++, k.att()));
+                }
+                return k;
+            }
+        }.apply(sortedComm);
+        return Formatter.format(
+                new AddBrackets(test).addBrackets(KOREToTreeNodes.apply(KOREToTreeNodes.up(test, alphaRenamed), test)), colorize);
+    }
+}

--- a/kernel/src/main/java/org/kframework/unparser/OutputModes.java
+++ b/kernel/src/main/java/org/kframework/unparser/OutputModes.java
@@ -7,5 +7,5 @@ package org.kframework.unparser;
  *
  */
 public enum OutputModes {
-    PRETTY, SOUND, KAST, BINARY, NONE
+    PRETTY, SOUND, KAST, BINARY, JSON , NONE
 }

--- a/kernel/src/main/java/org/kframework/unparser/OutputModes.java
+++ b/kernel/src/main/java/org/kframework/unparser/OutputModes.java
@@ -7,5 +7,19 @@ package org.kframework.unparser;
  *
  */
 public enum OutputModes {
-    PRETTY, SOUND, KAST, BINARY, JSON , NONE
+    PRETTY, SOUND, KAST, BINARY, JSON , NONE;
+
+    private String extension;
+    static {
+        PRETTY.extension = "kpretty";
+        SOUND.extension  = "ksound";
+        KAST.extension   = "kast";
+        BINARY.extension = "kbin";
+        JSON.extension   = "json";
+        NONE.extension   = "";
+    }
+
+    public String ext() {
+        return extension;
+    }
 }

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.Parameter;
 import com.google.inject.Inject;
 
 import org.kframework.utils.options.BaseEnumConverter;
+import org.kframework.utils.options.StringListConverter;
 
 import java.util.Map;
 import java.util.List;
@@ -73,15 +74,15 @@ public class PrintOptions {
         }
     }
 
-    @Parameter(names={"--output-omit"}, description="KLabels to omit from the output.")
+    @Parameter(names={"--output-omit"}, listConverter=StringListConverter.class, description="KLabels to omit from the output.")
     public List<String> omittedKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--output-flatten"}, description="Assoc KLabels to flatten arguments for (reducing output size).")
+    @Parameter(names={"--output-flatten"}, listConverter=StringListConverter.class, description="Assoc KLabels to flatten arguments for (reducing output size).")
     public List<String> flattenedKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--output-tokenize"}, description="KLabels to tokenize underneath (reducing output size).")
+    @Parameter(names={"--output-tokenize"}, listConverter=StringListConverter.class, description="KLabels to tokenize underneath (reducing output size).")
     public List<String> tokenizedKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--output-tostring"}, description="KLabels to be printed in toString() format.")
+    @Parameter(names={"--output-tostring"}, listConverter=StringListConverter.class, description="KLabels to be printed in toString() format.")
     public List<String> tostringKLabels = new ArrayList<>();
 }

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -1,24 +1,23 @@
 // Copyright (c) 2014-2018 K Team. All Rights Reserved.
-package org.kframework.krun;
+package org.kframework.unparser;
 
 import com.beust.jcommander.Parameter;
 import com.google.inject.Inject;
 
-import org.kframework.unparser.OutputModes;
 import org.kframework.utils.options.BaseEnumConverter;
 
 import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
 
-public class PrettyPrintOptions {
+public class PrintOptions {
 
-    public PrettyPrintOptions() {
+    public PrintOptions() {
     }
 
     //TODO(dwightguth): remove in Guice 4.0
     @Inject
-    public PrettyPrintOptions(Void v) {
+    public PrintOptions(Void v) {
     }
 
     @Parameter(names = "--color", description = "Use colors in output. Default is on.", converter=ColorModeConverter.class)

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -81,4 +81,7 @@ public class PrintOptions {
 
     @Parameter(names={"--output-tokenize"}, description="KLabels to tokenize underneath (reducing output size).")
     public List<String> tokenizedKLabels = new ArrayList<String>();
+
+    @Parameter(names={"--output-tostring"}, description="KLabels to be printed in toString() format.")
+    public List<String> tostringKLabels = new ArrayList<>();
 }

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -1,0 +1,124 @@
+// Copyright (c) 2015-2018 K Team. All Rights Reserved.
+package org.kframework.unparser;
+
+import org.kframework.kore.InjectedKLabel;
+import org.kframework.kore.K;
+import org.kframework.kore.KApply;
+import org.kframework.kore.KRewrite;
+import org.kframework.kore.KSequence;
+import org.kframework.kore.KToken;
+import org.kframework.kore.KVariable;
+import org.kframework.parser.json.JsonParser;
+import org.kframework.utils.errorsystem.KEMException;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.DataOutputStream;
+import java.io.ByteArrayOutputStream;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import javax.json.Json;
+import javax.json.stream.JsonGenerator;
+import javax.json.JsonWriterFactory;
+import javax.json.JsonArrayBuilder;
+import javax.json.JsonObject;
+import javax.json.JsonObjectBuilder;
+import javax.json.JsonWriter;
+import javax.json.JsonStructure;
+
+/**
+ * Writes a KAST term to the KAST Json format.
+ */
+public class ToJson {
+
+    public static void apply(OutputStream out, K k) {
+        try {
+            DataOutputStream data = new DataOutputStream(out);
+            JsonWriter jsonWriter = Json.createWriter(data);
+
+            JsonObjectBuilder kterm = Json.createObjectBuilder();
+            kterm.add("format", "KAST");
+            kterm.add("version", 1);
+            kterm.add("term", toJson(k));
+
+            jsonWriter.write(kterm.build());
+            jsonWriter.close();
+            data.close();
+        } catch (IOException e) {
+            throw KEMException.criticalError("Could not write K term to Json", e, k);
+        }
+    }
+
+    public static byte[] apply(K k) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        apply(out, k);
+        return out.toByteArray();
+    }
+
+    private DataOutputStream data;
+    private ToJson(DataOutputStream data) {
+        this.data = data;
+    }
+
+    private static JsonStructure toJson(K k) {
+        JsonObjectBuilder knode = Json.createObjectBuilder();
+        if (k instanceof KToken) {
+            KToken tok = (KToken) k;
+
+            knode.add("node", JsonParser.KTOKEN);
+            knode.add("sort", tok.sort().toString());
+            knode.add("token", tok.s());
+
+        } else if (k instanceof KApply) {
+            KApply app = (KApply) k;
+
+            knode.add("node", JsonParser.KAPPLY);
+            knode.add("label", app.klabel().name());
+            knode.add("variable", app.klabel() instanceof KVariable);
+
+            JsonArrayBuilder args = Json.createArrayBuilder();
+            for (K item : app.klist().asIterable()) {
+                args.add(toJson(item));
+            }
+
+            knode.add("arity", app.klist().size());
+            knode.add("args", args.build());
+
+        } else if (k instanceof KSequence) {
+            KSequence seq = (KSequence) k;
+
+            knode.add("node", JsonParser.KSEQUENCE);
+
+            JsonArrayBuilder items = Json.createArrayBuilder();
+            for (K item : seq.asIterable()) {
+                items.add(toJson(item));
+            }
+
+            knode.add("arity", seq.size());
+            knode.add("items", items.build());
+
+        } else if (k instanceof KVariable) {
+            KVariable var = (KVariable) k;
+
+            knode.add("node", JsonParser.KVARIABLE);
+            knode.add("name", var.name());
+
+        } else if (k instanceof KRewrite) {
+            KRewrite rew = (KRewrite) k;
+
+            knode.add("node", JsonParser.KREWRITE);
+            knode.add("lhs", toJson(rew.left()));
+            knode.add("rhs", toJson(rew.right()));
+
+        } else if (k instanceof InjectedKLabel) {
+            InjectedKLabel inj = (InjectedKLabel) k;
+
+            knode.add("node", JsonParser.INJECTEDKLABEL);
+            knode.add("name", inj.klabel().name());
+
+        }
+        return knode.build();
+    }
+}

--- a/kernel/src/main/java/org/kframework/utils/ColorUtil.java
+++ b/kernel/src/main/java/org/kframework/utils/ColorUtil.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2012-2018 K Team. All Rights Reserved.
 package org.kframework.utils;
 
-import org.kframework.krun.ColorSetting;
+import org.kframework.unparser.ColorSetting;
 
 import java.awt.Color;
 import java.awt.color.ColorSpace;

--- a/kernel/src/test/java/org/kframework/utils/ColorUtilTest.java
+++ b/kernel/src/test/java/org/kframework/utils/ColorUtilTest.java
@@ -2,7 +2,7 @@
 package org.kframework.utils;
 
 import org.junit.Test;
-import org.kframework.krun.ColorSetting;
+import org.kframework.unparser.ColorSetting;
 
 import static org.junit.Assert.*;
 

--- a/kore/src/main/scala/org/kframework/unparser/KOREToTreeNodes.scala
+++ b/kore/src/main/scala/org/kframework/unparser/KOREToTreeNodes.scala
@@ -23,7 +23,7 @@ object KOREToTreeNodes {
   }
 
   def up(mod: Module)(t: K): K = t match {
-    case v: KVariable => KToken(v.name, Sorts.KVariable, v.att)
+    case v: KVariable => KToken(v.toString, Sorts.KVariable, v.att)
     case t: KToken =>
       if (mod.tokenProductionsFor.contains(t.sort)) {
         t

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlCompileExecutionMode.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlCompileExecutionMode.java
@@ -18,6 +18,7 @@ import org.kframework.krun.modes.ExecutionMode;
 import org.kframework.main.GlobalOptions;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.unparser.ToBinary;
+import org.kframework.unparser.KPrint;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
@@ -40,6 +41,7 @@ public class OcamlCompileExecutionMode implements ExecutionMode {
     private final OcamlKRunOptions ocamlKRunOptions;
     private final DefinitionToOcaml converter;
     private final KRunOptions options;
+    private final KPrint kprint;
 
     @Inject
     public OcamlCompileExecutionMode(
@@ -50,6 +52,7 @@ public class OcamlCompileExecutionMode implements ExecutionMode {
             CompiledDefinition def,
             OcamlRewriter.InitializeDefinition init,
             KRunOptions options,
+            KPrint kprint,
             OcamlKRunOptions ocamlKRunOptions) {
         this.kem = kem;
         this.files = files;
@@ -57,6 +60,7 @@ public class OcamlCompileExecutionMode implements ExecutionMode {
         this.converter = new DefinitionToOcaml(kem, files, globalOptions, kompileOptions, null);
         converter.initialize(init.serialized, def);
         this.options = options;
+        this.kprint = kprint;
     }
 
     @Override
@@ -111,7 +115,7 @@ public class OcamlCompileExecutionMode implements ExecutionMode {
                 rewriter.createResourceObject("kore_term");
                 rewriter.createResourceObject("marshal_term");
                 rewriter.createResourceObject("plugin_path");
-                String outputFile = options.prettyPrint.outputFile;
+                String outputFile = kprint.options.outputFile;
                 if (outputFile == null) {
                     outputFile = "a.out";
                 }


### PR DESCRIPTION
This PR achieves 2 things:

(1) Adds class `KPrint` which acts as a wrapper around the various serializers (`pretty|json|binary|none|kast`), holding the serialization options in hand. This way any other part of K wishing to output information can make sure the output is affected by the options passed to `KPrint` by using the class. Various abstraction passes are added for doing lossy serializations.

(2) Adds the `ToJson` and `JsonParser` classes, which are the serializer/deserializer for Json.

@dwightguth how do you think we should test this? Ideally, we would have one "testset" which we run through all the serializer/deserializers/lossy serializations I think.