### PR TITLE
Use Zalando's fork of aws-maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,9 +125,9 @@
   <build>
     <extensions>
       <extension>
-        <groupId>org.springframework.build</groupId>
+        <groupId>org.zalando.org.springframework.build</groupId>
         <artifactId>aws-maven</artifactId>
-        <version>5.0.0.RELEASE</version>
+        <version>5.0.0.RELEASE-zal-2</version>
       </extension>
     </extensions>
     <pluginManagement>


### PR DESCRIPTION
Zalando' [fork](https://mvnrepository.com/artifact/org.zalando.org.springframework.build/aws-maven/5.0.0.RELEASE-zal-2):

* Updates the `amazonaws.version` from 1.7.1 to 1.11.39
* Does not depend on the whole `amazon-aws-sdk` package, only on the s3 component
* Does not have a transitive range dependency on `joda-time`, which was
problematic when packaging K with Nix

/cc @ehildenb @ttuegel