### PR TITLE
add code to generate kore from kast

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -1135,7 +1135,10 @@ public class ModuleToKORE {
         }
     }
 
-    private void convert(K k) {
+    @Override
+    public String toString() { return sb.toString(); }
+
+    public void convert(K k) {
         new VisitK() {
             @Override
             public void apply(KApply k) {

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -67,7 +67,7 @@ public class AddSortInjections {
         return result;
     }
 
-    private K addInjections(K term, Sort expectedSort) {
+    public K addInjections(K term, Sort expectedSort) {
         Sort actualSort = sort(term, expectedSort);
         if (actualSort == null) {
             actualSort = expectedSort;

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -5,6 +5,8 @@ import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import org.kframework.attributes.Source;
+import org.kframework.backend.kore.ModuleToKORE;
+import org.kframework.compile.AddSortInjections;
 import org.kframework.compile.ExpandMacros;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kore.K;
@@ -108,10 +110,17 @@ public class KastFrontEnd extends FrontEnd {
                 compiledMod = def.kompiledDefinition.getModule(options.module).get();
             }
             K parsed = def.getParser(mod, sort, kem).apply(FileUtil.read(stringToParse), source);
-            if (options.expandMacros) {
+            if (options.expandMacros || options.kore) {
                 parsed = new ExpandMacros(compiledMod, files, def.kompileOptions, false).expand(parsed);
             }
-            System.out.println(ToKast.apply(parsed));
+            if (options.kore) {
+              ModuleToKORE converter = new ModuleToKORE(compiledMod, files);
+              parsed = new AddSortInjections(compiledMod).addInjections(parsed, sort);
+              converter.convert(parsed);
+              System.out.println(converter.toString());
+            } else {
+              System.out.println(ToKast.apply(parsed));
+            }
             sw.printTotal("Total");
             return 0;
         } finally {

--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -91,6 +91,9 @@ public final class KastOptions {
     @Parameter(names="--expand-macros", description="Also expand macros in the parsed string.")
     public boolean expandMacros = false;
 
+    @Parameter(names="--kore", description="Output KORE-syntax instead of KAST-syntax.")
+    public boolean kore = false;
+
     @ParametersDelegate
     public Experimental experimental = new Experimental();
 


### PR DESCRIPTION
To run:
```
$ kompile imp.k --backend kore # generates imp.kore
$ kast --kore test.imp > test.kore
```

Note that this still needs to be plugged into the top cell initializer in order to become the initial configuration for imp.