### PR TITLE
Don't require interactivity in the build

### DIFF
--- a/k-distribution/src/main/scripts/bin/k-configure-opam-dev
+++ b/k-distribution/src/main/scripts/bin/k-configure-opam-dev
@@ -1,5 +1,5 @@
 #!/bin/sh
-opam init
+yes n | opam init
 opam repository add k "$(dirname "$0")/../lib/opam" \
  || opam repository set-url k "$(dirname "$0")/../lib/opam"
 opam update


### PR DESCRIPTION
Answer "no" by default to the question:
Do you want OPAM to modify ~/.profile and ~/.ocamlinit?