### PR TITLE
add attribute to injection symbol

### DIFF
--- a/k-distribution/include/kore/prelude.kore
+++ b/k-distribution/include/kore/prelude.kore
@@ -25,7 +25,7 @@ module KSEQ
 endmodule []
 
 module INJ
-  symbol inj{From,To}(From) : To []
+  symbol inj{From,To}(From) : To [injection{}()]
  
   axiom{S1,S2,S3,R} 
     \equals{S3,R}(

--- a/k-distribution/include/kore/prelude.kore
+++ b/k-distribution/include/kore/prelude.kore
@@ -25,7 +25,7 @@ module KSEQ
 endmodule []
 
 module INJ
-  symbol inj{From,To}(From) : To [injection{}()]
+  symbol inj{From,To}(From) : To [sortInjection{}()]
  
   axiom{S1,S2,S3,R} 
     \equals{S3,R}(


### PR DESCRIPTION
This attribute is used by the llvm backend to decide how to implement the triangle axiom.