### PR TITLE
ktest.mak: Made 2 variables mutable to support more customization in Makefile

### DIFF
--- a/k-distribution/include/ktest.mak
+++ b/k-distribution/include/ktest.mak
@@ -15,8 +15,8 @@ DEFDIR?=.
 # path relative to current definition of output/input files
 RESULTDIR?=$(TESTDIR)
 # all tests in test directory with matching file extension
-TESTS=$(wildcard $(TESTDIR)/*.$(EXT))
-PROOF_TESTS=$(wildcard $(TESTDIR)/*-spec.k)
+TESTS?=$(wildcard $(TESTDIR)/*.$(EXT))
+PROOF_TESTS?=$(wildcard $(TESTDIR)/*-spec.k)
 
 CHECK=| diff -
 


### PR DESCRIPTION
 Required for example to collect all tests recursively in a dir.