### PR TITLE
Allow making modifications/omissions to the output via command-line flags

### DIFF
--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -64,7 +64,7 @@ public class KProve {
         } else {
             exit = 1;
         }
-        kprint.prettyPrint(compiled._1(), compiled._1().getModule("LANGUAGE-PARSING").get(), compiledDefinition.kompileOptions, s -> kprint.outputFile(s), results);
+        kprint.prettyPrint(compiled._1(), compiled._1().getModule("LANGUAGE-PARSING").get(), s -> kprint.outputFile(s), results);
         return exit;
     }
 

--- a/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
@@ -92,7 +92,7 @@ public class KProveFrontEnd extends FrontEnd {
                 throw KEMException.criticalError("Definition file doesn't exist: " +
                         kproveOptions.specFile(files).getAbsolutePath());
             }
-            KPrint kprint = new KPrint(kem, files, tty, kproveOptions.print);
+            KPrint kprint = new KPrint(kem, files, tty, kproveOptions.print, compiledDef.get().kompileOptions);
             return new KProve(kem, sw, files, kprint).run(kproveOptions, compiledDef.get(), backend.get(), initializeRewriter.get());
         } finally {
             scope.exit();

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -88,7 +88,7 @@ public class KRun {
 
 
         if (result != null) {
-            kprint.prettyPrint(compiledDef.getParsedDefinition(), compiledDef.languageParsingModule(), compiledDef.kompileOptions, s -> kprint.outputFile(s), result._1());
+            kprint.prettyPrint(compiledDef.getParsedDefinition(), compiledDef.languageParsingModule(), s -> kprint.outputFile(s), result._1());
             return result._2();
         }
         return 0;

--- a/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
@@ -82,7 +82,7 @@ public class KRunFrontEnd extends FrontEnd {
     public int run() {
         scope.enter(kompiledDir.get());
         try {
-            KPrint kprint = new KPrint(kem, files, tty, krunOptions.print);
+            KPrint kprint = new KPrint(kem, files, tty, krunOptions.print, compiledDef.get().kompileOptions);
             for (int i = 0; i < krunOptions.experimental.profile - 1; i++) {
                 new KRun(kem, files, tty, kprint).run(compiledDef.get(),
                         krunOptions,

--- a/kernel/src/main/java/org/kframework/krun/modes/DebugMode/Commands.java
+++ b/kernel/src/main/java/org/kframework/krun/modes/DebugMode/Commands.java
@@ -84,7 +84,7 @@ public class Commands {
             CommandUtils utils = new CommandUtils(isSource);
             DebuggerState requestedState = session.getActiveState();
             if (requestedState != null) {
-                new KPrint().prettyPrint(compiledDefinition.getParsedDefinition(), compiledDefinition.languageParsingModule(), compiledDefinition.kompileOptions, s -> utils.print(s), requestedState.getCurrentK(), ColorSetting.ON);
+                new KPrint(compiledDefinition.kompileOptions).prettyPrint(compiledDefinition.getParsedDefinition(), compiledDefinition.languageParsingModule(), s -> utils.print(s), requestedState.getCurrentK(), ColorSetting.ON);
             } else {
                 throw KEMException.debuggerError("\"Requested State/Configuration Unreachable\",");
             }
@@ -307,7 +307,7 @@ public class Commands {
             if (disableOutput) {
                 return;
             }
-            new KPrint().prettyPrint(compiledDefinition.getParsedDefinition(), compiledDefinition.languageParsingModule(), compiledDefinition.kompileOptions, s -> System.out.println(s), result.getSubstitutions(), ColorSetting.ON);
+            new KPrint(compiledDefinition.kompileOptions).prettyPrint(compiledDefinition.getParsedDefinition(), compiledDefinition.languageParsingModule(), s -> System.out.println(s), result.getSubstitutions(), ColorSetting.ON);
         }
 
         private void print(byte[] bytes){

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -186,37 +186,28 @@ public class KPrint {
         return new TransformK() {
             @Override
             public K apply(KApply orig) {
-                K omitted   = omitTerm(mod, orig);
-                K tokenized = tokenizeTerm(mod, omitted);
-                return tokenized;
+                String name = orig.klabel().name();
+                return options.omittedKLabels.contains(name)   ? omitTerm(mod, orig)
+                     : options.tokenizedKLabels.contains(name) ? tokenizeTerm(mod, orig)
+                     : orig ;
             }
         }.apply(term);
     }
 
-    private K omitTerm(Module module, K k) {
-        if (! (k instanceof KApply)) return k;
-
-        KApply kapp = (KApply) k;
-        if (! options.omittedKLabels.contains(kapp.klabel().name())) return k;
-
+    private K omitTerm(Module mod, KApply kapp) {
         Sort finalSort = Sorts.K();
-        Option<Sort> termSort = module.sortFor().get(kapp.klabel());
+        Option<Sort> termSort = mod.sortFor().get(kapp.klabel());
         if (! termSort.isEmpty()) {
             finalSort = termSort.get();
         }
         return KToken(kapp.klabel().name(), finalSort);
     }
 
-    private K tokenizeTerm(Module module, K k) {
-        if (! (k instanceof KApply)) return k;
-
-        KApply kapp = (KApply) k;
-        if (! options.tokenizedKLabels.contains(kapp.klabel().name())) return k;
-
-        Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(module, false).getExtensionModule();
+    private K tokenizeTerm(Module mod, KApply kapp) {
+        Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(mod, false).getExtensionModule();
         String tokenizedTerm   = unparseTerm(kapp, unparsingModule, ColorSetting.OFF);
         Sort   finalSort       = Sorts.K();
-        Option<Sort> termSort  = module.sortFor().get(kapp.klabel());
+        Option<Sort> termSort  = mod.sortFor().get(kapp.klabel());
         if (! termSort.isEmpty()) {
             finalSort = termSort.get();
         }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -190,6 +190,7 @@ public class KPrint {
                 return options.omittedKLabels.contains(name)   ? omitTerm(mod, orig)
                      : options.tokenizedKLabels.contains(name) ? tokenizeTerm(mod, orig)
                      : options.flattenedKLabels.contains(name) ? flattenTerm(mod, orig)
+                     : options.tostringKLabels.contains(name)  ? tostringTerm(mod, orig)
                      : orig ;
             }
         }.apply(term);
@@ -224,5 +225,15 @@ public class KPrint {
             items = kapp.klist().items();
         }
         return KApply(kapp.klabel(), KList(items), kapp.att());
+    }
+
+    public static K tostringTerm(Module mod, KApply kapp) {
+        String       tostringTerm = kapp.toString();
+        Sort         finalSort    = Sorts.K();
+        Option<Sort> termSort     = mod.sortFor().get(kapp.klabel());
+        if (! termSort.isEmpty()) {
+            finalSort = termSort.get();
+        }
+        return KToken(tostringTerm, finalSort);
     }
 }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -189,6 +189,7 @@ public class KPrint {
                 String name = orig.klabel().name();
                 return options.omittedKLabels.contains(name)   ? omitTerm(mod, orig)
                      : options.tokenizedKLabels.contains(name) ? tokenizeTerm(mod, orig)
+                     : options.flattenedKLabels.contains(name) ? flattenTerm(mod, orig)
                      : orig ;
             }
         }.apply(term);
@@ -212,5 +213,16 @@ public class KPrint {
             finalSort = termSort.get();
         }
         return KToken(tokenizedTerm, finalSort);
+    }
+
+    public static K flattenTerm(Module mod, KApply kapp) {
+        List<K> items = new ArrayList<>();
+        Att att = mod.attributesFor().apply(KLabel(kapp.klabel().name()));
+        if (att.contains("assoc") && att.contains("unit")) {
+            items = Assoc.flatten(kapp.klabel(), kapp.klist().items(), KLabel(att.get("unit")));
+        } else {
+            items = kapp.klist().items();
+        }
+        return KApply(kapp.klabel(), KList(items), kapp.att());
     }
 }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -97,7 +97,8 @@ public class KPrint {
         return prettyPrint(def, module, result, options.color(tty.stdout, files.getEnv()));
     }
 
-    public byte[] prettyPrint(Definition def, Module module, K result, ColorSetting colorize) {
+    public byte[] prettyPrint(Definition def, Module module, K orig, ColorSetting colorize) {
+        K result = abstractTerm(module, orig);
         switch (options.output) {
             case KAST:
             case NONE:

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -26,6 +26,8 @@ import org.kframework.utils.file.TTYInfo;
 import scala.Tuple2;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -191,7 +193,7 @@ public class KPrint {
                 return options.omittedKLabels.contains(name)   ? omitTerm(mod, orig)
                      : options.tokenizedKLabels.contains(name) ? tokenizeTerm(mod, orig)
                      : options.flattenedKLabels.contains(name) ? flattenTerm(mod, orig)
-                     : options.tostringKLabels.contains(name)  ? tostringTerm(mod, orig)
+                     : options.tokastKLabels.contains(name)    ? toKASTTerm(mod, orig)
                      : orig ;
             }
         }.apply(term);
@@ -228,13 +230,18 @@ public class KPrint {
         return KApply(kapp.klabel(), KList(items), kapp.att());
     }
 
-    public static K tostringTerm(Module mod, KApply kapp) {
-        String       tostringTerm = kapp.toString();
-        Sort         finalSort    = Sorts.K();
-        Option<Sort> termSort     = mod.sortFor().get(kapp.klabel());
+    public static K toKASTTerm(Module mod, KApply kapp) {
+        String kastTerm;
+        try {
+            kastTerm = new String(KPrint.serialize(kapp, OutputModes.KAST), "UTF-8");
+        } catch (UnsupportedEncodingException e) {
+            kastTerm = kapp.toString();
+        }
+        Sort         finalSort = Sorts.K();
+        Option<Sort> termSort  = mod.sortFor().get(kapp.klabel());
         if (! termSort.isEmpty()) {
             finalSort = termSort.get();
         }
-        return KToken(tostringTerm, finalSort);
+        return KToken(kastTerm, finalSort);
     }
 }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -58,7 +58,7 @@ public class KPrint {
     }
 
     public KPrint(KompileOptions kompileOptions) {
-        this(new KExceptionManager(new GlobalOptions()), FileUtil.testFileUtil(), new TTYInfo(false, false, false), new PrintOptions(), kompileOptions);
+        this(new KExceptionManager(kompileOptions.global), FileUtil.testFileUtil(), new TTYInfo(false, false, false), new PrintOptions(), kompileOptions);
     }
 
     @Inject

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -231,12 +231,7 @@ public class KPrint {
     }
 
     public static K toKASTTerm(Module mod, KApply kapp) {
-        String kastTerm;
-        try {
-            kastTerm = new String(KPrint.serialize(kapp, OutputModes.KAST), "UTF-8");
-        } catch (UnsupportedEncodingException e) {
-            kastTerm = kapp.toString();
-        }
+        String       kastTerm  = ToKast.apply(kapp);
         Sort         finalSort = Sorts.K();
         Option<Sort> termSort  = mod.sortFor().get(kapp.klabel());
         if (! termSort.isEmpty()) {

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -118,10 +118,10 @@ public class KPrint {
     }
 
     public byte[] serialize(K term) {
-        return serialize(term, options.output);
+        return KPrint.serialize(term, options.output);
     }
 
-    public byte[] serialize(K term, OutputModes outputMode) {
+    public static byte[] serialize(K term, OutputModes outputMode) {
         switch (outputMode) {
             case KAST:
                 return (ToKast.apply(term) + "\n").getBytes();

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -89,6 +89,6 @@ public class PrintOptions {
     @Parameter(names={"--output-flatten"}, listConverter=StringListConverter.class, description="(Assoc) KLabels to flatten into one list.")
     public List<String> flattenedKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--output-tostring"}, listConverter=StringListConverter.class, description="KLabels to call toString on.")
-    public List<String> tostringKLabels = new ArrayList<String>();
+    @Parameter(names={"--output-tokast"}, listConverter=StringListConverter.class, description="KLabels to output as KAST tokens.")
+    public List<String> tokastKLabels = new ArrayList<String>();
 }

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -88,4 +88,7 @@ public class PrintOptions {
 
     @Parameter(names={"--output-flatten"}, listConverter=StringListConverter.class, description="(Assoc) KLabels to flatten into one list.")
     public List<String> flattenedKLabels = new ArrayList<String>();
+
+    @Parameter(names={"--output-tostring"}, listConverter=StringListConverter.class, description="KLabels to call toString on.")
+    public List<String> tostringKLabels = new ArrayList<String>();
 }

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -85,4 +85,7 @@ public class PrintOptions {
 
     @Parameter(names={"--output-tokenize"}, listConverter=StringListConverter.class, description="KLabels to tokenize underneath (reducing output size).")
     public List<String> tokenizedKLabels = new ArrayList<String>();
+
+    @Parameter(names={"--output-flatten"}, listConverter=StringListConverter.class, description="(Assoc) KLabels to flatten into one list.")
+    public List<String> flattenedKLabels = new ArrayList<String>();
 }

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -3,11 +3,15 @@ package org.kframework.unparser;
 
 import com.beust.jcommander.Parameter;
 import com.google.inject.Inject;
+
 import org.kframework.unparser.OutputModes;
 import org.kframework.unparser.ColorSetting;
 import org.kframework.utils.options.BaseEnumConverter;
+import org.kframework.utils.options.StringListConverter;
 
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 
 public class PrintOptions {
 
@@ -76,4 +80,9 @@ public class PrintOptions {
         }
     }
 
+    @Parameter(names={"--output-omit"}, listConverter=StringListConverter.class, description="KLabels to omit from the output.")
+    public List<String> omittedKLabels = new ArrayList<String>();
+
+    @Parameter(names={"--output-tokenize"}, listConverter=StringListConverter.class, description="KLabels to tokenize underneath (reducing output size).")
+    public List<String> tokenizedKLabels = new ArrayList<String>();
 }

--- a/kernel/src/test/java/org/kframework/unparser/AddBracketsTest.java
+++ b/kernel/src/test/java/org/kframework/unparser/AddBracketsTest.java
@@ -97,7 +97,7 @@ public class AddBracketsTest {
         ParseInModule parser = RuleGrammarGenerator.getCombinedGrammar(gen.getProgramsGrammar(test), true);
         K parsed = parseTerm(pgm, parser);
         KPrint kprint = new KPrint();
-        String unparsed = kprint.unparseTerm(parsed, test, new KompileOptions());
+        String unparsed = kprint.unparseTerm(parsed, test);
         assertEquals(pgm, unparsed);
     }
 


### PR DESCRIPTION
This adds (command-line) driven abstraction passes to `KPrint`. This is to be used with the serializers when communicating terms to other tools, not really by the pretty printer.

-   `--output-omit` will completely omit occurances of that KLabel from the output.
-   `--output-tokenize` will "tokenize" everything below specified KLabels (so it becomes a single AST node).
-   `--output-flatten` will flatten specified associated KLabels from cons-lists to assoc-ish lists.
-   `--output-tostring` calls `toString` on the given nodes in the AST and stores them as a `KToken` (faster than `--output-tokenize`).

Also `KPrint` has been refactored to take `kompileOptions` at construction time, so that there is one less argument to `prettyPrint`.