### PR TITLE
Update ocaml compiler build files to specify patches semantically

### DIFF
--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.03.0/4.03.0+k+fp/4.03.0+k+fp.comp
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.03.0/4.03.0+k+fp/4.03.0+k+fp.comp
@@ -1,10 +1,10 @@
 opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.tar.gz"
+patches: [ "%{root}%/repo/k/compilers/4.03.0/4.03.0+k/files/opam-compiler.patch" ]
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["patch" "-p1" "-i" "%{root}%/repo/k/compilers/4.03.0/4.03.0+k/files/opam-compiler.patch"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
   [make "world"]
   [make "world.opt"]

--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.03.0/4.03.0+k/4.03.0+k.comp
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.03.0/4.03.0+k/4.03.0+k.comp
@@ -1,8 +1,8 @@
 opam-version: "1"
 version: "4.03.0"
 src: "https://github.com/ocaml/ocaml/archive/4.03.tar.gz"
+patches: [ "%{root}%/repo/k/compilers/4.03.0/4.03.0+k/files/opam-compiler.patch" ]
 build: [
-  ["patch" "-p1" "-i" "%{root}%/repo/k/compilers/4.03.0/4.03.0+k/files/opam-compiler.patch"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]

--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k+fp/4.06.1+k+fp.comp
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k+fp/4.06.1+k+fp.comp
@@ -1,10 +1,10 @@
 opam-version: "1"
 version: "4.06.1"
 src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+patches: [ "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch" ]
 build: [
   ["mkdir" "-p" "%{lib}%/ocaml/"]
   ["sh" "-exc" "echo \"* : g = 1\" > %{lib}%/ocaml/ocaml_compiler_internal_params"]
-  ["patch" "-p1" "-i" "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch"]
   ["./configure" "-prefix" prefix "-with-debug-runtime" "-with-frame-pointers"]
   [make "world"]
   [make "world.opt"]

--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k+spacetime/4.06.1+k+spacetime.comp
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k+spacetime/4.06.1+k+spacetime.comp
@@ -1,8 +1,8 @@
 opam-version: "1"
 version: "4.06.1"
 src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+patches: [ "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch" ]
 build: [
-  ["patch" "-p1" "-i" "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch"]
   ["./configure"
     "-prefix" prefix "-with-debug-runtime" "-spacetime"
   ] { os != "openbsd" & os  != "freebsd" & os  != "darwin" }

--- a/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k/4.06.1+k.comp
+++ b/k-distribution/src/main/scripts/lib/opam/compilers/4.06.1/4.06.1+k/4.06.1+k.comp
@@ -1,8 +1,8 @@
 opam-version: "1"
 version: "4.06.1"
 src: "https://github.com/ocaml/ocaml/archive/4.06.1.tar.gz"
+patches: [ "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch" ]
 build: [
-  ["patch" "-p1" "-i" "%{root}%/repo/k/compilers/4.06.1/4.06.1+k/files/opam-compiler.patch"]
   ["./configure" "-prefix" prefix "-with-debug-runtime"]
   [make "world"]
   [make "world.opt"]


### PR DESCRIPTION
This format is supported by Opam 2.0.0, using this PR to test if it works with Opam 1.2.2.