### PR TITLE
strategy axiom for llvm backend (will not yet work with haskell)

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -721,7 +721,7 @@ module K-EQUAL
 
   syntax Bool ::= left:
                     K "==K" K           [function, functional, smtlib(=), hook(KEQUAL.eq), klabel(_==K_), symbol, latex({#1}\mathrel{=_K}{#2}), equalEqualK]
-                | K "=/=K" K          [function, functional, smtlib(distinct), hook(KEQUAL.ne), latex({#1}\mathrel{\neq_K}{#2}), notEqualEqualK]
+                | K "=/=K" K          [function, functional, smtlib(distinct), hook(KEQUAL.ne), klabel(_=/=K_), symbol, latex({#1}\mathrel{\neq_K}{#2}), notEqualEqualK]
 
   syntax priorities equalEqualK notEqualEqualK > boolOperation mlOp
   rule K1:K =/=K K2:K => notBool (K1 ==K K2)
@@ -1249,7 +1249,7 @@ module STRATEGY
     syntax #RuleTag ::= #LowerId                           [token]
                       | #UpperId                           [token]
 
-    syntax Strategy ::= #STUCK()
+    syntax Strategy ::= #STUCK() [symbol]
 
     syntax StrategyApply ::= "^" #RuleTag                      [klabel(#applyRule), symbol]
 

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -122,6 +122,7 @@ public class KoreBackend implements Backend {
                 .andThen(AddImplicitComputationCell::transformDefinition)
                 .andThen(resolveFreshConstants)
                 .andThen(new Strategy(kompileOptions.experimental.heatCoolStrategies).addStrategyCellToRulesTransformer())
+                .andThen(d -> Strategy.addStrategyRuleToMainModule(def.mainModule().name()).apply(d))
                 .andThen(ConcretizeCells::transformDefinition)
                 .andThen(subsortKItem)
                 .andThen(Kompile::addSemanticsModule)

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -487,11 +487,11 @@ public class ModuleToKORE {
                 if (isFunction(prod)) {
                     leftChildren = ((KApply) left).items();
                     equation = true;
-                    owise = rule.att().contains("owise");
                 } else if ((rule.att().contains("heat") || rule.att().contains("cool")) && heatCoolEq) {
                     equation = true;
                     productionSort = topCell;
                 }
+                owise = rule.att().contains("owise");
             }
             sb.append("// ");
             sb.append(rule.toString());
@@ -587,7 +587,16 @@ public class ModuleToKORE {
                     sb.append("\n\n");
                 }
             } else if (!rule.att().contains(Attribute.MACRO_KEY) && !rule.att().contains(Attribute.ALIAS_KEY) && !rule.att().contains(Attribute.ANYWHERE_KEY)) {
-                sb.append("  axiom{} \\and{");
+                sb.append("  axiom{} ");
+                if (owise) {
+                    // hack to deal with the strategy axiom for now
+                    sb.append("\\implies{");
+                    convert(topCell, false);
+                    sb.append("}(\\bottom{");
+                    convert(topCell, false);
+                    sb.append("}(),");
+                }
+                sb.append("\\and{");
                 convert(topCell, false);
                 sb.append("} (\n    ");
                 convertSideCondition(rule.requires(), topCell);
@@ -597,7 +606,11 @@ public class ModuleToKORE {
                 convertSideCondition(rule.ensures(), topCell);
                 sb.append(", ");
                 convert(rule.body());
-                sb.append("))\n  ");
+                sb.append("))");
+                if (owise) {
+                    sb.append(")");
+                }
+                sb.append("\n  ");
                 convert(attributes, rule.att());
                 sb.append("\n\n");
             }

--- a/kore/src/main/java/org/kframework/builtin/KLabels.java
+++ b/kore/src/main/java/org/kframework/builtin/KLabels.java
@@ -40,6 +40,7 @@ public class KLabels {
     public static final KLabel Map = KLabel("_Map_");
     public static final KLabel DotList = KLabel(".List");
     public static final KLabel EQUALS_K = KLabel("_==K_");
+    public static final KLabel NOT_EQUALS_K = KLabel("_=/=K_");
 
     public static final KLabel MAP_CHOICE = KLabel("Map:choice");
     public static final KLabel SET_CHOICE = KLabel("Set:choice");

--- a/kore/src/main/scala/org/kframework/Strategy.scala
+++ b/kore/src/main/scala/org/kframework/Strategy.scala
@@ -1,14 +1,47 @@
 package org.kframework
 
 import org.kframework.attributes.Att
+import org.kframework.builtin.BooleanUtils
 import org.kframework.builtin.KLabels
-import org.kframework.definition.{DefinitionTransformer, ModuleTransformer, Rule}
+import org.kframework.builtin.Sorts
+import org.kframework.definition.{DefinitionTransformer, ModuleTransformer, Module, Rule}
 import org.kframework.kore.KORE
+import org.kframework.kore.Sort
 import org.kframework.kore.Unapply.{KApply, KLabel}
 
 object Strategy {
   val strategyCellName = "<s>"
   val strategyCellLabel = KORE.KLabel(strategyCellName)
+
+  def addStrategyRuleToMainModule(mainModuleName: String) = {
+    DefinitionTransformer(
+      module =>
+        if (module.name != mainModuleName) {
+          module
+        } else {
+          Module(module.name, module.imports, module.localSentences + Rule(
+            KORE.KApply(strategyCellLabel,
+              KORE.KApply(KLabels.NO_DOTS),
+              KORE.KRewrite(
+                KORE.KVariable("S", Att.empty.add(classOf[Sort], Sorts.KItem)),
+                KORE.KSequence(
+                  KORE.KApply(KORE.KLabel("#STUCK")),
+                  KORE.KVariable("S", Att.empty.add(classOf[Sort], Sorts.KItem)),
+                )
+              ),
+              KORE.KApply(KLabels.DOTS)
+            ),
+            KORE.KApply(
+              KLabels.NOT_EQUALS_K, 
+              KORE.KVariable("S", Att.empty.add(classOf[Sort], Sorts.KItem)),
+              KORE.KApply(KORE.KLabel("#STUCK")),
+            ),
+            BooleanUtils.TRUE,
+            Att.empty.add("owise")
+          ), module.att)
+        }
+    )
+  }
 }
 
 class Strategy(heatCool: Boolean) {

--- a/kore/src/main/scala/org/kframework/Strategy.scala
+++ b/kore/src/main/scala/org/kframework/Strategy.scala
@@ -16,7 +16,7 @@ object Strategy {
   def addStrategyRuleToMainModule(mainModuleName: String) = {
     DefinitionTransformer(
       module =>
-        if (module.name != mainModuleName) {
+        if (module.name != mainModuleName || !module.importedModuleNames.contains("STRATEGY$SYNTAX")) {
           module
         } else {
           Module(module.name, module.imports, module.localSentences + Rule(


### PR DESCRIPTION
This axiom is obviously not correct in its current form, but since it is of the form `\implies(\bottom(), ...)`, it should not cause any problems for the haskell backend. The proper solution is to treat it like any other owise rule, but unfortunately this will be extremely verbose without further refactoring of the codebase, so we leave it off for now. This should, however, be sufficient to allow the LLVM backend to properly handle this axiom.