### PR TITLE
add [smt-prelude] attribute

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -265,7 +265,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
 
         StringBuilder sb = new StringBuilder();
 
-        for (Sort sort : Sets.difference(sorts, SMTLIB_BUILTIN_SORTS)) {
+        for (Sort sort : Sets.difference(sorts, Sets.union(SMTLIB_BUILTIN_SORTS, definition.smtPreludeSorts()))) {
             if (sort.equals(Sort.MAP) && krunOptions.experimental.smt.mapAsIntArray) {
                 sb.append("(define-sort Map () (Array Int Int))");
             } else {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -58,6 +58,9 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     public static final ImmutableSet<String> SMTLIB_BUILTIN_FUNCTIONS = ImmutableSet.of(
             "forall",
             "exists",
+            /* array theory */
+            "select",
+            "store",
             /* core theory */
             "not",
             "and",

--- a/kernel/src/main/java/org/kframework/kil/Attribute.java
+++ b/kernel/src/main/java/org/kframework/kil/Attribute.java
@@ -37,6 +37,7 @@ public class Attribute<T> extends ASTNode {
     public static final String SIGNIFICAND_KEY = "significand";
     public static final String SMTLIB_KEY = "smtlib";
     public static final String SMT_LEMMA_KEY = "smt-lemma";
+    public static final String SMT_PRELUDE_KEY = "smt-prelude";
     // Used to direct configuration abstraction,
     // generated when translating configuration declaration to productions.
     public static final String CELL_KEY = "cell";


### PR DESCRIPTION
Add `[smt-prelude]` attribute that indicates the sort declaration/definition is provided in the SMT prelude file.

Usage example:

K definition:
```
syntax MyMap [smt-prelude]
syntax Key [smt-prelude]
syntax Val [smt-prelude]

syntax MyMap ::= storeMyMap(MyMap, Key, Val) [function, smtlib(store)]
syntax Val ::= selectMyMap(MyMap, Key) [function, smtlib(select)]
```

SMT prelude:
```
(declare-sort Key)
(declare-sort Val)
(define-sort MyMap () (Array Key Val))
```

Note that the declaration/definition order is important in the SMT prelude file, which is not guaranteed by the current SMT encoder `KILtoSMTLib`.