### PR TITLE
resolve overloaded 0-ary productions to normal form

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -17,6 +17,7 @@ import org.kframework.compile.ResolveContexts;
 import org.kframework.compile.ResolveFreshConstants;
 import org.kframework.compile.ResolveFun;
 import org.kframework.compile.ResolveHeatCoolAttribute;
+import org.kframework.compile.ResolveOverloadedTerminators;
 import org.kframework.compile.ResolveSemanticCasts;
 import org.kframework.compile.ResolveStrict;
 import org.kframework.definition.Definition;
@@ -125,6 +126,7 @@ public class KoreBackend implements Backend {
                 .andThen(d -> Strategy.addStrategyRuleToMainModule(def.mainModule().name()).apply(d))
                 .andThen(ConcretizeCells::transformDefinition)
                 .andThen(subsortKItem)
+                .andThen(d -> DefinitionTransformer.fromKTransformer(new ResolveOverloadedTerminators(d.mainModule())::resolve, "resolve overloaded 0-ary productions").apply(d))
                 .andThen(Kompile::addSemanticsModule)
                 .apply(def);
     }

--- a/kernel/src/main/java/org/kframework/compile/ResolveOverloadedTerminators.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveOverloadedTerminators.java
@@ -1,0 +1,43 @@
+// Copyright (c) 2018 K Team. All Rights Reserved.
+package org.kframework.compile;
+
+import org.kframework.definition.Module;
+import org.kframework.definition.Production;
+import org.kframework.kore.*;
+import org.kframework.utils.errorsystem.KEMException;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.kframework.Collections.*;
+import static org.kframework.kore.KORE.*;
+
+public class ResolveOverloadedTerminators {
+
+    private final Module mod;
+    private final Set<KLabel> overloadedProds;
+
+    public ResolveOverloadedTerminators(Module mod) {
+        this.mod = mod;
+        overloadedProds = stream(mod.overloads().elements()).filter(p -> p.klabel().isDefined()).map(p -> p.klabel().get()).collect(Collectors.toSet());
+    }
+
+    public K resolve(K term) {
+        return new TransformK() {
+            @Override
+            public K apply(KApply kapp) {
+                if (overloadedProds.contains(kapp.klabel()) && kapp.items().isEmpty()) {
+                    Production prod = mod.productionsFor().apply(kapp.klabel()).head();
+                    Set<Production> candidates = stream(mod.overloads().elements()).filter(p -> p.klabel().isDefined() && p.att().get("klabel").equals(prod.att().get("klabel"))).collect(Collectors.toSet());
+                    candidates = mod.overloads().minimal(candidates);
+                    if (candidates.size() != 1) {
+                        throw KEMException.compilerError("Overloaded term does not have a least sort. Possible sorts: " + candidates, kapp);
+                    }
+                    return KApply(candidates.iterator().next().klabel().get(), KList(kapp.items()), kapp.att());
+                }
+                return super.apply(kapp);
+            }
+        }.apply(term);
+    }
+}

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -8,6 +8,7 @@ import org.kframework.attributes.Source;
 import org.kframework.backend.kore.ModuleToKORE;
 import org.kframework.compile.AddSortInjections;
 import org.kframework.compile.ExpandMacros;
+import org.kframework.compile.ResolveOverloadedTerminators;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kore.K;
 import org.kframework.main.FrontEnd;
@@ -112,6 +113,7 @@ public class KastFrontEnd extends FrontEnd {
             K parsed = def.getParser(mod, sort, kem).apply(FileUtil.read(stringToParse), source);
             if (options.expandMacros || options.kore) {
                 parsed = new ExpandMacros(compiledMod, files, def.kompileOptions, false).expand(parsed);
+                parsed = new ResolveOverloadedTerminators(compiledMod).resolve(parsed);
             }
             if (options.kore) {
               ModuleToKORE converter = new ModuleToKORE(compiledMod, files, def.topCellInitializer);

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -366,7 +366,7 @@ public class KILtoKORE extends KILTransformation<Object> {
 
         // Es ::= ".Es"
         prod3 = Production(KLabel(p.getTerminatorKLabel(kore)), sort, Seq(Terminal("." + sort.toString())),
-                attrsWithKilProductionId.remove("format").remove("strict"));
+                attrsWithKilProductionId.remove("format").remove("strict").add("klabel", p.getTerminatorKLabel(false)));
 
         res.add(prod1);
         res.add(prod3);

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import org.kframework.RewriterResult;
 import org.kframework.backend.kore.ModuleToKORE;
 import org.kframework.compile.AddSortInjections;
+import org.kframework.compile.ResolveOverloadedTerminators;
 import org.kframework.definition.Module;
 import org.kframework.definition.Rule;
 import org.kframework.kompile.CompiledDefinition;
@@ -70,6 +71,7 @@ public class LLVMRewriter implements Function<Module, Rewriter> {
                 Module mod = def.executionModule();
                 ModuleToKORE converter = new ModuleToKORE(mod, files, def.topCellInitializer);
                 K kWithInjections = new AddSortInjections(mod).addInjections(k);
+                kWithInjections = new ResolveOverloadedTerminators(mod).resolve(kWithInjections);
                 converter.convert(kWithInjections);
                 String koreOutput = "[initial-configuration{}(" + converter.toString() + ")]\n\nmodule TMP\nendmodule []\n";
                 String defPath = files.resolveKompiled("definition.kore").getAbsolutePath();

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
@@ -70,8 +70,8 @@ public class LLVMRewriter implements Function<Module, Rewriter> {
             public RewriterResult execute(K k, Optional<Integer> depth) {
                 Module mod = def.executionModule();
                 ModuleToKORE converter = new ModuleToKORE(mod, files, def.topCellInitializer);
-                K kWithInjections = new AddSortInjections(mod).addInjections(k);
-                kWithInjections = new ResolveOverloadedTerminators(mod).resolve(kWithInjections);
+                K kWithInjections = new ResolveOverloadedTerminators(mod).resolve(k);
+                kWithInjections = new AddSortInjections(mod).addInjections(kWithInjections);
                 converter.convert(kWithInjections);
                 String koreOutput = "[initial-configuration{}(" + converter.toString() + ")]\n\nmodule TMP\nendmodule []\n";
                 String defPath = files.resolveKompiled("definition.kore").getAbsolutePath();


### PR DESCRIPTION
This does not handle overloads in the most general case, but it is assumed that overloads other than list terminators are handled in disambiguation during parsing. If I discover further cases where patterns have not been normalized in rules, I will revisit this.