### PR TITLE
KItem architectural bug fixed

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/BuiltinList.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/BuiltinList.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 /**
  * Class representing an associative list.
  */
-public class BuiltinList extends Collection implements CollectionInternalRepresentation, HasGlobalContext {
+public class BuiltinList extends Collection implements CollectionInternalRepresentation {
 
     /**
      * Flattened list of children.

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/CollectionInternalRepresentation.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/CollectionInternalRepresentation.java
@@ -24,7 +24,7 @@ public interface CollectionInternalRepresentation extends KItemRepresentation {
             result = new KItem(
                     constructorLabel(),
                     KList.concatenate(component, result),
-                    sort(),
+                    globalContext(), sort(),
                     true,
                     component.att());
         }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -48,7 +48,7 @@ import java.util.stream.Collectors;
  * @author AndreiS
  */
 @SuppressWarnings("serial")
-public class KItem extends Term implements KItemRepresentation, HasGlobalContext {
+public class KItem extends Term implements KItemRepresentation {
 
     private final Term kLabel;
     private final Term kList;
@@ -64,10 +64,6 @@ public class KItem extends Term implements KItemRepresentation, HasGlobalContext
     private Boolean anywhereApplicable = null;
 
     private BitSet[] childrenDontCareRuleMask = null;
-
-    public KItem(KLabel kLabel, Term kList, Sort sort, boolean isExactSort, Att att) {
-        this(kLabel, kList, sort, isExactSort, Collections.singleton(sort), att);
-    }
 
     public static KItem of(Term kLabel, Term kList, GlobalContext global) {
         return of(kLabel, kList, global, Att.empty(), null);
@@ -90,29 +86,23 @@ public class KItem extends Term implements KItemRepresentation, HasGlobalContext
         return new KItem(kLabel, kList, global, global.stage, att, childrenDontCareRuleMask);
     }
 
-    public KItem(Term kLabel, Term kList, Sort sort, boolean isExactSort) {
-        this(kLabel, kList, sort, isExactSort, null, null);
+    public KItem(KLabel kLabel, Term kList, GlobalContext global, Sort sort, boolean isExactSort, Att att) {
+        this(kLabel, kList, global, sort, isExactSort, Collections.singleton(sort), att);
     }
 
-    private KItem(Term kLabel, Term kList, Sort sort, boolean isExactSort, Set<Sort> possibleSorts, Att att) {
+    public KItem(Term kLabel, Term kList, GlobalContext global, Sort sort, boolean isExactSort) {
+        this(kLabel, kList, global, sort, isExactSort, null, null);
+    }
+
+    private KItem(Term kLabel, Term kList, GlobalContext global, Sort sort, boolean isExactSort, Set<Sort> possibleSorts, Att att) {
         super(computeKind(kLabel), att);
         this.kLabel = kLabel;
         this.kList = kList;
         this.sort = sort;
         this.isExactSort = isExactSort;
         this.possibleSorts = possibleSorts;
-        this.global = null;
+        this.global = global;
         this.enableCache = false;
-    }
-
-    private static Kind computeKind(Term kLabel) {
-        if (kLabel instanceof KLabelConstant) {
-            org.kframework.kore.KLabel name = ((KLabelConstant) kLabel);
-            if (KLabels.DOTK.equals(name) || KLabels.KSEQ.equals(name)) {
-                return Kind.K;
-            }
-        }
-        return Kind.KITEM;
     }
 
     private KItem(Term kLabel, Term kList, GlobalContext global, Stage stage, Att att, BitSet[] childrenDonCareRuleMask) {
@@ -148,6 +138,16 @@ public class KItem extends Term implements KItemRepresentation, HasGlobalContext
             possibleSorts = Collections.singleton(sort);
             enableCache = false;
         }
+    }
+
+    private static Kind computeKind(Term kLabel) {
+        if (kLabel instanceof KLabelConstant) {
+            org.kframework.kore.KLabel name = ((KLabelConstant) kLabel);
+            if (KLabels.DOTK.equals(name) || KLabels.KSEQ.equals(name)) {
+                return Kind.K;
+            }
+        }
+        return Kind.KITEM;
     }
 
     private void computeSort() {

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemCollection.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemCollection.java
@@ -4,7 +4,7 @@ package org.kframework.backend.java.kil;
 /**
  * Created by dwightguth on 5/8/15.
  */
-public interface KItemCollection extends CollectionInternalRepresentation, HasGlobalContext {
+public interface KItemCollection extends CollectionInternalRepresentation {
 
     @Override
     default KLabel constructorLabel() {

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemRepresentation.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemRepresentation.java
@@ -9,7 +9,7 @@ import org.kframework.kore.KList;
 import java.util.List;
 import java.util.stream.Stream;
 
-public interface KItemRepresentation extends KoreRepresentation, KApply {
+public interface KItemRepresentation extends KoreRepresentation, KApply, HasGlobalContext {
     default Term kLabel() {
         return ((KItem) toKore()).kLabel();
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -33,7 +33,7 @@ import java.util.stream.Stream;
  * @see org.kframework.backend.java.symbolic.Equality
  * @see org.kframework.backend.java.symbolic.DisjunctiveFormula
  */
-public class ConjunctiveFormula extends Term implements CollectionInternalRepresentation, HasGlobalContext {
+public class ConjunctiveFormula extends Term implements CollectionInternalRepresentation {
 
     public static final String SEPARATOR = " /\\ ";
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/DisjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/DisjunctiveFormula.java
@@ -23,7 +23,7 @@ import java.util.stream.Collectors;
  *
  * @see org.kframework.backend.java.symbolic.ConjunctiveFormula
  */
-public class DisjunctiveFormula extends Term implements CollectionInternalRepresentation, HasGlobalContext {
+public class DisjunctiveFormula extends Term implements CollectionInternalRepresentation {
 
     private final PersistentUniqueList<ConjunctiveFormula> conjunctions;
 

--- a/java-backend/src/test/java/org/kframework/backend/java/kil/JavaSymbolicObjectTest.java
+++ b/java-backend/src/test/java/org/kframework/backend/java/kil/JavaSymbolicObjectTest.java
@@ -37,14 +37,14 @@ public class JavaSymbolicObjectTest extends BaseTestCase {
         assertEquals(Collections.singleton(v1), v1.variableSet());
         assertEquals(Collections.singleton(v1), v1.variableSet);
 
-        KItem k1 = new KItem(KLabelConstant.of(foo, definition), KList.EMPTY, Sort.of(KORE.Sort("bar@FOO")), true);
+        KItem k1 = new KItem(KLabelConstant.of(foo, definition), KList.EMPTY, null, Sort.of(KORE.Sort("bar@FOO")), true);
         assertEquals(Collections.emptySet(), k1.variableSet());
         assertEquals(Collections.emptySet(), k1.variableSet);
         assertEquals(Collections.emptySet(), k1.kLabel().variableSet);
         assertEquals(Collections.emptySet(), k1.kList().variableSet);
 
         Variable v2 = new Variable("bar", Sort.of(KORE.Sort("baz@FOO")));
-        KItem k2 = new KItem(KLabelConstant.of(foo, definition), v2, Sort.of(KORE.Sort("bar@FOO")), true);
+        KItem k2 = new KItem(KLabelConstant.of(foo, definition), v2, null, Sort.of(KORE.Sort("bar@FOO")), true);
         assertEquals(Collections.singleton(v2), k2.variableSet());
         assertEquals(Collections.singleton(v2), k2.variableSet);
         assertEquals(Collections.emptySet(), k2.kLabel().variableSet);
@@ -52,7 +52,7 @@ public class JavaSymbolicObjectTest extends BaseTestCase {
 
         Variable v3 = new Variable("baz", Sort.of(KORE.Sort("baz@FOO")));
         KList list = (KList) KList.concatenate(v3, k2);
-        KItem k3 = new KItem(KLabelConstant.of(foo, definition), list, Sort.of(KORE.Sort("bar@FOO")), true);
+        KItem k3 = new KItem(KLabelConstant.of(foo, definition), list, null, Sort.of(KORE.Sort("bar@FOO")), true);
         assertEquals(Sets.newHashSet(v2, v3), k3.variableSet());
         assertEquals(Sets.newHashSet(v2, v3), k3.variableSet);
         assertEquals(Collections.emptySet(), k3.kLabel().variableSet);
@@ -71,18 +71,18 @@ public class JavaSymbolicObjectTest extends BaseTestCase {
         Variable v1 = new Variable("foo", Sort.of(KORE.Sort("bar@FOO")));
         assertTrue(v1.isNormal());
 
-        KItem k1 = new KItem(KLabelConstant.of(foo, definition), KList.EMPTY, Sort.of(KORE.Sort("bar@FOO")), true);
+        KItem k1 = new KItem(KLabelConstant.of(foo, definition), KList.EMPTY, null, Sort.of(KORE.Sort("bar@FOO")), true);
         assertTrue(k1.isNormal());
         assertTrue(k1.kLabel().isNormal());
         assertTrue(k1.kList().isNormal());
 
-        KItem k2 = new KItem(KLabelConstant.of(isFoo, definition), KList.EMPTY, Sort.of(KORE.Sort("bar@FOO")), true);
+        KItem k2 = new KItem(KLabelConstant.of(isFoo, definition), KList.EMPTY, null, Sort.of(KORE.Sort("bar@FOO")), true);
         assertFalse(k2.isNormal());
         assertTrue(k2.kLabel().isNormal());
         assertTrue(k2.kList().isNormal());
 
         KList list = (KList) KList.concatenate(k1, k2);
-        KItem k3 = new KItem(KLabelConstant.of(foo, definition), list, Sort.of(KORE.Sort("bar@FOO")), true);
+        KItem k3 = new KItem(KLabelConstant.of(foo, definition), list, null, Sort.of(KORE.Sort("bar@FOO")), true);
         assertFalse(k3.isNormal());
         assertTrue(k3.kLabel().isNormal());
         assertSame(list, k3.kList());


### PR DESCRIPTION
 in some cases, depending on constructor used, it had `global == null`. Now it's always present (except unit tests).

Eliminates a NPE in K-gnosis.

Also reordered some members in KItem to clean up the mess.