### PR TITLE
Expose JavaExecutionOptions on command line

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
@@ -45,7 +45,8 @@ public class JavaBackendKModule extends AbstractKModule {
 
     @Override
     public List<Module> getKRunModules() {
-        return Collections.singletonList(new AbstractModule() {
+        List<Module> mods = super.getKRunModules();
+        mods.add(new AbstractModule() {
             @Override
             protected void configure() {
                 installJavaRewriter(binder());
@@ -55,17 +56,20 @@ public class JavaBackendKModule extends AbstractKModule {
                 checkPointBinder.addBinding("java").toInstance(50); //TODO(dwightguth): finesse this number
             }
         });
+        return mods;
     }
 
     @Override
     public List<Module> getKProveModules() {
-        return Collections.singletonList(new AbstractModule() {
+        List<Module> mods = super.getKProveModules();
+        mods.add(new AbstractModule() {
             @Override
             protected void configure() {
                 installJavaBackend(binder());
                 installJavaRewriter(binder());
             }
         });
+        return mods;
     }
 
     private void installJavaRewriter(Binder binder) {
@@ -77,12 +81,14 @@ public class JavaBackendKModule extends AbstractKModule {
 
     @Override
     public List<Module> getDefinitionSpecificKEqModules() {
-        return Collections.singletonList(new AbstractModule() {
+        List<Module> mods = super.getDefinitionSpecificKEqModules();
+        mods.add(new AbstractModule() {
             @Override
             protected void configure() {
                 installJavaBackend(binder());
                 installJavaRewriter(binder());
             }
         });
+        return mods;
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
@@ -7,8 +7,10 @@ import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
+import org.apache.commons.lang3.tuple.Pair;
 import org.kframework.backend.java.symbolic.InitializeRewriter;
 import org.kframework.backend.java.symbolic.JavaBackend;
+import org.kframework.backend.java.symbolic.JavaExecutionOptions;
 import org.kframework.compile.Backend;
 import org.kframework.kprove.KProve;
 import org.kframework.krun.ToolActivation;
@@ -24,6 +26,16 @@ import java.util.function.Function;
  * Created by dwightguth on 5/27/15.
  */
 public class JavaBackendKModule extends AbstractKModule {
+
+    @Override
+    public List<Pair<Class<?>, Boolean>> krunOptions() {
+        return Collections.singletonList(Pair.of(JavaExecutionOptions.class, true));
+    }
+
+    @Override
+    public List<Pair<Class<?>, Boolean>> kproveOptions() {
+        return Collections.singletonList(Pair.of(JavaExecutionOptions.class, true));
+    }
 
     @Override
     public List<Module> getKompileModules() {
@@ -49,6 +61,8 @@ public class JavaBackendKModule extends AbstractKModule {
         mods.add(new AbstractModule() {
             @Override
             protected void configure() {
+                bindOptions(JavaBackendKModule.this::krunOptions, binder());
+
                 installJavaRewriter(binder());
 
                 MapBinder<String, Integer> checkPointBinder = MapBinder.newMapBinder(
@@ -65,6 +79,8 @@ public class JavaBackendKModule extends AbstractKModule {
         mods.add(new AbstractModule() {
             @Override
             protected void configure() {
+                bindOptions(JavaBackendKModule.this::kproveOptions, binder());
+
                 installJavaBackend(binder());
                 installJavaRewriter(binder());
             }

--- a/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
@@ -6,6 +6,7 @@ import com.google.inject.Binder;
 import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
+import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kframework.backend.java.symbolic.InitializeRewriter;
@@ -17,6 +18,7 @@ import org.kframework.krun.ToolActivation;
 import org.kframework.krun.modes.ExecutionMode;
 import org.kframework.main.AbstractKModule;
 import org.kframework.rewriter.Rewriter;
+import org.kframework.utils.inject.Options;
 
 import java.util.Collections;
 import java.util.List;
@@ -68,6 +70,9 @@ public class JavaBackendKModule extends AbstractKModule {
                 MapBinder<String, Integer> checkPointBinder = MapBinder.newMapBinder(
                         binder(), String.class, Integer.class, Names.named("checkpointIntervalMap"));
                 checkPointBinder.addBinding("java").toInstance(50); //TODO(dwightguth): finesse this number
+
+                Multibinder<Class<?>> experimentalOptionsBinder = Multibinder.newSetBinder(binder(), new TypeLiteral<Class<?>>() {}, Options.class);
+                experimentalOptionsBinder.addBinding().toInstance(JavaExecutionOptions.class);
             }
         });
         return mods;
@@ -83,6 +88,9 @@ public class JavaBackendKModule extends AbstractKModule {
 
                 installJavaBackend(binder());
                 installJavaRewriter(binder());
+
+                Multibinder<Class<?>> experimentalOptionsBinder = Multibinder.newSetBinder(binder(), new TypeLiteral<Class<?>>() {}, Options.class);
+                experimentalOptionsBinder.addBinding().toInstance(JavaExecutionOptions.class);
             }
         });
         return mods;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -6,6 +6,7 @@ import com.google.inject.Inject;
 import org.kframework.backend.java.kil.KItem.KItemOperations;
 import org.kframework.backend.java.symbolic.BuiltinFunction;
 import org.kframework.backend.java.symbolic.Equality.EqualityOperations;
+import org.kframework.backend.java.symbolic.JavaExecutionOptions;
 import org.kframework.backend.java.symbolic.SMTOperations;
 import org.kframework.backend.java.symbolic.Stage;
 import org.kframework.backend.java.util.Profiler2;
@@ -29,6 +30,7 @@ public class GlobalContext implements Serializable {
     public final transient SMTOperations constraintOps;
     public final transient KItemOperations kItemOps;
     public final transient KRunOptions krunOptions;
+    public final transient JavaExecutionOptions javaExecutionOptions;
     public final transient KExceptionManager kem;
     private final transient Map<String, MethodHandle> hookProvider;
     public final transient FileUtil files;
@@ -40,6 +42,7 @@ public class GlobalContext implements Serializable {
             boolean deterministicFunctions,
             GlobalOptions globalOptions,
             KRunOptions krunOptions,
+            JavaExecutionOptions javaExecutionOptions,
             KExceptionManager kem,
             SMTOptions smtOptions,
             Map<String, MethodHandle> hookProvider,
@@ -49,6 +52,7 @@ public class GlobalContext implements Serializable {
         this.fs = fs;
         this.globalOptions = globalOptions;
         this.krunOptions = krunOptions;
+        this.javaExecutionOptions = javaExecutionOptions;
         this.kem = kem;
         this.hookProvider = hookProvider;
         this.files = files;
@@ -65,12 +69,13 @@ public class GlobalContext implements Serializable {
             SMTOptions smtOptions,
             KExceptionManager kem,
             KRunOptions krunOptions,
+            JavaExecutionOptions javaExecutionOptions,
             FileSystem fs,
             FileUtil files,
             Map<String, MethodHandle> hookProvider,
             Stage stage,
             Profiler2 profiler) {
-        this(fs, false, globalOptions, krunOptions, kem, smtOptions, hookProvider, files, stage, profiler);
+        this(fs, false, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, stage, profiler);
     }
 
     private transient BuiltinFunction builtinFunction;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -39,7 +39,6 @@ public class GlobalContext implements Serializable {
 
     public GlobalContext(
             FileSystem fs,
-            boolean deterministicFunctions,
             GlobalOptions globalOptions,
             KRunOptions krunOptions,
             JavaExecutionOptions javaExecutionOptions,
@@ -58,7 +57,7 @@ public class GlobalContext implements Serializable {
         this.files = files;
         this.equalityOps = new EqualityOperations(() -> def);
         this.constraintOps = new SMTOperations(() -> def, smtOptions, new Z3Wrapper(smtOptions, kem, globalOptions, files), kem, globalOptions);
-        this.kItemOps = new KItemOperations(stage, deterministicFunctions, kem, this::builtins, globalOptions);
+        this.kItemOps = new KItemOperations(stage, javaExecutionOptions.deterministicFunctions, kem, this::builtins, globalOptions);
         this.stage = stage;
         this.profiler = profiler;
     }
@@ -75,7 +74,7 @@ public class GlobalContext implements Serializable {
             Map<String, MethodHandle> hookProvider,
             Stage stage,
             Profiler2 profiler) {
-        this(fs, false, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, stage, profiler);
+        this(fs, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, stage, profiler);
     }
 
     private transient BuiltinFunction builtinFunction;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -103,11 +103,11 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
 
     @Override
     public synchronized Rewriter apply(Module mainModule) {
-        TermContext initializingContext = TermContext.builder(new GlobalContext(fs, deterministicFunctions, globalOptions, krunOptions, kem, smtOptions, hookProvider, files, Stage.INITIALIZING, profiler))
+        TermContext initializingContext = TermContext.builder(new GlobalContext(fs, deterministicFunctions, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, Stage.INITIALIZING, profiler))
                 .freshCounter(0).build();
         Definition definition;
         definition = initializeDefinition.invoke(mainModule, kem, initializingContext.global());
-        GlobalContext rewritingContext = new GlobalContext(fs, deterministicFunctions, globalOptions, krunOptions, kem, smtOptions, hookProvider, files, Stage.REWRITING, profiler);
+        GlobalContext rewritingContext = new GlobalContext(fs, deterministicFunctions, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, Stage.REWRITING, profiler);
         rewritingContext.setDefinition(definition);
 
         return new SymbolicRewriterGlue(mainModule, definition, definition, transitions, initializingContext.getCounterValue(), rewritingContext, kem, files, kompileOptions, sw);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -70,6 +70,7 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
     private static final int NEGATIVE_VALUE = -1;
     private final KompileOptions kompileOptions;
     private final Profiler2 profiler;
+    private final JavaExecutionOptions javaExecutionOptions;
 
     @Inject
     public InitializeRewriter(
@@ -79,6 +80,7 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
             SMTOptions smtOptions,
             KRunOptions krunOptions,
             KompileOptions kompileOptions,
+            JavaExecutionOptions javaExecutionOptions,
             FileUtil files,
             InitializeDefinition initializeDefinition,
             Stopwatch sw,
@@ -91,8 +93,9 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
         this.smtOptions = smtOptions;
         this.hookProvider = HookProvider.get(kem);
         this.transitions = kompileOptions.transition;
-        this.kompileOptions = kompileOptions;
         this.krunOptions = krunOptions;
+        this.kompileOptions = kompileOptions;
+        this.javaExecutionOptions = javaExecutionOptions;
         this.files = files;
         this.initializeDefinition = initializeDefinition;
         this.profiler = profiler;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -58,7 +58,6 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
 
     private final FileSystem fs;
     private final Stopwatch sw;
-    private final boolean deterministicFunctions;
     private final GlobalOptions globalOptions;
     private final KExceptionManager kem;
     private final SMTOptions smtOptions;
@@ -87,7 +86,6 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
             Profiler2 profiler) {
         this.fs = fs;
         this.sw = sw;
-        this.deterministicFunctions = false;
         this.globalOptions = globalOptions;
         this.kem = kem;
         this.smtOptions = smtOptions;
@@ -103,11 +101,11 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
 
     @Override
     public synchronized Rewriter apply(Module mainModule) {
-        TermContext initializingContext = TermContext.builder(new GlobalContext(fs, deterministicFunctions, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, Stage.INITIALIZING, profiler))
+        TermContext initializingContext = TermContext.builder(new GlobalContext(fs, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, Stage.INITIALIZING, profiler))
                 .freshCounter(0).build();
         Definition definition;
         definition = initializeDefinition.invoke(mainModule, kem, initializingContext.global());
-        GlobalContext rewritingContext = new GlobalContext(fs, deterministicFunctions, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, Stage.REWRITING, profiler);
+        GlobalContext rewritingContext = new GlobalContext(fs, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, Stage.REWRITING, profiler);
         rewritingContext.setDefinition(definition);
 
         return new SymbolicRewriterGlue(mainModule, definition, definition, transitions, initializingContext.getCounterValue(), rewritingContext, kem, files, kompileOptions, sw);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -2,7 +2,9 @@
 package org.kframework.backend.java.symbolic;
 
 import com.beust.jcommander.Parameter;
+import org.kframework.utils.inject.RequestScoped;
 
+@RequestScoped
 public final class JavaExecutionOptions {
 
     @Parameter(names="--deterministic-functions", description="Throw assertion failure during "

--- a/kernel/src/main/java/org/kframework/main/AbstractKModule.java
+++ b/kernel/src/main/java/org/kframework/main/AbstractKModule.java
@@ -32,6 +32,10 @@ public abstract class AbstractKModule implements KModule {
         return Collections.emptyList();
     }
 
+    public List<Pair<Class<?>, Boolean>> kproveOptions() {
+        return Collections.emptyList();
+    }
+
     public Map<String, String> javaBackendHooks() {
         return Collections.emptyMap();
     }
@@ -118,5 +122,14 @@ public abstract class AbstractKModule implements KModule {
     }
 
     @Override
-    public List<Module> getKProveModules() { return Lists.newArrayList(); }
+    public List<Module> getKProveModules() {
+        return Lists.newArrayList(new AbstractModule() {
+
+            @Override
+            protected void configure() {
+                bindOptions(AbstractKModule.this::kproveOptions, binder());
+                bindJavaBackendHooks(binder());
+            }
+        });
+    }
 }


### PR DESCRIPTION
@dwightguth this exposes the JavaExecutionOptions on the command-line. I attempted to mark them as experimental, but they still just show up in `--help` and not `-X`.

@denis-bogdanas you may be interested in this as well.