### PR TITLE
KILtoSMTLib: Improved translation of constraint and implication queries

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -122,14 +122,14 @@ public class ConstrainedTerm extends JavaSymbolicObject {
     }
 
     /**
-     * Checks if this constrained term implies the given constrained term, assuming the variables
-     * occurring only in the given constrained term (but not in this constrained term) are
+     * Checks if {@code this} implies {@code matchRHSTerm}, assuming the variables
+     * occurring only in {@code matchRHSTerm} (but not in {@code this}) are
      * existentially quantified.
      */
-    public ConjunctiveFormula matchImplies(ConstrainedTerm constrainedTerm, boolean expand, Set<String> matchingSymbols) {
-        ConjunctiveFormula constraint = ConjunctiveFormula.of(constrainedTerm.termContext().global())
+    public ConjunctiveFormula matchImplies(ConstrainedTerm matchRHSTerm, boolean expand, Set<String> matchingSymbols) {
+        ConjunctiveFormula constraint = ConjunctiveFormula.of(matchRHSTerm.termContext().global())
                 .add(data.constraint.substitution())
-                .add(data.term, constrainedTerm.data.term)
+                .add(data.term, matchRHSTerm.data.term)
                 .simplifyBeforePatternFolding(context);
         if (constraint.isFalseExtended()) {
             return null;
@@ -149,7 +149,7 @@ public class ConstrainedTerm extends JavaSymbolicObject {
 
         /* apply pattern folding */
         constraint = constraint.simplifyModuloPatternFolding(context)
-                .add(constrainedTerm.data.constraint);
+                .add(matchRHSTerm.data.constraint);
         if (constraint.isFalse()) {
             return null;
         }
@@ -187,13 +187,15 @@ public class ConstrainedTerm extends JavaSymbolicObject {
         context.setTopConstraint(data.constraint);
         constraint = (ConjunctiveFormula) constraint.evaluate(context);
 
-        Set<Variable> rightOnlyVariables = Sets.difference(constraint.variableSet(), Sets.union(variableSet(), termContext().getInitialVariables()));
-        constraint = constraint.orientSubstitution(rightOnlyVariables);
+        Set<Variable> matchRHSOnlyVars = Sets.difference(constraint.variableSet(), Sets.union(variableSet(), termContext().getInitialVariables()));
+        constraint = constraint.orientSubstitution(matchRHSOnlyVars);
 
-        ConjunctiveFormula leftHandSide = data.constraint;
-        ConjunctiveFormula rightHandSide = constraint.removeBindings(rightOnlyVariables);
-        rightHandSide = (ConjunctiveFormula) rightHandSide.substituteAndEvaluate(leftHandSide.substitution(), context);
-        if (!leftHandSide.implies(rightHandSide, rightOnlyVariables)) {
+        ConjunctiveFormula implicationLHS = data.constraint;
+        ConjunctiveFormula implicationRHS = constraint.removeBindings(matchRHSOnlyVars);
+        implicationRHS = (ConjunctiveFormula) implicationRHS.substituteAndEvaluate(implicationLHS.substitution(), context);
+
+        boolean implies = implicationLHS.implies(implicationRHS, matchRHSOnlyVars);
+        if (!implies) {
             return null;
         }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -802,12 +802,16 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
         return implies(constraint, Collections.emptySet());
     }
 
-    public boolean implies(ConjunctiveFormula constraint, Set<Variable> rightOnlyVariables) {
+    /**
+     * Checks if {@code this} implies {@code rightHandSide}, assuming that {@code existentialQuantVars}
+     * are existentially quantified.
+     */
+    public boolean implies(ConjunctiveFormula rightHandSide, Set<Variable> existentialQuantVars) {
         // TODO(AndreiS): this can prove "stuff -> false", it needs fixing
-        assert !constraint.isFalseExtended();
+        assert !rightHandSide.isFalseExtended();
 
         LinkedList<Pair<ConjunctiveFormula, ConjunctiveFormula>> implications = new LinkedList<>();
-        implications.add(Pair.of(this, constraint));
+        implications.add(Pair.of(this, rightHandSide));
         while (!implications.isEmpty()) {
             Pair<ConjunctiveFormula, ConjunctiveFormula> implication = implications.remove();
             ConjunctiveFormula left = implication.getLeft();
@@ -820,10 +824,10 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                 System.err.println("Attempting to prove: \n\t" + left + "\n  implies \n\t" + right);
             }
 
-            right = right.orientSubstitution(rightOnlyVariables);
+            right = right.orientSubstitution(existentialQuantVars);
             right = left.simplifyConstraint(right);
-            right = right.orientSubstitution(rightOnlyVariables);
-            if (right.isTrue() || (right.equalities().isEmpty() && rightOnlyVariables.containsAll(right.substitution().keySet()))) {
+            right = right.orientSubstitution(existentialQuantVars);
+            if (right.isTrue() || (right.equalities().isEmpty() && existentialQuantVars.containsAll(right.substitution().keySet()))) {
                 if (global.globalOptions.debug) {
                     System.err.println("Implication proved by simplification");
                 }
@@ -845,7 +849,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                 continue;
             }
 
-            if (!impliesSMT(left, right, rightOnlyVariables)) {
+            if (!impliesSMT(left, right, existentialQuantVars)) {
                 if (global.globalOptions.debug) {
                     System.err.println("Failure!");
                 }
@@ -899,13 +903,17 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
 
     private static final Map<Triple<ConjunctiveFormula, ConjunctiveFormula, Set<Variable>>, Boolean> impliesSMTCache = Collections.synchronizedMap(new HashMap<>());
 
+    /**
+     * Checks if {@code left} implies {@code right}, assuming that {@code existentialQuantVars}
+     * are existentially quantified.
+     */
     private static boolean impliesSMT(
             ConjunctiveFormula left,
             ConjunctiveFormula right,
-            Set<Variable> rightOnlyVariables) {
-        Triple<ConjunctiveFormula, ConjunctiveFormula, Set<Variable>> triple = Triple.of(left, right, rightOnlyVariables);
+            Set<Variable> existentialQuantVars) {
+        Triple<ConjunctiveFormula, ConjunctiveFormula, Set<Variable>> triple = Triple.of(left, right, existentialQuantVars);
         if (!impliesSMTCache.containsKey(triple)) {
-            impliesSMTCache.put(triple, left.global.constraintOps.impliesSMT(left, right, rightOnlyVariables));
+            impliesSMTCache.put(triple, left.global.constraintOps.impliesSMT(left, right, existentialQuantVars));
         }
         return impliesSMTCache.get(triple);
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -184,10 +184,12 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             ConjunctiveFormula rightHandSide,
             Set<Variable> existentialQuantVars) {
         KILtoSMTLib leftTransformer = new KILtoSMTLib(true, leftHandSide.globalContext());
-        KILtoSMTLib rightTransformer = new KILtoSMTLib(false,
+        // termAbstractionMap is shared between transformers
+        KILtoSMTLib rightTransformer = new KILtoSMTLib(true,
                 rightHandSide.globalContext().getDefinition(),
                 rightHandSide.globalContext().krunOptions,
-                rightHandSide.globalContext(), new HashMap<>());
+                rightHandSide.globalContext(), leftTransformer.termAbstractionMap);
+
         CharSequence leftExpression = leftTransformer.translate(leftHandSide).expression();
         String rightExpression = rightTransformer.translate(rightHandSide).expression().toString();
         StringBuilder sb = new StringBuilder(1024);
@@ -219,15 +221,21 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     private final KRunOptions krunOptions;
 
     /**
-     * Flag set to true if it is sounds to skip equalities that cannot be translated.
+     * Flag indicating whether KItem terms and equalities that cannot be translated can be abstracted away into
+     * fresh variables. If the flag is false and untranslatable term is encountered, an exception will be thrown instead.
      */
     private final boolean skipUnsupportedEqualities;
     private final HashSet<Variable> variables;
     private final HashMap<Term, Variable> termAbstractionMap;
     private final HashMap<UninterpretedToken, Integer> tokenEncoding;
 
-    public KILtoSMTLib(boolean skipUnsupportedEqualities, GlobalContext global) {
+    private KILtoSMTLib(boolean skipUnsupportedEqualities, GlobalContext global) {
         this(skipUnsupportedEqualities, global.getDefinition(), global.krunOptions, global, new HashMap<>());
+    }
+
+    private KILtoSMTLib(boolean skipUnsupportedEqualities, Definition definition, KRunOptions krunOptions,
+                        GlobalContext global) {
+        this(skipUnsupportedEqualities, definition, krunOptions, global, new HashMap<>());
     }
 
     private KILtoSMTLib(boolean skipUnsupportedEqualities, Definition definition, KRunOptions krunOptions,
@@ -419,7 +427,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             try {
                 CharSequence left = translateTerm(equality.leftHandSide());
                 CharSequence right = translateTerm(equality.rightHandSide());
-                sb.append(" (= ");
+                sb.append("\n\t(= ");
                 sb.append(left);
                 sb.append(" ");
                 sb.append(right);
@@ -450,7 +458,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         }
     }
 
-    private CharSequence abstractThroughAnonVariable(Term term, RuntimeException e) {
+    private String abstractThroughAnonVariable(Term term, RuntimeException e) {
         if (skipUnsupportedEqualities){
                 Variable variable = termAbstractionMap.get(term);
                 if (variable == null) {
@@ -487,7 +495,8 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             label = "store";
         }
         if (label == null) {
-            throw new SMTTranslationFailure("missing SMTLib translation for " + kLabel);
+            return new SMTLibTerm(abstractThroughAnonVariable(kItem,
+                    new SMTTranslationFailure("missing SMTLib translation for " + kLabel)));
         }
 
         if (krunOptions.experimental.smt.floatsAsPO) {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -4,7 +4,6 @@ package org.kframework.backend.java.symbolic;
 import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.Pair;
 import org.kframework.attributes.Att;
@@ -183,57 +182,61 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     public static String translateImplication(
             ConjunctiveFormula leftHandSide,
             ConjunctiveFormula rightHandSide,
-            Set<Variable> rightHandSideOnlyVariables) {
+            Set<Variable> existentialQuantVars) {
         KILtoSMTLib leftTransformer = new KILtoSMTLib(true, leftHandSide.globalContext());
-        KILtoSMTLib rightTransformer = new KILtoSMTLib(false, rightHandSide.globalContext());
-        String leftExpression = leftTransformer.translate(leftHandSide).expression();
-        String rightExpression = rightTransformer.translate(rightHandSide).expression();
-        StringBuilder sb = new StringBuilder();
-        sb.append(leftTransformer.getSortAndFunctionDeclarations(
-                Sets.union(leftTransformer.variables(), rightTransformer.variables())));
+        KILtoSMTLib rightTransformer = new KILtoSMTLib(false,
+                rightHandSide.globalContext().getDefinition(),
+                rightHandSide.globalContext().krunOptions,
+                rightHandSide.globalContext(), new HashMap<>());
+        CharSequence leftExpression = leftTransformer.translate(leftHandSide).expression();
+        String rightExpression = rightTransformer.translate(rightHandSide).expression().toString();
+        StringBuilder sb = new StringBuilder(1024);
+        Sets.SetView<Variable> allVars = Sets.union(leftTransformer.variables(), rightTransformer.variables());
+        Set<Variable> usedExistentialQuantVars = Sets.intersection(existentialQuantVars, rightTransformer.variables());
+        sb.append(leftTransformer.getSortAndFunctionDeclarations(allVars));
         sb.append(leftTransformer.getAxioms());
-        sb.append(leftTransformer.getConstantDeclarations(Sets.difference(
-                Sets.union(leftTransformer.variables(), rightTransformer.variables()),
-                rightHandSideOnlyVariables)));
-        sb.append("(assert (and ");
+        sb.append(leftTransformer.getConstantDeclarations(Sets.difference(allVars, usedExistentialQuantVars)));
+
+        sb.append("(assert (and\n  ");
         sb.append(leftExpression);
-        sb.append(" (not ");
-        rightHandSideOnlyVariables = Sets.intersection(
-                rightTransformer.variables(),
-                rightHandSideOnlyVariables);
-        if (!rightHandSideOnlyVariables.isEmpty()) {
+        sb.append("\n  (not ");
+        if (!usedExistentialQuantVars.isEmpty()) {
             sb.append("(exists (");
-            sb.append(leftTransformer.getQuantifiedVariables(rightHandSideOnlyVariables));
+            sb.append(leftTransformer.getQuantifiedVariables(usedExistentialQuantVars));
             sb.append(") ");
         }
         sb.append(rightExpression);
-        if (!rightHandSideOnlyVariables.isEmpty()) {
+        if (!usedExistentialQuantVars.isEmpty()) {
             sb.append(")");
         }
-        sb.append(")))");
+        sb.append(")\n))");
         return sb.toString();
     }
 
     private final Definition definition;
 
+    private final GlobalContext globalContext;
     private final KRunOptions krunOptions;
 
     /**
      * Flag set to true if it is sounds to skip equalities that cannot be translated.
      */
-    private final boolean skipEqualities;
+    private final boolean skipUnsupportedEqualities;
     private final HashSet<Variable> variables;
-    private final HashMap<Term, Variable> termAbstractionMap = Maps.newHashMap();
+    private final HashMap<Term, Variable> termAbstractionMap;
     private final HashMap<UninterpretedToken, Integer> tokenEncoding;
 
-    public KILtoSMTLib(boolean skipEqualities, GlobalContext global) {
-        this(skipEqualities, global.getDefinition(), global.krunOptions);
+    public KILtoSMTLib(boolean skipUnsupportedEqualities, GlobalContext global) {
+        this(skipUnsupportedEqualities, global.getDefinition(), global.krunOptions, global, new HashMap<>());
     }
 
-    private KILtoSMTLib(boolean skipEqualities, Definition definition, KRunOptions krunOptions) {
+    private KILtoSMTLib(boolean skipUnsupportedEqualities, Definition definition, KRunOptions krunOptions,
+                        GlobalContext global, HashMap<Term, Variable> termAbstractionMap) {
+        this.skipUnsupportedEqualities = skipUnsupportedEqualities;
         this.definition = definition;
         this.krunOptions = krunOptions;
-        this.skipEqualities = skipEqualities;
+        this.globalContext = global;
+        this.termAbstractionMap = termAbstractionMap;
         variables = new HashSet<>();
         tokenEncoding = new HashMap<>();
     }
@@ -243,7 +246,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         if (astNode instanceof SMTLibTerm) {
             return (SMTLibTerm) astNode;
         } else {
-            throw new SMTTranslationFailure();
+            throw new SMTTranslationFailure("Attempting to translate an unsupported term of type " + object.getClass());
         }
     }
 
@@ -301,7 +304,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         for (Rule rule : definition.functionRules().values()) {
             if (rule.att().contains(Attribute.SMT_LEMMA_KEY)) {
                 try {
-                    KILtoSMTLib kil2SMT = new KILtoSMTLib(false, definition, krunOptions);
+                    KILtoSMTLib kil2SMT = new KILtoSMTLib(false, globalContext);
                     String leftExpression = kil2SMT.translate(rule.leftHandSide()).expression();
                     String rightExpression = kil2SMT.translate(rule.rightHandSide()).expression();
                     sb.append("(assert ");
@@ -396,10 +399,10 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
      * Ignores the substitution of the symbolic constraint.
      */
     @Override
-    public JavaSymbolicObject transform(ConjunctiveFormula constraint) {
+    public SMTLibTerm transform(ConjunctiveFormula constraint) {
         assert constraint.disjunctions().isEmpty() : "disjunctions are not supported by SMT translation";
         Set<Equality> equalities = Sets.newHashSet(constraint.equalities());
-        if (!skipEqualities) {
+        if (!skipUnsupportedEqualities) {
             constraint.substitution().entrySet().stream()
                     .map(entry -> new Equality(entry.getKey(), entry.getValue(), constraint.globalContext()))
                     .forEach(equalities::add);
@@ -414,8 +417,8 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         boolean isEmptyAdd = true;
         for (Equality equality : equalities) {
             try {
-                String left = translateTerm(equality.leftHandSide());
-                String right = translateTerm(equality.rightHandSide());
+                CharSequence left = translateTerm(equality.leftHandSide());
+                CharSequence right = translateTerm(equality.rightHandSide());
                 sb.append(" (= ");
                 sb.append(left);
                 sb.append(" ");
@@ -424,7 +427,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
                 isEmptyAdd = false;
             } catch (UnsupportedOperationException e) {
                 // TODO(AndreiS): fix this translation and the exceptions
-                if (skipEqualities){
+                if (skipUnsupportedEqualities){
                     /* it is sound to skip the equalities that cannot be translated */
                     e.printStackTrace();
                 } else {
@@ -439,25 +442,29 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         return new SMTLibTerm(sb.toString());
     }
 
-    public String translateTerm(Term term) {
+    public CharSequence translateTerm(Term term) {
         try {
             return translate(term).expression();
         } catch (SMTTranslationFailure | UnsupportedOperationException e) {
-            if (skipEqualities){
+            return abstractThroughAnonVariable(term, e);
+        }
+    }
+
+    private CharSequence abstractThroughAnonVariable(Term term, RuntimeException e) {
+        if (skipUnsupportedEqualities){
                 Variable variable = termAbstractionMap.get(term);
                 if (variable == null) {
                     variable = Variable.getAnonVariable(term.sort());
                     termAbstractionMap.put(term, variable);
                 }
                 return variable.name();
-            } else {
-                throw e;
-            }
+        } else {
+            throw e;
         }
     }
 
     @Override
-    public JavaSymbolicObject transform(KItem kItem) {
+    public SMTLibTerm transform(KItem kItem) {
         if (!(kItem.kLabel() instanceof KLabelConstant)) {
             throw new UnsupportedOperationException();
         }
@@ -480,7 +487,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             label = "store";
         }
         if (label == null) {
-            throw new UnsupportedOperationException("missing SMTLib translation for " + kLabel);
+            throw new SMTTranslationFailure("missing SMTLib translation for " + kLabel);
         }
 
         if (krunOptions.experimental.smt.floatsAsPO) {
@@ -557,17 +564,17 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     }
 
     @Override
-    public JavaSymbolicObject transform(BoolToken boolToken) {
+    public SMTLibTerm transform(BoolToken boolToken) {
         return new SMTLibTerm(Boolean.toString(boolToken.booleanValue()));
     }
 
     @Override
-    public JavaSymbolicObject transform(IntToken intToken) {
+    public SMTLibTerm transform(IntToken intToken) {
         return new SMTLibTerm(intToken.javaBackendValue());
     }
 
     @Override
-    public JavaSymbolicObject transform(FloatToken floatToken) {
+    public SMTLibTerm transform(FloatToken floatToken) {
         if (krunOptions.experimental.smt.floatsAsPO
                 && (floatToken.bigFloatValue().isPositiveZero() || floatToken.bigFloatValue().isNegativeZero())) {
             return new SMTLibTerm("float_zero");
@@ -581,7 +588,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     }
 
     @Override
-    public JavaSymbolicObject transform(BitVector bitVector) {
+    public SMTLibTerm transform(BitVector bitVector) {
         StringBuilder sb = new StringBuilder();
         sb.append("#b");
         for (int i = bitVector.bitwidth() - 1; i >= 0; --i) {
@@ -592,7 +599,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     }
 
     @Override
-    public JavaSymbolicObject transform(UninterpretedToken uninterpretedToken) {
+    public SMTLibTerm transform(UninterpretedToken uninterpretedToken) {
         if (tokenEncoding.get(uninterpretedToken) == null) {
             tokenEncoding.put(uninterpretedToken, tokenEncoding.size());
         }
@@ -605,7 +612,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     }
 
     @Override
-    public JavaSymbolicObject<Term> transform(Variable variable) {
+    public SMTLibTerm transform(Variable variable) {
         variables.add(variable);
         return new SMTLibTerm("|" + variable.name() + "|");
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
@@ -63,17 +63,18 @@ public class SMTOperations {
 
     /**
      * Checks if {@code left => right}, or {@code left /\ !right} is unsat.
+     * Assuming that {@code existentialQuantVars} are existentially quantified.
      */
     public boolean impliesSMT(
             ConjunctiveFormula left,
             ConjunctiveFormula right,
-            Set<Variable> rightOnlyVariables) {
+            Set<Variable> existentialQuantVars) {
         if (smtOptions.smt == SMTSolver.Z3) {
             try {
                 left.globalContext().profiler.queryBuildTimer.start();
                 CharSequence query;
                 try {
-                    query = KILtoSMTLib.translateImplication(left, right, rightOnlyVariables);
+                    query = KILtoSMTLib.translateImplication(left, right, existentialQuantVars);
                 } finally {
                     left.globalContext().profiler.queryBuildTimer.stop();
                 }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTTranslationFailure.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTTranslationFailure.java
@@ -1,4 +1,23 @@
 // Copyright (c) 2015-2018 K Team. All Rights Reserved.
 package org.kframework.backend.java.symbolic;
 
-public class SMTTranslationFailure extends RuntimeException {}
+public class SMTTranslationFailure extends RuntimeException {
+    public SMTTranslationFailure() {
+    }
+
+    public SMTTranslationFailure(String message) {
+        super(message);
+    }
+
+    public SMTTranslationFailure(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public SMTTranslationFailure(Throwable cause) {
+        super(cause);
+    }
+
+    public SMTTranslationFailure(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+        super(message, cause, enableSuppression, writableStackTrace);
+    }
+}


### PR DESCRIPTION
KILtoSMTLib: 1 Improved translation of constraint and implication queries.
A term that has no smtlib attribute will be abstracted to a fresh anonymous variable. Previously the whole LHS/RHS of the equality that contained the term was abstracted to a variable. This lead to significant information loss making most Z3 queries useless.
This translation was also enabled for implciation RHS now. It is proved sound.

2. Making Z3 queries a bit prettier for easy debug.

Please only review 2nd commit. 1st is just refactoring.

A summary of the improvement for Z3 query generation
=============================================
Intro: A z3 query can have one of 3 results: unsat, sat or unknown. kprove treats unknown results as sat. So for the purpose of deductive capability, only unsat results matter. There are 2 types of queries: constraint and implication.

For constraint formulas
------------------
Previously, if we had a formula like

foo(A) == X /\ (baz(B) orBool goo(B) ) == true

where foo and bar and baz have smtlib attribute, but `goo` doesn't, it would be translated into
foo(A) == X /\ F1 == true

Where
F1 == (baz(B) orBool goo(B) )

The whole LHS of the 2nd equality was substituted with a fresh var.
As you see, this led to information loss that could lead to query result "unknown" where in fact it was unsat.

After K update:
Now only the term without smtlib is translated into fresh var, so we have this Z3 query instead:

foo(A) == X /\ (baz(B) orBool F1 ) == true

where
F1 == goo(B)

In some cases this is enough to prove the query unsat.

For implication formulas
------------------
In the old version of K:
  - For implication LHS substitution with fresh vars worked same way as for constraint formulas.
  - For implication RHS, if a term without smtlib attribute was encountered, an exception would be thrown which appears in logs as "query build failure" message.

In the new version of K:
  - Improved term substitution works for both LHS and RHS according to algorithm above. Variables map is shared between LHS and RHS.

Proof of soundness
--------------------------
For any logical formula foo(bar(X)):
```
foo(X, bar(Y)) <=> foo(X, F1) /\ F1 = bar(X)
```

where `F1` is a fresh var that substitutes all instances of bar(X) in initial formula.

But because kprove doesn't use the substitution itself when generating the query, the formula that Z3 actually tries to prove is reduced:
```
foo(X, F1)
```

Now proving that a formula is unsat is equivalent to:

`forall(vars, formula == false)`

But the reduced formula is more general than the full formula, thus if reduced formula is unsat, then full formula is too:

```
forall(X,F1, foo(X, F1) == false)
  =>
forall(X, foo(X, F1) /\ F1 = bar(X) == false)
```
because the 2nd is just a particuar case of the 1st.

Alternatively, it follows from this general truth:
`forall(X, not f(X)) => forall(X, not(f(X) /\ g(X)) )`

This is true for any form of f, whether constraint or implication, regardless of whether it uses existentially quantified vars inside or not.

I did a paper proof for the exact query that kprove generates for implications, with existentially quantified vars, and as expected it is also true. Below is only the formula:
```
L(X) -> exists(Y, R(X,Y)) 

is translated into:

forall(X, not (L(X) /\ not exists(Y, R(X, Y)) ) )
```

Now to question why Stefan didn't implement this sort of substitution before. At the time there were no methods to easily debug whether a Z3 query is fine-grained enough. So he just preferred the query generation to fail with a warning and he would add smtlib attribute for function terms mentioned in the warnings. But now we have easy to use log messages from which it is simple to figure out whether a Z3 query conveis all the required information of the original ConjunctiveFormula or not. Try the option `--debug-z3-queries` on some spec.

A bit about performance
----------------
On specs I worked on recently, with old K 90% of implication queries were generated anyway and only 10% failed with a warning. With new K all 100% were generated, as expected, total z3 time was 1-2 s more total execution time was about the same. So I guess this has no impact on performance on big specs.

Update: Middle ground solution
=============================================
Suppose we have 3 implications:

1. `f(X) => g(X)`
2. `f(X) => g(X, ugly(X))`
3. `f(X, ugly(X)) => g(X, ugly(X))`

where `f` and `g` are functions annotated with `[smtlib]`, thus translatable. And `ugly` is not annotated.

Old Z3 translation:
```
1. f(X) => g(X)
2. fail
3. fail
```

Current Z3 translation:
```
1. f(X) => g(X)
2. f(X) => g(X,Y)
3. f(X,Y) => g(X,Y)
```
(this is not the only change in "current Z3 translation", only the part related to this example)

"Middle ground" Z3 translation:
```
1. f(X) => g(X)
2. fail
3. f(X,Y) => g(X,Y)
```

Reason: if Y is a fresh variable that appears only on implication RHS, then implication can only be true if RHS is simplifiable to something that doesn't contain `Y`. This is unlikely to happen in kprove. Most likely such implications appear because kprove doesn't have all the information to further evaluate the term that caused the implication. Thus they are unpro and can be dropped. Just an observation based on an isolated case, so I really don't have a better argument. Here is the implication that gave me this idea:

```
...
  implies
ConjunctiveFormula(
  equalities:
    _==K_(
      chop(#bufElm(...)),,
      #bufElm(...)
    )
```

This implication happened because after I removed range conversion lemmas, there was no lemma for `#bufElm(_) < pow256 => true`. And rule for `chop` wants this in its side condition. So most likely this sort of queries happen due to rules with unsatisfiable side conditions.

How much this will increase performance? No idea. On old z3 translation, on a spec with ~4k implications, Only 10% impliations were failing at query build stage. On the current spec `encodeTransactionData` - we'll see in Jenkins.
