### PR TITLE
split DEFAULT-STRATEGY into concrete vs symbolic versions

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -1308,10 +1308,28 @@ module STRATEGY
     configuration <s> $STRATEGY:K  </s>
 endmodule
 
+// module DEFAULT-STRATEGY
+//     imports syntax STRATEGY
+
+//     rule ~ regular => ^ regular [anywhere]
+
+//     rule initSCell(_) => <s> ^ regular </s>
+// endmodule
+
+module DEFAULT-STRATEGY-CONCRETE [concrete]
+    imports syntax STRATEGY
+    rule ~ regular => ^ regular [anywhere]
+endmodule
+
+module DEFAULT-STRATEGY-SYMBOLIC [symbolic]
+    imports syntax STRATEGY
+    rule <s> ~ regular => ^ regular ... </s>
+endmodule
+
 module DEFAULT-STRATEGY
     imports syntax STRATEGY
-
-    rule ~ regular => ^ regular [anywhere]
+    imports DEFAULT-STRATEGY-CONCRETE
+    imports DEFAULT-STRATEGY-SYMBOLIC
 
     rule initSCell(_) => <s> ^ regular </s>
 endmodule

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -1308,14 +1308,6 @@ module STRATEGY
     configuration <s> $STRATEGY:K  </s>
 endmodule
 
-// module DEFAULT-STRATEGY
-//     imports syntax STRATEGY
-
-//     rule ~ regular => ^ regular [anywhere]
-
-//     rule initSCell(_) => <s> ^ regular </s>
-// endmodule
-
 module DEFAULT-STRATEGY-CONCRETE [concrete]
     imports syntax STRATEGY
     rule ~ regular => ^ regular [anywhere]


### PR DESCRIPTION
We need this since the Haskell backend does not support `[anywhere]` rules. 