### PR TITLE
Ensure that with `--io on/off` we always get an extra newline on stdin

### DIFF
--- a/k-distribution/tutorial/1_k/4_imp++/lesson_4/tests/div.imp.out
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_4/tests/div.imp.out
@@ -11,7 +11,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -35,7 +35,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -59,7 +59,7 @@
       2 |-> 1
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -83,7 +83,7 @@
       2 |-> 2
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -107,7 +107,7 @@
       2 |-> 3
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/1_k/4_imp++/lesson_5/exercises/no-duplicate-declarations/tests/div.imp.out
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_5/exercises/no-duplicate-declarations/tests/div.imp.out
@@ -15,7 +15,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -43,7 +43,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -71,7 +71,7 @@
       2 |-> 1
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -99,7 +99,7 @@
       2 |-> 2
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -127,7 +127,7 @@
       2 |-> 3
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/1_k/4_imp++/lesson_5/tests/div.imp.out
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_5/tests/div.imp.out
@@ -11,7 +11,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -35,7 +35,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -59,7 +59,7 @@
       2 |-> 1
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -83,7 +83,7 @@
       2 |-> 2
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -107,7 +107,7 @@
       2 |-> 3
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/1_k/4_imp++/lesson_6/tests/div.imp.out
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_6/tests/div.imp.out
@@ -7,7 +7,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -27,7 +27,7 @@
       2 |-> 1
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -47,7 +47,7 @@
       2 |-> 2
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -67,7 +67,7 @@
       2 |-> 3
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -95,7 +95,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/1_k/4_imp++/lesson_7/exercises/abort/tests/div.imp.out
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_7/exercises/abort/tests/div.imp.out
@@ -18,7 +18,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -49,7 +49,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -80,7 +80,7 @@
       2 |-> 1
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -111,7 +111,7 @@
       2 |-> 2
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -142,7 +142,7 @@
       2 |-> 3
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/1_k/4_imp++/lesson_7/tests/div.imp.out
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_7/tests/div.imp.out
@@ -18,7 +18,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -49,7 +49,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -80,7 +80,7 @@
       2 |-> 1
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -111,7 +111,7 @@
       2 |-> 2
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -142,7 +142,7 @@
       2 |-> 3
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/1_k/4_imp++/lesson_8/tests/div.imp.out
+++ b/k-distribution/tutorial/1_k/4_imp++/lesson_8/tests/div.imp.out
@@ -18,7 +18,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -49,7 +49,7 @@
       2 |-> 0
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -80,7 +80,7 @@
       2 |-> 1
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -111,7 +111,7 @@
       2 |-> 2
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -142,7 +142,7 @@
       2 |-> 3
     </store>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/2_languages/1_simple/1_untyped/exercises/break-continue/tests/threads/threads_05.simple.out
+++ b/k-distribution/tutorial/2_languages/1_simple/1_untyped/exercises/break-continue/tests/threads/threads_05.simple.out
@@ -20,7 +20,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -56,7 +56,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -92,7 +92,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -128,7 +128,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -164,7 +164,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/2_languages/1_simple/1_untyped/exercises/parameter-passing-styles/tests/threads/threads_05.simple.out
+++ b/k-distribution/tutorial/2_languages/1_simple/1_untyped/exercises/parameter-passing-styles/tests/threads/threads_05.simple.out
@@ -20,7 +20,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -56,7 +56,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -92,7 +92,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -128,7 +128,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -164,7 +164,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/2_languages/1_simple/1_untyped/tests/threads/threads_05.simple.out
+++ b/k-distribution/tutorial/2_languages/1_simple/1_untyped/tests/threads/threads_05.simple.out
@@ -20,7 +20,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -56,7 +56,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -92,7 +92,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -128,7 +128,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -164,7 +164,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/2_languages/1_simple/2_typed/2_dynamic/exercises/functions-with-throws/tests/threads_05.simple.out
+++ b/k-distribution/tutorial/2_languages/1_simple/2_typed/2_dynamic/exercises/functions-with-throws/tests/threads_05.simple.out
@@ -20,7 +20,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -56,7 +56,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -92,7 +92,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -128,7 +128,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -164,7 +164,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/2_languages/1_simple/2_typed/2_dynamic/exercises/typed-exceptions/tests/threads_05.simple.out
+++ b/k-distribution/tutorial/2_languages/1_simple/2_typed/2_dynamic/exercises/typed-exceptions/tests/threads_05.simple.out
@@ -20,7 +20,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -56,7 +56,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -92,7 +92,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -128,7 +128,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -164,7 +164,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/k-distribution/tutorial/2_languages/1_simple/2_typed/2_dynamic/tests/threads_05.simple.out
+++ b/k-distribution/tutorial/2_languages/1_simple/2_typed/2_dynamic/tests/threads_05.simple.out
@@ -20,7 +20,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -56,7 +56,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -92,7 +92,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -128,7 +128,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>
@@ -164,7 +164,7 @@
       SetItem ( 1 )
     </terminated>
     <input>
-      ListItem ( #buffer ( "" ) )
+      ListItem ( #buffer ( "\n" ) )
       ListItem ( "off" )
       ListItem ( #istream ( 0 ) )
     </input>

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -215,7 +215,7 @@ public class KRun {
             throw KEMException.internalError("IO error detected reading from stdin", e);
         }
         if (buffer == null) {
-            return "";
+            buffer = "";
         }
         return buffer + "\n";
     }


### PR DESCRIPTION
Not sure if this is the correct fix, but it would make sense given the fact that we are consistently seeing one extra/too-few newlines in the stdin stream of SIMPLE programs in other PRs.