### PR TITLE
State logging functionality to support tools like klab

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -59,7 +59,7 @@ public class GlobalContext implements Serializable {
         this.files = files;
         this.equalityOps = new EqualityOperations(() -> def);
         this.stateLog = new StateLog(javaExecutionOptions, files);
-        this.constraintOps = new SMTOperations(() -> def, smtOptions, new Z3Wrapper(smtOptions, kem, globalOptions, files), kem, globalOptions);
+        this.constraintOps = new SMTOperations(() -> def, smtOptions, new Z3Wrapper(smtOptions, kem, globalOptions, files, stateLog), kem, globalOptions);
         this.kItemOps = new KItemOperations(stage, javaExecutionOptions.deterministicFunctions, kem, this::builtins, globalOptions);
         this.stage = stage;
         this.profiler = profiler;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -10,6 +10,7 @@ import org.kframework.backend.java.symbolic.JavaExecutionOptions;
 import org.kframework.backend.java.symbolic.SMTOperations;
 import org.kframework.backend.java.symbolic.Stage;
 import org.kframework.backend.java.util.Profiler2;
+import org.kframework.backend.java.util.StateLog;
 import org.kframework.backend.java.util.Z3Wrapper;
 import org.kframework.krun.KRunOptions;
 import org.kframework.krun.api.io.FileSystem;
@@ -36,6 +37,7 @@ public class GlobalContext implements Serializable {
     public final transient FileUtil files;
     public final transient GlobalOptions globalOptions;
     public final transient Profiler2 profiler;
+    public final StateLog stateLog;
 
     public GlobalContext(
             FileSystem fs,
@@ -56,6 +58,7 @@ public class GlobalContext implements Serializable {
         this.hookProvider = hookProvider;
         this.files = files;
         this.equalityOps = new EqualityOperations(() -> def);
+        this.stateLog = new StateLog(javaExecutionOptions, files);
         this.constraintOps = new SMTOperations(() -> def, smtOptions, new Z3Wrapper(smtOptions, kem, globalOptions, files), kem, globalOptions);
         this.kItemOps = new KItemOperations(stage, javaExecutionOptions.deterministicFunctions, kem, this::builtins, globalOptions);
         this.stage = stage;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Rule.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Rule.java
@@ -26,6 +26,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.kframework.kore.K;
+import static org.kframework.kore.KORE.KRewrite;
+
 
 /**
  * A K rule in the format of the Java Rewrite Engine.
@@ -152,6 +155,10 @@ public class Rule extends JavaSymbolicObject<Rule> {
 
     public ImmutableList<Term> ensures() {
         return ensures;
+    }
+
+    public K toKRewrite() {
+        return KRewrite(leftHandSide, rightHandSide, att());
     }
 
     public ConstrainedTerm createLhsPattern(TermContext termContext) {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -12,6 +12,7 @@ import org.kframework.backend.java.builtins.IntToken;
 import org.kframework.backend.java.kil.*;
 import org.kframework.backend.java.util.Constants;
 import org.kframework.backend.java.util.RewriteEngineUtils;
+import org.kframework.backend.java.util.StateLog;
 import org.kframework.builtin.KLabels;
 
 import javax.annotation.Nullable;
@@ -849,6 +850,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                 continue;
             }
 
+            global.stateLog.log(StateLog.LogEvent.IMPLICATION, left, right);
             if (!impliesSMT(left, right, existentialQuantVars)) {
                 if (global.globalOptions.debug) {
                     System.err.println("Failure!");

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -2,7 +2,14 @@
 package org.kframework.backend.java.symbolic;
 
 import com.beust.jcommander.Parameter;
+
+import org.kframework.backend.java.util.StateLog;
 import org.kframework.utils.inject.RequestScoped;
+import org.kframework.utils.options.BaseEnumConverter;
+
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
 
 @RequestScoped
 public final class JavaExecutionOptions {
@@ -29,5 +36,28 @@ public final class JavaExecutionOptions {
             + "tagged with the javaBackendValue of --apply-tag, or fail with an error explaining why the rule did not apply.")
     public Integer auditingStep;
 
+    @Parameter(names={"--state-log"}, description="Output symbolic execution debugging information")
+    public boolean stateLog = false;
+
+    @Parameter(names={"--state-log-path"}, description="Path where the debugging information should be stored")
+    public String stateLogPath;
+
+    @Parameter(names={"--state-log-id"}, description="Id of the current execution")
+    public String stateLogId;
+
+    @Parameter(names={"--state-log-events"}, converter=LogEventConverter.class, description="Comma-separated list of events to log: [OPEN|REACHINIT|REACHTARGET|REACHPROVED|NODE|RULE|SRULE|RULEATTEMPT|IMPLICATION|Z3QUERY|Z3RESULT|CLOSE]")
+    public List<StateLog.LogEvent> stateLogEvents = Collections.emptyList();
+
+    public static class LogEventConverter extends BaseEnumConverter<StateLog.LogEvent> {
+
+        public LogEventConverter(String optionName) {
+            super(optionName);
+        }
+
+        @Override
+        public Class<StateLog.LogEvent> enumClass() {
+            return StateLog.LogEvent.class;
+        }
+    }
 }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/util/StateLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/StateLog.java
@@ -1,0 +1,143 @@
+// Copyright (c) 2018 K Team. All Rights Reserved.
+package org.kframework.backend.java.util;
+
+import org.kframework.backend.java.symbolic.JavaExecutionOptions;
+import org.kframework.definition.Module;
+import org.kframework.kore.K;
+import org.kframework.krun.KRun;
+import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
+import org.kframework.unparser.KPrint;
+import org.kframework.unparser.OutputModes;
+import org.kframework.utils.file.FileUtil;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
+import java.io.OutputStream;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import org.apache.commons.io.output.WriterOutputStream;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.lang.Math;
+
+public class StateLog {
+
+    // *ALL* `public` methods *MUST* return `void` and have their first line be `if (! this.loggingOn) return;`
+    private final boolean        loggingOn;
+    private final File           loggingPath;
+    private final File           blobsDir;
+    private final List<LogEvent> logEvents;
+
+    private String      sessionId;
+    private PrintWriter sessionLog;
+
+    private boolean inited;
+    private long    startTime;
+
+    public StateLog() {
+        this.inited      = false;
+        this.loggingOn   = false;
+        this.loggingPath = null;
+        this.blobsDir    = null;
+        this.logEvents   = Collections.emptyList();
+    }
+
+    public StateLog(JavaExecutionOptions javaExecutionOptions, FileUtil files) {
+        this.inited    = false;
+        this.loggingOn = javaExecutionOptions.stateLog;
+
+        this.loggingPath = javaExecutionOptions.stateLogPath == null
+                         ? files.resolveKompiled("stateLog")
+                         : new File(javaExecutionOptions.stateLogPath);
+
+        if (javaExecutionOptions.stateLogId != null) this.sessionId = javaExecutionOptions.stateLogId;
+
+        this.blobsDir = new File(loggingPath, "blobs/");
+        this.blobsDir.mkdirs();
+
+        this.logEvents = javaExecutionOptions.stateLogEvents;
+    }
+
+    public void open(String defaultSessionId) {
+        if ((! this.loggingOn) || this.inited) return;
+        this.inited = true;
+        if (this.sessionId == null) this.sessionId = defaultSessionId;
+        File logFile = new File(this.loggingPath, this.sessionId + ".log");
+        PrintWriter sessionLog;
+        try {
+            this.sessionLog = new PrintWriter(logFile);
+            System.err.println("StateLog: " + logFile);
+        } catch (FileNotFoundException e) {
+            e.printStackTrace();
+        }
+        this.startTime = System.currentTimeMillis();
+        this.log(LogEvent.OPEN);
+    }
+
+    public static enum LogEvent {
+        OPEN, REACHINIT, REACHTARGET, REACHPROVED, NODE, RULE, SRULE, RULEATTEMPT, IMPLICATION, Z3QUERY, Z3RESULT, CLOSE
+    }
+
+    public void log(String logItem) {
+        if (! this.loggingOn) return;
+        this.sessionLog.println((System.currentTimeMillis() - this.startTime) + " " + logItem);
+        this.sessionLog.flush();
+    }
+
+    public void log(LogEvent logCode, K... terms) {
+        if (! (this.loggingOn && this.logEvents.contains(logCode))) return;
+        ArrayList<String> nodeIds = new ArrayList<String>();
+        for (K term: terms) {
+            nodeIds.add(writeNode(term));
+        }
+        String nodeId = String.join("_", nodeIds);
+        this.log(logCode.toString() + " " + nodeId);
+    }
+
+    public void close() {
+        if (! this.loggingOn) return;
+        this.log(LogEvent.CLOSE);
+        this.sessionLog.close();
+    }
+
+    private static String hash(K in) {
+        MessageDigest m = null;
+        String hashtext = "__";
+        try {
+            m = MessageDigest.getInstance("MD5");
+            m.reset();
+            m.update(KPrint.serialize(in, OutputModes.KAST));
+            byte[] digest = m.digest();
+            BigInteger bigInt = new BigInteger(1,digest);
+            hashtext = bigInt.toString(16);
+        } catch (NoSuchAlgorithmException e) {
+            e.printStackTrace();
+        }
+        return hashtext;
+    }
+
+    private String writeNode(K contents) {
+        String fileCode   = hash(contents);
+        File   outputFile = new File(this.blobsDir, fileCode + "." + OutputModes.JSON.ext());
+        if (! outputFile.exists()) {
+            try {
+                String out = new String(KPrint.serialize(contents, OutputModes.JSON), StandardCharsets.UTF_8);
+                PrintWriter fOut = new PrintWriter(outputFile);
+                fOut.println(out);
+                fOut.close();
+            } catch (FileNotFoundException e) {
+                System.err.println("Could not open node output file: " + outputFile.getAbsolutePath());
+                e.printStackTrace();
+            }
+        }
+        return fileCode;
+    }
+}

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -199,7 +199,7 @@ public class KPrint {
         }.apply(term);
     }
 
-    private K omitTerm(Module mod, KApply kapp) {
+    private static K omitTerm(Module mod, KApply kapp) {
         Sort finalSort = Sorts.K();
         Option<Sort> termSort = mod.sortFor().get(kapp.klabel());
         if (! termSort.isEmpty()) {

--- a/kernel/src/main/java/org/kframework/unparser/OutputModes.java
+++ b/kernel/src/main/java/org/kframework/unparser/OutputModes.java
@@ -7,5 +7,19 @@ package org.kframework.unparser;
  *
  */
 public enum OutputModes {
-    PRETTY, PROGRAM, KAST, BINARY, JSON, NONE
+    PRETTY, PROGRAM, KAST, BINARY, JSON, NONE;
+
+    private String extension;
+    static {
+        PRETTY.extension  = "kpretty";
+        PROGRAM.extension = "pgm";
+        KAST.extension    = "kast";
+        BINARY.extension  = "kbin";
+        JSON.extension    = "json";
+        NONE.extension    = "";
+    }
+
+    public String ext() {
+        return extension;
+    }
 }

--- a/kore/src/main/scala/org/kframework/builtin/Sorts.scala
+++ b/kore/src/main/scala/org/kframework/builtin/Sorts.scala
@@ -39,4 +39,7 @@ object Sorts {
   val GeneratedCounterCell = Sort("GeneratedCounterCell")
 
   val Id = Sort("Id")
+
+  val Z3Query  = Sort("Z3Query")
+  val Z3Result = Sort("Z3Result")
 }


### PR DESCRIPTION
This PR implements the following options for the Java backend:

-   `--state-log`: dumps information about (1) current term, (2) rules applied, and (3) z3 queries made as java backend is executing.
-   `--state-log-path`: override default directory to log state information too (default is in *-kompiled directory).
-   `--state-log-id`: override default identifier used to refer to this state logging run.
-   `--state-log-events`: specify which log events you're interested in collecting.