### PR TITLE
java-backend bugfix: #getKLabelString

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -14,6 +14,7 @@ import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.symbolic.ConjunctiveFormula;
 import org.kframework.backend.java.symbolic.CopyOnWriteTransformer;
 import org.kframework.backend.java.symbolic.PatternMatcher;
+import org.kframework.kore.KVariable;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -201,6 +202,8 @@ public class MetaK {
     public static StringToken getKLabelString(Term term, TermContext context) {
         if (term instanceof KItem) {
             return StringToken.of(((KItem) term).kLabel().toString());
+        } else if (term instanceof KVariable){
+            return null;
         } else {
             return StringToken.of("");
         }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -16,6 +16,7 @@ import org.kframework.backend.java.kil.Term;
 import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.util.HookProvider;
 import org.kframework.backend.java.util.Profiler2;
+import org.kframework.backend.java.util.RuleSourceUtil;
 import org.kframework.builtin.KLabels;
 import org.kframework.compile.*;
 import org.kframework.definition.Module;
@@ -354,6 +355,12 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
                 termContext.setTopConstraint(constraint);
                 //simplify the constraint in its own context, to force full evaluation of terms.
                 constraint = constraint.simplify(termContext);
+                if (constraint.isFalseExtended()) {
+                    StringBuilder sb = new StringBuilder();
+                    sb.append("Rule requires clause evaluates to false:\n");
+                    RuleSourceUtil.appendRuleAndSource(rule, sb);
+                    throw KEMException.criticalError(sb.toString());
+                }
 
                 return new org.kframework.backend.java.kil.Rule(
                         rule.label(),


### PR DESCRIPTION
1. #getKLabelString properly handles variable arguments.
2. Added check that requires clause of a spec rule is not false.

Tested in verified-smart-contracts/k-test.

DO NOT MERGE