### PR TITLE
Pr term init fix

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -575,8 +575,6 @@ public class SymbolicRewriter {
         List<ConstrainedTerm> queue = new ArrayList<>();
         List<ConstrainedTerm> nextQueue = new ArrayList<>();
 
-        initialTerm = initialTerm.expandPatterns(true);
-
         global.stateLog.log(StateLog.LogEvent.REACHINIT,   initialTerm.term(), initialTerm.constraint());
         global.stateLog.log(StateLog.LogEvent.REACHTARGET, targetTerm.term(),  targetTerm.constraint());
 


### PR DESCRIPTION
java-backend: bugfix: properly evaluate the term, constraint and ensures clause before calling proveRule().

Before this change incorrect top constraint was sometimes present before calling lhs.expandPatterns(), from ProcessProofRules phase of another spec rule.

Summary of the changes before proveRule:
- Fully evaluate and simplify the constraint.
- LHS (initial term) is built from fully evaluated constraint and rule LHS which is already fully evalauted.
- initialTerm.expandPatterns() was moved from proveRule() to InitializeRewriter where it should have been in the first place.
- Evaluate the ensures clause.
- Build RHS (target term) from evalauted ensures and rule RHS, which is already fully evaluated.
- reset constraint (not needed, just for safety)

Problems with previous implementation:
- constraint and ensures clause were not fully evaluated. The previous pre-processing in ProcessProofRules only evaluates the LHS and RHS. This whole sequence is extraordinarily poorly written and error-prone, that's why it's not obvious.
- Cosntraint in termContext was not reset after initialization phase. Consequently, inside SymbolicRewriter.proveRule(), line `initialTerm.expandPattern()` could evaluate with wrong context and lead to funny issues.

@daejunpark Please review only 2nd commit. 1st commit is same as #231 .

DO NOT MERGE (I want to merge all PRs in a certain sequence).