### PR TITLE
Correctly stop kserver and use uniform way of setting KSERVER_SOCKET

### DIFF
--- a/k-distribution/src/main/scripts/bin/spawn-kserver
+++ b/k-distribution/src/main/scripts/bin/spawn-kserver
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
 
-if [[ "$KSERVER_SOCKET" == "" ]]; then
-  KSERVER_SOCKET="$HOME/.kserver"
-fi
-
+source "$(dirname "$0")/../lib/setenv"
 "$(dirname "$0")/kserver" --socket "$KSERVER_SOCKET" &>> "$1" &

--- a/k-distribution/src/main/scripts/lib/checkJava
+++ b/k-distribution/src/main/scripts/lib/checkJava
@@ -23,10 +23,7 @@ function setarch {
   fi
 }
 
-if [[ "$KSERVER_SOCKET" == "" ]]; then
-  KSERVER_SOCKET="$HOME/.kserver"
-fi
-
+KSERVER_SOCKET="${KSERVER_SOCKET:-$HOME/.kserver}"
 KSERVER_INSTANCE="ng --nailgun-server local:$KSERVER_SOCKET/socket"
 version=$($KSERVER_INSTANCE org.kframework.main.JavaVersion 2>&1)
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
This should stop the zombie kservers from sticking around.

I've also changed the build to call `stop-kserver` regardless of the exit status of `make` in the k-exercises directory.