### PR TITLE
Uniform way of setting KSERVER_SOCKET in lib/checkJava

### DIFF
--- a/k-distribution/src/main/scripts/bin/spawn-kserver
+++ b/k-distribution/src/main/scripts/bin/spawn-kserver
@@ -1,7 +1,4 @@
 #!/usr/bin/env bash
 
-if [[ "$KSERVER_SOCKET" == "" ]]; then
-  KSERVER_SOCKET="$HOME/.kserver"
-fi
-
+source "$(dirname "$0")/../lib/setenv"
 "$(dirname "$0")/kserver" --socket "$KSERVER_SOCKET" &>> "$1" &

--- a/k-distribution/src/main/scripts/lib/checkJava
+++ b/k-distribution/src/main/scripts/lib/checkJava
@@ -23,10 +23,7 @@ function setarch {
   fi
 }
 
-if [[ "$KSERVER_SOCKET" == "" ]]; then
-  KSERVER_SOCKET="$HOME/.kserver"
-fi
-
+KSERVER_SOCKET="${KSERVER_SOCKET:-$HOME/.kserver}"
 KSERVER_INSTANCE="ng --nailgun-server local:$KSERVER_SOCKET/socket"
 version=$($KSERVER_INSTANCE org.kframework.main.JavaVersion 2>&1)
 if [ $? -eq 0 ]; then

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -14,6 +14,10 @@ KSERVER_SOCKET="$WORKSPACE/kserver"
 KSERVER_LOG="$WORKSPACE/kserver.log"
 export KSERVER_SOCKET
 
+notif "CLEANING REPO"
+mvn clean
+git clean -dfx
+
 notif "SETTING UP OPAM/PERL ENVIRONMENTS"
 eval `opam config env`
 eval `perl -I$HOME/perl5/lib/perl5 -Mlocal::lib`

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+set -e
+
+nprocs="$(grep -c '^processor' /proc/cpuinfo)"
+
+eval `opam config env`
+eval `perl -I$HOME/perl5/lib/perl5 -Mlocal::lib`
+
+echo "=== RUNNING LOCAL TESTS ==="
+cd ${WORKSPACE}/k-pr
+git submodule update --init
+mvn verify -U
+
+echo "=== RUNNING K EXERCISES ==="
+cd ${WORKSPACE}/k-pr
+rm -rf k-exercises
+git clone 'git@github.com:kframework/k-exercises.git'
+cd k-exercises/tutorial
+export KSERVER_SOCKET=$(pwd)/kserver
+../../k-distribution/target/release/k/bin/spawn-kserver kserver.log
+sleep 5
+make -j"$nprocs"
+../../k-distribution/target/release/k/bin/stop-kserver || true
+
+echo "=== RUNNING RV-MATCH TESTS ==="
+cd ${WORKSPACE}
+rm -rf rv-match
+git clone git@github.com:runtimeverification/rv-match.git
+cd rv-match
+git submodule update --init -- c-semantics
+rm -rf k
+cp -r ${WORKSPACE}/k-pr k
+mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -10,6 +10,10 @@ notif() {
 
 NPROCS="${NPROCS:-$(grep -c '^processor' /proc/cpuinfo)}"
 WORKSPACE="${WORKSPACE:-$(pwd)}"
+
+K_EXERCISES_REPO="${K_EXERCISES_REPO:-git@github.com:kframework/k-exercises.git}"
+RVMATCH_REPO="${RVMATCH_REPO:-git@github.com:runtimeverification/rv-match.git}"
+
 KSERVER_SOCKET="$WORKSPACE/kserver"
 KSERVER_LOG="$WORKSPACE/kserver.log"
 export KSERVER_SOCKET
@@ -34,7 +38,7 @@ sleep 5
 
 notif "CLONING K EXERCISES"
 rm -rf k-exercises
-git clone 'git@github.com:kframework/k-exercises.git'
+git clone "$K_EXERCISES_REPO" k-exercises
 
 notif "RUNNING K EXERCISES"
 (   cd k-exercises/tutorial
@@ -46,7 +50,7 @@ notif "KILLING KSERVER"
 
 notif "CLONING/PREPARING RV-MATCH"
 rm -rf rv-match
-git clone git@github.com:runtimeverification/rv-match.git
+git clone "$RVMATCH_REPO" rv-match
 (   cd rv-match
     git submodule update --init -- c-semantics k
     cd k

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -44,12 +44,18 @@ notif "RUNNING K EXERCISES"
 notif "KILLING KSERVER"
 ./k-distribution/target/release/k/bin/stop-kserver || true
 
-# notif "RUNNING RV-MATCH TESTS"
-# cd ${WORKSPACE}
-# rm -rf rv-match
-# git clone git@github.com:runtimeverification/rv-match.git
-# cd rv-match
-# git submodule update --init -- c-semantics
-# rm -rf k
-# cp -r ${WORKSPACE}/k-pr k
-# mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc
+notif "CLONING/PREPARING RV-MATCH"
+rm -rf rv-match
+git clone git@github.com:runtimeverification/rv-match.git
+(   cd rv-match
+    git submodule update --init -- c-semantics k
+    cd k
+    git fetch ../../
+    git checkout FETCH_HEAD
+    mvn package -DskipTests
+)
+
+notif "RUNNING RV-MATCH TESTS"
+(   cd rv-match
+    mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc
+)

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -2,33 +2,50 @@
 
 set -e
 
-nprocs="$(grep -c '^processor' /proc/cpuinfo)"
+notif() {
+    echo -e "\n$@" \
+            "\n================================================================================" \
+            "\n" >&2
+}
 
+NPROCS="${NPROCS:-$(grep -c '^processor' /proc/cpuinfo)}"
+WORKSPACE="${WORKSPACE:-$(pwd)}"
+KSERVER_SOCKET="$WORKSPACE/kserver"
+KSERVER_LOG="$WORKSPACE/kserver.log"
+export KSERVER_SOCKET
+
+notif "SETTING UP OPAM/PERL ENVIRONMENTS"
 eval `opam config env`
 eval `perl -I$HOME/perl5/lib/perl5 -Mlocal::lib`
 
-echo "=== RUNNING LOCAL TESTS ==="
-cd ${WORKSPACE}/k-pr
+notif "CLONING SUBMODULES"
 git submodule update --init
+
+notif "BUILDING/RUNNING LOCAL TESTS"
 mvn verify -U
 
-echo "=== RUNNING K EXERCISES ==="
-cd ${WORKSPACE}/k-pr
+notif "STARTING KSERVER"
+./k-distribution/target/release/k/bin/spawn-kserver "$KSERVER_LOG"
+sleep 5
+
+notif "CLONING K EXERCISES"
 rm -rf k-exercises
 git clone 'git@github.com:kframework/k-exercises.git'
-cd k-exercises/tutorial
-export KSERVER_SOCKET=$(pwd)/kserver
-../../k-distribution/target/release/k/bin/spawn-kserver kserver.log
-sleep 5
-make -j"$nprocs"
-../../k-distribution/target/release/k/bin/stop-kserver || true
 
-echo "=== RUNNING RV-MATCH TESTS ==="
-cd ${WORKSPACE}
-rm -rf rv-match
-git clone git@github.com:runtimeverification/rv-match.git
-cd rv-match
-git submodule update --init -- c-semantics
-rm -rf k
-cp -r ${WORKSPACE}/k-pr k
-mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc
+notif "RUNNING K EXERCISES"
+(   cd k-exercises/tutorial
+    make -j"$NPROCS"
+)
+
+notif "KILLING KSERVER"
+./k-distribution/target/release/k/bin/stop-kserver || true
+
+# notif "RUNNING RV-MATCH TESTS"
+# cd ${WORKSPACE}
+# rm -rf rv-match
+# git clone git@github.com:runtimeverification/rv-match.git
+# cd rv-match
+# git submodule update --init -- c-semantics
+# rm -rf k
+# cp -r ${WORKSPACE}/k-pr k
+# mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc


### PR DESCRIPTION
stop-kserver now correctly calls `source lib/setenv`, which will set the KSERVER_SOCKET.