### PR TITLE
Make Jenkins testing script runnable locally without Jenkins environment setup

### DIFF
--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -41,12 +41,14 @@ rm -rf k-exercises
 git clone "$K_EXERCISES_REPO" k-exercises
 
 notif "RUNNING K EXERCISES"
+exit_status='0'
 (   cd k-exercises/tutorial
     make -j"$NPROCS"
-)
+) || exit_status="$?"
 
 notif "KILLING KSERVER"
 ./k-distribution/target/release/k/bin/stop-kserver || true
+[[ "$exit_status" == '0' ]] || exit "$exit_status"
 
 notif "CLONING/PREPARING RV-MATCH"
 rm -rf rv-match

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -14,6 +14,10 @@ KSERVER_SOCKET="$WORKSPACE/kserver"
 KSERVER_LOG="$WORKSPACE/kserver.log"
 export KSERVER_SOCKET
 
+notif "CLEANING REPO"
+mvn clean
+git clean -dfx
+
 notif "SETTING UP OPAM/PERL ENVIRONMENTS"
 eval `opam config env`
 eval `perl -I$HOME/perl5/lib/perl5 -Mlocal::lib`

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -8,7 +8,7 @@ notif() {
             "\n" >&2
 }
 
-NPROCS="${NPROCS:-$(grep -c '^processor' /proc/cpuinfo)}"
+NPROCS="${NPROCS:-$(nproc)}"
 WORKSPACE="${WORKSPACE:-$(pwd)}"
 
 K_EXERCISES_REPO="${K_EXERCISES_REPO:-git@github.com:kframework/k-exercises.git}"

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -10,6 +10,10 @@ notif() {
 
 NPROCS="${NPROCS:-$(grep -c '^processor' /proc/cpuinfo)}"
 WORKSPACE="${WORKSPACE:-$(pwd)}"
+
+K_EXERCISES_REPO="${K_EXERCISES_REPO:-git@github.com:kframework/k-exercises.git}"
+RVMATCH_REPO="${RVMATCH_REPO:-git@github.com:runtimeverification/rv-match.git}"
+
 KSERVER_SOCKET="$WORKSPACE/kserver"
 KSERVER_LOG="$WORKSPACE/kserver.log"
 export KSERVER_SOCKET
@@ -34,7 +38,7 @@ sleep 5
 
 notif "CLONING K EXERCISES"
 rm -rf k-exercises
-git clone 'git@github.com:kframework/k-exercises.git'
+git clone "$K_EXERCISES_REPO" k-exercises
 
 notif "RUNNING K EXERCISES"
 (   cd k-exercises/tutorial
@@ -46,7 +50,7 @@ notif "KILLING KSERVER"
 
 notif "CLONING/PREPARING RV-MATCH"
 rm -rf rv-match
-git clone git@github.com:runtimeverification/rv-match.git
+git clone "$RVMATCH_REPO" rv-match
 (   cd rv-match
     git submodule update --init -- c-semantics k
     cd k

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -44,12 +44,18 @@ notif "RUNNING K EXERCISES"
 notif "KILLING KSERVER"
 ./k-distribution/target/release/k/bin/stop-kserver || true
 
-# notif "RUNNING RV-MATCH TESTS"
-# cd ${WORKSPACE}
-# rm -rf rv-match
-# git clone git@github.com:runtimeverification/rv-match.git
-# cd rv-match
-# git submodule update --init -- c-semantics
-# rm -rf k
-# cp -r ${WORKSPACE}/k-pr k
-# mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc
+notif "CLONING/PREPARING RV-MATCH"
+rm -rf rv-match
+git clone git@github.com:runtimeverification/rv-match.git
+(   cd rv-match
+    git submodule update --init -- c-semantics k
+    cd k
+    git fetch ../../
+    git checkout FETCH_HEAD
+    mvn package -DskipTests
+)
+
+notif "RUNNING RV-MATCH TESTS"
+(   cd rv-match
+    mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc
+)

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -36,7 +36,6 @@ notif "STARTING KSERVER"
 sleep 5
 
 notif "CLONING K EXERCISES"
-rm -rf k-exercises
 git clone "$K_EXERCISES_REPO" k-exercises
 
 notif "RUNNING K EXERCISES"

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -20,7 +20,7 @@ export KSERVER_SOCKET
 
 notif "CLEANING REPO"
 mvn clean
-git clean -dfx
+git clean -dffx
 
 notif "SETTING UP OPAM/PERL ENVIRONMENTS"
 eval `opam config env`

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -2,33 +2,50 @@
 
 set -e
 
-nprocs="$(grep -c '^processor' /proc/cpuinfo)"
+notif() {
+    echo -e "\n$@" \
+            "\n================================================================================" \
+            "\n" >&2
+}
 
+NPROCS="${NPROCS:-$(grep -c '^processor' /proc/cpuinfo)}"
+WORKSPACE="${WORKSPACE:-$(pwd)}"
+KSERVER_SOCKET="$WORKSPACE/kserver"
+KSERVER_LOG="$WORKSPACE/kserver.log"
+export KSERVER_SOCKET
+
+notif "SETTING UP OPAM/PERL ENVIRONMENTS"
 eval `opam config env`
 eval `perl -I$HOME/perl5/lib/perl5 -Mlocal::lib`
 
-echo "=== RUNNING LOCAL TESTS ==="
-cd ${WORKSPACE}/k-pr
+notif "CLONING SUBMODULES"
 git submodule update --init
+
+notif "BUILDING/RUNNING LOCAL TESTS"
 mvn verify -U
 
-echo "=== RUNNING K EXERCISES ==="
-cd ${WORKSPACE}/k-pr
+notif "STARTING KSERVER"
+./k-distribution/target/release/k/bin/spawn-kserver "$KSERVER_LOG"
+sleep 5
+
+notif "CLONING K EXERCISES"
 rm -rf k-exercises
 git clone 'git@github.com:kframework/k-exercises.git'
-cd k-exercises/tutorial
-export KSERVER_SOCKET=$(pwd)/kserver
-../../k-distribution/target/release/k/bin/spawn-kserver kserver.log
-sleep 5
-make -j"$nprocs"
-../../k-distribution/target/release/k/bin/stop-kserver || true
 
-echo "=== RUNNING RV-MATCH TESTS ==="
-cd ${WORKSPACE}
-rm -rf rv-match
-git clone git@github.com:runtimeverification/rv-match.git
-cd rv-match
-git submodule update --init -- c-semantics
-rm -rf k
-cp -r ${WORKSPACE}/k-pr k
-mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc
+notif "RUNNING K EXERCISES"
+(   cd k-exercises/tutorial
+    make -j"$NPROCS"
+)
+
+notif "KILLING KSERVER"
+./k-distribution/target/release/k/bin/stop-kserver || true
+
+# notif "RUNNING RV-MATCH TESTS"
+# cd ${WORKSPACE}
+# rm -rf rv-match
+# git clone git@github.com:runtimeverification/rv-match.git
+# cd rv-match
+# git submodule update --init -- c-semantics
+# rm -rf k
+# cp -r ${WORKSPACE}/k-pr k
+# mvn verify -U -DskipKTest -DbuildProfile=x86_64-gcc-glibc

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -19,7 +19,6 @@ KSERVER_LOG="$WORKSPACE/kserver.log"
 export KSERVER_SOCKET
 
 notif "CLEANING REPO"
-mvn clean
 git clean -dffx
 
 notif "SETTING UP OPAM/PERL ENVIRONMENTS"


### PR DESCRIPTION
The script is organized slightly (so that parameters come at the top), and more notifications about build process are produced.

Also, the rv-match testing is done differently. Instead of cloning to subdirectory `$WORKSPACE/k-pr`, we're cloning directly to `$WORKSPACE`. K-Exercises tests are unaffected, but rv-match is now cloned to a subdirectory `$WORKSPACE/rv-match`, and we use manually update the K submodule inside RV-match to point directly at the HEAD of the checkout of K at `$WORKSPACE`. (so no more `rm ... ; cp ...` going on, just `git ...` operation).