### PR TITLE
[WIP] Scala parser tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,8 @@
 [submodule "llvm-backend/src/main/native/llvm-backend"]
 	path = llvm-backend/src/main/native/llvm-backend
 	url = https://github.com/kframework/llvm-backend
+	ignore = untracked
+[submodule "haskell-backend/src/main/native/haskell-backend"]
+	path = haskell-backend/src/main/native/haskell-backend
+	url = https://github.com/kframework/kore
+	ignore = untracked

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ source $HOME/.cargo/env
 rustup toolchain install 1.28.0
 rustup default 1.28.0
 curl -sSL https://get.haskellstack.org/ | sh
-
 ```
 
 If you install this list of dependencies, continue directly to the Install section.
@@ -62,9 +61,9 @@ rustup default 1.28.0
 
 ## Haskell Stack
 
-To install, go to https://docs.haskellstack.org/en/stable/README/ and follow the instructions.
+To install, go to <https://docs.haskellstack.org/en/stable/README/> and follow the instructions.
+You may need to do `stack upgrade` to ensure the latest version of Haskell Stack.
 
-	
 ## Miscellaneous
 
 Also required:

--- a/haskell-backend/pom.xml
+++ b/haskell-backend/pom.xml
@@ -50,6 +50,12 @@
                 <exec executable="stack" dir="${project.basedir}/src/main/native/haskell-backend" failonerror="true">
                   <arg value="build" />
                 </exec>
+                <mkdir dir="${project.build.directory}/stack-install" />
+                <exec executable="stack" dir="${project.basedir}/src/main/native/haskell-backend" failonerror="true">
+                  <arg value="install" />
+                  <arg value="--local-bin-path" />
+                  <arg value="${project.build.directory}/stack-install" />
+                </exec>
               </target>
             </configuration>
             <goals>

--- a/haskell-backend/pom.xml
+++ b/haskell-backend/pom.xml
@@ -28,10 +28,6 @@
     </dependency>
   </dependencies>
 
-  <properties>
-    <project.build.type>Release</project.build.type>
-  </properties>
-
   <build>
     <plugins>
       <plugin>

--- a/haskell-backend/pom.xml
+++ b/haskell-backend/pom.xml
@@ -28,11 +28,35 @@
     </dependency>
   </dependencies>
 
+  <properties>
+    <project.build.type>Release</project.build.type>
+  </properties>
+
   <build>
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
         <version>2.17</version>
+      </plugin>
+      <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <id>build-haskell</id>
+            <phase>compile</phase>
+            <configuration>
+              <target>
+                <exec executable="stack" dir="${project.basedir}/src/main/native/haskell-backend" failonerror="true">
+                  <arg value="build" />
+                </exec>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/k-distribution/src/main/assembly/bin.xml
+++ b/k-distribution/src/main/assembly/bin.xml
@@ -72,5 +72,11 @@
       <directory>${project.basedir}/../llvm-backend/target/build/install/include</directory>
       <outputDirectory>/include</outputDirectory>
     </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../haskell-backend/target/stack-install</directory>
+      <outputDirectory>/bin</outputDirectory>
+      <fileMode>775</fileMode>
+      <directoryMode>775</directoryMode>
+    </fileSet>
   </fileSets>
 </assembly>

--- a/kore/pom.xml
+++ b/kore/pom.xml
@@ -21,6 +21,11 @@
       <version>3.3.2</version>
     </dependency>
     <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.4</version>
+    </dependency>
+    <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>18.0</version>
@@ -77,5 +82,10 @@
         </configuration>
       </plugin>
     </plugins>
+    <resources>
+      <resource>
+        <directory>haskell-backend/src/main/native/haskell-backend/src/test/resources</directory>
+      </resource>
+    </resources>
   </build>
 </project>

--- a/kore/src/test/scala/org/kframework/parser/kore/parser/TextToKoreTest.scala
+++ b/kore/src/test/scala/org/kframework/parser/kore/parser/TextToKoreTest.scala
@@ -1,0 +1,424 @@
+package org.kframework.parser.kore.parser
+
+import java.io.EOFException
+
+import junit.framework.TestFailure
+import org.apache.commons.io.FileUtils
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.kframework.parser.kore.Builders
+import org.kframework.parser.kore.implementation.DefaultBuilders
+import org.kframework.parser.kore.parser.{KoreToText, ParseError, TextToKore}
+
+class TextToKoreTest {
+
+  /**
+    * Tests for parsing sorts.
+    */
+  @Test def test_sort_1(): Unit = {
+    parseFromFile("test-sort-1.kore")
+  }
+  @Test def test_sort_2(): Unit = {
+    parseFromFile("test-sort-2.kore")
+  }
+  @Test def test_sort_3(): Unit = {
+    parseFromFile("test-sort-3.kore")
+  }
+  @Test def test_sort_4(): Unit = {
+    parseFromFile("test-sort-4.kore")
+  }
+
+
+  /**
+    * Tests for parsing symbols.
+    */
+  @Test def test_symbol_1(): Unit = {
+    parseFromFile("test-symbol-1.kore")
+  }
+  @Test def test_symbol_2(): Unit = {
+    parseFromFile("test-symbol-2.kore")
+  }
+  @Test def test_symbol_3(): Unit = {
+    parseFromFile("test-symbol-3.kore")
+  }
+  @Test def test_symbol_4(): Unit = {
+    parseFromFile("test-symbol-4.kore")
+  }
+  @Test def test_symbol_5(): Unit = {
+    parseFromFile("test-symbol-5.kore")
+  }
+  @Test def test_symbol_6(): Unit = {
+    parseFromFile("test-symbol-6.kore")
+  }
+  @Test def test_symbol_7(): Unit = {
+    parseFromFile("test-symbol-7.kore")
+  }
+  @Test def test_symbol_8(): Unit = {
+    parseFromFile("test-symbol-8.kore")
+  }
+
+  /**
+    * Tests for hooks.
+    */
+  @Test def test_hooks_1(): Unit = {
+    parseFromFile("test-hooks-1.kore")
+  }
+
+  @Test def test_hooks_2(): Unit = {
+    parseFromFile("test-hooks-2.kore")
+  }
+
+  @Test def test_hooks_3(): Unit = {
+    parseFromFile("test-hooks-3.kore")
+  }
+
+  /**
+    * Tests for parsing aliases.
+    */
+  @Test def test_alias_1(): Unit = {
+    parseFromFile("test-alias-1.kore")
+  }
+  @Test def test_alias_2(): Unit = {
+    parseFromFile("test-alias-2.kore")
+  }
+  @Test def test_alias_3(): Unit = {
+    parseFromFile("test-alias-3.kore")
+  }
+  @Test def test_alias_4(): Unit = {
+    parseFromFile("test-alias-4.kore")
+  }
+  @Test def test_alias_5(): Unit = {
+    parseFromFile("test-alias-5.kore")
+  }
+  @Test def test_alias_6(): Unit = {
+    parseFromFile("test-alias-6.kore")
+  }
+  @Test def test_alias_7(): Unit = {
+    parseFromFile("test-alias-7.kore")
+  }
+  @Test def test_alias_8(): Unit = {
+    parseFromFile("test-alias-8.kore")
+  }
+
+  /**
+    * Tests for parsing patterns.
+    */
+  @Test def test_pattern_1(): Unit = {
+    parseFromFile("test-pattern-1.kore")
+  }
+  @Test def test_pattern_2(): Unit = {
+    parseFromFile("test-pattern-2.kore")
+  }
+  @Test def test_pattern_3(): Unit = {
+    parseFromFile("test-pattern-3.kore")
+  }
+  @Test def test_pattern_4(): Unit = {
+    parseFromFile("test-pattern-4.kore")
+  }
+  @Test def test_pattern_5(): Unit = {
+    parseFromFile("test-pattern-5.kore")
+  }
+  @Test def test_pattern_6(): Unit = {
+    parseFromFile("test-pattern-6.kore")
+  }
+  @Test def test_pattern_7(): Unit = {
+    parseFromFile("test-pattern-7.kore")
+  }
+  @Test def test_pattern_8(): Unit = {
+    parseFromFile("test-pattern-8.kore")
+  }
+  @Test def test_pattern_9(): Unit = {
+    parseFromFile("test-pattern-9.kore")
+  }
+  @Test def test_pattern_10(): Unit = {
+    parseFromFile("test-pattern-10.kore")
+  }
+  @Test def test_pattern_11(): Unit = {
+    parseFromFile("test-pattern-11.kore")
+  }
+  @Test def test_pattern_12(): Unit = {
+    parseFromFile("test-pattern-12.kore")
+  }
+  @Test def test_pattern_13(): Unit = {
+    parseFromFile("test-pattern-13.kore")
+  }
+  /**
+    * Tests for parsing attributes.
+    */
+  @Test def test_attribute_1(): Unit = {
+    parseFromFile("test-attribute-1.kore")
+  }
+  @Test def test_attribute_2(): Unit = {
+    parseFromFile("test-attribute-2.kore")
+  }
+
+  /**
+    * Tests for comments.
+    */
+  @Test def test_comment_1(): Unit = {
+    parseFromFile("test-comment-1.kore")
+  }
+  @Test def test_comment_2(): Unit = {
+    parseFromFile("test-comment-2.kore")
+  }
+  @Test def test_comment_3(): Unit = {
+    parseFromFile("test-comment-3.kore")
+  }
+  @Test def test_comment_4(): Unit = {
+    parseFromFile("test-comment-4.kore")
+  }
+  @Test def test_comment_5(): Unit = {
+    parseFromFile("test-comment-5.kore")
+  }
+  @Test def test_comment_6(): Unit = {
+    parseFromFile("test-comment-6.kore")
+  }
+  @Test def test_comment_7(): Unit = {
+    parseFromFile("test-comment-7.kore")
+  }
+
+  /**
+    * Tests for strings.
+    */
+  @Test def test_string_1(): Unit = {
+    parseFromFile("test-string-1.kore")
+  }
+  @Test def test_string_2(): Unit = {
+    parseFromFile("test-string-2.kore")
+  }
+  @Test def test_string_3(): Unit = {
+    parseFromFile("test-string-3.kore")
+  }
+  @Test def test_string_4(): Unit = {
+    parseFromFile("test-string-4.kore")
+  }
+  @Test def test_string_5(): Unit = {
+    parseFromFile("test-string-5.kore")
+  }
+  @Test def test_string_6(): Unit = {
+    parseFromFile("test-string-6.kore")
+  }
+  @Test def test_string_7(): Unit = {
+    parseFromFile("test-string-7.kore")
+  }
+
+
+  /**
+    * Tests for exception and error handling.
+    */
+  @Test def test_exception_1(): Unit = {
+    parseFromFileExpectParseException("test-sort-5.kore")
+  }
+  @Test def test_exception_2(): Unit = {
+    parseFromFileExpectParseException("test-exception-2.kore")
+  }
+  @Test def test_exception_3(): Unit = {
+    parseFromFileExpectParseException("test-exception-3.kore")
+  }
+  @Test def test_exception_4(): Unit = {
+    parseFromFileExpectParseException("test-exception-4.kore")
+  }
+  @Test def test_exception_5(): Unit = {
+    parseFromFileExpectParseException("test-exception-5.kore")
+  }
+  @Test def test_exception_6(): Unit = {
+    parseFromFileExpectParseException("test-exception-6.kore")
+  }
+  @Test def test_exception_7(): Unit = {
+    parseFromFileExpectParseException("test-exception-7.kore")
+  }
+  @Test def test_exception_8(): Unit = {
+    parseFromFileExpectParseException("test-exception-8.kore")
+  }
+  @Test def test_exception_9(): Unit = {
+    parseFromFileExpectParseException("test-exception-9.kore")
+  }
+  @Test def test_exception_10(): Unit = {
+    parseFromFileExpectParseException("test-exception-10.kore")
+  }
+  @Test def test_exception_11(): Unit = {
+    parseFromFileExpectParseException("test-exception-11.kore")
+  }
+  @Test def test_exception_12(): Unit = {
+    parseFromFileExpectParseException("test-exception-12.kore")
+  }
+  @Test def test_exception_13(): Unit = {
+    parseFromFileExpectParseException("test-exception-13.kore")
+  }
+  @Test def test_exception_14(): Unit = {
+    parseFromFileExpectParseException("test-exception-14.kore")
+  }
+  @Test def test_exception_15(): Unit = {
+    parseFromFileExpectParseException("test-exception-15.kore")
+  }
+  @Test def test_exception_16(): Unit = {
+    parseFromFileExpectParseException("test-exception-16.kore")
+  }
+  @Test def test_exception_17(): Unit = {
+    parseFromFileExpectParseException("test-exception-17.kore")
+  }
+  @Test def test_exception_18(): Unit = {
+    parseFromFileExpectParseException("test-exception-18.kore")
+  }
+  @Test def test_exception_19(): Unit = {
+    parseFromFileExpectParseException("test-exception-19.kore")
+  }
+  @Test def test_exception_20(): Unit = {
+    parseFromFileExpectParseException("test-exception-20.kore")
+  }
+  @Test def test_exception_21(): Unit = {
+    parseFromFileExpectParseException("test-exception-21.kore")
+  }
+  @Test def test_exception_22(): Unit = {
+    parseFromFileExpectParseException("test-sort-6.kore")
+  }
+  @Test def test_exception_23(): Unit = {
+    parseFromFileExpectParseException("test-exception-23.kore")
+  }
+  @Test def test_exception_24(): Unit = {
+    parseFromFileExpectParseException("test-exception-24.kore")
+  }
+  @Test def test_exception_25(): Unit = {
+    parseFromFileExpectParseException("test-exception-25.kore")
+  }
+  @Test def test_exception_26(): Unit = {
+    parseFromFileExpectParseException("test-exception-26.kore")
+  }
+  @Test def test_exception_27(): Unit = {
+    parseFromFileExpectParseException("test-exception-27.kore")
+  }
+
+  /**
+    * Tests for scanner
+    */
+  @Test def test_scanner_1(): Unit = {
+    parseFromFile("test-scanner-1.kore")
+  }
+
+  /**
+    * Comprehensive tests for parsing complete and meaningful modules.
+    */
+
+
+  @Test def test_bool(): Unit = {
+    parseFromFile("bool.kore")
+  }
+  @Test def test_nat(): Unit = {
+    parseFromFile("nat.kore")
+  }
+  @Test def test_list(): Unit = {
+    parseFromFile("list.kore")
+  }
+  @Test def test_lambda(): Unit = {
+    parseFromFile("lambda.kore")
+  }
+  @Test def test_imp(): Unit = {
+    parseFromFile("imp.kore")
+  }
+  @Test def test_imp2(): Unit = {
+    parseFromFile("imp2.kore")
+  }
+
+
+  def strip(s: String): String = {
+    trim(s.stripMargin)
+  }
+
+  def trim(s: String): String = {
+    s.replaceAll("^\\s+|\\s+$", "") // s.replaceAll("^\\s+", "").replaceAll("\\s+$", "")
+  }
+
+  def parseFromStringWithExpected(s: String, expected: String): Unit = {
+    val src = io.Source.fromString(s)
+    try {
+      parseTest(SourceFOS(src), s)
+    } finally {
+      src.close()
+    }
+  }
+
+  def parseFromString(s: String): Unit = {
+    val src = io.Source.fromString(s)
+    try {
+      parseTest(SourceFOS(src), s)
+    } finally {
+      src.close()
+    }
+  }
+
+  def parseFromFile(file: String): Unit = {
+    val f = FileUtils.toFile(getClass.getResource("/" + file))
+    parseTest(FileFOS(f), FileUtils.readFileToString(f))
+  }
+
+  def parseFromFileExpectParseException(file: String): Unit = {
+    try {
+      parseFromFile(file) // expect ParseError being thrown
+      throw new Exception("Parse " + file + " succeeded while excepting ParseError.")
+    }
+    catch {
+      case _ : ParseError => // Expected
+    }
+  }
+
+  sealed trait FileOrSource
+  case class FileFOS(x: java.io.File) extends FileOrSource
+  case class SourceFOS(x: io.Source) extends FileOrSource
+
+  /** Tests if parse is correct by checking if
+    *   src ~~ unparse(parse(src))
+    * where src is a kore definition source file and
+    *       ~~ is the equiv relation modulo whitespaces & comments.
+    * Property:
+    *     src1 ~~ src2
+    * iff canonicalString(src1) == canonicalString(src2)
+    */
+  def parseTest(src: FileOrSource, expected: String): Unit = {
+    //TODO: Make test file parametric over builders.
+    val builder: Builders = DefaultBuilders
+    val begin = java.lang.System.nanoTime()
+    val minikore = src match {
+      case src: FileFOS => TextToKore(builder).parse(src.x)
+      case src: SourceFOS => TextToKore(builder).parse(src.x)
+    }
+    val end = java.lang.System.nanoTime(); println(end - begin)
+    val textOfMiniKore = KoreToText(minikore)
+
+    val canonicalString = src match {
+      case src: FileFOS => TextToKore(builder).canonicalString(src.x)
+      case src: SourceFOS => TextToKore(builder).canonicalString(src.x)
+    }
+
+    val canonicalStringOfTextOfMiniKore = src match {
+      case src: FileFOS => TextToKore(builder).canonicalString(textOfMiniKore)
+      case src: SourceFOS => TextToKore(builder).canonicalString(textOfMiniKore)
+    }
+    println(canonicalString)
+    println(canonicalStringOfTextOfMiniKore)
+    assertEquals(canonicalString, canonicalStringOfTextOfMiniKore)
+
+    // val outputfile = new java.io.File("/tmp/x")
+    // FileUtils.writeStringToFile(outputfile, text)
+    // if (expected == text) () // t == u(p(t))
+    // else if (trim(expected) == trim(text)) () // t == u(p(t)) modulo leading/trailing whitespaces
+    // else {
+    // assertEquals(expected.replaceAll("\\s+", ""), text.replaceAll("\\s+", "")) //   t  ==   u(p(t))  modulo whitespaces
+    // assertEquals(minikore, new TextToKore(builder).parse(io.Source.fromString(text))) // p(t) == p(u(p(t)))
+    // }
+  }
+
+  //  @Test def errorTest(): Unit = {
+  //    new TextToMini().error('a', "abc") match {
+  //      case ParseError(msg) =>
+  //        assertEquals(
+  //          strip("""
+  //            |ERROR: Line 0: Column 0: Expected 'a', but abc
+  //            |null
+  //            |^
+  //            |"""),
+  //          msg)
+  //      case _ => assert(false)
+  //    }
+  //  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
               <configLocation>src/main/config/checkstyle-copyright.xml</configLocation>
               <failsOnError>true</failsOnError>
               <consoleOutput>true</consoleOutput>
-              <excludes>llvm-backend/src/main/native/**,k-distribution/include/kore/prelude.kore,.idea/**,**/com/davekoelle/**,**/src/main/sdf/syntax/Integration.sdf</excludes>
+              <excludes>haskel-backend/src/main/native/**,llvm-backend/src/main/native/**,k-distribution/include/kore/prelude.kore,.idea/**,**/com/davekoelle/**,**/src/main/sdf/syntax/Integration.sdf</excludes>
             </configuration>
           </execution>
           <execution>
@@ -226,7 +226,7 @@
                 <sourceDirectory>${project.basedir}</sourceDirectory>
               </sourceDirectories>
               <includes>**/*.k</includes>
-              <excludes>llvm-backend/src/main/native/**</excludes>
+              <excludes>haskell-backend/src/main/native/**,llvm-backend/src/main/native/**</excludes>
               <configLocation>src/main/config/checkstyle-k.xml</configLocation>
               <failsOnError>true</failsOnError>
               <consoleOutput>true</consoleOutput>

--- a/src/main/scripts/jenkins
+++ b/src/main/scripts/jenkins
@@ -26,6 +26,11 @@ eval `opam config env`
 eval `perl -I$HOME/perl5/lib/perl5 -Mlocal::lib`
 source $HOME/.cargo/env
 
+notif "UPGRADING LOCAL STACK"
+export PATH=$HOME/.local/bin:$PATH
+stack upgrade --force-download
+stack --version
+
 notif "CLONING SUBMODULES"
 git submodule update --init --recursive
 


### PR DESCRIPTION
The [Kore parser in Scala](https://github.com/kframework/kore/tree/2104fc2ff35c580ee00cd0ebd742e076425d47c4/src/main/scala/org/kframework/kore) was using [the same tests](https://github.com/kframework/kore/tree/master/src/test/resources). This parser code was moved to [this repo](https://github.com/kframework/k/tree/master/kore/src/main/scala/org/kframework/parser/kore) but the [tests](https://github.com/kframework/kore/tree/2104fc2ff35c580ee00cd0ebd742e076425d47c4/src/test/scala/org/kframework) were not migrated yet.

currently failing tests:
```
Failed tests:
  test_string_1(org.kframework.parser.kore.parser.TextToKoreTest): expected:<[key{}("[\]?")]moduleTEST-STRIN...> but was:<[key{}("[]?")]moduleTEST-STRIN...>
  test_string_2(org.kframework.parser.kore.parser.TextToKoreTest): expected:<[key{}("[\]a")]moduleTEST-STRIN...> but was:<[key{}("[]a")]moduleTEST-STRIN...>
  test_string_3(org.kframework.parser.kore.parser.TextToKoreTest): expected:<[key{}("[\]v")]moduleTEST-STRIN...> but was:<[key{}("[]v")]moduleTEST-STRIN...>
  test_string_4(org.kframework.parser.kore.parser.TextToKoreTest): expected:<[key{}("[\0]7777")]moduleTEST-ST...> but was:<[key{}("[]7777")]moduleTEST-ST...>
  test_string_5(org.kframework.parser.kore.parser.TextToKoreTest): expected:<[key{}("[\]x7777")]moduleTEST-S...> but was:<[key{}("[]x7777")]moduleTEST-S...>
  test_string_6(org.kframework.parser.kore.parser.TextToKoreTest): expected:<[key{}("[\u00A9]")]moduleTEST-STRING...> but was:<[key{}("[©]")]moduleTEST-STRING...>
  test_string_7(org.kframework.parser.kore.parser.TextToKoreTest): expected:<[key{}("[\]U000120FF")]moduleTE...> but was:<[key{}("[]U000120FF")]moduleTE...>
```