### PR TITLE
java-backend: performance optimization

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/SMTLibTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/SMTLibTerm.java
@@ -6,14 +6,14 @@ import org.kframework.backend.java.symbolic.Visitor;
 
 public class SMTLibTerm extends Term {
 
-    private final String expression;
+    private final CharSequence expression;
 
-    public SMTLibTerm(String expression) {
+    public SMTLibTerm(CharSequence expression) {
         super(Kind.KITEM);
         this.expression = expression;
     }
 
-    public String expression() {
+    public CharSequence expression() {
         return expression;
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -9,7 +9,25 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.kframework.backend.java.builtins.BoolToken;
 import org.kframework.backend.java.builtins.IntToken;
-import org.kframework.backend.java.kil.*;
+import org.kframework.backend.java.kil.Bottom;
+import org.kframework.backend.java.kil.BuiltinList;
+import org.kframework.backend.java.kil.BuiltinMap;
+import org.kframework.backend.java.kil.CollectionInternalRepresentation;
+import org.kframework.backend.java.kil.ConstrainedTerm;
+import org.kframework.backend.java.kil.DataStructures;
+import org.kframework.backend.java.kil.GlobalContext;
+import org.kframework.backend.java.kil.JavaSymbolicObject;
+import org.kframework.backend.java.kil.KItem;
+import org.kframework.backend.java.kil.KLabel;
+import org.kframework.backend.java.kil.KLabelConstant;
+import org.kframework.backend.java.kil.KList;
+import org.kframework.backend.java.kil.Kind;
+import org.kframework.backend.java.kil.LocalRewriteTerm;
+import org.kframework.backend.java.kil.Sort;
+import org.kframework.backend.java.kil.SortSignature;
+import org.kframework.backend.java.kil.Term;
+import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.util.Constants;
 import org.kframework.backend.java.util.RewriteEngineUtils;
 import org.kframework.backend.java.util.StateLog;
@@ -825,7 +843,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
             }
 
             if (global.globalOptions.debug) {
-                System.err.println("Attempting to prove: \n\t" + left + "\n  implies \n\t" + right);
+                System.err.format("Attempting to prove: \n\t%s\n  implies \n\t%s\n", left, right);
             }
 
             right = right.orientSubstitution(existentialQuantVars);
@@ -845,7 +863,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                 // TODO (AndreiS): handle KList variables
                 Term condition = ((KList) ite.kList()).get(0);
                 if (global.globalOptions.debug) {
-                    System.err.println("Split on " + condition);
+                    System.err.format("Split on %s\n", condition);
                 }
                 TermContext context = TermContext.builder(global).build();
                 implications.add(Pair.of(left.add(condition, BoolToken.TRUE).simplify(context), right));

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -32,6 +32,7 @@ import org.kframework.krun.KRunOptions;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.Formatter;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -170,16 +171,23 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             /* bool2int */
             "smt_bool2int");
 
-    public static String translateConstraint(ConjunctiveFormula constraint) {
+    public static CharSequence translateConstraint(ConjunctiveFormula constraint) {
         KILtoSMTLib kil2SMT = new KILtoSMTLib(true, constraint.globalContext());
-        String expression = kil2SMT.translate(constraint).expression();
-        return kil2SMT.getSortAndFunctionDeclarations(kil2SMT.variables())
-                + kil2SMT.getAxioms()
-                + kil2SMT.getConstantDeclarations(kil2SMT.variables())
-                + "(assert " + expression + ")";
+
+        //this line has side effects used later
+        CharSequence expression = kil2SMT.translate(constraint).expression();
+
+        StringBuilder sb = new StringBuilder(1024);
+        kil2SMT.appendSortAndFunctionDeclarations(sb, kil2SMT.variables());
+        kil2SMT.appendAxioms(sb);
+        kil2SMT.appendConstantDeclarations(sb, kil2SMT.variables());
+        sb.append("(assert ")
+                .append(expression)
+                .append(")");
+        return sb;
     }
 
-    public static String translateImplication(
+    public static CharSequence translateImplication(
             ConjunctiveFormula leftHandSide,
             ConjunctiveFormula rightHandSide,
             Set<Variable> existentialQuantVars) {
@@ -195,16 +203,16 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         StringBuilder sb = new StringBuilder(1024);
         Sets.SetView<Variable> allVars = Sets.union(leftTransformer.variables(), rightTransformer.variables());
         Set<Variable> usedExistentialQuantVars = Sets.intersection(existentialQuantVars, rightTransformer.variables());
-        sb.append(leftTransformer.getSortAndFunctionDeclarations(allVars));
-        sb.append(leftTransformer.getAxioms());
-        sb.append(leftTransformer.getConstantDeclarations(Sets.difference(allVars, usedExistentialQuantVars)));
+        leftTransformer.appendSortAndFunctionDeclarations(sb, allVars);
+        leftTransformer.appendAxioms(sb);
+        leftTransformer.appendConstantDeclarations(sb, Sets.difference(allVars, usedExistentialQuantVars));
 
         sb.append("(assert (and\n  ");
         sb.append(leftExpression);
         sb.append("\n  (not ");
         if (!usedExistentialQuantVars.isEmpty()) {
             sb.append("(exists (");
-            sb.append(leftTransformer.getQuantifiedVariables(usedExistentialQuantVars));
+            leftTransformer.appendQuantifiedVariables(sb, usedExistentialQuantVars);
             sb.append(") ");
         }
         sb.append(rightExpression);
@@ -212,7 +220,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             sb.append(")");
         }
         sb.append(")\n))");
-        return sb.toString();
+        return sb;
     }
 
     private final Definition definition;
@@ -263,7 +271,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         }
     }
 
-    private String getSortAndFunctionDeclarations(Set<Variable> variables) {
+    private StringBuilder appendSortAndFunctionDeclarations(StringBuilder sb, Set<Variable> variables) {
         Set<Sort> sorts = new HashSet<>();
         List<KLabelConstant> functions = new ArrayList<>();
         for (KLabelConstant kLabel : definition.kLabels()) {
@@ -282,8 +290,6 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         for (Variable variable : variables) {
             sorts.add(renameSort(variable.sort()));
         }
-
-        StringBuilder sb = new StringBuilder();
 
         for (Sort sort : Sets.difference(sorts, Sets.union(SMTLIB_BUILTIN_SORTS, definition.smtPreludeSorts()))) {
             if (sort.equals(Sort.MAP) && krunOptions.experimental.smt.mapAsIntArray) {
@@ -309,21 +315,20 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             sb.append(")\n");
         }
 
-        return sb.toString();
+        return sb;
     }
 
-    private String getAxioms() {
-        StringBuilder sb = new StringBuilder();
+    private CharSequence appendAxioms(StringBuilder sb) {
         for (Rule rule : definition.functionRules().values()) {
             if (rule.att().contains(Attribute.SMT_LEMMA_KEY)) {
                 try {
                     KILtoSMTLib kil2SMT = new KILtoSMTLib(false, globalContext);
-                    String leftExpression = kil2SMT.translate(rule.leftHandSide()).expression();
-                    String rightExpression = kil2SMT.translate(rule.rightHandSide()).expression();
+                    CharSequence leftExpression = kil2SMT.translate(rule.leftHandSide()).expression();
+                    CharSequence rightExpression = kil2SMT.translate(rule.rightHandSide()).expression();
                     sb.append("(assert ");
                     if (!kil2SMT.variables().isEmpty()) {
                         sb.append("(forall (");
-                        sb.append(kil2SMT.getQuantifiedVariables(kil2SMT.variables()));
+                        kil2SMT.appendQuantifiedVariables(sb, kil2SMT.variables());
                         sb.append(") ");
                         //sb.append(") (! ");
                     }
@@ -342,11 +347,10 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
                 } catch (UnsupportedOperationException e) { }
             }
         }
-        return sb.toString();
+        return sb;
     }
 
-    private String getConstantDeclarations(Set<Variable> variables) {
-        StringBuilder sb = new StringBuilder();
+    private CharSequence appendConstantDeclarations(StringBuilder sb, Set<Variable> variables) {
         for (Variable variable : variables) {
             sb.append("(declare-fun ");
             sb.append("|").append(variable.name()).append("|");
@@ -356,11 +360,10 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             sb.append(sortName);
             sb.append(")\n");
         }
-        return sb.toString();
+        return sb;
     }
 
-    private String getQuantifiedVariables(Set<Variable> variables) {
-        StringBuilder sb = new StringBuilder();
+    private CharSequence appendQuantifiedVariables(StringBuilder sb, Set<Variable> variables) {
         for (Variable variable : variables) {
             sb.append("(");
             sb.append("|").append(variable.name()).append("|");
@@ -370,7 +373,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             sb.append(sortName);
             sb.append(")");
         }
-        return sb.toString();
+        return sb;
     }
 
     private String getSortName(Variable variable) {
@@ -422,7 +425,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         }
 
         if (equalities.isEmpty()) {
-            return new SMTLibTerm("true");
+            return new SMTLibTerm(Boolean.TRUE.toString());
         }
 
         StringBuilder sb = new StringBuilder();
@@ -452,7 +455,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             sb.append(" true");
         }
         sb.append(")");
-        return new SMTLibTerm(sb.toString());
+        return new SMTLibTerm(sb);
     }
 
     public CharSequence translateTerm(Term term) {
@@ -540,7 +543,8 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             // smtlib expression instead of operator
             String expression = label;
             for (int i = 0; i < kList.getContents().size(); i++) {
-                expression = expression.replaceAll("#" + (i + 1) + "(?![0-9])", translate(kList.get(i)).expression());
+                expression = expression.replaceAll("#" + (i + 1) + "(?![0-9])",
+                        translate(kList.get(i)).expression().toString());
             }
             return new SMTLibTerm(expression);
         }
@@ -571,7 +575,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
                 sb.append(translate(argument).expression());
             }
             sb.append(")");
-            return new SMTLibTerm(sb.toString());
+            return new SMTLibTerm(sb);
         } else {
             return new SMTLibTerm(label);
         }
@@ -595,10 +599,13 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         }
         assert !krunOptions.experimental.smt.floatsAsPO;
 
-        return new SMTLibTerm(String.format(
+        StringBuilder sb = new StringBuilder();
+        new Formatter(sb).format(
                 "((_ asFloat %d %d) roundNearestTiesToEven %s 0)",
                 floatToken.exponent(), floatToken.bigFloatValue().precision(),
-                floatToken.bigFloatValue().toString("%f")));
+                floatToken.bigFloatValue().toString("%f"));
+
+        return new SMTLibTerm(sb);
     }
 
     @Override
@@ -609,7 +616,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             BigInteger value = bitVector.unsignedValue();
             sb.append(value.testBit(i) ? "1" : "0");
         }
-        return new SMTLibTerm(sb.toString());
+        return new SMTLibTerm(sb);
     }
 
     @Override

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -187,6 +187,11 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         return sb;
     }
 
+    /**
+     * Generates the z3 query for "left /\ !right".
+     * left -> right <==> !(left /\ !right)
+     * => this query should be unsat for implication to be proven.
+     */
     public static CharSequence translateImplication(
             ConjunctiveFormula leftHandSide,
             ConjunctiveFormula rightHandSide,

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
@@ -77,6 +77,9 @@ public class SMTOperations {
                 } finally {
                     left.globalContext().profiler.queryBuildTimer.stop();
                 }
+                if (global.debug) {
+                    System.err.format("\nz3 query: %s\n", query);
+                }
                 return z3.isUnsat(query, smtOptions.z3ImplTimeout, left.globalContext().profiler.z3Implication);
             } catch (UnsupportedOperationException | SMTTranslationFailure e) {
                 if (!smtOptions.ignoreMissingSMTLibWarning) {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
@@ -46,7 +46,7 @@ public class SMTOperations {
             constraint.globalContext().profiler.queryBuildTimer.start();
             CharSequence query;
             try {
-                query = KILtoSMTLib.translateConstraint(constraint);
+                query = KILtoSMTLib.translateConstraint(constraint).toString();
             } finally {
                 constraint.globalContext().profiler.queryBuildTimer.stop();
             }
@@ -73,7 +73,7 @@ public class SMTOperations {
                 left.globalContext().profiler.queryBuildTimer.start();
                 CharSequence query;
                 try {
-                    query = KILtoSMTLib.translateImplication(left, right, existentialQuantVars);
+                    query = KILtoSMTLib.translateImplication(left, right, existentialQuantVars).toString();
                 } finally {
                     left.globalContext().profiler.queryBuildTimer.stop();
                 }


### PR DESCRIPTION
1. Reduced the usage of StringBuilder.toString().
2. Replaced System.out.println with System.out.format() when makes sense.

Questionable effect, but other commits in K-gnosis depend on it. Prerequisite to PR the rest.