### PR TITLE
try to reuse node for docker container

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,6 +67,7 @@ pipeline {
         docker {
           image 'ubuntu:bionic'
           args '-u 0'
+          reuseNode true
         }
       }
       options { skipDefaultCheckout() }


### PR DESCRIPTION
I believe this should solve the deadlock we experienced with K builds. The issue as I understand it is that the jenkins job locks an executor at the top level at the beginning of the pipeline and doesn't release it until the end, but it currently requires a second executor in order to test the debian package. So if all our builds are stuck at that step, it will deadlock trying to create a second executor for the build instead of reusing the one that was already present. This should cause it to launch the container on the same node, thus not requiring a new executor and preventing the deadlock.