### PR TITLE
Java Backend logging batch 1

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -825,7 +825,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
             }
 
             if (global.globalOptions.debug) {
-                System.err.println("Attempting to prove: \n\t" + left + "\n  implies \n\t" + right);
+                System.err.println("\nAttempting to prove:\n================= \n\t" + left + "\n  implies \n\t" + right);
             }
 
             right = right.orientSubstitution(existentialQuantVars);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/EquivChecker.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/EquivChecker.java
@@ -131,7 +131,7 @@ public class EquivChecker {
             ++steps;
             for (ConstrainedTerm curr : queue) {
 
-                java.util.List<ConstrainedTerm> nexts = rewriter.fastComputeRewriteStep(curr, false, true, true);
+                java.util.List<ConstrainedTerm> nexts = rewriter.fastComputeRewriteStep(curr, false, true, true, steps);
 
                 if (nexts.isEmpty()) {
                     /* final term */

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
@@ -2,34 +2,22 @@
 
 package org.kframework.backend.java.symbolic;
 
-import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.ListMultimap;
-import com.google.common.collect.Multiset;
-import com.google.common.collect.Multisets;
-import com.google.common.collect.Sets;
+import com.google.common.collect.*;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.kframework.attributes.Att;
 import org.kframework.backend.java.builtins.BoolToken;
 import org.kframework.backend.java.compile.KOREtoBackendKIL;
 import org.kframework.backend.java.kil.*;
+import org.kframework.backend.java.utils.BitSet;
 import org.kframework.builtin.KLabels;
 import org.kframework.kore.KApply;
-import org.kframework.backend.java.utils.BitSet;
 
-import java.util.ArrayList;
+import java.util.*;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
-import java.util.Queue;
-import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.kframework.Collections.*;
+import static org.kframework.Collections.List;
 
 /**
  * A very fast interpreted matching implementation based on merging the rules into a decision-tree like structure.
@@ -83,7 +71,7 @@ public class FastRuleMatcher {
             boolean computeOne,
             List<String> transitions,
             boolean proveFlag,
-            TermContext context) {
+            TermContext context, int step) {
 
         ruleMask.stream().forEach(i -> constraints[i] = ConjunctiveFormula.of(context.global()));
         empty = BitSet.apply(ruleCount);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -210,7 +210,7 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
             List<org.kframework.backend.java.kil.Rule> javaRules = processProofRules.getJavaRules();
             KOREtoBackendKIL converter = processProofRules.getConverter();
             TermContext termContext = processProofRules.getTermContext();
-            List<org.kframework.backend.java.kil.Rule> allRules = javaRules.stream()
+            List<org.kframework.backend.java.kil.Rule> specRules = javaRules.stream()
                     .map(org.kframework.backend.java.kil.Rule::renameVariables)
                     .collect(Collectors.toList());
 
@@ -230,7 +230,7 @@ public class InitializeRewriter implements Function<Module, Rewriter> {
                         ConstrainedTerm lhs = r.createLhsPattern(termContext);
                         ConstrainedTerm rhs = r.createRhsPattern();
                         termContext.setInitialVariables(lhs.variableSet());
-                        return rewriter.proveRule(r, lhs, rhs, allRules, kem);
+                        return rewriter.proveRule(r, lhs, rhs, specRules, kem);
                     })
                     .flatMap(List::stream)
                     .collect(Collectors.toList());

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -47,6 +47,21 @@ public final class JavaExecutionOptions {
     @Parameter(names={"--state-log-events"}, converter=LogEventConverter.class, description="Comma-separated list of events to log: [OPEN|REACHINIT|REACHTARGET|REACHPROVED|NODE|RULE|SRULE|RULEATTEMPT|IMPLICATION|Z3QUERY|Z3RESULT|CLOSE]")
     public List<StateLog.LogEvent> stateLogEvents = Collections.emptyList();
 
+    @Parameter(names="--branching-allowed", arity=1, description="Number of branching events allowed before a forcible stop.")
+    public int branchingAllowed = Integer.MAX_VALUE;
+
+    @Parameter(names="--log", description="Log every step. KEVM only.")
+    public boolean log = false;
+
+    @Parameter(names="--log-stmts-only", description="Log only steps that execute a statement, without intermediary steps. " +
+            "Except when intermediary steps are important for other reason, like branching. KEVM only.")
+    public boolean logStmtsOnly = false;
+
+    @Parameter(names="--log-basic",
+            description="Log most basic information: summary of initial step, final steps and final implications." +
+                    " All custom logging only works for KEVM-based specs.")
+    public boolean logBasic = false;
+
     public static class LogEventConverter extends BaseEnumConverter<StateLog.LogEvent> {
 
         public LogEventConverter(String optionName) {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -588,21 +588,21 @@ public class SymbolicRewriter {
         queue.add(initialTerm);
         boolean guarded = false;
         int step = 0;
-        globalOptions.logBasic |= globalOptions.logStmtsOnly | globalOptions.log;
+        global.javaExecutionOptions.logBasic |= global.javaExecutionOptions.logStmtsOnly | global.javaExecutionOptions.log;
 
-        if (globalOptions.log) {
+        if (global.javaExecutionOptions.log) {
             System.out.println("\nTarget term\n=====================\n");
             System.out.println(targetTerm);
         }
         KItem targetCallData = getCell((KItem) targetTerm.term(), "<callData>");
-        int branchingRemaining = globalOptions.branchingAllowed;
+        int branchingRemaining = global.javaExecutionOptions.branchingAllowed;
         boolean nextStepLogEnabled = false;
         while (!queue.isEmpty()) {
             step++;
             int v = 0;
-            boolean oldLogEnabled = globalOptions.log;
+            boolean oldLogEnabled = global.javaExecutionOptions.log;
             if (nextStepLogEnabled) {
-                globalOptions.log = true;
+                global.javaExecutionOptions.log = true;
             }
             nextStepLogEnabled = false;
 
@@ -619,30 +619,30 @@ public class SymbolicRewriter {
                                          && !kSequence.get(1).toString().equals("#execute_EVM(.KList)")
                                  //case <k> has only one item: it must be #halt
                                  : kContent != null && kContent.toString().equals("#halt_EVM(.KList)");
-                boolean oldLog = globalOptions.log;
+                boolean oldLog = global.javaExecutionOptions.log;
 
                 if (term.implies(targetTerm)) {
                     global.stateLog.log(StateLog.LogEvent.REACHPROVED, term.term(), term.constraint());
                     successPaths++;
-                    if (globalOptions.logBasic) {
+                    if (global.javaExecutionOptions.logBasic) {
                         System.out.println("\n============\nStep " + step + ": eliminated!\n============\n");
                         logStep(step, v, targetCallData, term, true);
                     }
                     continue;
                 } else {
-                    logStep(step, v, targetCallData, term, step == 1 && globalOptions.logBasic);
+                    logStep(step, v, targetCallData, term, step == 1 && global.javaExecutionOptions.logBasic);
                 }
 
                 //stopping at halt
                 if (isHalt) {
-                    if (!globalOptions.log) {
-                        logStep(step, v, targetCallData, term, globalOptions.logBasic);
+                    if (!global.javaExecutionOptions.log) {
+                        logStep(step, v, targetCallData, term, global.javaExecutionOptions.logBasic);
                     }
                     System.out.println("Halt! Terminating branch.");
                     proofResults.add(term);
                     continue;
                 } else {
-                    logStep(step, v, targetCallData, term, step == 1 && globalOptions.logBasic);
+                    logStep(step, v, targetCallData, term, step == 1 && global.javaExecutionOptions.logBasic);
                 }
 
                 /* TODO(AndreiS): terminate the proof with failure based on the klabel _~>_
@@ -669,11 +669,11 @@ public class SymbolicRewriter {
                     ConstrainedTerm result = applySpecRules(term, specRules);
                     if (result != null) {
                         nextStepLogEnabled = true;
-                        if (!globalOptions.log) {
+                        if (!global.javaExecutionOptions.log) {
                             logStep(step, v, targetCallData, term, true);
                         }
                         // re-running constraint generation again for debug purposes
-                        if (globalOptions.logBasic) {
+                        if (global.javaExecutionOptions.logBasic) {
                             System.err.println("\nApplying specification rule\n=========================\n");
                         }
                         if (visited.add(result)) {
@@ -693,7 +693,7 @@ public class SymbolicRewriter {
                     // DISABLE EXCEPTION CHECKSTYLE
                 } catch (Throwable e) {
                     // ENABLE EXCEPTION CHECKSTYLE
-                    if (!globalOptions.log) {
+                    if (!global.javaExecutionOptions.log) {
                         logStep(step, v, targetCallData, term, true);
                     }
                     System.out.println("\n\nTerm throwing exception\n============================\n\n");
@@ -706,7 +706,7 @@ public class SymbolicRewriter {
                     throw e;
                 }
                 if (results.isEmpty()) {
-                    if (!globalOptions.log) {
+                    if (!global.javaExecutionOptions.log) {
                         logStep(step, v, targetCallData, term, true);
                     }
                     System.out.println("\nStep above: " + step + ", evaluation ended with no successors.");
@@ -716,7 +716,7 @@ public class SymbolicRewriter {
 
                 if (results.size() > 1) {
                     nextStepLogEnabled = true;
-                    if (!globalOptions.log) {
+                    if (!global.javaExecutionOptions.log) {
                         logStep(step, v, targetCallData, term, true);
                     }
                     if (branchingRemaining == 0) {
@@ -726,7 +726,7 @@ public class SymbolicRewriter {
                         continue;
                     } else {
                         branchingRemaining--;
-                        if (globalOptions.logBasic) {
+                        if (global.javaExecutionOptions.logBasic) {
                             System.out.println("\nBranching!\n=====================\n");
                         }
                     }
@@ -743,7 +743,7 @@ public class SymbolicRewriter {
                         nextQueue.add(result);
                     }
                 }
-                globalOptions.log = oldLog;
+                global.javaExecutionOptions.log = oldLog;
             }
 
             /* swap the queues */
@@ -754,7 +754,7 @@ public class SymbolicRewriter {
             nextQueue.clear();
             guarded = true;
 
-            globalOptions.log = oldLogEnabled;
+            global.javaExecutionOptions.log = oldLogEnabled;
         }
 
         if (globalOptions.verbose) {
@@ -785,7 +785,7 @@ public class SymbolicRewriter {
     }
 
     private void logStep(int step, int v, KItem targetCallData, ConstrainedTerm term, boolean forced) {
-        if (!globalOptions.logBasic) {
+        if (!global.javaExecutionOptions.logBasic) {
             return;
         }
         KItem top = (KItem) term.term();
@@ -809,14 +809,14 @@ public class SymbolicRewriter {
             forced = true;
         }
 
-        boolean inNewStmt = globalOptions.logStmtsOnly && kSequence != null && inNewStmt(kSequence);
+        boolean inNewStmt = global.javaExecutionOptions.logStmtsOnly && kSequence != null && inNewStmt(kSequence);
 
-        if (globalOptions.log || forced || inNewStmt) {
+        if (global.javaExecutionOptions.log || forced || inNewStmt) {
             System.out.format("\nSTEP %d v%d : %.3f s \n===================\n",
                     step, v, (System.currentTimeMillis() - global.profiler.getStartTime()) / 1000.);
         }
 
-        if (globalOptions.log || forced || inNewStmt) {
+        if (global.javaExecutionOptions.log || forced || inNewStmt) {
             //Pretty printing no longer viable, too slow after last rebase.
             //KProve.prettyPrint(k);
             System.out.println(toStringOrEmpty(k));

--- a/kernel/src/main/java/org/kframework/main/GlobalOptions.java
+++ b/kernel/src/main/java/org/kframework/main/GlobalOptions.java
@@ -89,19 +89,4 @@ public final class GlobalOptions {
 
     @Parameter(names={"--warnings-to-errors", "-w2e"}, description="Convert warnings to errors.")
     public boolean warnings2errors = false;
-
-    @Parameter(names="--branching-allowed", arity=1, description="Number of branching events allowed before a forcible stop.")
-    public int branchingAllowed = Integer.MAX_VALUE;
-
-    @Parameter(names="--log", description="Log every step. KEVM only.")
-    public boolean log = false;
-
-    @Parameter(names="--log-stmts-only", description="Log only steps that execute a statement, without intermediary steps. " +
-            "Except when intermediary steps are important for other reason, like branching. KEVM only.")
-    public boolean logStmtsOnly = false;
-
-    @Parameter(names="--log-basic",
-            description="Log most basic information: summary of initial step, final steps and final implications." +
-                    " All custom logging only works for KEVM-based specs.")
-    public boolean logBasic = false;
 }

--- a/kernel/src/main/java/org/kframework/main/GlobalOptions.java
+++ b/kernel/src/main/java/org/kframework/main/GlobalOptions.java
@@ -89,4 +89,19 @@ public final class GlobalOptions {
 
     @Parameter(names={"--warnings-to-errors", "-w2e"}, description="Convert warnings to errors.")
     public boolean warnings2errors = false;
+
+    @Parameter(names="--branching-allowed", arity=1, description="Number of branching events allowed before a forcible stop.")
+    public int branchingAllowed = Integer.MAX_VALUE;
+
+    @Parameter(names="--log", description="Log every step. KEVM only.")
+    public boolean log = false;
+
+    @Parameter(names="--log-stmts-only", description="Log only steps that execute a statement, without intermediary steps. " +
+            "Except when intermediary steps are important for other reason, like branching. KEVM only.")
+    public boolean logStmtsOnly = false;
+
+    @Parameter(names="--log-basic",
+            description="Log most basic information: summary of initial step, final steps and final implications." +
+                    " All custom logging only works for KEVM-based specs.")
+    public boolean logBasic = false;
 }


### PR DESCRIPTION
This is the first batch of logging features from K branch `gnosis`. Options implemented here are not in their final state, they were further generalized in later commits and made semantics-agnostic. Yet it is only feasible to put in the first PR this much. Later improvements will follow.

# Text from important commits

## Commit 1
Java Backend Logging PR1: options --log, --log-basic, --log-stmts-only, --branching-allowed.

Details:
  - logging options: --log, --log-basic, --log-stmts-only. They log a KEVM-specific subset of configuration at certain steps.
  - option --branching-allowed to limit branchings. If allowed number of branchings is exceeded, execution ends.

Additional:
  - added parameter `step` to some methods, for debugging.
  - optimized printing of the term when exception is thrown.
  - other minor logs. All enabled by at least --log-basic.

## Commit 2
Java Backend KEVM customization: Detecting final state, when first item in <k> is #halt and there is nothing left to execute.
If this state is reached and target term is not matched, execution is halted.

Useful in kprove, to prevent further symbolic execution and needless branching that would happen if spec would continue to evaluate past intended final state.

If specification does not use #halt in target term or is non-KEVM, this customization has no effect.
Temporary. Was replaced by more general and semantics-agnostic `--halt-cells`, that is about to be PRed.
