### PR TITLE
Java Backend Logging: First batch of logging features

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -96,8 +96,8 @@ public class ConstrainedTerm extends JavaSymbolicObject {
         return data.constraint;
     }
 
-    public boolean implies(ConstrainedTerm constrainedTerm, Rule specRule) {
-        ConjunctiveFormula conjunctiveFormula = matchImplies(constrainedTerm, true,
+    public boolean implies(ConstrainedTerm constrainedTerm, Rule specRule, boolean logFailures) {
+        ConjunctiveFormula conjunctiveFormula = matchImplies(constrainedTerm, true, logFailures,
                 new FormulaContext(FormulaContext.Kind.FinalImplication, specRule), specRule.matchingSymbols());
         return conjunctiveFormula != null;
     }
@@ -130,12 +130,12 @@ public class ConstrainedTerm extends JavaSymbolicObject {
      * @return If implication value is {@code true}, return the unification constraint:
      * implicationLHS /\ implicationRHS. Otherwise return {@code true}.
      */
-    public ConjunctiveFormula matchImplies(ConstrainedTerm matchRHSTerm, boolean expand,
+    public ConjunctiveFormula matchImplies(ConstrainedTerm matchRHSTerm, boolean expand, boolean logFailures,
                                            FormulaContext formulaContext, Set<String> matchingSymbols) {
         ConjunctiveFormula constraint = ConjunctiveFormula.of(matchRHSTerm.termContext().global())
                 .add(data.constraint.substitution())
                 .add(data.term, matchRHSTerm.data.term)
-                .simplifyBeforePatternFolding(context);
+                .simplifyBeforePatternFolding(context, logFailures);
         if (constraint.isFalseExtended()) {
             return null;
         }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -579,6 +579,10 @@ public class KItem extends Term implements KItemRepresentation {
                                 appliedRule = rule;
                             }
 
+                            if (kItem.global.javaExecutionOptions.logRulesPublic && result != null) {
+                                RuleSourceUtil.printRuleAndSource(rule);
+                            }
+
                             /*
                              * If the function definitions do not need to be deterministic, try them in order
                              * and apply the first one that matches.
@@ -696,6 +700,10 @@ public class KItem extends Term implements KItemRepresentation {
                 RuleAuditing.succeed(rule);
                 Term rightHandSide = rule.rightHandSide();
                 rightHandSide = rightHandSide.substituteAndEvaluate(solution, context);
+
+                if (global.javaExecutionOptions.logRulesPublic) {
+                    RuleSourceUtil.printRuleAndSource(rule);
+                }
                 return rightHandSide;
             } finally {
                 if (RuleAuditing.isAuditBegun()) {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -372,7 +372,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
 
 
     public ConjunctiveFormula simplify() {
-        return simplify(false, true, TermContext.builder(global).build());
+        return simplify(false, true, TermContext.builder(global).build(), false);
     }
 
     /**
@@ -380,7 +380,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
      * Decomposes equalities by using unification.
      */
     public ConjunctiveFormula simplify(TermContext context) {
-        return simplify(false, true, context);
+        return simplify(false, true, context, false);
     }
 
     /**
@@ -388,19 +388,19 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
      * between builtin data structures will remain intact if they cannot be
      * resolved completely.
      */
-    public ConjunctiveFormula simplifyBeforePatternFolding(TermContext context) {
-        return simplify(false, false, context);
+    public ConjunctiveFormula simplifyBeforePatternFolding(TermContext context, boolean logFailures) {
+        return simplify(false, false, context, logFailures);
     }
 
     public ConjunctiveFormula simplifyModuloPatternFolding(TermContext context) {
-        return simplify(true, true, context);
+        return simplify(true, true, context, false);
     }
 
     /**
      * Simplifies this conjunctive formula as much as possible.
      * Decomposes equalities by using unification.
      */
-    private ConjunctiveFormula simplify(boolean patternFolding, boolean partialSimplification, TermContext context) {
+    private ConjunctiveFormula simplify(boolean patternFolding, boolean partialSimplification, TermContext context, boolean logFailures) {
         assert !isFalse();
         ConjunctiveFormula originalTopConstraint = context.getTopConstraint();
         Substitution<Variable, Term> substitution = this.substitution;
@@ -431,7 +431,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                         if (equality.isSimplifiableByCurrentAlgorithm()) {
                             // (decompose + conflict)*
                             FastRuleMatcher unifier = new FastRuleMatcher(global, 1);
-                            ConjunctiveFormula unificationConstraint = unifier.unifyEquality(leftHandSide, rightHandSide, patternFolding, partialSimplification, false, context);
+                            ConjunctiveFormula unificationConstraint = unifier.unifyEquality(leftHandSide, rightHandSide, patternFolding, partialSimplification, false, context, logFailures);
                             if (unificationConstraint.isFalse()) {
                                 return falsify(
                                         substitution,

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/EquivChecker.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/EquivChecker.java
@@ -132,7 +132,7 @@ public class EquivChecker {
             ++steps;
             for (ConstrainedTerm curr : queue) {
 
-                java.util.List<ConstrainedTerm> nexts = rewriter.fastComputeRewriteStep(curr, false, true, true);
+                java.util.List<ConstrainedTerm> nexts = rewriter.fastComputeRewriteStep(curr, false, true, true, steps);
 
                 if (nexts.isEmpty()) {
                     /* final term */
@@ -142,7 +142,7 @@ public class EquivChecker {
             loop:
                 for (ConstrainedTerm next : nexts) {
                     for (int i = 0; i < numSyncPoints; i++) {
-                        ConjunctiveFormula constraint = next.matchImplies(targetSyncNodes.get(i), true,
+                        ConjunctiveFormula constraint = next.matchImplies(targetSyncNodes.get(i), true, false,
                                 new FormulaContext(FormulaContext.Kind.EquivImplication, null, next.termContext().global()), null);
                         if (constraint != null) {
                             SyncNode node = new SyncNode(currSyncNode.startSyncPoint, currSyncNode, next, constraint);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -182,6 +182,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
                 rewritingContext.profiler.logInitTime();
             }
             rewritingContext.setExecutionPhase(true);
+            rewritingContext.javaExecutionOptions.logRulesPublic = rewritingContext.javaExecutionOptions.logRules;
             RewriterResult result = rewriter.rewrite(new ConstrainedTerm(backendKil, termContext), depth.orElse(-1));
             rewritingContext.stateLog.close();
             return result;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -58,12 +58,12 @@ public final class JavaExecutionOptions {
     @Parameter(names="--branching-allowed", arity=1, description="Number of branching events allowed before a forcible stop.")
     public int branchingAllowed = Integer.MAX_VALUE;
 
-    @Parameter(names="--log", description="Log every step. KEVM only.")
+    @Parameter(names="--log", description="Log every step.")
     public boolean log = false;
 
     @Parameter(names="--log-basic",
-            description="Log most basic information: summary of initial step, final steps and final implications." +
-                    " All custom logging only works for KEVM-based specs.")
+            description="Log most basic information: summary of initial step, final steps and final implications, " +
+                    "branching points.")
     public boolean logBasic = false;
 
     @Parameter(names="--log-cells", description="Specify what subset of configuration has to be printed when" +
@@ -83,7 +83,9 @@ public final class JavaExecutionOptions {
     public List<String> logCells = Arrays.asList("k", "output", "statusCode", "localMem", "pc", "gas", "wordStack",
             "callData", "accounts");
 
-    @Parameter(names="--log-rules", description="Log applied rules.")
+    @Parameter(names="--log-rules", description="Log applied rules." +
+            "Including \"virtual rewrites\", e.g. rules applied in side conditions of other rules, that in the end " +
+            "don't have all their side conditions satisfied and are not applied.")
     public boolean logRules = false;
 
     @Parameter(names="--debug-z3",

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -7,6 +7,7 @@ import org.kframework.backend.java.util.StateLog;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.BaseEnumConverter;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -54,6 +55,37 @@ public final class JavaExecutionOptions {
             description="Clear function cache after initialization phase. Frees some memory. Use IN ADDITION to --cache-func")
     public boolean cacheFunctionsOptimized = false;
 
+    @Parameter(names="--branching-allowed", arity=1, description="Number of branching events allowed before a forcible stop.")
+    public int branchingAllowed = Integer.MAX_VALUE;
+
+    @Parameter(names="--log", description="Log every step. KEVM only.")
+    public boolean log = false;
+
+    @Parameter(names="--log-basic",
+            description="Log most basic information: summary of initial step, final steps and final implications." +
+                    " All custom logging only works for KEVM-based specs.")
+    public boolean logBasic = false;
+
+    @Parameter(names="--log-cells", description="Specify what subset of configuration has to be printed when" +
+            " an execution step is logged." +
+            " Usage format: --log-pretty \"v2,v2,...\" , where v1,v2,... are either cell names," +
+            " cell names in parentheses (like \"(k)\") or one of: \"(#pc)\", \"(#result)\". " +
+            " The cells specified without parentheses are printed with toString()." +
+            " The cells specified in parentheses are pretty-printed. Certain cells have custom formatting." +
+            " The last 2 options mean:" +
+            " (#pc) = pretty print the path condition (constraint)." +
+            " (#result) = fully pretty-print the final result (e.g. the configuration for paths that were not proved)." +
+            " This last option is very slow." +
+            " Default value is:" +
+            " --log-cells k,output,statusCode,localMem,pc,gas,wordStack,callData,accounts" +
+            " Recommended alternative value:" +
+            " --log-cells \"(k),output,statusCode,localMem,pc,gas,wordStack,callData,accounts,(#pc)\"")
+    public List<String> logCells = Arrays.asList("k", "output", "statusCode", "localMem", "pc", "gas", "wordStack",
+            "callData", "accounts");
+
+    @Parameter(names="--log-rules", description="Log applied rules.")
+    public boolean logRules = false;
+
     @Parameter(names="--debug-z3",
             description="Log formulae fed to z3 together with the rule that triggered them.")
     public boolean debugZ3 = false;
@@ -61,6 +93,8 @@ public final class JavaExecutionOptions {
     @Parameter(names="--debug-z3-queries",
             description="Log actual z3 queries. Activates --debug-z3 automatically.")
     public boolean debugZ3Queries = false;
+
+    public boolean logRulesPublic = false;
 
     public static class LogEventConverter extends BaseEnumConverter<StateLog.LogEvent> {
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -26,6 +26,7 @@ import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.util.StateLog;
 import org.kframework.backend.java.util.FormulaContext;
+import org.kframework.backend.java.util.RuleSourceUtil;
 import org.kframework.backend.java.utils.BitSet;
 import org.kframework.builtin.KLabels;
 import org.kframework.kore.FindK;
@@ -44,6 +45,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.io.File;
 
@@ -73,6 +75,7 @@ public class SymbolicRewriter {
         this.theFastMatcher = new FastRuleMatcher(global, definition.ruleTable.size());
         this.transition = true;
         this.global = global;
+        parseLogCells();
     }
 
     public KOREtoBackendKIL getConstructor() {
@@ -99,7 +102,7 @@ public class SymbolicRewriter {
     }
 
     private List<ConstrainedTerm> computeRewriteStep(ConstrainedTerm constrainedTerm, int step, boolean computeOne) {
-        return fastComputeRewriteStep(constrainedTerm, computeOne, false, false);
+        return fastComputeRewriteStep(constrainedTerm, computeOne, false, false, step);
     }
 
     /**
@@ -145,7 +148,7 @@ public class SymbolicRewriter {
 
     }
 
-    public List<ConstrainedTerm> fastComputeRewriteStep(ConstrainedTerm subject, boolean computeOne, boolean narrowing, boolean proofFlag) {
+    public List<ConstrainedTerm> fastComputeRewriteStep(ConstrainedTerm subject, boolean computeOne, boolean narrowing, boolean proofFlag, int step) {
         global.stateLog.log(StateLog.LogEvent.NODE, subject.term(), subject.constraint());
         List<ConstrainedTerm> results = new ArrayList<>();
         if (definition.automaton == null) {
@@ -159,10 +162,13 @@ public class SymbolicRewriter {
                 computeOne,
                 transitions,
                 proofFlag,
-                subject.termContext());
+                subject.termContext(), step);
         for (FastRuleMatcher.RuleMatchResult matchResult : matches) {
             Rule rule = definition.ruleTable.get(matchResult.ruleIndex);
             global.stateLog.log(StateLog.LogEvent.RULEATTEMPT, rule.toKRewrite());
+            if (global.javaExecutionOptions.logRulesPublic) {
+                RuleSourceUtil.printRuleAndSource(rule);
+            }
 
             Substitution<Variable, Term> substitution =
                     rule.att().contains(Att.refers_THIS_CONFIGURATION()) ?
@@ -598,15 +604,35 @@ public class SymbolicRewriter {
         boolean guarded = false;
         int step = 0;
 
+        global.javaExecutionOptions.logBasic |= global.javaExecutionOptions.log;
+        global.globalOptions.verbose |= global.javaExecutionOptions.logBasic;
         global.javaExecutionOptions.debugZ3Queries |= global.globalOptions.debug;
         global.javaExecutionOptions.debugZ3 |= global.javaExecutionOptions.debugZ3Queries;
+        //to avoid printing initialization-phase rules
+        global.javaExecutionOptions.logRulesPublic = global.javaExecutionOptions.logRules;
 
+        if (global.javaExecutionOptions.log) {
+            System.out.println("\nTarget term\n=====================\n");
+            System.out.println(targetTerm);
+        }
+        int branchingRemaining = global.javaExecutionOptions.branchingAllowed;
+        boolean nextStepLogEnabled = false;
+        boolean originalLog = global.javaExecutionOptions.log;
         while (!queue.isEmpty()) {
             step++;
+            int v = 0;
+            global.javaExecutionOptions.log |= nextStepLogEnabled;
+            nextStepLogEnabled = false;
 
             for (ConstrainedTerm term : queue) {
-                if (term.implies(targetTerm, rule)) {
+                v++;
+                boolean alreadyLogged = logStep(step, v, term, step == 1, false);
+                if (term.implies(targetTerm, rule, false)) {
                     global.stateLog.log(StateLog.LogEvent.REACHPROVED, term.term(), term.constraint());
+                    if (global.javaExecutionOptions.logBasic) {
+                        logStep(step, v, term, true, alreadyLogged);
+                        System.out.println("\n============\nStep " + step + ": eliminated!\n============\n");
+                    }
                     successPaths++;
                     continue;
                 }
@@ -634,6 +660,12 @@ public class SymbolicRewriter {
                 if (guarded) {
                     ConstrainedTerm result = applySpecRules(term, specRules);
                     if (result != null) {
+                        nextStepLogEnabled = true;
+                        logStep(step, v, term, true, alreadyLogged);
+                        // re-running constraint generation again for debug purposes
+                        if (global.javaExecutionOptions.logBasic) {
+                            System.err.println("\nApplying specification rule\n=========================\n");
+                        }
                         if (visited.add(result)) {
                             nextQueue.add(result);
                         } else {
@@ -645,12 +677,44 @@ public class SymbolicRewriter {
                     }
                 }
 
-                List<ConstrainedTerm> results = fastComputeRewriteStep(term, false, true, true);
+                List<ConstrainedTerm> results;
+                try {
+                    results = fastComputeRewriteStep(term, false, true, true, step);
+                    // DISABLE EXCEPTION CHECKSTYLE
+                } catch (Throwable e) {
+                    // ENABLE EXCEPTION CHECKSTYLE
+                    logStep(step, v, term, true, alreadyLogged);
+                    System.out.println("\n\nTerm throwing exception\n============================\n\n");
+                    //KProve.prettyPrint(term.term());
+                    System.out.println(term.term());
+                    System.out.print("/\\");
+                    //KProve.prettyPrint(term.constraint());
+                    System.out.println(term.constraint().toString().replaceAll("#And", "\n#And"));
+                    e.printStackTrace();
+                    throw e;
+                }
                 if (results.isEmpty()) {
+                    logStep(step, v, term, true, alreadyLogged);
+                    System.out.println("\nStep above: " + step + ", evaluation ended with no successors.");
                     /* final term */
                     proofResults.add(term);
                 }
 
+                if (results.size() > 1) {
+                    nextStepLogEnabled = true;
+                    logStep(step, v, term, true, alreadyLogged);
+                    if (branchingRemaining == 0) {
+                        System.out.println("\nHalt on branching!\n=====================\n");
+
+                        proofResults.addAll(results);
+                        continue;
+                    } else {
+                        branchingRemaining--;
+                        if (global.javaExecutionOptions.logBasic) {
+                            System.out.println("\nBranching!\n=====================\n");
+                        }
+                    }
+                }
                 for (ConstrainedTerm cterm : results) {
                     ConstrainedTerm result = new ConstrainedTerm(
                             cterm.term(),
@@ -672,6 +736,8 @@ public class SymbolicRewriter {
             nextQueue = temp;
             nextQueue.clear();
             guarded = true;
+
+            global.javaExecutionOptions.log = originalLog;
         }
 
         if (global.globalOptions.verbose) {
@@ -697,18 +763,109 @@ public class SymbolicRewriter {
         global.profiler.printResult();
     }
 
+    //map value = log format: true = pretty, false = toString()
+    private Map<String, Boolean> cellsToLog = new LinkedHashMap<>();
+    private boolean prettyPC;
+    private boolean prettyResult;
+
+    private void parseLogCells() {
+        for (String cell : global.javaExecutionOptions.logCells) {
+            boolean pretty = false;
+            if (cell.startsWith("(") && cell.endsWith(")")) {
+                pretty = true;
+                cell = cell.substring(1, cell.length() - 1);
+            }
+            if (cell.equals("#pc")) {
+                prettyPC = pretty;
+            } else if (cell.equals("#result")) {
+                prettyResult = pretty;
+            } else {
+                cellsToLog.put(cell, pretty);
+            }
+        }
+    }
+
+    /**
+     * @return whether it was actually logged
+     */
+    private boolean logStep(int step, int v, ConstrainedTerm term, boolean forced, boolean alreadyLogged) {
+        if (alreadyLogged || !global.javaExecutionOptions.logBasic) {
+            return false;
+        }
+        global.profiler.logOverheadTimer.start();
+        KItem top = (KItem) term.term();
+
+        if (global.javaExecutionOptions.log || forced || global.javaExecutionOptions.logRulesPublic) {
+            System.out.format("\nSTEP %d v%d : %.3f s \n===================\n",
+                    step, v, (System.currentTimeMillis() - global.profiler.getStartTime()) / 1000.);
+        }
+
+        boolean actuallyLogged = global.javaExecutionOptions.log || forced;
+        if (actuallyLogged) {
+            for(String cellName : cellsToLog.keySet()) {
+                boolean pretty = cellsToLog.get(cellName);
+                KItem cell = getCell(top, "<" + cellName + ">");
+                if (cell == null) {
+                    continue;
+                }
+                print(cell, pretty);
+            }
+
+            System.out.println("/\\");
+            if (prettyPC) {
+                global.prettyPrinter.prettyPrint(term.constraint());
+            } else {
+                System.out.println(term.constraint().toStringMultiline());
+            }
+        }
+        global.profiler.logOverheadTimer.stop();
+        return actuallyLogged;
+    }
+
+    private void print(K cell, boolean pretty) {
+        if (pretty) {
+            global.prettyPrinter.prettyPrint(cell);
+        } else {
+            System.out.println(toStringOrEmpty(cell));
+        }
+    }
+
+    private String toStringOrEmpty(Object o) {
+        return o != null ? o.toString() : "";
+    }
+
+    private Pattern cellLabelPattern = Pattern.compile("<.+>");
+
+    private KItem getCell(KItem root, String label) {
+        if (root.klabel().name().equals(label)) {
+            return root;
+        }
+        for (K child : root.klist().items()) {
+            if (child instanceof KItem && cellLabelPattern.matcher(((KItem) child).klabel().name()).matches()) {
+                KItem result = getCell((KItem) child, label);
+                if (result != null) {
+                    return result;
+                }
+            }
+        }
+        return null;
+    }
+
     /**
      * Applies the first applicable specification rule and returns the result.
      */
     private ConstrainedTerm applySpecRules(ConstrainedTerm constrainedTerm, List<Rule> specRules) {
         for (Rule specRule : specRules) {
             ConstrainedTerm pattern = specRule.createLhsPattern(constrainedTerm.termContext());
-            ConjunctiveFormula constraint = constrainedTerm.matchImplies(pattern, true,
+            ConjunctiveFormula constraint = constrainedTerm.matchImplies(pattern, true, false,
                     new FormulaContext(FormulaContext.Kind.SpecRule, specRule), specRule.matchingSymbols());
             if (constraint != null) {
                 ConstrainedTerm result = buildResult(specRule, constraint, null, true, constrainedTerm.termContext(),
                         new FormulaContext(FormulaContext.Kind.SpecConstr, specRule));
                 global.stateLog.log(StateLog.LogEvent.SRULE, specRule.toKRewrite());
+                if (global.javaExecutionOptions.logRulesPublic) {
+                    RuleSourceUtil.printRuleAndSource(specRule);
+                }
                 return result;
             }
         }


### PR DESCRIPTION
## Main additions
- option --log to print a subset of configuration specified in `--log-cells` at each step.
- option --log-basic - same as --log but only at certain important steps such as branchings, application of spec rule.
  Plus enables multiple other minor logs.
- option --log-cells. Generalized logging. Added ability to specify the list of cells to log, and which of these cells to be pretty-printed.
- option --branching-allowed to limit branchings. If allowed number of branchings is exceeded, execution ends.
- option --log-rule, prints rule source for all invoked rules of in all contexts. Both kprove and krun.
- final implication debug: Logging the non-matching sub-terms when final implication does not match, if at least --log-basic is provided.

## Minor additions
- added parameter `step` to some methods, for debugging.
- Custom formatting when entire term is printed, without using the slow pretty printing.


