### PR TITLE
KProve architecture extension: made pretty printing available to Rewriter

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackendKModule.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackendKModule.java
@@ -7,7 +7,7 @@ import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import org.apache.commons.lang3.tuple.Pair;
-import org.kframework.compile.Backend;
+import org.kframework.definition.Definition;
 import org.kframework.main.AbstractKModule;
 import org.kframework.rewriter.Rewriter;
 
@@ -56,8 +56,8 @@ public class HaskellBackendKModule extends AbstractKModule {
     private void installHaskellRewriter(Binder binder) {
         bindOptions(HaskellBackendKModule.this::krunOptions, binder);
 
-        MapBinder<String, Function<org.kframework.definition.Module, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
-                binder, TypeLiteral.get(String.class), new TypeLiteral<Function<org.kframework.definition.Module, Rewriter>>() {
+        MapBinder<String, Function<Definition, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
+                binder, TypeLiteral.get(String.class), new TypeLiteral<Function<Definition, Rewriter>>() {
                 });
         rewriterBinder.addBinding("haskell").to(HaskellRewriter.class);
     }

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -8,6 +8,7 @@ import org.kframework.backend.kore.KoreBackend;
 import org.kframework.backend.kore.ModuleToKORE;
 import org.kframework.compile.AddSortInjections;
 import org.kframework.compile.RewriteToTop;
+import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
 import org.kframework.definition.Rule;
 import org.kframework.kompile.CompiledDefinition;
@@ -48,7 +49,7 @@ import static org.kframework.builtin.BooleanUtils.*;
 
 
 @RequestScoped
-public class HaskellRewriter implements Function<Module, Rewriter> {
+public class HaskellRewriter implements Function<Definition, Rewriter> {
 
     private final FileUtil files;
     private final CompiledDefinition def;
@@ -79,7 +80,8 @@ public class HaskellRewriter implements Function<Module, Rewriter> {
     }
 
     @Override
-    public Rewriter apply(Module module) {
+    public Rewriter apply(Definition definition) {
+        Module module = definition.mainModule();
         if (!module.equals(def.executionModule()) && kProveOptions.specModule != null) {
             throw KEMException.criticalError("Invalid module specified for rewriting. Haskell backend only supports rewriting over" +
                     " the definition's main module.");

--- a/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/JavaBackendKModule.java
@@ -13,9 +13,7 @@ import org.kframework.backend.java.symbolic.InitializeRewriter;
 import org.kframework.backend.java.symbolic.JavaBackend;
 import org.kframework.backend.java.symbolic.JavaExecutionOptions;
 import org.kframework.compile.Backend;
-import org.kframework.kprove.KProve;
-import org.kframework.krun.ToolActivation;
-import org.kframework.krun.modes.ExecutionMode;
+import org.kframework.definition.Definition;
 import org.kframework.main.AbstractKModule;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.utils.inject.Options;
@@ -97,8 +95,8 @@ public class JavaBackendKModule extends AbstractKModule {
     }
 
     private void installJavaRewriter(Binder binder) {
-        MapBinder<String, Function<org.kframework.definition.Module, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
-                binder, TypeLiteral.get(String.class), new TypeLiteral<Function<org.kframework.definition.Module, Rewriter>>() {
+        MapBinder<String, Function<Definition, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
+                binder, TypeLiteral.get(String.class), new TypeLiteral<Function<Definition, Rewriter>>() {
                 });
         rewriterBinder.addBinding("java").to(InitializeRewriter.class);
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -2,7 +2,6 @@
 
 package org.kframework.backend.java.kil;
 
-import com.google.inject.Inject;
 import org.kframework.backend.java.kil.KItem.KItemOperations;
 import org.kframework.backend.java.symbolic.BuiltinFunction;
 import org.kframework.backend.java.symbolic.Equality.EqualityOperations;
@@ -15,6 +14,8 @@ import org.kframework.backend.java.util.Z3Wrapper;
 import org.kframework.krun.KRunOptions;
 import org.kframework.krun.api.io.FileSystem;
 import org.kframework.main.GlobalOptions;
+import org.kframework.unparser.KPrint;
+import org.kframework.backend.java.util.PrettyPrinter;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.options.SMTOptions;
@@ -38,6 +39,7 @@ public class GlobalContext implements Serializable {
     public final transient GlobalOptions globalOptions;
     public final transient Profiler2 profiler;
     public final StateLog stateLog;
+    public final PrettyPrinter prettyPrinter;
     public final transient FunctionCache functionCache = new FunctionCache();
 
     public GlobalContext(
@@ -50,7 +52,9 @@ public class GlobalContext implements Serializable {
             Map<String, MethodHandle> hookProvider,
             FileUtil files,
             Stage stage,
-            Profiler2 profiler) {
+            Profiler2 profiler,
+            KPrint kprint,
+            org.kframework.definition.Definition coreDefinition) {
         this.fs = fs;
         this.globalOptions = globalOptions;
         this.krunOptions = krunOptions;
@@ -64,21 +68,7 @@ public class GlobalContext implements Serializable {
         this.kItemOps = new KItemOperations(stage, javaExecutionOptions.deterministicFunctions, kem, this::builtins, globalOptions);
         this.stage = stage;
         this.profiler = profiler;
-    }
-
-    @Inject
-    public GlobalContext(
-            GlobalOptions globalOptions,
-            SMTOptions smtOptions,
-            KExceptionManager kem,
-            KRunOptions krunOptions,
-            JavaExecutionOptions javaExecutionOptions,
-            FileSystem fs,
-            FileUtil files,
-            Map<String, MethodHandle> hookProvider,
-            Stage stage,
-            Profiler2 profiler) {
-        this(fs, globalOptions, krunOptions, javaExecutionOptions, kem, smtOptions, hookProvider, files, stage, profiler);
+        prettyPrinter = new PrettyPrinter(kprint, coreDefinition);
     }
 
     private transient BuiltinFunction builtinFunction;
@@ -98,5 +88,4 @@ public class GlobalContext implements Serializable {
     public Definition getDefinition() {
         return def;
     }
-
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/util/PrettyPrinter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/PrettyPrinter.java
@@ -1,0 +1,28 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+package org.kframework.backend.java.util;
+
+import org.kframework.backend.java.kil.GlobalContext;
+import org.kframework.definition.Definition;
+import org.kframework.definition.Module;
+import org.kframework.kore.K;
+import org.kframework.unparser.KPrint;
+
+/**
+ * @author Denis Bogdanas
+ * Created on 07-Feb-19.
+ */
+public class PrettyPrinter {
+    public final KPrint kprint;
+    public final Definition def;
+    public final Module module;
+
+    public PrettyPrinter(KPrint kprint, Definition def) {
+        this.kprint = kprint;
+        this.def = def;
+        this.module = def.getModule("LANGUAGE-PARSING").get();
+    }
+
+    public void prettyPrint(K target) {
+        kprint.prettyPrint(def, module, kprint::outputFile, target);
+    }
+}

--- a/kernel/src/main/java/org/kframework/keq/KEq.java
+++ b/kernel/src/main/java/org/kframework/keq/KEq.java
@@ -31,17 +31,17 @@ public class KEq {
             CompiledDefinition def2,
             KEqOptions keqOptions,
             Backend backend,
-            Function<Module, Rewriter> commonGen,
-            Function<Module, Rewriter> gen1,
-            Function<Module, Rewriter> gen2) {
-        Rewriter commonRewriter = commonGen.apply(commonDef.executionModule());
+            Function<Definition, Rewriter> commonGen,
+            Function<Definition, Rewriter> gen1,
+            Function<Definition, Rewriter> gen2) {
+        Rewriter commonRewriter = commonGen.apply(commonDef.kompiledDefinition);
 
         Tuple2<Definition, Module> compiled1 = KProve.getProofDefinition(files.resolveWorkingDirectory(keqOptions.spec1), keqOptions.defModule1, keqOptions.specModule1, def1, backend, files, kem, sw);
-        Rewriter rewriter1 = gen1.apply(compiled1._1().mainModule());
+        Rewriter rewriter1 = gen1.apply(compiled1._1());
         Module spec1 = compiled1._2();
 
         Tuple2<Definition, Module> compiled2 = KProve.getProofDefinition(files.resolveWorkingDirectory(keqOptions.spec2), keqOptions.defModule2, keqOptions.specModule2, def2, backend, files, kem, sw);
-        Rewriter rewriter2 = gen2.apply(compiled2._1().mainModule());
+        Rewriter rewriter2 = gen2.apply(compiled2._1());
         Module spec2 = compiled2._2();
 
         boolean isEquivalent = commonRewriter.equivalence(rewriter1, rewriter2, spec1, spec2);

--- a/kernel/src/main/java/org/kframework/keq/KEqFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/keq/KEqFrontEnd.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import org.kframework.compile.Backend;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
@@ -39,9 +40,9 @@ public class KEqFrontEnd extends FrontEnd {
     private final Provider<CompiledDefinition> compiledDef;
     private final Provider<CompiledDefinition> compiledDef1;
     private final Provider<CompiledDefinition> compiledDef2;
-    private final Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter;
-    private final Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter1;
-    private final Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter2;
+    private final Provider<Function<Definition, Rewriter>> initializeRewriter;
+    private final Provider<Function<Definition, Rewriter>> initializeRewriter1;
+    private final Provider<Function<Definition, Rewriter>> initializeRewriter2;
 
     @Inject
     public KEqFrontEnd(
@@ -61,9 +62,9 @@ public class KEqFrontEnd extends FrontEnd {
             @Main Provider<CompiledDefinition> compiledDef,
             @Spec1 Provider<CompiledDefinition> compiledDef1,
             @Spec2 Provider<CompiledDefinition> compiledDef2,
-            @Main Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter,
-            @Spec1 Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter1,
-            @Spec2 Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter2) {
+            @Main Provider<Function<Definition, Rewriter>> initializeRewriter,
+            @Spec1 Provider<Function<Definition, Rewriter>> initializeRewriter1,
+            @Spec2 Provider<Function<Definition, Rewriter>> initializeRewriter2) {
         super(kem, globalOptions, usage, experimentalUsage, jarInfo, files);
         this.scope = scope;
         this.kompiledDir = kompiledDir;
@@ -85,7 +86,7 @@ public class KEqFrontEnd extends FrontEnd {
     @Override
     protected int run() {
         CompiledDefinition commonDef, def1, def2;
-        Function<org.kframework.definition.Module, Rewriter> commonRewriter, rewriter1, rewriter2;
+        Function<Definition, Rewriter> commonRewriter, rewriter1, rewriter2;
         Backend backend;
         scope.enter(kompiledDir.get());
         try {

--- a/kernel/src/main/java/org/kframework/keq/KEqModule.java
+++ b/kernel/src/main/java/org/kframework/keq/KEqModule.java
@@ -16,6 +16,7 @@ import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.main.Tool;
 import org.kframework.rewriter.Rewriter;
+import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
@@ -70,6 +71,11 @@ public class KEqModule extends AbstractModule {
 
     @Provides
     SMTOptions smtOptions(KEqOptions options) { return options.smt; }
+
+    @Provides
+    PrintOptions printOptions(KEqOptions options) {
+        return options.print;
+    }
 
     public static class MainExecutionContextModule extends AnnotatedByDefinitionModule {
 

--- a/kernel/src/main/java/org/kframework/keq/KEqModule.java
+++ b/kernel/src/main/java/org/kframework/keq/KEqModule.java
@@ -5,8 +5,8 @@ import com.google.inject.Module;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
-import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.BackendModule;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.krun.api.io.FileSystem;
@@ -36,10 +36,6 @@ public class KEqModule extends AbstractModule {
         @Override
         protected void configure() {
             //bind backend implementations of tools to their interfaces
-            MapBinder<String, Function<org.kframework.definition.Module, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
-                    binder(), TypeLiteral.get(String.class), new TypeLiteral<Function<org.kframework.definition.Module, Rewriter>>() {
-                    });
-
             install(new BackendModule());
 
             bind(FileUtil.class);
@@ -47,8 +43,8 @@ public class KEqModule extends AbstractModule {
         }
 
         @Provides
-        Function<org.kframework.definition.Module, Rewriter> getRewriter(KompileOptions options, Map<String, Provider<Function<org.kframework.definition.Module, Rewriter>>> map, KExceptionManager kem) {
-            Provider<Function<org.kframework.definition.Module, Rewriter>> provider = map.get(options.backend);
+        Function<Definition, Rewriter> getRewriter(KompileOptions options, Map<String, Provider<Function<Definition, Rewriter>>> map, KExceptionManager kem) {
+            Provider<Function<Definition, Rewriter>> provider = map.get(options.backend);
             if (provider == null) {
                 throw KEMException.criticalError("Backend " + options.backend + " does not support execution. Supported backends are: "
                         + map.keySet());

--- a/kernel/src/main/java/org/kframework/keq/KEqOptions.java
+++ b/kernel/src/main/java/org/kframework/keq/KEqOptions.java
@@ -4,6 +4,7 @@ package org.kframework.keq;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import org.kframework.main.GlobalOptions;
+import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.DefinitionLoadingOptions;
 import org.kframework.utils.options.SMTOptions;
@@ -18,6 +19,9 @@ public final class KEqOptions {
 
     @ParametersDelegate
     public SMTOptions smt = new SMTOptions();
+
+    @ParametersDelegate
+    public PrintOptions print = new PrintOptions();
 
     @Parameter(names={"--definition1", "-d1"}, description="Path to the directory in which the first kompiled " +
             "K definition resides. The default is the unique, only directory with the suffix '-kompiled' " +

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -42,9 +42,9 @@ public class KProve {
         this.kprint = kprint;
     }
 
-    public int run(KProveOptions options, CompiledDefinition compiledDefinition, Backend backend, Function<Module, Rewriter> rewriterGenerator) {
+    public int run(KProveOptions options, CompiledDefinition compiledDefinition, Backend backend, Function<Definition, Rewriter> rewriterGenerator) {
         Tuple2<Definition, Module> compiled = getProofDefinition(options.specFile(files), options.defModule, options.specModule, compiledDefinition, backend, files, kem, sw);
-        Rewriter rewriter = rewriterGenerator.apply(compiled._1().mainModule());
+        Rewriter rewriter = rewriterGenerator.apply(compiled._1());
         Module specModule = compiled._2();
 
         K results = rewriter.prove(specModule);

--- a/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveFrontEnd.java
@@ -6,12 +6,8 @@ import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Provider;
 import org.kframework.compile.Backend;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.CompiledDefinition;
-import org.kframework.krun.KRun;
-import org.kframework.krun.KRunModule;
-import org.kframework.krun.KRunOptions;
-import org.kframework.krun.RewriterModule;
-import org.kframework.krun.modes.ExecutionMode;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.rewriter.Rewriter;
@@ -51,7 +47,7 @@ public class KProveFrontEnd extends FrontEnd {
     private final FileUtil files;
     private final Provider<CompiledDefinition> compiledDef;
     private final Provider<Backend> backend;
-    private final Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter;
+    private final Provider<Function<Definition, Rewriter>> initializeRewriter;
     private final TTYInfo tty;
     private final Stopwatch sw;
 
@@ -68,7 +64,7 @@ public class KProveFrontEnd extends FrontEnd {
             FileUtil files,
             Provider<CompiledDefinition> compiledDef,
             Provider<Backend> backend,
-            Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter,
+            Provider<Function<Definition, Rewriter>> initializeRewriter,
             TTYInfo tty,
             Stopwatch sw) {
         super(kem, options, usage, experimentalUsage, jarInfo, files);

--- a/kernel/src/main/java/org/kframework/kprove/KProveModule.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveModule.java
@@ -4,13 +4,12 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
-import org.kframework.keq.KEqFrontEnd;
-import org.kframework.keq.KEqOptions;
 import org.kframework.kompile.BackendModule;
 import org.kframework.krun.RewriterModule;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.main.Tool;
+import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.inject.Options;
 import org.kframework.utils.options.DefinitionLoadingOptions;
 import org.kframework.utils.options.SMTOptions;
@@ -33,6 +32,11 @@ public class KProveModule extends AbstractModule {
     @Provides
     GlobalOptions globalOptions(KProveOptions options) {
         return options.global;
+    }
+
+    @Provides
+    PrintOptions printOptions(KProveOptions options) {
+        return options.print;
     }
 
     @Provides

--- a/kernel/src/main/java/org/kframework/krun/KRun.java
+++ b/kernel/src/main/java/org/kframework/krun/KRun.java
@@ -6,7 +6,7 @@ import org.kframework.attributes.Source;
 import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Sorts;
 import org.kframework.compile.ConfigurationInfoFromModule;
-import org.kframework.definition.Module;
+import org.kframework.definition.Definition;
 import org.kframework.definition.Rule;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kore.Assoc;
@@ -70,7 +70,7 @@ public class KRun {
         }
     }
 
-    public int run(CompiledDefinition compiledDef, KRunOptions options, Function<Module, Rewriter> rewriterGenerator, ExecutionMode executionMode) {
+    public int run(CompiledDefinition compiledDef, KRunOptions options, Function<Definition, Rewriter> rewriterGenerator, ExecutionMode executionMode) {
         String pgmFileName = options.configurationCreation.pgm();
         K program;
         if (options.configurationCreation.term()) {

--- a/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/krun/KRunFrontEnd.java
@@ -5,6 +5,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.inject.Inject;
 import com.google.inject.Module;
 import com.google.inject.Provider;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.krun.modes.ExecutionMode;
 import org.kframework.main.FrontEnd;
@@ -45,7 +46,7 @@ public class KRunFrontEnd extends FrontEnd {
     private final KRunOptions krunOptions;
     private final FileUtil files;
     private final Provider<CompiledDefinition> compiledDef;
-    private final Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter;
+    private final Provider<Function<Definition, Rewriter>> initializeRewriter;
     private final Provider<ExecutionMode> executionMode;
     private final TTYInfo tty;
 
@@ -61,7 +62,7 @@ public class KRunFrontEnd extends FrontEnd {
             KRunOptions krunOptions,
             FileUtil files,
             Provider<CompiledDefinition> compiledDef,
-            Provider<Function<org.kframework.definition.Module, Rewriter>> initializeRewriter,
+            Provider<Function<Definition, Rewriter>> initializeRewriter,
             Provider<ExecutionMode> executionMode,
             TTYInfo tty) {
         super(kem, options, usage, experimentalUsage, jarInfo, files);

--- a/kernel/src/main/java/org/kframework/krun/RewriterModule.java
+++ b/kernel/src/main/java/org/kframework/krun/RewriterModule.java
@@ -3,9 +3,7 @@ package org.kframework.krun;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provider;
 import com.google.inject.Provides;
-import com.google.inject.TypeLiteral;
-import com.google.inject.multibindings.MapBinder;
-import org.kframework.definition.Module;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.krun.api.io.FileSystem;
 import org.kframework.krun.ioserver.filesystem.portable.PortableFileSystem;
@@ -20,18 +18,14 @@ import java.util.function.Function;
 public class RewriterModule extends AbstractModule {
     @Override
     protected void configure() {
-        MapBinder<String, Function<Module, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
-                binder(), TypeLiteral.get(String.class), new TypeLiteral<Function<org.kframework.definition.Module, Rewriter>>() {
-                });
-
         bind(FileUtil.class);
 
         bind(FileSystem.class).to(PortableFileSystem.class);
     }
 
     @Provides
-    Function<org.kframework.definition.Module, Rewriter> getRewriter(KompileOptions options, Map<String, Provider<Function<Module, Rewriter>>> map, KExceptionManager kem) {
-        Provider<Function<org.kframework.definition.Module, Rewriter>> provider = map.get(options.backend);
+    Function<Definition, Rewriter> getRewriter(KompileOptions options, Map<String, Provider<Function<Definition, Rewriter>>> map, KExceptionManager kem) {
+        Provider<Function<Definition, Rewriter>> provider = map.get(options.backend);
         if (provider == null) {
             throw KEMException.criticalError("Backend " + options.backend + " does not support execution. Supported backends are: "
                     + map.keySet());

--- a/kernel/src/main/java/org/kframework/krun/modes/DebugMode/DebugExecutionMode.java
+++ b/kernel/src/main/java/org/kframework/krun/modes/DebugMode/DebugExecutionMode.java
@@ -13,7 +13,7 @@ import jline.console.completer.NullCompleter;
 import jline.console.completer.StringsCompleter;
 import org.kframework.debugger.KDebug;
 import org.kframework.debugger.KoreKDebug;
-import org.kframework.definition.Module;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kore.K;
 import org.kframework.krun.KRun;
@@ -88,8 +88,8 @@ public class DebugExecutionMode implements ExecutionMode {
 
 
     @Override
-    public Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Module, Rewriter> rewriter, CompiledDefinition compiledDefinition) {
-        KDebug debugger = new KoreKDebug(k.theConfig, rewriter.apply(compiledDefinition.executionModule()), checkpointInterval, files, kem, kRunOptions, compiledDefinition);
+    public Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Definition, Rewriter> rewriterGenerator, CompiledDefinition compiledDefinition) {
+        KDebug debugger = new KoreKDebug(k.theConfig, rewriterGenerator.apply(compiledDefinition.kompiledDefinition), checkpointInterval, files, kem, kRunOptions, compiledDefinition);
         ConsoleReader reader = getConsoleReader();
         while (true) {
             try {

--- a/kernel/src/main/java/org/kframework/krun/modes/ExecutionMode.java
+++ b/kernel/src/main/java/org/kframework/krun/modes/ExecutionMode.java
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-2019 K Team. All Rights Reserved.
 package org.kframework.krun.modes;
 
-import org.kframework.definition.Module;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kore.K;
 import org.kframework.krun.KRun;
@@ -12,10 +12,11 @@ import java.util.function.Function;
 
 /**
  * Created by Manasvi on 6/16/15.
- *
+ * <p>
  * Interface for KRun Execution Modes.
  */
 public interface ExecutionMode {
 
-    Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Module, Rewriter> rewriter, CompiledDefinition compiledDefinition);
+    Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Definition, Rewriter> rewriter,
+                               CompiledDefinition compiledDefinition);
 }

--- a/kernel/src/main/java/org/kframework/krun/modes/KRunExecutionMode.java
+++ b/kernel/src/main/java/org/kframework/krun/modes/KRunExecutionMode.java
@@ -5,14 +5,13 @@ import com.google.inject.Inject;
 import org.kframework.RewriterResult;
 import org.kframework.attributes.Source;
 import org.kframework.builtin.BooleanUtils;
-import org.kframework.definition.Module;
+import org.kframework.definition.Definition;
 import org.kframework.definition.Rule;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kore.K;
 import org.kframework.kore.KORE;
 import org.kframework.krun.KRun;
 import org.kframework.krun.KRunOptions;
-import org.kframework.krun.SearchResult;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
@@ -39,8 +38,8 @@ public class KRunExecutionMode implements ExecutionMode {
     }
 
     @Override
-    public Tuple2<K, Integer> execute(KRun.InitialConfiguration config, Function<Module, Rewriter> rewriterGenerator, CompiledDefinition compiledDefinition) {
-        Rewriter rewriter = rewriterGenerator.apply(compiledDefinition.executionModule());
+    public Tuple2<K, Integer> execute(KRun.InitialConfiguration config, Function<Definition, Rewriter> rewriterGenerator, CompiledDefinition compiledDefinition) {
+        Rewriter rewriter = rewriterGenerator.apply(compiledDefinition.kompiledDefinition);
         K k = config.theConfig;
         Rule pattern = null, parsedPattern = null;
         if (kRunOptions.pattern != null) {

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackendKModule.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackendKModule.java
@@ -6,6 +6,7 @@ import com.google.inject.Module;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import org.apache.commons.lang3.tuple.Pair;
+import org.kframework.definition.Definition;
 import org.kframework.main.AbstractKModule;
 import org.kframework.rewriter.Rewriter;
 
@@ -44,8 +45,8 @@ public class LLVMBackendKModule extends AbstractKModule {
         return Collections.singletonList(new AbstractModule() {
             @Override
             protected void configure() {
-                MapBinder<String, Function<org.kframework.definition.Module, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
-                        binder(), TypeLiteral.get(String.class), new TypeLiteral<Function<org.kframework.definition.Module, Rewriter>>() {
+                MapBinder<String, Function<Definition, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
+                        binder(), TypeLiteral.get(String.class), new TypeLiteral<Function<Definition, Rewriter>>() {
                         });
                 rewriterBinder.addBinding("llvm").to(LLVMRewriter.class);
 

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import org.kframework.RewriterResult;
 import org.kframework.backend.kore.ModuleToKORE;
 import org.kframework.compile.AddSortInjections;
+import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
 import org.kframework.definition.Rule;
 import org.kframework.kompile.CompiledDefinition;
@@ -38,7 +39,7 @@ import java.util.function.Function;
 
 
 @RequestScoped
-public class LLVMRewriter implements Function<Module, Rewriter> {
+public class LLVMRewriter implements Function<Definition, Rewriter> {
 
     private final FileUtil files;
     private final CompiledDefinition def;
@@ -59,7 +60,8 @@ public class LLVMRewriter implements Function<Module, Rewriter> {
     }
 
     @Override
-    public Rewriter apply(Module module) {
+    public Rewriter apply(Definition definition) {
+        Module module = definition.mainModule();
         if (!module.equals(def.executionModule())) {
             throw KEMException.criticalError("Invalid module specified for rewriting. LLVM backend only supports rewriting over" +
                     " the definition's main module.");

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/InterpreterExecutionMode.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/InterpreterExecutionMode.java
@@ -2,7 +2,7 @@
 package org.kframework.backend.ocaml;
 
 import com.google.inject.Inject;
-import org.kframework.definition.Module;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.K;
@@ -48,7 +48,7 @@ public class InterpreterExecutionMode implements ExecutionMode {
     }
 
     @Override
-    public Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Module, Rewriter> unused, CompiledDefinition compiledDefinition) {
+    public Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Definition, Rewriter> unused, CompiledDefinition compiledDefinition) {
         OcamlRewriter rewriter = new OcamlRewriter(files, converter, options);
         K config = k.theConfig;
         k.theConfig = null;

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlBackendKModule.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlBackendKModule.java
@@ -7,6 +7,7 @@ import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.MapBinder;
 import com.google.inject.name.Names;
 import org.apache.commons.lang3.tuple.Pair;
+import org.kframework.definition.Definition;
 import org.kframework.krun.ToolActivation;
 import org.kframework.krun.modes.ExecutionMode;
 import org.kframework.main.AbstractKModule;
@@ -54,8 +55,8 @@ public class OcamlBackendKModule extends AbstractKModule {
 
                 bindOptions(OcamlBackendKModule.this::krunOptions, binder());
 
-                MapBinder<String, Function<org.kframework.definition.Module, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
-                        binder(), TypeLiteral.get(String.class), new TypeLiteral<Function<org.kframework.definition.Module, Rewriter>>() {
+                MapBinder<String, Function<Definition, Rewriter>> rewriterBinder = MapBinder.newMapBinder(
+                        binder(), TypeLiteral.get(String.class), new TypeLiteral<Function<Definition, Rewriter>>() {
                         });
                 rewriterBinder.addBinding("ocaml").to(OcamlRewriter.class);
 

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlCompileExecutionMode.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlCompileExecutionMode.java
@@ -5,7 +5,7 @@ import com.google.inject.Inject;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.kframework.builtin.Sorts;
-import org.kframework.definition.Module;
+import org.kframework.definition.Definition;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.Assoc;
@@ -60,7 +60,7 @@ public class OcamlCompileExecutionMode implements ExecutionMode {
     }
 
     @Override
-    public Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Module, Rewriter> ignored, CompiledDefinition compiledDefinition) {
+    public Tuple2<K, Integer> execute(KRun.InitialConfiguration k, Function<Definition, Rewriter> ignored, CompiledDefinition compiledDefinition) {
         if (compiledDefinition.exitCodePattern != null) {
             // serializedVars will not be evaluated at program load.
             // This is faster, but their definition may not include impure functions

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlRewriter.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlRewriter.java
@@ -5,6 +5,7 @@ import com.google.inject.Inject;
 import org.apache.commons.lang3.StringUtils;
 import org.kframework.RewriterResult;
 import org.kframework.builtin.KLabels;
+import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
 import org.kframework.definition.Rule;
 import org.kframework.kompile.CompiledDefinition;
@@ -13,7 +14,6 @@ import org.kframework.kore.K;
 import org.kframework.kore.KVariable;
 import org.kframework.krun.KRunOptions;
 import org.kframework.krun.RunProcess;
-import org.kframework.kserver.KServerFrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.main.Main;
 import org.kframework.parser.binary.BinaryParser;
@@ -45,7 +45,7 @@ import java.util.stream.Stream;
 import static org.kframework.kore.KORE.*;
 
 @RequestScoped
-public class OcamlRewriter implements Function<Module, Rewriter> {
+public class OcamlRewriter implements Function<Definition, Rewriter> {
 
     private final FileUtil files;
     private final CompiledDefinition def;
@@ -80,7 +80,8 @@ public class OcamlRewriter implements Function<Module, Rewriter> {
     }
 
     @Override
-    public Rewriter apply(Module module) {
+    public Rewriter apply(Definition definition) {
+        Module module = definition.mainModule();
         if (!module.equals(def.executionModule())) {
             throw KEMException.criticalError("Invalid module specified for rewriting. Ocaml backend only supports rewriting over" +
                     " the definition's main module.");


### PR DESCRIPTION
Kernel: refactoring: rewriterGenerator now takes as argument kore Definition instead of Module.

Java Backend: building the class PrettyPrinter that incapsulates all components necessary to pretty print a K term. Used in logging PR.
