### PR TITLE
Java Backend: Z3 query build optimization

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -871,8 +871,12 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                 continue;
             }
 
-            global.stateLog.log(StateLog.LogEvent.IMPLICATION, left, right);
-            if (!impliesSMT(left, right, existentialQuantVars)) {
+            //Removing LHS substitution because it's not used to build Z3 query anyway.
+            //Improves Z3 cache efficiency.
+            ConjunctiveFormula leftWithoutSubst = ConjunctiveFormula.of(ImmutableMapSubstitution.empty(),
+                    left.equalities(), left.disjunctions(), left.globalContext());
+            global.stateLog.log(StateLog.LogEvent.IMPLICATION, leftWithoutSubst, right);
+            if (!impliesSMT(leftWithoutSubst, right, existentialQuantVars)) {
                 if (global.globalOptions.debug) {
                     System.err.println("Failure!");
                 }


### PR DESCRIPTION
Java Backend: Z3 query build optimization:
removing substitution from implication LHS, because it's not used in query build process anyway. Massively improves cache hit rate on some specs and improves performance.

## Proof that HS substitution is not used

1. argument `allowNewVars` is true here:
https://github.com/kframework/k/blob/1768d7f317dd00bbd149995fe62203df68ba869d/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java#L199

2. When `allowNewVars` is true, substitution is not used when translating ConjuncitveFormula:

https://github.com/kframework/k/blob/1768d7f317dd00bbd149995fe62203df68ba869d/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java#L429-L433
