### PR TITLE
New [matching]

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -95,8 +95,8 @@ public class ConstrainedTerm extends JavaSymbolicObject {
         return data.constraint;
     }
 
-    public boolean implies(ConstrainedTerm constrainedTerm) {
-        ConjunctiveFormula conjunctiveFormula = matchImplies(constrainedTerm, true, null);
+    public boolean implies(ConstrainedTerm constrainedTerm, Rule specRule) {
+        ConjunctiveFormula conjunctiveFormula = matchImplies(constrainedTerm, true, specRule.matchingSymbols());
         return conjunctiveFormula != null;
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/ConstrainedTerm.java
@@ -124,6 +124,9 @@ public class ConstrainedTerm extends JavaSymbolicObject {
      * Checks if {@code this} implies {@code matchRHSTerm}, assuming the variables
      * occurring only in {@code matchRHSTerm} (but not in {@code this}) are
      * existentially quantified.
+     *
+     * @return If implication value is {@code true}, return the unification constraint:
+     * implicationLHS /\ implicationRHS. Otherwise return {@code true}.
      */
     public ConjunctiveFormula matchImplies(ConstrainedTerm matchRHSTerm, boolean expand, Set<String> matchingSymbols) {
         ConjunctiveFormula constraint = ConjunctiveFormula.of(matchRHSTerm.termContext().global())

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -616,8 +616,8 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
      * even if #f is NOT injective.
      */
     public ConjunctiveFormula resolveMatchingSymbols(Set<String> matchingSymbols) {
-        PersistentUniqueList<Equality> equalities = this.equalities;
-        PersistentUniqueList<Equality> newEqualities = equalities;
+        PersistentUniqueList<Equality> resultEqualities = PersistentUniqueList.empty();
+        PersistentUniqueList<Equality> newEqualities = this.equalities;
 
         while (!newEqualities.isEmpty()) {
             PersistentUniqueList<Equality> curEqualities = newEqualities;
@@ -635,19 +635,21 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                         if (lKList.size() == rKList.size()) {
                             for (int i = 0; i < lKList.size(); ++i) {
                                 Equality newEquality = new Equality(lKList.get(i), rKList.get(i), global); // X == Y
-                                equalities = equalities.plus(newEquality);
                                 newEqualities = newEqualities.plus(newEquality);
                             }
+                            continue;
                         }
                     }
                 }
+                //anything but continue above
+                resultEqualities = resultEqualities.plus(equality);
             }
         }
 
-        if (equalities == this.equalities) {
+        if (resultEqualities.equals(this.equalities)) {
             return this;
         } else {
-            return new ConjunctiveFormula(substitution, equalities, disjunctions, truthValue, falsifyingEquality, global);
+            return new ConjunctiveFormula(substitution, resultEqualities, disjunctions, truthValue, falsifyingEquality, global);
         }
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -586,7 +586,7 @@ public class SymbolicRewriter {
         while (!queue.isEmpty()) {
             step++;
             for (ConstrainedTerm term : queue) {
-                if (term.implies(targetTerm)) {
+                if (term.implies(targetTerm, rule)) {
                     global.stateLog.log(StateLog.LogEvent.REACHPROVED, term.term(), term.constraint());
                     successPaths++;
                     continue;


### PR DESCRIPTION
From commit messages:

## Java backend: [matching] attribute. Generalized.
In previous implementation, after matching ConjunctiveFormula would have both the old equalities and the new ones. In the present implementation, equalities that were simplified by [matching] are not preserved, only those that can no longer be simplified. This extends the area of applicability of [matching]. Previously, due to other magic in kprove, it worked only when the argument of matching symbol was a function. Now it works for any arguments.

See this slack post for more info:
https://runtimeverification.slack.com/archives/CA1CQKLMQ/p1546026489019300

And the original PR for [matching]:
https://github.com/runtimeverification/verified-smart-contracts/pull/52

## Java backend: [matching] : enabled for final implication
Previously it was only used for applying a spec rule.

If a separate set of matching symbols is needed for proving the rule and for applying it, then rule can be divid