### PR TITLE
java-backend: Cache ConjunctiveFormula.simplify()

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -8,6 +8,7 @@ import org.kframework.backend.java.symbolic.Equality.EqualityOperations;
 import org.kframework.backend.java.symbolic.JavaExecutionOptions;
 import org.kframework.backend.java.symbolic.SMTOperations;
 import org.kframework.backend.java.symbolic.Stage;
+import org.kframework.backend.java.util.FormulaSimplificationCache;
 import org.kframework.backend.java.util.Profiler2;
 import org.kframework.backend.java.util.StateLog;
 import org.kframework.backend.java.util.Z3Wrapper;
@@ -41,6 +42,7 @@ public class GlobalContext implements Serializable {
     public final StateLog stateLog;
     public final PrettyPrinter prettyPrinter;
     public final transient FunctionCache functionCache = new FunctionCache();
+    public final transient FormulaSimplificationCache formulaCache = new FormulaSimplificationCache();
 
     private boolean isExecutionPhase = true;
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -396,11 +396,25 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
         return simplify(true, true, context, false);
     }
 
+    private ConjunctiveFormula simplify(boolean patternFolding, boolean partialSimplification,
+                                        TermContext context, boolean logFailures) {
+        ConjunctiveFormula cachedResult = global.formulaCache
+                .cacheGet(this, patternFolding, partialSimplification, context);
+        if (cachedResult != null) {
+            return cachedResult;
+        }
+
+        ConjunctiveFormula result = simplifyImpl(patternFolding, partialSimplification, context, logFailures);
+        global.formulaCache.cachePut(this, patternFolding, partialSimplification, context, result);
+        return result;
+    }
+
     /**
      * Simplifies this conjunctive formula as much as possible.
      * Decomposes equalities by using unification.
      */
-    private ConjunctiveFormula simplify(boolean patternFolding, boolean partialSimplification, TermContext context, boolean logFailures) {
+    private ConjunctiveFormula simplifyImpl(boolean patternFolding, boolean partialSimplification, TermContext context,
+                                            boolean logFailures) {
         assert !isFalse();
         ConjunctiveFormula originalTopConstraint = context.getTopConstraint();
         Substitution<Variable, Term> substitution = this.substitution;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -51,6 +51,9 @@ public final class JavaExecutionOptions {
     @Parameter(names="--cache-func", description="Cache evaluation results of pure functions. Enabled by default.", arity = 1)
     public boolean cacheFunctions = true;
 
+    @Parameter(names="--cache-formulas", description="Cache results of ConjunctiveFormula.simplify().")
+    public boolean cacheFormulas = false;
+
     @Parameter(names="--cache-func-optimized",
             description="Clear function cache after initialization phase. Frees some memory. Use IN ADDITION to --cache-func")
     public boolean cacheFunctionsOptimized = false;

--- a/java-backend/src/main/java/org/kframework/backend/java/util/FormulaSimplificationCache.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/FormulaSimplificationCache.java
@@ -1,0 +1,64 @@
+// Copyright (c) 2013-2018 K Team. All Rights Reserved.
+package org.kframework.backend.java.util;
+
+import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.symbolic.ConjunctiveFormula;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * @author Denis Bogdanas
+ * Created on 11-Nov-18.
+ */
+public class FormulaSimplificationCache {
+
+    private class Entry {
+        private final ConjunctiveFormula formula;
+        private final boolean patternFolding;
+        private final boolean partialSimplification;
+        private final ConjunctiveFormula constraint;
+
+        public Entry(ConjunctiveFormula formula, boolean patternFolding, boolean partialSimplification,
+                     ConjunctiveFormula constraint) {
+            this.formula = formula;
+            this.patternFolding = patternFolding;
+            this.partialSimplification = partialSimplification;
+            this.constraint = constraint;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (!(o instanceof Entry)) return false;
+            Entry entry = (Entry) o;
+            return patternFolding == entry.patternFolding &&
+                    partialSimplification == entry.partialSimplification &&
+                    Objects.equals(formula, entry.formula) &&
+                    Objects.equals(constraint, entry.constraint);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(formula, patternFolding, partialSimplification, constraint);
+        }
+    }
+
+    private Map<Entry, ConjunctiveFormula> evaluationCache = new HashMap<>();
+
+    public ConjunctiveFormula cacheGet(ConjunctiveFormula formula, boolean patternFolding,
+                                       boolean partialSimplification, TermContext context) {
+        return context.global().javaExecutionOptions.cacheFunctions
+                ? evaluationCache.get(new Entry(formula, patternFolding, partialSimplification, context.getTopConstraint()))
+                : null;
+    }
+
+    public void cachePut(ConjunctiveFormula formula, boolean patternFolding, boolean partialSimplification,
+                         TermContext context, ConjunctiveFormula result) {
+        if (context.global().javaExecutionOptions.cacheFunctions) {
+            evaluationCache.put(new Entry(formula, patternFolding, partialSimplification, context.getTopConstraint()), result);
+            evaluationCache.put(new Entry(result, patternFolding, partialSimplification, context.getTopConstraint()), result);
+        }
+    }
+}

--- a/java-backend/src/main/java/org/kframework/backend/java/util/FormulaSimplificationCache.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/FormulaSimplificationCache.java
@@ -49,14 +49,14 @@ public class FormulaSimplificationCache {
 
     public ConjunctiveFormula cacheGet(ConjunctiveFormula formula, boolean patternFolding,
                                        boolean partialSimplification, TermContext context) {
-        return context.global().javaExecutionOptions.cacheFunctions
+        return context.global().javaExecutionOptions.cacheFormulas
                 ? evaluationCache.get(new Entry(formula, patternFolding, partialSimplification, context.getTopConstraint()))
                 : null;
     }
 
     public void cachePut(ConjunctiveFormula formula, boolean patternFolding, boolean partialSimplification,
                          TermContext context, ConjunctiveFormula result) {
-        if (context.global().javaExecutionOptions.cacheFunctions) {
+        if (context.global().javaExecutionOptions.cacheFormulas) {
             evaluationCache.put(new Entry(formula, patternFolding, partialSimplification, context.getTopConstraint()), result);
             evaluationCache.put(new Entry(result, patternFolding, partialSimplification, context.getTopConstraint()), result);
         }

--- a/java-backend/src/main/java/org/kframework/backend/java/util/FormulaSimplificationCache.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/FormulaSimplificationCache.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2013-2018 K Team. All Rights Reserved.
+// Copyright (c) 2019 K Team. All Rights Reserved.
 package org.kframework.backend.java.util;
 
 import org.kframework.backend.java.kil.TermContext;


### PR DESCRIPTION
Caching results of `ConjunctiveFormula.simplify()`. Disabled by default, enabled with `--cache-formulas`. 

Performance increase in current VSC Jenkins suite is only 5%, but maybe it's more noticeable on certain rules or it was bigger in the past. Might still be useful in future.
