### PR TITLE
Java Backend: Z3 query pretty-printing and printing anonymous vars

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Variable.java
@@ -124,6 +124,10 @@ public class Variable extends Term implements org.kframework.kore.KVariable {
         return name;
     }
 
+    public String longName() {
+        return originalName + name;
+    }
+
     @Override
     public Seq<org.kframework.kore.Sort> params() {
         return Seq();

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -359,7 +359,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     private CharSequence appendConstantDeclarations(StringBuilder sb, Set<Variable> variables) {
         for (Variable variable : variables) {
             sb.append("(declare-fun ");
-            sb.append("|").append(variable.name()).append("|");
+            sb.append("|").append(variable.longName()).append("|");
             sb.append(" () ");
             String sortName;
             sortName = getSortName(variable);
@@ -372,7 +372,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     private CharSequence appendQuantifiedVariables(StringBuilder sb, Set<Variable> variables) {
         for (Variable variable : variables) {
             sb.append("(");
-            sb.append("|").append(variable.name()).append("|");
+            sb.append("|").append(variable.longName()).append("|");
             sb.append(" ");
             String sortName;
             sortName = getSortName(variable);
@@ -478,11 +478,14 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             if (allowNewVars) {
                 variable = Variable.getAnonVariable(term.sort());
                 termAbstractionMap.put(term, variable);
+                if (globalContext.javaExecutionOptions.debugZ3Queries) {
+                    System.err.format("\t%s ::= %s\n", variable.longName(), term);
+                }
             } else {
                 throw e;
             }
         }
-        return variable.name();
+        return variable.longName();
     }
 
     @Override
@@ -559,7 +562,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
         switch (label) {
             case "exists":
                 Variable variable = (Variable) kList.get(0);
-                label = "exists ((" + variable.name() + " " + variable.sort() + ")) ";
+                label = "exists ((" + variable.longName() + " " + variable.sort() + ")) ";
                 arguments = ImmutableList.of(kList.get(1));
                 break;
             case "extract":
@@ -647,7 +650,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
     @Override
     public SMTLibTerm transform(Variable variable) {
         variables.add(variable);
-        return new SMTLibTerm("|" + variable.name() + "|");
+        return new SMTLibTerm("|" + variable.longName() + "|");
     }
 
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
@@ -45,6 +45,9 @@ public class SMTOperations {
         try {
             constraint.globalContext().profiler.queryBuildTimer.start();
             CharSequence query;
+            if (javaExecutionOptions.debugZ3Queries) {
+                System.err.println("\nAnonymous vars in query:");
+            }
             try {
                 query = KILtoSMTLib.translateConstraint(constraint).toString();
             } finally {
@@ -80,6 +83,9 @@ public class SMTOperations {
             try {
                 left.globalContext().profiler.queryBuildTimer.start();
                 CharSequence query;
+                if (javaExecutionOptions.debugZ3Queries) {
+                    System.err.println("\nAnonymous vars in query:");
+                }
                 try {
                     query = KILtoSMTLib.translateImplication(left, right, existentialQuantVars).toString();
                 } finally {


### PR DESCRIPTION
Improved variable names in z3 queries. Logging anonymous variables created by z3 translation. Option --debug-z3-query is more useful now.

Variable names in queries now correspond to their toString() names in `ConjunctiveFormula`. Example log fragment:

```
...
(declare-fun |W0| () Int)
(declare-fun |W1| () Int)
(assert (and
  true
  (not (and
	(= (<= |W1| |W0|) true)))
))

Z3 query result: sat

Z3 Implication (Function rule implication) failed:
ConjunctiveFormula(
)
  implies
ConjunctiveFormula(
  equalities:
    _==K_(_<=Int__INT(W1:Int,, W0:Int),, Bool(#"true"))
)
```
