### PR TITLE
Java Backend: toString() cache

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -11,6 +11,7 @@ import org.kframework.backend.java.symbolic.Stage;
 import org.kframework.backend.java.util.FormulaSimplificationCache;
 import org.kframework.backend.java.util.Profiler2;
 import org.kframework.backend.java.util.StateLog;
+import org.kframework.backend.java.util.ToStringCache;
 import org.kframework.backend.java.util.Z3Wrapper;
 import org.kframework.krun.KRunOptions;
 import org.kframework.krun.api.io.FileSystem;
@@ -43,6 +44,7 @@ public class GlobalContext implements Serializable {
     public final PrettyPrinter prettyPrinter;
     public final transient FunctionCache functionCache = new FunctionCache();
     public final transient FormulaSimplificationCache formulaCache = new FormulaSimplificationCache();
+    public final transient ToStringCache toStringCache = new ToStringCache();
 
     private boolean isExecutionPhase = true;
 

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -788,6 +788,19 @@ public class KItem extends Term implements KItemRepresentation {
 
     @Override
     public String toString() {
+        String cached = global.toStringCache.get(this);
+        if (cached != null) {
+            return cached;
+        }
+
+        String result = toStringImpl();
+        if (global.javaExecutionOptions.cacheToString) {
+            global.toStringCache.put(this, result);
+        }
+        return result;
+    }
+
+    public String toStringImpl() {
         return kLabel + "(" + kList.toString() + ")";
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -51,12 +51,17 @@ public final class JavaExecutionOptions {
     @Parameter(names="--cache-func", description="Cache evaluation results of pure functions. Enabled by default.", arity = 1)
     public boolean cacheFunctions = true;
 
-    @Parameter(names="--cache-formulas", description="Cache results of ConjunctiveFormula.simplify().")
-    public boolean cacheFormulas = false;
-
     @Parameter(names="--cache-func-optimized",
             description="Clear function cache after initialization phase. Frees some memory. Use IN ADDITION to --cache-func")
     public boolean cacheFunctionsOptimized = false;
+
+    @Parameter(names="--cache-formulas", description="Cache results of ConjunctiveFormula.simplify().")
+    public boolean cacheFormulas = false;
+
+    @Parameter(names="--cache-tostring",
+            description="Cache toString() result for KItem, Equality and DisjunctiveFormula. " +
+                    "Speeds up logging but eats more memory.", arity = 1)
+    public boolean cacheToString = true;
 
     @Parameter(names="--format-failures", description="Format failure final states. By default they are printed all " +
             "on one line, using ConstrainedTerm.toString(). If option is enabled, they are printed a bit nicer, " +

--- a/java-backend/src/main/java/org/kframework/backend/java/util/ToStringCache.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/ToStringCache.java
@@ -1,0 +1,31 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+package org.kframework.backend.java.util;
+
+import org.kframework.backend.java.kil.KItem;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author Denis Bogdanas
+ * Created on 31-Jan-19.
+ */
+public class ToStringCache {
+    private Map<KItem, String> toStringCache = new HashMap<>();
+
+    public String get(KItem kItem) {
+        return toStringCache.get(kItem);
+    }
+
+    public void put(KItem kItem, String str) {
+        toStringCache.put(kItem, str);
+    }
+
+    public void clear() {
+        toStringCache.clear();
+    }
+
+    public int size() {
+        return toStringCache.size();
+    }
+}


### PR DESCRIPTION
Java Backend: Caching toString() for KItem. Speeds up all logging. Enabled with `--cache-tostring`.

Performance increase was ~25% some time ago before I optimized conjunctive formulas. At that time log size was several times bigger. Didn't use this option recently.