### PR TITLE
Java Backend: option --format-failures

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -58,6 +58,12 @@ public final class JavaExecutionOptions {
             description="Clear function cache after initialization phase. Frees some memory. Use IN ADDITION to --cache-func")
     public boolean cacheFunctionsOptimized = false;
 
+    @Parameter(names="--format-failures", description="Format failure final states. By default they are printed all " +
+            "on one line, using ConstrainedTerm.toString(). If option is enabled, they are printed a bit nicer, " +
+            "using custom ConjunctiveFormula formatter, but still fast. Disabled by default for output compatibility " +
+            "with other backends. Recommended to enable for Java backend.")
+    public boolean formatFailures = false;
+
     @Parameter(names="--branching-allowed", arity=1, description="Number of branching events allowed before a forcible stop.")
     public int branchingAllowed = Integer.MAX_VALUE;
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -737,11 +737,12 @@ public class SymbolicRewriter {
             global.javaExecutionOptions.log = originalLog;
         }
 
-        for (ConstrainedTerm term : proofResults) {
-            printTermAndConstraint(term);
-        }
-        if (proofResults.isEmpty()) {
-            System.out.println(KLabels.ML_TRUE);
+        if (global.javaExecutionOptions.formatFailures && !proofResults.isEmpty()) {
+            for (ConstrainedTerm term : proofResults) {
+                printTermAndConstraint(term);
+            }
+            proofResults.clear();
+            proofResults.add(new ConstrainedTerm(BoolToken.FALSE, initialTerm.termContext()));
         }
 
         if (global.globalOptions.verbose) {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -740,6 +740,20 @@ public class SymbolicRewriter {
             global.javaExecutionOptions.log = originalLog;
         }
 
+        for (ConstrainedTerm term : proofResults) {
+            print(term.term(), prettyResult);
+            System.out.print("/\\");
+            if (prettyResult) {
+                global.prettyPrinter.prettyPrint(term.constraint());
+            } else {
+                System.out.println(term.constraint().toStringMultiline());
+            }
+            System.out.println();
+        }
+        if (proofResults.isEmpty()) {
+            System.out.println(KLabels.ML_TRUE);
+        }
+
         if (global.globalOptions.verbose) {
             printSummaryBox(rule, proofResults, successPaths, step);
         }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -37,7 +37,6 @@ import org.kframework.kore.KORE;
 import org.kframework.rewriter.SearchType;
 import org.kframework.utils.errorsystem.KExceptionManager;
 
-import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -614,8 +613,8 @@ public class SymbolicRewriter {
         global.javaExecutionOptions.logRulesPublic = global.javaExecutionOptions.logRules;
 
         if (global.javaExecutionOptions.log) {
-            System.out.println("\nTarget term\n=====================\n");
-            System.out.println(targetTerm);
+            System.err.println("\nTarget term\n=====================\n");
+            System.err.println(targetTerm);
         }
         int branchingRemaining = global.javaExecutionOptions.branchingAllowed;
         boolean nextStepLogEnabled = false;
@@ -633,7 +632,7 @@ public class SymbolicRewriter {
                     global.stateLog.log(StateLog.LogEvent.REACHPROVED, term.term(), term.constraint());
                     if (global.javaExecutionOptions.logBasic) {
                         logStep(step, v, term, true, alreadyLogged);
-                        System.out.println("\n============\nStep " + step + ": eliminated!\n============\n");
+                        System.err.println("\n============\nStep " + step + ": eliminated!\n============\n");
                     }
                     successPaths++;
                     continue;
@@ -686,14 +685,14 @@ public class SymbolicRewriter {
                 } catch (Throwable e) {
                     // ENABLE EXCEPTION CHECKSTYLE
                     logStep(step, v, term, true, alreadyLogged);
-                    System.out.println("\n\nTerm throwing exception\n============================\n\n");
+                    System.err.println("\n\nTerm throwing exception\n============================\n\n");
                     printTermAndConstraint(term, false);
                     e.printStackTrace();
                     throw e;
                 }
                 if (results.isEmpty()) {
                     logStep(step, v, term, true, alreadyLogged);
-                    System.out.println("\nStep above: " + step + ", evaluation ended with no successors.");
+                    System.err.println("\nStep above: " + step + ", evaluation ended with no successors.");
                     /* final term */
                     proofResults.add(term);
                 }
@@ -702,14 +701,14 @@ public class SymbolicRewriter {
                     nextStepLogEnabled = true;
                     logStep(step, v, term, true, alreadyLogged);
                     if (branchingRemaining == 0) {
-                        System.out.println("\nHalt on branching!\n=====================\n");
+                        System.err.println("\nHalt on branching!\n=====================\n");
 
                         proofResults.addAll(results);
                         continue;
                     } else {
                         branchingRemaining--;
                         if (global.javaExecutionOptions.logBasic) {
-                            System.out.println("\nBranching!\n=====================\n");
+                            System.err.println("\nBranching!\n=====================\n");
                         }
                     }
                 }
@@ -757,9 +756,9 @@ public class SymbolicRewriter {
     }
 
     public void printTermAndConstraint(ConstrainedTerm term, boolean pretty) {
-        print(term.term(), System.out, pretty);
-        printConstraint(term.constraint(), System.out, pretty);
-        System.out.println();
+        print(term.term(), pretty);
+        printConstraint(term.constraint(), pretty);
+        System.err.println();
     }
 
     private void printSummaryBox(Rule rule, List<ConstrainedTerm> proofResults, int successPaths, int step) {
@@ -824,28 +823,28 @@ public class SymbolicRewriter {
                 if (cell == null) {
                     continue;
                 }
-                print(cell, System.err, pretty);
+                print(cell, pretty);
             }
-            printConstraint(term.constraint(), System.err, prettyPC);
+            printConstraint(term.constraint(), prettyPC);
         }
         global.profiler.logOverheadTimer.stop();
         return actuallyLogged;
     }
 
-    private void print(K cell, PrintStream out, boolean pretty) {
+    private void print(K cell, boolean pretty) {
         if (pretty) {
-            global.prettyPrinter.prettyPrint(cell, out);
+            global.prettyPrinter.prettyPrint(cell, System.err);
         } else {
-            out.println(toStringOrEmpty(cell));
+            System.err.println(toStringOrEmpty(cell));
         }
     }
 
-    private void printConstraint(ConjunctiveFormula constraint, PrintStream out, boolean pretty) {
-        out.println("/\\");
+    private void printConstraint(ConjunctiveFormula constraint, boolean pretty) {
+        System.err.println("/\\");
         if (pretty) {
-            global.prettyPrinter.prettyPrint(constraint, out);
+            global.prettyPrinter.prettyPrint(constraint, System.err);
         } else {
-            out.println(constraint.toStringMultiline());
+            System.err.println(constraint.toStringMultiline());
         }
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -2,6 +2,7 @@
 package org.kframework.backend.java.symbolic;
 
 import com.google.common.base.Stopwatch;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.apache.commons.lang3.tuple.Pair;
@@ -737,18 +738,18 @@ public class SymbolicRewriter {
             global.javaExecutionOptions.log = originalLog;
         }
 
+        List<ConstrainedTerm> tweakedProofResults = proofResults;
         if (global.javaExecutionOptions.formatFailures && !proofResults.isEmpty()) {
             for (ConstrainedTerm term : proofResults) {
                 printTermAndConstraint(term);
             }
-            proofResults.clear();
-            proofResults.add(new ConstrainedTerm(BoolToken.FALSE, initialTerm.termContext()));
+            tweakedProofResults = ImmutableList.of(new ConstrainedTerm(BoolToken.FALSE, initialTerm.termContext()));
         }
 
         if (global.globalOptions.verbose) {
             printSummaryBox(rule, proofResults, successPaths, step);
         }
-        return proofResults;
+        return tweakedProofResults;
     }
 
     public void printTermAndConstraint(ConstrainedTerm term) {

--- a/java-backend/src/main/java/org/kframework/backend/java/util/PrettyPrinter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/PrettyPrinter.java
@@ -1,11 +1,12 @@
 // Copyright (c) 2019 K Team. All Rights Reserved.
 package org.kframework.backend.java.util;
 
-import org.kframework.backend.java.kil.GlobalContext;
 import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
 import org.kframework.kore.K;
 import org.kframework.unparser.KPrint;
+
+import java.io.OutputStream;
 
 /**
  * @author Denis Bogdanas
@@ -23,6 +24,10 @@ public class PrettyPrinter {
     }
 
     public void prettyPrint(K target) {
-        kprint.prettyPrint(def, module, kprint::outputFile, target);
+        prettyPrint(target, System.out);
+    }
+
+    public void prettyPrint(K target, OutputStream out) {
+        kprint.prettyPrint(def, module, output -> kprint.outputFile(output, out), target);
     }
 }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -26,7 +26,7 @@ import org.kframework.utils.file.TTYInfo;
 import scala.Tuple2;
 
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
+import java.io.OutputStream;
 
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -36,7 +36,6 @@ import java.util.Map;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
-import scala.Some;
 import scala.Option;
 
 import static org.kframework.kore.KORE.*;
@@ -76,9 +75,13 @@ public class KPrint {
     }
 
     public void outputFile(byte[] output) {
+        outputFile(output, System.out);
+    }
+
+    public void outputFile(byte[] output, OutputStream out) {
         if (options.outputFile == null) {
             try {
-                System.out.write(output);
+                out.write(output);
             } catch (IOException e) {
                 throw KEMException.internalError(e.getMessage(), e);
             }


### PR DESCRIPTION
Added a custom formatting of failure final states. Enabled with `--format-failures`. This required a small extension to `KPrint` and some refactorings in `SymbolicRewriter` to avoid duplicates. See commit messages for details.
