### PR TITLE
Send sentence labels to Kore

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/checks/CheckLabels.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckLabels.java
@@ -1,0 +1,32 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+package org.kframework.compile.checks;
+
+import org.kframework.definition.Module;
+import org.kframework.definition.Sentence;
+import org.kframework.utils.errorsystem.KEMException;
+
+import java.util.Set;
+import java.util.TreeSet;
+
+/**
+ * Check that all sentence labels in a module are unique.
+ */
+public class CheckLabels {
+    private final Set<KEMException> errors;
+
+    public CheckLabels(Set<KEMException> errors) {
+        this.errors = errors;
+    }
+
+    private final Set<String> labels = new TreeSet<>();
+
+    public void check(Sentence sentence) {
+        if (sentence.label().isPresent()) {
+            String label = sentence.label().get();
+            if (!labels.add(label)) {
+                errors.add(KEMException.compilerError("Found duplicate sentence label " + label, sentence));
+            }
+        }
+    }
+}
+

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -11,6 +11,7 @@ import org.kframework.compile.*;
 import org.kframework.compile.checks.CheckConfigurationCells;
 import org.kframework.compile.checks.CheckImports;
 import org.kframework.compile.checks.CheckKLabels;
+import org.kframework.compile.checks.CheckLabels;
 import org.kframework.compile.checks.CheckRHSVariables;
 import org.kframework.compile.checks.CheckRewrite;
 import org.kframework.compile.checks.CheckSortTopUniqueness;
@@ -236,6 +237,8 @@ public class Kompile {
         Consumer<Module> checkModuleKLabels = m -> stream(m.localSentences()).forEach(s -> checkKLabels.check(s, m));
         stream(parsedDef.mainModule().importedModules()).forEach(checkModuleKLabels);
         checkModuleKLabels.accept(parsedDef.mainModule());
+
+        stream(parsedDef.modules()).forEach(m -> stream(m.localSentences()).forEach(new CheckLabels(errors)::check));
 
         if (!errors.isEmpty()) {
             kem.addAllKException(errors.stream().map(e -> e.exception).collect(Collectors.toList()));

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -47,6 +47,7 @@ public class KILtoKORE extends KILTransformation<Object> {
     private org.kframework.kil.loader.Context context;
     private final boolean syntactic;
     private final boolean kore;
+    private String moduleName;
 
     public KILtoKORE(org.kframework.kil.loader.Context context, boolean syntactic, boolean kore) {
         this.context = context;
@@ -93,6 +94,9 @@ public class KILtoKORE extends KILTransformation<Object> {
     private org.kframework.definition.Module apply(Module mainModule, Set<Module> allKilModules,
                                                   Map<String, org.kframework.definition.Module> koreModules,
                                                   scala.collection.Seq<Module> visitedModules) {
+        // Record the current module name for constructing the label attribute.
+        moduleName = mainModule.getName();
+
         checkCircularModuleImports(mainModule, visitedModules);
         CheckListDecl.check(mainModule);
         Set<org.kframework.definition.Sentence> items = mainModule.getItems().stream()
@@ -178,9 +182,17 @@ public class KILtoKORE extends KILTransformation<Object> {
     }
 
     public org.kframework.definition.Bubble apply(StringSentence sentence) {
-        return Bubble(sentence.getType(), sentence.getContent(), convertAttributes(sentence)
-                .add("contentStartLine", Integer.class, sentence.getContentStartLine())
-                .add("contentStartColumn", Integer.class, sentence.getContentStartColumn()));
+        org.kframework.attributes.Att attrs =
+            convertAttributes(sentence)
+            .add("contentStartLine", Integer.class, sentence.getContentStartLine())
+            .add("contentStartColumn", Integer.class, sentence.getContentStartColumn());
+
+        String label = sentence.getLabel();
+        if (!label.isEmpty()) {
+            attrs = attrs.add("label", moduleName + "." + label);
+        }
+
+        return Bubble(sentence.getType(), sentence.getContent(), attrs);
     }
 
 

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -308,6 +308,7 @@ trait Sentence extends HasLocation {
   def withAtt(att: Att): Sentence
   def location: Optional[Location] = att.getOptional(classOf[Location])
   def source: Optional[Source] = att.getOptional(classOf[Source])
+  def label: Optional[String] = att.getOptional("label")
 }
 
 // deprecated


### PR DESCRIPTION
Sentence labels are given to the `label` attribute in generated Kore definitions. Sentence labels must be unique in each module. The user-defined label is prefixed with the module name.

We discussed using the `name` Kore attribute instead of `label`, but I think consistency is important to avoid confusion, and the frontend code uses the term "label".