### PR TITLE
Add option to turn off alpha renaming

### DIFF
--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -167,7 +167,13 @@ public class KPrint {
                 return super.apply(k);
             }
         }.apply(input);
-        K alphaRenamed = new TransformK() {
+        K alphaRenamed = alphaRename(sortedComm);
+
+        return unparseInternal(test, alphaRenamed, colorize);
+    }
+
+    private K alphaRename(K input) {
+        return new TransformK() {
             Map<KVariable, KVariable> renames = new HashMap<>();
             int newCount = 0;
 
@@ -178,8 +184,7 @@ public class KPrint {
                 }
                 return k;
             }
-        }.apply(sortedComm);
-        return unparseInternal(test, alphaRenamed, colorize);
+        }.apply(input);
     }
 
     private String unparseInternal(Module mod, K input, ColorSetting colorize) {

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -230,7 +230,7 @@ public class KPrint {
         return KToken(tokenizedTerm, finalSort);
     }
 
-    public static K flattenTerm(Module mod, KApply kapp) {
+    private static K flattenTerm(Module mod, KApply kapp) {
         List<K> items = new ArrayList<>();
         Att att = mod.attributesFor().apply(KLabel(kapp.klabel().name()));
         if (att.contains("assoc") && att.contains("unit")) {
@@ -241,7 +241,7 @@ public class KPrint {
         return KApply(kapp.klabel(), KList(items), kapp.att());
     }
 
-    public static K toKASTTerm(Module mod, KApply kapp) {
+    private static K toKASTTerm(Module mod, KApply kapp) {
         String       kastTerm  = ToKast.apply(kapp);
         Sort         finalSort = Sorts.K();
         Option<Sort> termSort  = mod.sortFor().get(kapp.klabel());

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -158,17 +158,8 @@ public class KPrint {
     public K abstractTerm(Module mod, K term) {
         K collectionsSorted = sortCollections(mod, term);
         K alphaRenamed      = options.noAlphaRenaming ? collectionsSorted : alphaRename(collectionsSorted);
-        K squashedTerm      = new TransformK() {
-            @Override
-            public K apply(KApply orig) {
-                String name = orig.klabel().name();
-                return options.omittedKLabels.contains(name)   ? omitTerm(mod, orig)
-                     : options.tokenizedKLabels.contains(name) ? tokenizeTerm(mod, orig)
-                     : options.tokastKLabels.contains(name)    ? toKASTTerm(mod, orig)
-                     : super.apply(orig) ;
-            }
-        }.apply(alphaRenamed);
-        K flattenedTerm = flattenTerms(mod, squashedTerm);
+        K squashedTerm      = squashTerms(mod, alphaRenamed);
+        K flattenedTerm     = flattenTerms(mod, squashedTerm);
 
         return flattenedTerm;
     }
@@ -208,6 +199,19 @@ public class KPrint {
                     return renames.computeIfAbsent(k, k2 -> KVariable("V" + newCount++, k.att()));
                 }
                 return k;
+            }
+        }.apply(input);
+    }
+
+    private K squashTerms(Module mod, K input) {
+        return new TransformK() {
+            @Override
+            public K apply(KApply orig) {
+                String name = orig.klabel().name();
+                return options.omittedKLabels.contains(name)   ? omitTerm(mod, orig)
+                     : options.tokenizedKLabels.contains(name) ? tokenizeTerm(mod, orig)
+                     : options.tokastKLabels.contains(name)    ? toKASTTerm(mod, orig)
+                     : super.apply(orig) ;
             }
         }.apply(input);
     }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -166,7 +166,7 @@ public class KPrint {
                      : options.tokenizedKLabels.contains(name) ? tokenizeTerm(mod, orig)
                      : options.flattenedKLabels.contains(name) ? flattenTerm(mod, orig)
                      : options.tokastKLabels.contains(name)    ? toKASTTerm(mod, orig)
-                     : orig ;
+                     : super.apply(orig) ;
             }
         }.apply(alphaRenamed);
     }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -167,9 +167,8 @@ public class KPrint {
                 return super.apply(k);
             }
         }.apply(input);
-        K alphaRenamed = alphaRename(sortedComm);
 
-        return unparseInternal(test, alphaRenamed, colorize);
+        return unparseInternal(test, sortedComm, colorize);
     }
 
     private K alphaRename(K input) {
@@ -194,6 +193,7 @@ public class KPrint {
     }
 
     public K abstractTerm(Module mod, K term) {
+        K alphaRenamed = options.noAlphaRenaming ? term : alphaRename(term);
         return new TransformK() {
             @Override
             public K apply(KApply orig) {
@@ -204,7 +204,7 @@ public class KPrint {
                      : options.tokastKLabels.contains(name)    ? toKASTTerm(mod, orig)
                      : orig ;
             }
-        }.apply(term);
+        }.apply(alphaRenamed);
     }
 
     private static K omitTerm(Module mod, KApply kapp) {

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -156,8 +156,8 @@ public class KPrint {
     }
 
     public K abstractTerm(Module mod, K term) {
-        K collectionsSorted = sortCollections(mod, term);
-        K alphaRenamed      = options.noAlphaRenaming ? collectionsSorted : alphaRename(collectionsSorted);
+        K collectionsSorted = options.noSortCollections ? term              : sortCollections(mod, term);
+        K alphaRenamed      = options.noAlphaRenaming   ? collectionsSorted : alphaRename(collectionsSorted);
         K squashedTerm      = squashTerms(mod, alphaRenamed);
         K flattenedTerm     = flattenTerms(mod, squashedTerm);
 

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -146,18 +146,22 @@ public class KPrint {
     }
 
     public String unparseTerm(K input, Module test, ColorSetting colorize) {
-        K sortedComm = new TransformK() {
+        return unparseInternal(test, sortCollections(test, input), colorize);
+    }
+
+    private K sortCollections(Module mod, K input) {
+        return new TransformK() {
             @Override
             public K apply(KApply k) {
                 if (k.klabel() instanceof KVariable) {
                     return super.apply(k);
                 }
-                Att att = test.attributesFor().apply(KLabel(k.klabel().name()));
+                Att att = mod.attributesFor().apply(KLabel(k.klabel().name()));
                 if (att.contains("comm") && att.contains("assoc") && att.contains("unit")) {
                     List<K> items = new ArrayList<>(Assoc.flatten(k.klabel(), k.klist().items(), KLabel(att.get("unit"))));
                     List<Tuple2<String, K>> printed = new ArrayList<>();
                     for (K item : items) {
-                        String s = unparseInternal(test, apply(item), ColorSetting.OFF);
+                        String s = unparseInternal(mod, apply(item), ColorSetting.OFF);
                         printed.add(Tuple2.apply(s, item));
                     }
                     printed.sort(Comparator.comparing(Tuple2::_1, new AlphanumComparator()));
@@ -167,8 +171,6 @@ public class KPrint {
                 return super.apply(k);
             }
         }.apply(input);
-
-        return unparseInternal(test, sortedComm, colorize);
     }
 
     private K alphaRename(K input) {

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -91,4 +91,7 @@ public class PrintOptions {
 
     @Parameter(names={"--output-tokast"}, listConverter=StringListConverter.class, description="KLabels to output as KAST tokens.")
     public List<String> tokastKLabels = new ArrayList<String>();
+
+    @Parameter(names={"--no-alpha-renaming"}, listConverter=StringListConverter.class, description="KLabels to output as KAST tokens.")
+    public boolean noAlphaRenaming = false;
 }

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -94,4 +94,7 @@ public class PrintOptions {
 
     @Parameter(names={"--no-alpha-renaming"}, listConverter=StringListConverter.class, description="KLabels to output as KAST tokens.")
     public boolean noAlphaRenaming = false;
+
+    @Parameter(names={"--no-sort-collections"}, listConverter=StringListConverter.class, description="Do not sort collections before printing (for speed).")
+    public boolean noSortCollections = false;
 }


### PR DESCRIPTION
This moves alpha renaming into part of the abstraction pass of `prettyPrint`, which means that direct calls to `serialize` and `unparseTerm` will not have the alpha renaming happen anymore. I only found one direct call to `unparseTerm`, in the file `kernel/src/test/java/org/kframework/unparser/AddBracketsTest.java`, so I'm not sure if that one is affected.