### PR TITLE
Java Backend: Bugfix - remove unnecessary cast in result building expression

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -24,7 +24,6 @@ import org.kframework.definition.Rule;
 import org.kframework.kil.Attribute;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.K;
-import org.kframework.kore.KApply;
 import org.kframework.krun.KRunOptions;
 import org.kframework.krun.api.io.FileSystem;
 import org.kframework.main.GlobalOptions;
@@ -270,8 +269,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
                     .collect(Collectors.toList());
 
             K result = proofResults.stream()
-                    .map(ConstrainedTerm::term)
-                    .map(t -> (KApply) t)
+                    .map(constrainedTerm -> (K) constrainedTerm.term())
                     .reduce(((k1, k2) -> KApply(KLabels.ML_AND, k1, k2))).orElse(KApply(KLabels.ML_TRUE));
             rewritingContext.stateLog.close();
             return result;


### PR DESCRIPTION
Required for recent option --format-failures. That is because when option is enabled and evaluation fails, result is not of type `KApply`.