### PR TITLE
update substitution module to use KVar and hook

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Sort.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Sort.java
@@ -47,7 +47,7 @@ public final class Sort implements org.kframework.kore.Sort, Serializable {
     public static final Sort STRING         =   Sort.of(Sorts.String());
     public static final Sort BIT_VECTOR     =   Sort.of(Sorts.MInt());
 
-    public static final Sort KVARIABLE      =   Sort.of(KORE.Sort("KVariable"));
+    public static final Sort KVARIABLE      =   Sort.of(KORE.Sort("KVar"));
 
     public static final Sort META_VARIABLE  =   Sort.of(KORE.Sort("MetaVariable"));
     public static final Sort BOTTOM         =   Sort.of(KORE.Sort("Bottom"));

--- a/k-distribution/include/builtin/substitution.k
+++ b/k-distribution/include/builtin/substitution.k
@@ -1,11 +1,38 @@
 // Copyright (c) 2015-2019 K Team. All Rights Reserved.
 
+module KVAR-PROGRAM-PARSING
+  imports BUILTIN-ID-TOKENS
+
+  syntax KVar ::= r"(?<![A-Za-z0-9\\_])[A-Za-z\\_][A-Za-z0-9\\_]*"     [prec(1), notInRules, token, autoReject]
+  
+              | #LowerId                                             [notInRules, token, autoReject]
+              | #UpperId                                             [notInRules, token, autoReject]
+endmodule
+
+module KVAR-SYNTAX
+  syntax KVar [token, hook(KVAR.KVar)]
+endmodule
+
+module KVAR
+  imports KVAR-SYNTAX
+  imports KVAR-SYMBOLIC
+endmodule
+
+module KVAR-SYMBOLIC [symbolic, kast]
+  imports KVAR-SYNTAX
+  imports STRING
+
+  syntax KVar ::= String2KVar (String) [function, functional, hook(STRING.string2var)]
+  syntax KVar ::= freshKVar(Int)    [freshGenerator, function, functional]
+  syntax KItem  ::= "#parseToken"  "(" String "," String ")"  [function, klabel(#parseKVar), hook(STRING.parseToken)]
+  rule String2KVar(S:String) => {#parseToken("KVar", S)}:>KVar
+  rule freshKVar(I:Int) => String2KVar("_" +String Int2String(I))
+endmodule
+
 module SUBSTITUTION
   imports MAP
+  imports KVAR
 
-  // used for user-defined substitution only
-  syntax KVariable
-
-  syntax K ::= K "[" K "/" K "]"  [function, hook(SUBSTITUTION.substOne), impure, poly(0, 1)]
+  syntax K ::= K "[" KItem "/" KItem "]"  [function, hook(SUBSTITUTION.substOne), impure, poly(0, 1)]
   syntax K ::= K "[" Map "]"      [function, hook(SUBSTITUTION.substMany), impure, poly(0, 1)]
 endmodule

--- a/k-distribution/include/builtin/substitution.k
+++ b/k-distribution/include/builtin/substitution.k
@@ -4,7 +4,7 @@ module KVAR-PROGRAM-PARSING
   imports BUILTIN-ID-TOKENS
 
   syntax KVar ::= r"(?<![A-Za-z0-9\\_])[A-Za-z\\_][A-Za-z0-9\\_]*"     [prec(1), notInRules, token, autoReject]
-  
+
               | #LowerId                                             [notInRules, token, autoReject]
               | #UpperId                                             [notInRules, token, autoReject]
 endmodule

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_2.5/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_2.5/lambda.k
@@ -6,12 +6,11 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder]
   syntax Exp ::= Val
                | Exp Exp              [left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]   [anywhere]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]   [anywhere]
 endmodule

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_2/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_2/lambda.k
@@ -6,12 +6,11 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder]
   syntax Exp ::= Val
                | Exp Exp              [left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 endmodule

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_3/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_3/lambda.k
@@ -6,13 +6,12 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 endmodule

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_4/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_4/lambda.k
@@ -6,13 +6,12 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 endmodule

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_5/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_5/lambda.k
@@ -6,15 +6,14 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 
   syntax Val ::= Int | Bool
   syntax Exp ::= Exp "*" Exp          [strict, left]

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_6/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_6/lambda.k
@@ -6,15 +6,14 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 
   syntax Val ::= Int | Bool
   syntax Exp ::= Exp "*" Exp          [strict, left]

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_7/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_7/lambda.k
@@ -6,15 +6,14 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 
   syntax Val ::= Int | Bool
   syntax Exp ::= Exp "*" Exp          [strict, left]
@@ -30,12 +29,12 @@ module LAMBDA
   rule if true  then E else _ => E
   rule if false then _ else E => E
 
-  syntax Exp ::= "let" Id "=" Exp "in" Exp
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp
   rule let X = E in E':Exp => (lambda X . E') E                        [macro]
 
-  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
-  syntax Id ::= "$x" | "$y"
-  rule letrec F:Id X:Id = E in E'
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
+  syntax KVar ::= "$x" [token] | "$y" [token]
+  rule letrec F:KVar X:KVar = E in E'
     => let F =
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_8/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_8/lambda.k
@@ -6,15 +6,14 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 
   syntax Val ::= Int | Bool
   syntax Exp ::= Exp "*" Exp          [strict, left]
@@ -30,11 +29,11 @@ module LAMBDA
   rule if true  then E else _ => E
   rule if false then _ else E => E
 
-  syntax Exp ::= "let" Id "=" Exp "in" Exp
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp
   rule let X = E in E':Exp => (lambda X . E') E                        [macro]
 
-  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
-               | "mu" Id "." Exp      [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'    [macro]
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
+               | "mu" KVar "." Exp      [binder, latex(\mu{#1}.{#2})]
+  rule letrec F:KVar X = E in E' => let F = mu F . lambda X . E in E'    [macro]
   rule mu X . E => E[(mu X . E) / X]
 endmodule

--- a/k-distribution/tutorial/1_k/1_lambda/lesson_9/lambda.k
+++ b/k-distribution/tutorial/1_k/1_lambda/lesson_9/lambda.k
@@ -87,17 +87,16 @@ interleaved) order.
 
 //@ The initial syntax of our $\lambda$-calculus:
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [left, strict]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
 //@ \section{$\beta$-reduction}
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 
 /*@ \section{Integer and Boolean Builtins}
 The LAMBDA arithmetic and Boolean expression constructs are simply rewritten
@@ -132,7 +131,7 @@ Note that the \texttt{if} construct is strict only in its first argument. */
 The let binder is a derived construct, because it can be defined using
 $\lambda$. */
 
-  syntax Exp ::= "let" Id "=" Exp "in" Exp
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp
   rule let X = E in E':Exp => (lambda X . E') E                         [macro]
 
 /*@ \section{Letrec Binder}
@@ -140,8 +139,8 @@ We prefer a definition based on the $\mu$ construct.  Note that $\mu$ is not
 really necessary, but it makes the definition of letrec easier to understand
 and faster to execute. */
 
-  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
-               | "mu" Id "." Exp                  [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:Id X:Id = E in E' => let F = mu F . lambda X . E in E' [macro]
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
+               | "mu" KVar "." Exp                  [binder, latex(\mu{#1}.{#2})]
+  rule letrec F:KVar X:KVar = E in E' => let F = mu F . lambda X . E in E' [macro]
   rule mu X . E => E[(mu X . E) / X]
 endmodule

--- a/k-distribution/tutorial/1_k/3_lambda++/lesson_1/lambda.k
+++ b/k-distribution/tutorial/1_k/3_lambda++/lesson_1/lambda.k
@@ -7,15 +7,14 @@ module LAMBDA-SEMANTICS
   imports SUBSTITUTION
   imports syntax DEFAULT-CONFIGURATION
 
-  syntax Val ::= Id
-               | "lambda" Id "." Exp  [binder, latex(\lambda{#1}.{#2})]
+  syntax Val ::= KVar
+               | "lambda" KVar "." Exp  [binder, latex(\lambda{#1}.{#2})]
   syntax Exp ::= Val
                | Exp Exp              [strict, left]
                | "(" Exp ")"          [bracket]
-  syntax KVariable ::= Id
   syntax KResult ::= Val
 
-  rule (lambda X:Id . E:Exp) V:Val => E[V / X]
+  rule (lambda X:KVar . E:Exp) V:Val => E[V / X]
 
   syntax Val ::= Int | Bool
   syntax Exp ::= Exp "*" Exp          [strict, left]
@@ -31,12 +30,12 @@ module LAMBDA-SEMANTICS
   rule if true  then E else _ => E
   rule if false then _ else E => E
 
-  syntax Exp ::= "let" Id "=" Exp "in" Exp
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp
   rule let X = E in E':Exp => (lambda X . E') E                        [macro]
 
-  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
-               | "mu" Id "." Exp                 [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'    [macro]
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
+               | "mu" KVar "." Exp                 [binder, latex(\mu{#1}.{#2})]
+  rule letrec F:KVar X = E in E' => let F = mu F . lambda X . E in E'    [macro]
   rule mu X . E => E[(mu X . E) / X]
 
   syntax Exp ::= "callcc" Exp  [strict]

--- a/k-distribution/tutorial/1_k/5_types/lesson_1.9/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_1.9/lambda.k
@@ -10,11 +10,10 @@ module LAMBDA
                 | Type "->" Type
                 | "(" Type ")"                 [bracket]
 
-  syntax Exp ::= Id
-               | "lambda" Id ":" Type "." Exp  [binder]
+  syntax Exp ::= KVar
+               | "lambda" KVar ":" Type "." Exp  [binder]
                | Exp Exp                       [left]
                | "(" Exp ")"                   [bracket]
-  syntax KVariable ::= Id
 
   syntax Exp ::= Type
 
@@ -41,11 +40,11 @@ module LAMBDA
   syntax Exp ::= "if" Exp "then" Exp "else" Exp
   rule if bool then T:Type else T => T         [anywhere]
 
-  syntax Exp ::= "let" Id ":" Type "=" Exp "in" Exp
+  syntax Exp ::= "let" KVar ":" Type "=" Exp "in" Exp
   rule let X : T = E in E' => (lambda X : T . E') E                   [macro]
 
-  syntax Exp ::= "letrec" Id ":" Type Id ":" Type "=" Exp "in" Exp
-               | "mu" Id ":" Type "." Exp      [binder]
+  syntax Exp ::= "letrec" KVar ":" Type KVar ":" Type "=" Exp "in" Exp
+               | "mu" KVar ":" Type "." Exp      [binder]
   rule letrec F : T1  X : T2 = E in E'
     => let F : T1 = mu F : T1 . lambda X : T2 . E in E'               [macro]
   rule mu X : T . E => (T -> T) (E[T/X])         [anywhere]

--- a/k-distribution/tutorial/1_k/5_types/lesson_2/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_2/lambda.k
@@ -10,14 +10,12 @@ module LAMBDA
                 | Type "->" Type
                 | "(" Type ")"                 [bracket]
 
-  syntax Exp ::= Id
-               | "lambda" Id ":" Type "." Exp  [binder]
+  syntax Exp ::= KVar
+               | "lambda" KVar ":" Type "." Exp  [binder]
                | Exp Exp                       [strict, left]
                | "(" Exp ")"                   [bracket]
 
   syntax Exp ::= Type
-
-  syntax KVariable ::= Id
 
   syntax KResult ::= Type
 
@@ -42,11 +40,11 @@ module LAMBDA
   syntax Exp ::= "if" Exp "then" Exp "else" Exp                       [strict]
   rule if bool then T:Type else T => T
 
-  syntax Exp ::= "let" Id ":" Type "=" Exp "in" Exp
+  syntax Exp ::= "let" KVar ":" Type "=" Exp "in" Exp
   rule let X : T = E in E' => (lambda X : T . E') E                   [macro]
 
-  syntax Exp ::= "letrec" Id ":" Type Id ":" Type "=" Exp "in" Exp
-               | "mu" Id ":" Type "." Exp                             [binder]
+  syntax Exp ::= "letrec" KVar ":" Type KVar ":" Type "=" Exp "in" Exp
+               | "mu" KVar ":" Type "." Exp                             [binder]
   rule letrec F : T1  X : T2 = E in E'
     => let F : T1 = mu F : T1 . lambda X : T2 . E in E'               [macro]
   rule mu X : T . E => (T -> T) (E[T/X])

--- a/k-distribution/tutorial/1_k/5_types/lesson_4/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_4/lambda.k
@@ -6,25 +6,24 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Exp ::= Int | Bool | Id
+  syntax Exp ::= Int | Bool | KVar
                | "(" Exp ")"                      [bracket]
                | Exp Exp                          [strict, left]
                > Exp "*" Exp                      [strict, left]
                | Exp "/" Exp                      [strict]
                > Exp "+" Exp                      [strict, left]
                > Exp "<=" Exp                     [strict]
-               > "lambda" Id "." Exp              [binder]
+               > "lambda" KVar "." Exp              [binder]
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" Id "=" Exp "in" Exp        [binder]
-               | "letrec" Id Id "=" Exp "in" Exp  [binder]
-               | "mu" Id "." Exp                  [binder]
+               | "let" KVar "=" Exp "in" Exp        [binder]
+               | "letrec" KVar KVar "=" Exp "in" Exp  [binder]
+               | "mu" KVar "." Exp                  [binder]
 
   syntax Type ::= "int" | "bool"
                 | Type "->" Type
                 | "(" Type ")"                    [bracket]
 
   syntax Exp ::= Type
-  syntax KVariable ::= Id
   syntax KResult ::= Type
 
   configuration <k color="green"> $PGM:Exp </k>

--- a/k-distribution/tutorial/1_k/5_types/lesson_7/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_7/lambda.k
@@ -6,25 +6,24 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Exp ::= Int | Bool | Id
+  syntax Exp ::= Int | Bool | KVar
                | "(" Exp ")"                      [bracket]
                | Exp Exp                          [strict, left]
                > Exp "*" Exp                      [strict, left]
                | Exp "/" Exp                      [strict]
                > Exp "+" Exp                      [strict, left]
                > Exp "<=" Exp                     [strict]
-               > "lambda" Id "." Exp              [binder]
+               > "lambda" KVar "." Exp              [binder]
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" Id "=" Exp "in" Exp        [binder]
-               | "letrec" Id Id "=" Exp "in" Exp  [binder]
-               | "mu" Id "." Exp                  [binder]
+               | "let" KVar "=" Exp "in" Exp        [binder]
+               | "letrec" KVar KVar "=" Exp "in" Exp  [binder]
+               | "mu" KVar "." Exp                  [binder]
 
   syntax Type ::= "int" | "bool"
                 | Type "->" Type
                 | "(" Type ")"                    [bracket]
 
   syntax Exp ::= Type
-  syntax KVariable ::= Id
   syntax KResult ::= Type
 
   configuration <k color="green"> $PGM:Exp </k>

--- a/k-distribution/tutorial/1_k/5_types/lesson_8/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_8/lambda.k
@@ -6,25 +6,24 @@ module LAMBDA
   imports DOMAINS
   imports SUBSTITUTION
 
-  syntax Exp ::= Int | Bool | Id
+  syntax Exp ::= Int | Bool | KVar
                | "(" Exp ")"                      [bracket]
                | Exp Exp                          [strict, left]
                > Exp "*" Exp                      [strict, left]
                | Exp "/" Exp                      [strict]
                > Exp "+" Exp                      [strict, left]
                > Exp "<=" Exp                     [strict]
-               > "lambda" Id "." Exp              [binder]
+               > "lambda" KVar "." Exp              [binder]
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" Id "=" Exp "in" Exp
-               | "letrec" Id Id "=" Exp "in" Exp
-               | "mu" Id "." Exp                  [binder]
+               | "let" KVar "=" Exp "in" Exp
+               | "letrec" KVar KVar "=" Exp "in" Exp
+               | "mu" KVar "." Exp                  [binder]
 
   syntax Type ::= "int" | "bool"
                 | Type "->" Type
                 | "(" Type ")"                    [bracket]
 
   syntax Exp ::= Type
-  syntax KVariable ::= Id
   syntax KResult ::= Type
 
   configuration <k color="green"> $PGM:Exp </k>
@@ -32,21 +31,21 @@ module LAMBDA
 
   rule I:Int => int
   rule B:Bool => bool
-  rule <k> X:Id => T ...</k>  <tenv>... X |-> T ...</tenv>
+  rule <k> X:KVar => T ...</k>  <tenv>... X |-> T ...</tenv>
   rule T1:Type  * T2:Type => T1 = int ~> T2 = int ~> int
   rule T1:Type  / T2:Type => T1 = int ~> T2 = int ~> int
   rule T1:Type  + T2:Type => T1 = int ~> T2 = int ~> int
   rule T1:Type <= T2:Type => T1 = int ~> T2 = int ~> bool
 
   syntax Exp ::= Exp "->" Exp                  [strict]
-  rule <k> lambda X:Id . E => ?T:Type -> E ~> setTenv(TEnv) ...</k>
+  rule <k> lambda X:KVar . E => ?T:Type -> E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 
   rule T1:Type T2:Type => T1 = (T2 -> ?T:Type) ~> ?T
   rule if T:Type then T1:Type else T2:Type => T = bool ~> T1 = T2 ~> T1
   rule let X = E in E' => E'[E/X]                                       [macro]
   rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
-  rule <k> mu X:Id . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
+  rule <k> mu X:KVar . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 
   syntax KItem ::= Type "=" Type

--- a/k-distribution/tutorial/1_k/5_types/lesson_9.5/lambda.k
+++ b/k-distribution/tutorial/1_k/5_types/lesson_9.5/lambda.k
@@ -5,18 +5,19 @@ require "substitution.k"
 
 module LAMBDA-SYNTAX
   imports DOMAINS-SYNTAX
-  syntax Exp ::= Int | Bool | Id
+  imports KVAR
+  syntax Exp ::= Int | Bool | KVar
                | "(" Exp ")"                      [bracket]
                | Exp Exp                          [strict, left]
                > Exp "*" Exp                      [strict, left]
                | Exp "/" Exp                      [strict]
                > Exp "+" Exp                      [strict, left]
                > Exp "<=" Exp                     [strict]
-               > "lambda" Id "." Exp
+               > "lambda" KVar "." Exp
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" Id "=" Exp "in" Exp        [strict(2)]
-               | "letrec" Id Id "=" Exp "in" Exp
-               | "mu" Id "." Exp
+               | "let" KVar "=" Exp "in" Exp        [strict(2)]
+               | "letrec" KVar KVar "=" Exp "in" Exp
+               | "mu" KVar "." Exp
 endmodule
 
 module LAMBDA
@@ -31,8 +32,6 @@ module LAMBDA
 
   syntax Exp ::= Type
 
-
-  syntax KVariable ::= Id
   syntax KResult ::= Type
 
   configuration <k color="green"> $PGM:Exp </k>
@@ -40,14 +39,14 @@ module LAMBDA
 
   rule I:Int => int
   rule B:Bool => bool
-  rule <k> X:Id => T ...</k>  <tenv>... X |-> T:Type ...</tenv>
+  rule <k> X:KVar => T ...</k>  <tenv>... X |-> T:Type ...</tenv>
   rule int * int => int
   rule int / int => int
   rule int + int => int
   rule int <= int => bool
 
   syntax Exp ::= Exp "->" Exp                  [strict]
-  rule <k> lambda X:Id . E => ?T:Type -> E ~> setTenv(TEnv) ...</k>
+  rule <k> lambda X:KVar . E => ?T:Type -> E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 
   rule (T1:Type -> T2:Type) T1 => T2
@@ -58,11 +57,11 @@ module LAMBDA
        <tenv> TEnv
         => TEnv[X <- (forall #metaKVariables(T) -Set #metaKVariables(setTenv(TEnv))) T]
        </tenv>
-  rule <k> X:Id => #renameMetaKVariables(T, Tvs) ...</k>
+  rule <k> X:KVar => #renameMetaKVariables(T, Tvs) ...</k>
        <tenv>... X |-> (forall Tvs) T ...</tenv>
 
   rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
-  rule <k> mu X:Id . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
+  rule <k> mu X:KVar . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 
   syntax KItem ::= setTenv(Map)

--- a/k-distribution/tutorial/2_languages/3_fun/1_untyped/2_substitution/fun-untyped.k
+++ b/k-distribution/tutorial/2_languages/3_fun/1_untyped/2_substitution/fun-untyped.k
@@ -218,7 +218,7 @@ module FUN-UNTYPED
   syntax Val ::= ConstructorName
 
   rule isVal(fun _) => true
-  syntax KVariable ::= Name
+  syntax KVar ::= Name
   syntax Name ::= freshName(Int)    [freshGenerator, function]
   rule freshName(I:Int) => {#parseToken("Name", "#" +String Int2String(I))}:>Name
 


### PR DESCRIPTION
Java backend substitution still uses the KVar sort internally and ignores the hook introduced, but this PR should make it possible to execute substitution in the llvm backend.