### PR TITLE
better TermCons.toString

### DIFF
--- a/kore/src/main/scala/org/kframework/parser/TreeNodesToKORE.scala
+++ b/kore/src/main/scala/org/kframework/parser/TreeNodesToKORE.scala
@@ -20,7 +20,7 @@ class TreeNodesToKORE(parseSort: java.util.function.Function[String, Sort], stri
   def apply(t: Term): K = t match {
     case c@Constant(s, p) => KToken(s, p.sort, locationToAtt(c.location, c.source))
     case t@TermCons(items, p) => termConsToKApply(t, items, p)
-    case Ambiguity(items) => KApply(KLabel("AMB"), KList(items.asScala.toList map apply asJava), Att)
+    case Ambiguity(items) => KApply(KLabel("amb"), KList(items.asScala.toList map apply asJava), Att)
   }
 
   def anonVar(sort: Sort): K = {

--- a/kore/src/main/scala/org/kframework/parser/treeNodes.scala
+++ b/kore/src/main/scala/org/kframework/parser/treeNodes.scala
@@ -4,6 +4,7 @@ package org.kframework.parser
 
 import org.kframework.attributes.{Source, Location}
 import org.kframework.definition.Production
+import org.kframework.kore.KORE.Sort
 import java.util._
 import java.lang.Iterable
 import org.pcollections.{ConsPStack, PStack}
@@ -38,7 +39,7 @@ case class TermCons private(items: PStack[Term], production: Production)
   def `with`(i: Int, e: Term) = TermCons(items.`with`(items.size() - 1 - i, e), production, location, source)
 
   def replaceChildren(newChildren: Collection[Term]) = TermCons(ConsPStack.from(newChildren), production, location, source)
-  override def toString() = production.klabel.getOrElse("NOKLABEL") + "(...)"
+  override def toString() = new TreeNodesToKORE(s => Sort(s), false).apply(this).toString()
 
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(TermCons.this);
 }


### PR DESCRIPTION
previously we make TermCons.toString less expressive because its old implementation was quadratic. I ran into a case today where that change made it essentially impossible to determine the nature of a detected parser ambiguity, so I am now introducing a better fix that should hopefully print in linear time while also providing better information.