### PR TITLE
kernel: Global option --shutdown-wait-time

### DIFF
--- a/kernel/src/main/java/org/kframework/main/FrontEnd.java
+++ b/kernel/src/main/java/org/kframework/main/FrontEnd.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2014-2019 K Team. All Rights Reserved.
 package org.kframework.main;
 
+import org.kframework.utils.InterrupterRunnable;
 import org.kframework.utils.StringUtil;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KException;
@@ -48,6 +49,11 @@ public abstract class FrontEnd {
                 jarInfo.printVersionMessage();
                 retval = 0;
             } else {
+                if (globalOptions.shutdownWaitTime > 0 && ! Main.isNailgun()) {
+                    //Will interrupt the thread on Ctrl+C and allow the backend to terminate gracefully.
+                    Runtime.getRuntime().addShutdownHook(new Thread(
+                            new InterrupterRunnable(Thread.currentThread(), globalOptions.shutdownWaitTime)));
+                }
                 try {
                     retval = run();
                 } catch (ParameterException e) {

--- a/kernel/src/main/java/org/kframework/main/GlobalOptions.java
+++ b/kernel/src/main/java/org/kframework/main/GlobalOptions.java
@@ -89,4 +89,11 @@ public final class GlobalOptions {
 
     @Parameter(names={"--warnings-to-errors", "-w2e"}, description="Convert warnings to errors.")
     public boolean warnings2errors = false;
+
+    @Parameter(names={"--shutdown-wait-time"}, description="If the option is set, a shutdown hook will be registered " +
+            "that, once invoked, interrupts the main thread and waits its termination. The wait time is the argument " +
+            "of this option, in ms. Useful if K is interrupted by Ctrl+C, because it allows the backend to detect " +
+            "interruption and print diagnostics information. Currently interruption detection is implemented in " +
+            "Java Backend. If K is invoked from KServer (e.g. Nailgun), the option is ignored.")
+    public int shutdownWaitTime = 0;
 }

--- a/kernel/src/main/java/org/kframework/utils/InterrupterRunnable.java
+++ b/kernel/src/main/java/org/kframework/utils/InterrupterRunnable.java
@@ -1,0 +1,29 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+package org.kframework.utils;
+
+/**
+ * A runnable that interrupts the given thread when invoked, then awaits termination for the given wait time, in ms.
+ *
+ * @author Denis Bogdanas
+ * Created on 24-Dec-18.
+ */
+public class InterrupterRunnable implements Runnable {
+
+    private final Thread thread;
+    private final int waitTime;
+
+    public InterrupterRunnable(Thread thread, int waitTime) {
+        this.thread = thread;
+        this.waitTime = waitTime;
+    }
+
+    @Override
+    public void run() {
+        thread.interrupt();
+        try {
+            thread.join(waitTime);
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
# Description from GlobalOptions help
If the option is set, a shutdown hook will be registered that, once invoked, interrupts the main thread and waits its termination. The wait time is the argument of this option, in ms. Useful if K is interrupted by Ctrl+C, because it allows the backend to detect interruption and print diagnostics information. Currently interruption detection is implemented in Java Backend. If K is invoked from KServer (e.g. Nailgun), the option is ignored.