### PR TITLE
Do not parameterize productions with no klabel associated with them

### DIFF
--- a/k-distribution/tests/regression-new/Makefile
+++ b/k-distribution/tests/regression-new/Makefile
@@ -28,6 +28,7 @@ SUBDIRS=issue-2273 \
 	boundary-cells-opt/bc-c2 \
 	boundary-cells-opt/bc-c1c2 \
 	prelude-warnings \
-	equals-formatting
+	equals-formatting \
+	kore-brackets
 
 include ../../include/ktest-group.mak

--- a/k-distribution/tests/regression-new/Makefile
+++ b/k-distribution/tests/regression-new/Makefile
@@ -19,11 +19,11 @@ SUBDIRS=issue-2273 \
 	or-llvm \
 	or-ocaml \
 	issue-313 \
-        checks \
+	checks \
 	withConfig \
 	withConfig-llvm \
 	pattern-macro \
-        boundary-cells-opt/bc-none \
+	boundary-cells-opt/bc-none \
 	boundary-cells-opt/bc-c1 \
 	boundary-cells-opt/bc-c2 \
 	boundary-cells-opt/bc-c1c2 \

--- a/k-distribution/tests/regression-new/kore-brackets/Makefile
+++ b/k-distribution/tests/regression-new/kore-brackets/Makefile
@@ -1,0 +1,8 @@
+DEF=korebrkt
+EXT=korebrkt
+TESTDIR=.
+KOMPILE_BACKEND=kore
+export KOMPILE_BACKEND
+KOMPILE_FLAGS=--debug
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/kore-brackets/korebrkt.k
+++ b/k-distribution/tests/regression-new/kore-brackets/korebrkt.k
@@ -1,0 +1,13 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+
+module KOREBRKT-SYNTAX
+  imports INT
+
+  syntax K ::= "[" K "]" [bracket, poly(0, 1)]
+endmodule
+
+module KOREBRKT
+  imports KOREBRKT-SYNTAX
+
+  configuration <k color="green"> $PGM:Int </k>
+endmodule

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -969,7 +969,7 @@ public class ModuleToKORE {
     }
 
     private Production computePolyProd(Production prod) {
-        if (!prod.att().contains("poly"))
+        if (prod.klabel().isEmpty() || !prod.att().contains("poly"))
             return prod.withAtt(prod.att().add("originalPrd", Production.class, prod));
         List<Set<Integer>> poly = RuleGrammarGenerator.computePositions(prod);
         polyKLabels.put(prod.klabel().get().name(), poly);


### PR DESCRIPTION
Productions with no klabel are ones like subsorts `syntax A ::= B`, and brackets `syntax A ::= "(" B ")" [bracket]`. When they also have `poly` attribute, they are treated as parameterized sorts, but since they have no klabel we cannot generate a parameterized symbol in the kore output for them.