### PR TITLE
Fix bug involving use of Sets.union

### DIFF
--- a/k-distribution/include/ktest.mak
+++ b/k-distribution/include/ktest.mak
@@ -8,6 +8,8 @@ KRUN=$(abspath $(MAKEFILE_PATH)/../bin/krun)
 KDEP=$(abspath $(MAKEFILE_PATH)/../bin/kdep)
 # and kprove
 KPROVE=$(abspath $(MAKEFILE_PATH)/../bin/kprove)
+# and ksearch
+KSEARCH=$(abspath $(MAKEFILE_PATH)/../bin/krun) --search-all
 # path relative to current definition of test programs
 TESTDIR?=tests
 # path to put -kompiled directory in
@@ -17,6 +19,7 @@ RESULTDIR?=$(TESTDIR)
 # all tests in test directory with matching file extension
 TESTS?=$(wildcard $(TESTDIR)/*.$(EXT))
 PROOF_TESTS?=$(wildcard $(TESTDIR)/*-spec.k)
+SEARCH_TESTS?=$(wildcard $(TESTDIR)/*.$(EXT).search)
 # default KOMPILE_BACKEND
 KOMPILE_BACKEND?=ocaml
 
@@ -25,16 +28,19 @@ CHECK=| diff -
 .PHONY: kompile krun all clean update-results proofs
 
 # run all tests
-all: kompile krun proofs
+all: kompile krun proofs searches
 
 # run only kompile
 kompile: $(DEFDIR)/$(DEF)-kompiled/timestamp
 
 $(DEFDIR)/%-kompiled/timestamp: %.k
 	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG) $< -d $(DEFDIR)
+
 krun: $(TESTS)
 
 proofs: $(PROOF_TESTS)
+
+searches: $(SEARCH_TESTS)
 
 # run all tests and regenerate output files
 update-results: krun proofs
@@ -55,6 +61,13 @@ ifeq ($(TESTDIR),$(RESULTDIR))
 	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $@.out
 else
 	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+endif
+
+%.search: kompile
+ifeq ($(TESTDIR),$(RESULTDIR))
+	$(KSEARCH) $@ $(KSEARCH_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $@.out
+else
+	$(KSEARCH) $@ $(KSEARCH_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 clean:

--- a/k-distribution/tests/regression-new/Makefile
+++ b/k-distribution/tests/regression-new/Makefile
@@ -29,6 +29,7 @@ SUBDIRS=issue-2273 \
 	boundary-cells-opt/bc-c1c2 \
 	prelude-warnings \
 	equals-formatting \
-	kore-brackets
+	kore-brackets \
+	quadratic-poly-unparsing
 
 include ../../include/ktest-group.mak

--- a/k-distribution/tests/regression-new/quadratic-poly-unparsing/Makefile
+++ b/k-distribution/tests/regression-new/quadratic-poly-unparsing/Makefile
@@ -1,0 +1,6 @@
+DEF=nondet
+EXT=nondet
+TESTDIR=.
+KOMPILE_BACKEND=haskell
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/quadratic-poly-unparsing/initial.nondet.search
+++ b/k-distribution/tests/regression-new/quadratic-poly-unparsing/initial.nondet.search
@@ -1,0 +1,1 @@
+initial

--- a/k-distribution/tests/regression-new/quadratic-poly-unparsing/initial.nondet.search.out
+++ b/k-distribution/tests/regression-new/quadratic-poly-unparsing/initial.nondet.search.out
@@ -1,0 +1,39 @@
+  {
+    Result
+  #Equals
+    <k>
+      final1
+    </k>
+  }
+#Or
+  {
+    Result
+  #Equals
+    <k>
+      final2
+    </k>
+  }
+#Or
+  {
+    Result
+  #Equals
+    <k>
+      initial
+    </k>
+  }
+#Or
+  {
+    Result
+  #Equals
+    <k>
+      next1
+    </k>
+  }
+#Or
+  {
+    Result
+  #Equals
+    <k>
+      next2
+    </k>
+  }

--- a/k-distribution/tests/regression-new/quadratic-poly-unparsing/nondet.k
+++ b/k-distribution/tests/regression-new/quadratic-poly-unparsing/nondet.k
@@ -1,0 +1,19 @@
+module NONDET
+
+  import DOMAINS
+
+  syntax S
+    ::= "initial"
+      | "next1"  | "next2"
+      | "final1" | "final2"
+      | "unreachable"
+
+  rule initial => next1
+
+  rule initial => next2
+
+  rule next1 => final1
+
+  rule next2 => final2
+
+endmodule

--- a/kore/src/main/scala/org/kframework/parser/Transformer.scala
+++ b/kore/src/main/scala/org/kframework/parser/Transformer.scala
@@ -4,8 +4,6 @@ package org.kframework.parser
 
 import java.util
 
-import com.google.common.collect.Sets
-
 import collection.JavaConverters._
 import org.kframework.Collections._
 
@@ -128,17 +126,25 @@ trait EAsSet[E] {
   /**
    * Merges the set of problematic (i.e., Left) results.
    */
-  def mergeErrors(a: java.util.Set[E], b: java.util.Set[E]): java.util.Set[E] = Sets.union(a, b)
+  def mergeErrors(a: java.util.Set[E], b: java.util.Set[E]): java.util.Set[E] = {
+    val c = new java.util.HashSet[E](a);
+    c.addAll(b);
+    c
+  }
 
-  val errorUnit: java.util.Set[E] = Sets.newHashSet()
+  val errorUnit: java.util.Set[E] = new java.util.HashSet[E]()
 }
 
 trait WAsSet[W] {
-  val warningUnit: java.util.Set[W] = Sets.newHashSet();
+  val warningUnit: java.util.Set[W] = new java.util.HashSet[W]()
   /**
    * Merges the set of problematic (i.e., Left) results.
    */
-  def mergeWarnings(a: java.util.Set[W], b: java.util.Set[W]): java.util.Set[W] = Sets.union(a, b)
+  def mergeWarnings(a: java.util.Set[W], b: java.util.Set[W]): java.util.Set[W] = {
+    val c = new java.util.HashSet[W](a);
+    c.addAll(b);
+    c
+  }
 }
 
 abstract class SetsGeneralTransformer[E, W]


### PR DESCRIPTION
Our old version of Guava apparently has a memory explosion if you use Sets.union repeatedly in a tight loop. So I replaced the critical uses of it in Transformers.scala with calls to the java.util methods. We may want to consider bumping the guava version at some point, but I don't believe it's critical for this bugfix.