### PR TITLE
Java Backend: move options chaining logic to InitializeRewriter.

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -108,6 +108,14 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
         this.initializeDefinition = initializeDefinition;
         this.kprint = kprint;
         this.profiler = profiler;
+        chainOptions();
+    }
+
+    public void chainOptions() {
+        javaExecutionOptions.debugZ3Queries |= javaExecutionOptions.debugFormulas;
+        javaExecutionOptions.debugZ3 |= javaExecutionOptions.debugZ3Queries;
+        javaExecutionOptions.logBasic |= javaExecutionOptions.log || javaExecutionOptions.debugZ3;
+        globalOptions.verbose |= javaExecutionOptions.logBasic;
     }
 
     @Override
@@ -262,6 +270,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
                 rewritingContext.profiler.logInitTime(rewritingContext);
             }
             rewritingContext.setExecutionPhase(true);
+            rewritingContext.javaExecutionOptions.logRulesPublic = rewritingContext.javaExecutionOptions.logRules;
             List<ConstrainedTerm> proofResults = javaRules.stream()
                     .filter(r -> !r.att().contains(Attribute.TRUSTED_KEY))
                     .map(r -> {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -617,13 +617,6 @@ public class SymbolicRewriter {
         boolean guarded = false;
         int step = 0;
 
-        global.javaExecutionOptions.debugZ3Queries |= global.javaExecutionOptions.debugFormulas;
-        global.javaExecutionOptions.debugZ3 |= global.javaExecutionOptions.debugZ3Queries;
-        global.javaExecutionOptions.logBasic |= global.javaExecutionOptions.log || global.javaExecutionOptions.debugZ3;
-        global.globalOptions.verbose |= global.javaExecutionOptions.logBasic;
-        //to avoid printing initialization-phase rules
-        global.javaExecutionOptions.logRulesPublic = global.javaExecutionOptions.logRules;
-
         if (prettyInitTerm != null) {
             System.err.println("\nInitial term\n=====================\n");
             printTermAndConstraint(initialTerm, prettyInitTerm);


### PR DESCRIPTION
Makes them available to all tools, from initialization phase.