### PR TITLE
Java Backend exception handling: FastRuleMatcher: adding stack frames when exception is caught

### DIFF
--- a/kernel/src/main/java/org/kframework/main/FrontEnd.java
+++ b/kernel/src/main/java/org/kframework/main/FrontEnd.java
@@ -68,9 +68,10 @@ public abstract class FrontEnd {
             retval = 113;
             if (globalOptions.debug()) {
                 e.printStackTrace();
+            } else {
+                kem.registerThrown(e);
+                kem.print();
             }
-            kem.registerThrown(e);
-            kem.print();
         }
         return retval;
     }


### PR DESCRIPTION
Essentially this replaces System.err messages with stack frames, like it is done in `KItem.evaluateFunction()`.
