### PR TITLE
fix llvm backend in debian package

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -24,7 +24,7 @@ override_dh_auto_install:
 	src/main/scripts/debian_package
 
 override_dh_strip:
-	dh_strip -Xliballoc.a -Xlibarithmetic.a -XlibAST.a -Xlibconfigurationparser.a -XlibParser.a -Xlibstrings.a
+	dh_strip -Xliballoc.a -Xlibarithmetic.a -XlibAST.a -Xlibconfigurationparser.a -XlibParser.a -Xlibstrings.a -Xlibmeta.a -Xlibio.a
 
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )

--- a/src/main/scripts/test-in-container
+++ b/src/main/scripts/test-in-container
@@ -8,3 +8,7 @@ echo 'Starting kserver...'
 cd tutorial
 echo 'Testing tutorial in user environment...'
 make -j`nproc`
+cd ~
+echo "module TEST imports BOOL endmodule" > test.k
+kompile test.k --backend llvm
+kompile test.k --backend haskell


### PR DESCRIPTION
We had a bug where dh_strip was stripping the symbols from libmeta.a in the llvm backend because we forgot to update debian/rules.