### PR TITLE
Java Backend logging: Option --log-success-pc-diff & better ConjunctiveFormula logging

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/EquivChecker.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/EquivChecker.java
@@ -125,14 +125,16 @@ public class EquivChecker {
         java.util.List<ConstrainedTerm> queue = new ArrayList<>();
         java.util.List<ConstrainedTerm> nextQueue = new ArrayList<>();
 
-        queue.add(currSyncNode.currSyncNode);
+        ConstrainedTerm initTerm = currSyncNode.currSyncNode;
+        queue.add(initTerm);
 
         int steps = 0;
         while (!queue.isEmpty()) {
             ++steps;
             for (ConstrainedTerm curr : queue) {
 
-                java.util.List<ConstrainedTerm> nexts = rewriter.fastComputeRewriteStep(curr, false, true, true, steps);
+                java.util.List<ConstrainedTerm> nexts = rewriter.fastComputeRewriteStep(curr, false, true, true, steps,
+                        initTerm);
 
                 if (nexts.isEmpty()) {
                     /* final term */

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -126,6 +126,10 @@ public final class JavaExecutionOptions {
             "By default only failure final states are logged.")
     public boolean logSuccessFinalStates = false;
 
+    @Parameter(names = "--log-success-pc-diff", description = "Log to stdout the difference between final state path " +
+            "condition and initial state path condition, for success paths.")
+    public boolean logSuccessPCDiff = false;
+
     @Parameter(names="--log-progress", description="Print progress bar")
     public boolean logProgress = false;
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -156,9 +156,13 @@ public class SymbolicRewriter {
 
     }
 
+    /**
+     * @param proofFlag if true, ignore rules related to I/O.
+     * @param step      for debugging only
+     * @param initTerm  for logging only
+     */
     public List<ConstrainedTerm> fastComputeRewriteStep(ConstrainedTerm subject, boolean computeOne, boolean narrowing,
-                                                        boolean proofFlag, int step,
-                                                        ConstrainedTerm initTerm) {
+                                                        boolean proofFlag, int step, ConstrainedTerm initTerm) {
         global.stateLog.log(StateLog.LogEvent.NODE, subject.term(), subject.constraint());
         List<ConstrainedTerm> results = new ArrayList<>();
         if (definition.automaton == null) {


### PR DESCRIPTION
1. Option --log-success-pc-diff to print new PC entries for success final states.
2. When ConjunctiveFormula is logged, group separately entries from initial state and new entries.