### PR TITLE
java-backend/FastRuleMatcher: more informative error message when crashing on map unification

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
@@ -689,7 +689,16 @@ public class FastRuleMatcher {
     }
 
     private BitSet unifyMap(BuiltinMap map, BuiltinMap otherMap, BitSet ruleMask, scala.collection.immutable.List<Pair<Integer, Integer>> path, boolean logFailures) {
-        assert map.collectionFunctions().isEmpty() && otherMap.collectionFunctions().isEmpty();
+        if (!(map.collectionFunctions().isEmpty() && otherMap.collectionFunctions().isEmpty())) {
+            String mapErrorString = "Unevaluated function symbols in Map unification problem between:\n"
+                                  + "\n"
+                                  + "    " + map.toString() + "\n"
+                                  + "\n"
+                                  + "and:\n"
+                                  + "\n"
+                                  + "    " + otherMap.toString() + "\n";
+            throw KEMException.criticalError(mapErrorString);
+        }
 
         Map<Term, Term> entries = map.getEntries();
         Map<Term, Term> otherEntries = otherMap.getEntries();


### PR DESCRIPTION
Instead of crashing when a map has unevaluated function symbols, just fail unification.

Need to double-check that this won't cause unsound behavior though.