### PR TITLE
kore: Att: removed lazy hashCode

### DIFF
--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -6,8 +6,6 @@ import org.kframework.Collections._
 
 case class Att(att: Map[(String, Class[_]), Any]) extends AttributesToString {
 
-  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Att.this)
-
   def contains(cls: Class[_]): Boolean = att.contains((cls.getName, cls))
   def contains(key: String): Boolean = att.contains((key, classOf[String]))
   def contains(key: String, cls: Class[_]): Boolean = att.contains((key, cls))


### PR DESCRIPTION
For some reason it was computed incorrectly, as if Att would be a mutable object. This interfered with `Map.contains(Att)` algorithm and led to unnecessary parse cache invalidation.

### Effect
Performance impact is insignificant, but who knows might be important later/elsewhere.

Before, when running kprove sum-to-n for the first time after clean kompile:
```
Parse spec modules [1035/1037 rules]                         =  0.020s
```
after:
```
Parse spec modules [186/1037 rules]                          =  0.021s
```
