### PR TITLE
Meta-level functionality for retrieving/manipulating the current constraint

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -231,6 +231,14 @@ public class MetaK {
     }
 
     /**
+     * Returns the {@link ConjunctiveFormula} constraint of a given {@link Term}.
+     *
+     */
+    public static ConjunctiveFormula getConstraint(Term term, TermContext context) {
+        return ConjunctiveFormula.of(context.global());
+    }
+
+    /**
      * Returns the K label of a specified {@link KItem}.
      *
      * @param kItem

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -13,11 +13,16 @@ import org.kframework.backend.java.kil.TermContext;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.symbolic.ConjunctiveFormula;
 import org.kframework.backend.java.symbolic.CopyOnWriteTransformer;
+import org.kframework.backend.java.symbolic.DisjunctiveFormula;
+import org.kframework.backend.java.symbolic.Equality;
+import org.kframework.backend.java.symbolic.ImmutableMapSubstitution;
 import org.kframework.backend.java.symbolic.PatternMatcher;
+import org.kframework.backend.java.symbolic.PersistentUniqueList;
 import org.kframework.kore.KVariable;
 
 import java.util.HashSet;
 import java.util.Set;
+import org.pcollections.PSet;
 
 
 /**
@@ -232,10 +237,52 @@ public class MetaK {
 
     /**
      * Returns the {@link ConjunctiveFormula} constraint of a given {@link Term}.
+     * The resulting constraint will be restricted to the parts relevant given the variables in the term.
      *
      */
     public static ConjunctiveFormula getConstraint(Term term, TermContext context) {
-        return ConjunctiveFormula.of(context.global());
+        ConjunctiveFormula currentConstraint = context.getTopConstraint();
+        if (! currentConstraint.isUnknown()) {
+            return currentConstraint;   // current constraint is either true or false
+        } else {
+            PSet<Variable> termVariables = term.variableSet();
+            if (! MetaK.varsIntersect(currentConstraint.variableSet(), termVariables)) {
+                return ConjunctiveFormula.of(context.global());    // current constraint does not restrict term, so use true
+            } else {
+                Set<DisjunctiveFormula> disjuncts = new HashSet<DisjunctiveFormula>();
+                for (ConjunctiveFormula conjunct: currentConstraint.getDisjunctiveNormalForm().conjunctions()) {
+                    if (MetaK.varsIntersect(conjunct.variableSet(), termVariables)) {
+                        Set<Equality> conjuncts = new HashSet<Equality>();
+                        for (Equality equality: conjunct.equalities()) {
+                            if (MetaK.varsIntersect(equality.variableSet(), termVariables)) {
+                                conjuncts.add(equality);
+                            }
+                        }
+                        ConjunctiveFormula newConjunct = ConjunctiveFormula.of( ImmutableMapSubstitution.empty()
+                                                                              , PersistentUniqueList.from(conjuncts)
+                                                                              , PersistentUniqueList.empty()
+                                                                              , context.global()
+                                                                              );
+                        disjuncts.add(newConjunct.getDisjunctiveNormalForm());
+                    }
+                }
+                ConjunctiveFormula finalConjunct = ConjunctiveFormula.of( ImmutableMapSubstitution.empty()
+                                                                        , PersistentUniqueList.empty()
+                                                                        , PersistentUniqueList.from(disjuncts)
+                                                                        , context.global()
+                                                                        );
+                return finalConjunct;
+            }
+        }
+    }
+
+    public static boolean varsIntersect(PSet<Variable> vs1, PSet<Variable> vs2) {
+        for (Variable v : vs1) {
+            if (vs2.contains(v)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -28,6 +28,52 @@ import java.util.Set;
 public class MetaK {
 
     /**
+     * Unifies two {@link Term}s, returning the set of unifiers.
+     *
+     * @param term1
+     *            the first term
+     * @param term2
+     *            the second term
+     * @param context
+     *            the term context
+     * @return {@link BuiltinSet}, the set of {@link BuiltinMap} unifiers (if provably unifiable)
+     *         {@code null}, if not provably unifiable/non-unifiable
+     */
+    public static Term unify(Term term1, Term term2, TermContext context) {
+        ConjunctiveFormula constraint = ConjunctiveFormula.of(context.global());
+        if (term1 instanceof KList && term2 instanceof KList) {
+            if (((KList) term1).size() != ((KList) term2).size()) {
+                return null; // TODO: Return empty map, "no unifiers"? Or is that incorrect because we don't do fully general AC unification?
+            }
+            for (int i = 0; i < ((KList) term1).size(); i++) {
+                constraint = constraint.add(((KList) term1).get(i), ((KList) term2).get(i));
+            }
+        } else {
+            constraint = constraint.add(term1, term2);
+        }
+
+        BuiltinSet.Builder substsBuilder = BuiltinSet.builder(context.global());
+        constraint = constraint.simplify(context);
+        if (constraint.isFalse()) {
+            return substsBuilder.build(); // TODO: Is this correct? no unifiers?
+        }
+
+        for (ConjunctiveFormula solution : constraint.getDisjunctiveNormalForm().conjunctions()) {
+            solution = solution.simplify(context);
+            if (solution.isSubstitution()) {
+                BuiltinMap.Builder substBuilder = BuiltinMap.builder(context.global());
+                substBuilder.putAll(solution.substitution());
+                substsBuilder.add(substBuilder.build());
+            } else if (!solution.isFalse()) {
+                /* when none of the solutions is true and at least one of the
+                 * them is not certainly false, the result is unknown */
+                return null; // TODO: Return partial list of unifiers?
+            }
+        }
+        return substsBuilder.build();
+    }
+
+    /**
      * Checks if two given {@link Term}s can be unified.
      *
      * @param term1

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -300,6 +300,11 @@ public class MetaK {
         return BoolToken.TRUE;
     }
 
+    public static BoolToken printConstraint(TermContext context) {
+        System.out.println(context.getTopConstraint().toString());
+        return BoolToken.TRUE;
+    }
+
     /**
      * Returns the K label of a specified {@link KItem}.
      *

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -286,6 +286,14 @@ public class MetaK {
     }
 
     /**
+     * Set's the top-level constraint to the given {@link Term}.
+     */
+    public static BoolToken setConstraint(Term constraint, TermContext context) {
+        context.setTopConstraint((ConjunctiveFormula) constraint);
+        return BoolToken.TRUE;
+    }
+
+    /**
      * Returns the K label of a specified {@link KItem}.
      *
      * @param kItem

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -236,6 +236,13 @@ public class MetaK {
     }
 
     /**
+     * Returns the {@link ConjunctiveFormula} top-level constraint.
+     */
+    public static ConjunctiveFormula getFullConstraint(TermContext context) {
+        return context.getTopConstraint();
+    }
+
+    /**
      * Returns the {@link ConjunctiveFormula} constraint of a given {@link Term}.
      * The resulting constraint will be restricted to the parts relevant given the variables in the term.
      *

--- a/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/builtins/MetaK.java
@@ -14,7 +14,6 @@ import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.symbolic.ConjunctiveFormula;
 import org.kframework.backend.java.symbolic.CopyOnWriteTransformer;
 import org.kframework.backend.java.symbolic.DisjunctiveFormula;
-import org.kframework.backend.java.symbolic.Equality;
 import org.kframework.backend.java.symbolic.ImmutableMapSubstitution;
 import org.kframework.backend.java.symbolic.PatternMatcher;
 import org.kframework.backend.java.symbolic.PersistentUniqueList;
@@ -248,48 +247,7 @@ public class MetaK {
      *
      */
     public static ConjunctiveFormula getConstraint(Term term, TermContext context) {
-        ConjunctiveFormula currentConstraint = context.getTopConstraint();
-        if (! currentConstraint.isUnknown()) {
-            return currentConstraint;   // current constraint is either true or false
-        } else {
-            PSet<Variable> termVariables = term.variableSet();
-            if (! MetaK.varsIntersect(currentConstraint.variableSet(), termVariables)) {
-                return ConjunctiveFormula.of(context.global());    // current constraint does not restrict term, so use true
-            } else {
-                Set<DisjunctiveFormula> disjuncts = new HashSet<DisjunctiveFormula>();
-                for (ConjunctiveFormula conjunct: currentConstraint.getDisjunctiveNormalForm().conjunctions()) {
-                    if (MetaK.varsIntersect(conjunct.variableSet(), termVariables)) {
-                        Set<Equality> conjuncts = new HashSet<Equality>();
-                        for (Equality equality: conjunct.equalities()) {
-                            if (MetaK.varsIntersect(equality.variableSet(), termVariables)) {
-                                conjuncts.add(equality);
-                            }
-                        }
-                        ConjunctiveFormula newConjunct = ConjunctiveFormula.of( ImmutableMapSubstitution.empty()
-                                                                              , PersistentUniqueList.from(conjuncts)
-                                                                              , PersistentUniqueList.empty()
-                                                                              , context.global()
-                                                                              );
-                        disjuncts.add(newConjunct.getDisjunctiveNormalForm());
-                    }
-                }
-                ConjunctiveFormula finalConjunct = ConjunctiveFormula.of( ImmutableMapSubstitution.empty()
-                                                                        , PersistentUniqueList.empty()
-                                                                        , PersistentUniqueList.from(disjuncts)
-                                                                        , context.global()
-                                                                        );
-                return finalConjunct;
-            }
-        }
-    }
-
-    public static boolean varsIntersect(PSet<Variable> vs1, PSet<Variable> vs2) {
-        for (Variable v : vs1) {
-            if (vs2.contains(v)) {
-                return true;
-            }
-        }
-        return false;
+        return ConjunctiveFormula.getRestrictedConstraint(term, context);
     }
 
     /**

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/Equality.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/Equality.java
@@ -12,6 +12,8 @@ import org.kframework.backend.java.util.Constants;
 import com.google.inject.Provider;
 import org.kframework.builtin.KLabels;
 
+import org.pcollections.PSet;
+
 /**
  * An equality between two canonicalized terms.
  */
@@ -60,6 +62,12 @@ public class Equality implements Serializable {
 
     public Term rightHandSide() {
         return rightHandSide;
+    }
+
+    public PSet<Variable> variableSet() {
+        PSet<Variable> vSet = leftHandSide.variableSet();
+        vSet.plusAll(rightHandSide.variableSet());
+        return vSet;
     }
 
     private boolean isTermEquality(Term term) {

--- a/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
+++ b/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
@@ -171,6 +171,7 @@ UNIFICATION.variables : org.kframework.backend.java.builtins.MetaK.trueVariables
 UNIFICATION.variablesMap : org.kframework.backend.java.builtins.MetaK.variablesMap
 UNIFICATION.freezeVariables : org.kframework.backend.java.builtins.MetaK.freezeVariables
 UNIFICATION.unifiable : org.kframework.backend.java.builtins.MetaK.unifiable
+UNIFICATION.unify : org.kframework.backend.java.builtins.MetaK.unify
 KREFLECTION.getKLabel : org.kframework.backend.java.builtins.MetaK.getKLabel
 KREFLECTION.getKLabelString : org.kframework.backend.java.builtins.MetaK.getKLabelString
 KREFLECTION.configuration : org.kframework.backend.java.builtins.MetaK.configuration

--- a/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
+++ b/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
@@ -172,6 +172,7 @@ UNIFICATION.variablesMap : org.kframework.backend.java.builtins.MetaK.variablesM
 UNIFICATION.freezeVariables : org.kframework.backend.java.builtins.MetaK.freezeVariables
 UNIFICATION.unifiable : org.kframework.backend.java.builtins.MetaK.unifiable
 UNIFICATION.unify : org.kframework.backend.java.builtins.MetaK.unify
+KREFLECTION.getFullConstraint : org.kframework.backend.java.builtins.MetaK.getFullConstraint
 KREFLECTION.getConstraint : org.kframework.backend.java.builtins.MetaK.getConstraint
 KREFLECTION.setConstraint : org.kframework.backend.java.builtins.MetaK.setConstraint
 KREFLECTION.getKLabel : org.kframework.backend.java.builtins.MetaK.getKLabel

--- a/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
+++ b/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
@@ -173,6 +173,7 @@ UNIFICATION.freezeVariables : org.kframework.backend.java.builtins.MetaK.freezeV
 UNIFICATION.unifiable : org.kframework.backend.java.builtins.MetaK.unifiable
 UNIFICATION.unify : org.kframework.backend.java.builtins.MetaK.unify
 KREFLECTION.getConstraint : org.kframework.backend.java.builtins.MetaK.getConstraint
+KREFLECTION.setConstraint : org.kframework.backend.java.builtins.MetaK.setConstraint
 KREFLECTION.getKLabel : org.kframework.backend.java.builtins.MetaK.getKLabel
 KREFLECTION.getKLabelString : org.kframework.backend.java.builtins.MetaK.getKLabelString
 KREFLECTION.configuration : org.kframework.backend.java.builtins.MetaK.configuration

--- a/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
+++ b/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
@@ -172,6 +172,7 @@ UNIFICATION.variablesMap : org.kframework.backend.java.builtins.MetaK.variablesM
 UNIFICATION.freezeVariables : org.kframework.backend.java.builtins.MetaK.freezeVariables
 UNIFICATION.unifiable : org.kframework.backend.java.builtins.MetaK.unifiable
 UNIFICATION.unify : org.kframework.backend.java.builtins.MetaK.unify
+KREFLECTION.getConstraint : org.kframework.backend.java.builtins.MetaK.getConstraint
 KREFLECTION.getKLabel : org.kframework.backend.java.builtins.MetaK.getKLabel
 KREFLECTION.getKLabelString : org.kframework.backend.java.builtins.MetaK.getKLabelString
 KREFLECTION.configuration : org.kframework.backend.java.builtins.MetaK.configuration

--- a/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
+++ b/java-backend/src/main/resources/org/kframework/backend/java/symbolic/hooks.properties
@@ -175,6 +175,7 @@ UNIFICATION.unify : org.kframework.backend.java.builtins.MetaK.unify
 KREFLECTION.getFullConstraint : org.kframework.backend.java.builtins.MetaK.getFullConstraint
 KREFLECTION.getConstraint : org.kframework.backend.java.builtins.MetaK.getConstraint
 KREFLECTION.setConstraint : org.kframework.backend.java.builtins.MetaK.setConstraint
+KREFLECTION.printConstraint : org.kframework.backend.java.builtins.MetaK.printConstraint
 KREFLECTION.getKLabel : org.kframework.backend.java.builtins.MetaK.getKLabel
 KREFLECTION.getKLabelString : org.kframework.backend.java.builtins.MetaK.getKLabelString
 KREFLECTION.configuration : org.kframework.backend.java.builtins.MetaK.configuration

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -838,6 +838,7 @@ module K-REFLECTION
   syntax K ::= "#configuration" [function, impure, hook(KREFLECTION.configuration)]
   syntax String ::= #sort(K) [function, hook(KREFLECTION.sort)]
   syntax KItem ::= #fresh(String)   [function, hook(KREFLECTION.fresh), impure]
+  syntax K ::= "#getFullConstraint" [function, hook(KREFLECTION.getFullConstraint), impure]
   syntax K ::= #getConstraint(K) [function, hook(KREFLECTION.getConstraint), impure]
   syntax Bool ::= #setConstraint(K) [function, hook(KREFLECTION.setConstraint), impure]
   syntax KItem ::= getKLabel(K)  [function, hook(KREFLECTION.getKLabel)]

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -841,6 +841,7 @@ module K-REFLECTION
   syntax K ::= "#getFullConstraint" [function, hook(KREFLECTION.getFullConstraint), impure]
   syntax K ::= #getConstraint(K) [function, hook(KREFLECTION.getConstraint), impure]
   syntax Bool ::= #setConstraint(K) [function, hook(KREFLECTION.setConstraint), impure]
+  syntax Bool ::= "#printConstraint" [function, hook(KREFLECTION.printConstraint), impure]
   syntax KItem ::= getKLabel(K)  [function, hook(KREFLECTION.getKLabel)]
 
   syntax String ::= #getenv(String) [function, impure, hook(KREFLECTION.getenv)]

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -838,6 +838,7 @@ module K-REFLECTION
   syntax K ::= "#configuration" [function, impure, hook(KREFLECTION.configuration)]
   syntax String ::= #sort(K) [function, hook(KREFLECTION.sort)]
   syntax KItem ::= #fresh(String)   [function, hook(KREFLECTION.fresh), impure]
+  syntax K ::= #getConstraint(K) [function, hook(KREFLECTION.getConstraint), impure]
   syntax KItem ::= getKLabel(K)  [function, hook(KREFLECTION.getKLabel)]
 
   syntax String ::= #getenv(String) [function, impure, hook(KREFLECTION.getenv)]

--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -839,6 +839,7 @@ module K-REFLECTION
   syntax String ::= #sort(K) [function, hook(KREFLECTION.sort)]
   syntax KItem ::= #fresh(String)   [function, hook(KREFLECTION.fresh), impure]
   syntax K ::= #getConstraint(K) [function, hook(KREFLECTION.getConstraint), impure]
+  syntax Bool ::= #setConstraint(K) [function, hook(KREFLECTION.setConstraint), impure]
   syntax KItem ::= getKLabel(K)  [function, hook(KREFLECTION.getKLabel)]
 
   syntax String ::= #getenv(String) [function, impure, hook(KREFLECTION.getenv)]
@@ -846,7 +847,6 @@ module K-REFLECTION
   // meaningful only for the purposes of compilation to a binary, otherwise
   // undefined
   syntax List ::= #argv() [function, hook(KREFLECTION.argv)]
-
 endmodule
 
 module K-REFLECTION-SYMBOLIC [symbolic]

--- a/k-distribution/include/builtin/unification.k
+++ b/k-distribution/include/builtin/unification.k
@@ -17,6 +17,8 @@ module UNIFICATION
 
   syntax Bool ::= #unifiable(K,K) [function, hook(UNIFICATION.unifiable), impure]
 
+  syntax K ::= #unify(K, K) [function, hook(UNIFICATION.unify), impure]
+
   syntax MetaVariable
 
 endmodule


### PR DESCRIPTION
Allows for some meta-programming in K over the current constraint.

SBC uses this functionality, and @nishantjr requested similar functionality which this may help for.