### PR TITLE
java-backend profiler: counters for exit points for function/anywhere evaluation

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -300,19 +300,9 @@ public class KItem extends Term implements KItemRepresentation {
                     if (result.isCacheable(this)) {
                         this.cachePut(constraint, result, context);
                     }
-                    if (profiler.resFuncNanoTimer.getLevel() == 1) {
-                        profiler.countResFuncTopUncached++;
-                    } else {
-                        profiler.countResFuncRecursiveUncached++;
-                    }
                 }
             } else {
                 result = global.kItemOps.resolveFunctionAndAnywhere(this, context);
-                if (profiler.resFuncNanoTimer.getLevel() == 1) {
-                    profiler.countResFuncTopUncached++;
-                } else {
-                    profiler.countResFuncRecursiveUncached++;
-                }
             }
         } finally {
             profiler.resFuncNanoTimer.stop();

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -325,7 +325,8 @@ public class SymbolicRewriter {
                 //noinspection RedundantCast
                 newContents.set(path.head().getLeft(), buildRHS(newContents.get(path.head().getLeft()), substitution,
                         (scala.collection.immutable.List<Pair<Integer, Integer>>) path.tail(), rhs, context));
-                return KItem.of(kItemSubject.kLabel(), KList.concatenate(newContents), context.global()).applyAnywhereRules(context);
+                return KItem.of(kItemSubject.kLabel(), KList.concatenate(newContents), context.global())
+                        .resolveFunctionAndAnywhere(context);
             } else if (subject instanceof BuiltinList) {
                 BuiltinList builtinListSubject = (BuiltinList) subject;
                 List<Term> newContents = new ArrayList<>(builtinListSubject.children);
@@ -376,7 +377,8 @@ public class SymbolicRewriter {
         }
 
         if (subject instanceof KItem) {
-            return KItem.of(((KItem) subject).kLabel(), KList.concatenate(newContents), context.global()).applyAnywhereRules(context);
+            return KItem.of(((KItem) subject).kLabel(), KList.concatenate(newContents), context.global())
+                    .resolveFunctionAndAnywhere(context);
         } else
             //noinspection ConstantConditions
             if (subject instanceof BuiltinList) {

--- a/java-backend/src/main/java/org/kframework/backend/java/util/Counter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/Counter.java
@@ -1,0 +1,46 @@
+package org.kframework.backend.java.util;
+
+import org.apache.commons.lang3.mutable.MutableInt;
+
+/**
+ * @author Denis Bogdanas
+ * Created on 01-Apr-19.
+ */
+public class Counter {
+    private String name;
+    private MutableInt level;
+    private int countTop;
+    private int countRecursive;
+
+    protected Counter(String name, MutableInt levelHolder) {
+        this.name = name;
+        this.level = levelHolder;
+    }
+
+    protected Counter(String name, MutableInt level, int countTop, int countRecursive) {
+        this.name = name;
+        this.level = level;
+        this.countTop = countTop;
+        this.countRecursive = countRecursive;
+    }
+
+    public void increment() {
+        if (level.intValue() == 1) {
+            countTop++;
+        } else {
+            countRecursive++;
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getCountTop() {
+        return countTop;
+    }
+
+    public int getCountRecursive() {
+        return countRecursive;
+    }
+}

--- a/java-backend/src/main/java/org/kframework/backend/java/util/CounterStopwatch.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/CounterStopwatch.java
@@ -15,7 +15,8 @@ public class CounterStopwatch implements Comparable<CounterStopwatch> {
     private long lastStartNano;
 
     private int level = 0;
-    private int count;
+    private int countTop;
+    private int countRecursive;
 
     public CounterStopwatch(String name) {
         this.name = name;
@@ -24,7 +25,9 @@ public class CounterStopwatch implements Comparable<CounterStopwatch> {
     public void start() {
         if (level == 0) {
             lastStartNano = System.nanoTime();
-            count++;
+            countTop++;
+        } else {
+            countRecursive++;
         }
         level++;
     }
@@ -73,8 +76,12 @@ public class CounterStopwatch implements Comparable<CounterStopwatch> {
         return Long.compare(duration, o.duration);
     }
 
-    public int getCount() {
-        return count;
+    public int getCountTop() {
+        return countTop;
+    }
+
+    public int getCountRecursive() {
+        return countRecursive;
     }
 
     public int getLevel() {
@@ -83,5 +90,12 @@ public class CounterStopwatch implements Comparable<CounterStopwatch> {
 
     public String getName() {
         return name;
+    }
+
+    public CounterStopwatch minus(CounterStopwatch other) {
+        CounterStopwatch result = new CounterStopwatch("");
+        result.countTop = this.countTop - other.countTop;
+        result.duration = this.duration - other.duration;
+        return result;
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/util/Profiler2.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/Profiler2.java
@@ -33,13 +33,26 @@ public class Profiler2 {
     private TimeMemoryEntry initStats;
     private List<TimeMemoryEntry> cacheMeasuringStats = new ArrayList<>();
 
-    public final CounterStopwatch resFuncNanoTimer = new CounterStopwatch("resolveFunction");
-    public final CounterStopwatch evaluateFunctionNanoTimer = new CounterStopwatch("evaluateFunction");
-    public final CounterStopwatch applyAnywhereRulesNanoTimer
-            = new CounterStopwatch("applyAnywhereRules", evaluateFunctionNanoTimer.getSharedLevelHolder());
-    public final CounterStopwatch logOverheadTimer = new CounterStopwatch("Log");
-    public final CounterStopwatch queryBuildTimer = new CounterStopwatch("Z3 query build");
-    public final CounterStopwatch impliesSMTTimer = new CounterStopwatch("impliesSMT");
+    public final CounterStopwatch resFuncNanoTimer = new CounterStopwatch("resolveFunctionAndAnywhere time");
+    public final CounterStopwatch evaluateFunctionNanoTimer = resFuncNanoTimer.newSubTimer("evaluateFunction time");
+    public final Counter evalFuncBuiltinCounter = evaluateFunctionNanoTimer.newCounter("builtin evaluation");
+    public final Counter evalFuncRuleCounter = evaluateFunctionNanoTimer.newCounter("function rule");
+    public final Counter evalFuncSortPredicateCounter = evaluateFunctionNanoTimer.newCounter("sort predicate");
+    public final Counter evalFuncOwiseCounter = evaluateFunctionNanoTimer.newCounter("owise rule");
+    public final Counter evalFuncNoRuleApplicableCounter = evaluateFunctionNanoTimer.newCounter("no rule applicable");
+    public final Counter evalFuncNoRuleCounter = evaluateFunctionNanoTimer.newCounter("no function rules");
+
+    public final CounterStopwatch applyAnywhereRulesNanoTimer = resFuncNanoTimer
+            .newSubTimer("applyAnywhereRules time", evaluateFunctionNanoTimer.getSharedLevelHolder());
+    public final Counter applyAnywhereBuiltinCounter = applyAnywhereRulesNanoTimer.newCounter("builtin evaluation");
+    public final Counter applyAnywhereRuleCounter = applyAnywhereRulesNanoTimer.newCounter("anywhere rule");
+    public final Counter applyAnywhereNoRuleApplicableCounter =
+            applyAnywhereRulesNanoTimer.newCounter("no rule applicable");
+    public final Counter applyAnywhereNoRuleCounter = applyAnywhereRulesNanoTimer.newCounter("no anywhere rules");
+
+    public final CounterStopwatch logOverheadTimer = new CounterStopwatch("log time");
+    public final CounterStopwatch queryBuildTimer = new CounterStopwatch("query build time");
+    public final CounterStopwatch impliesSMTTimer = new CounterStopwatch("impliesSMT time");
 
     public int countResFuncTopUncached = 0;
     public int countResFuncRecursiveUncached = 0;
@@ -68,30 +81,16 @@ public class Profiler2 {
         TimeMemoryEntry[] intermediate = getIntermediateStats(initStats);
         System.err.format("\n\nInit+Execution time:    %8.3f s\n",
                 currentStats.timeDiff(parsingStats, intermediate));
-        if (queryBuildTimer.getCountTop() > 0) {
-            System.err.format("  query build time:     %s\n", queryBuildTimer);
-        }
+        printTimer("  ", queryBuildTimer, null);
         for (Z3Profiler profiler : z3Profilers.values()) {
-            if (profiler.getQueryCount() > 0) {
-                profiler.print();
-            }
+            profiler.print();
         }
 
+        //todo print nested too
         System.err.format("  Time and top-level event counts:\n");
-        System.err.format("  resolveFunctionAndAnywhere time: %s,      # %10d\n",
-                resFuncNanoTimer, resFuncNanoTimer.getCountTop());
-        System.err.format("    evaluateFunction time          : %s,      # %10d\n",
-                evaluateFunctionNanoTimer, evaluateFunctionNanoTimer.getCountTop());
-        System.err.format("    applyAnywhereRules time        : %s,      # %10d\n",
-                applyAnywhereRulesNanoTimer, applyAnywhereRulesNanoTimer.getCountTop());
-        CounterStopwatch resFuncOther = resFuncNanoTimer
-                .minus(evaluateFunctionNanoTimer).minus(applyAnywhereRulesNanoTimer);
-        System.err.format("    resolveFunc... remaining time  : %s\n", resFuncOther);
-        System.err.format("                         # cached  : %10s,      # %10d\n", "", resFuncOther.getCountTop());
-        if (logOverheadTimer.getCountTop() > 0) {
-            System.err.format("  log time                       : %s,      # %10d\n",
-                    logOverheadTimer, logOverheadTimer.getCountTop());
-        }
+        printTimer("  ", resFuncNanoTimer, "remaining time & # cached");
+        printTimer("  ", logOverheadTimer, null);
+        printTimer("  ", impliesSMTTimer, null);
 
         if (afterExecution) {
             System.err.format("\nMax memory : %d MB\n", Runtime.getRuntime().maxMemory() / (1024 * 1024));
@@ -109,17 +108,28 @@ public class Profiler2 {
         System.err.format("resolveFunction recursive cached  : %d\n",
                 resFuncNanoTimer.getCountRecursive() - countResFuncRecursiveUncached);
 
-        if (impliesSMTTimer.getCountTop() > 0) {
-            System.err.format("\nimpliesSMT time :    %s\n", impliesSMTTimer);
-            System.err.format("impliesSMT count:    %s\n", impliesSMTTimer.getCountTop());
-        }
-
         //Has some overhead. Enable from class Profiler if needed, by setting value below to true.
         if (Profiler.enableProfilingMode.get()) {
             System.err.println("==================");
             Profiler.printResult();
         }
         System.err.println("==================================\n");
+    }
+
+    public static void printTimer(String prefix, CounterStopwatch timer, String leftoverTimerName) {
+        if (timer.getDuration() == 0 && timer.getCountTop() == 0) {
+            return;
+        }
+        System.err.format("%s%-33s: %s,      # %10d\n", prefix, timer.getName(), timer, timer.getCountTop());
+        for (CounterStopwatch subTimer : timer.getSubTimers(leftoverTimerName)) {
+            printTimer(prefix + "  ", subTimer, "remaining");
+        }
+        for (Counter counter : timer.getCounters("other")) {
+            if (counter.getCountTop() > 0) {
+                System.err.format("%s%-33s: %10s,      # %10d\n",
+                        prefix + "  ", counter.getName(), "", counter.getCountTop());
+            }
+        }
     }
 
     private void printStats(TimeMemoryEntry currentStats, boolean afterExecution) {

--- a/java-backend/src/main/java/org/kframework/backend/java/util/Profiler2.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/Profiler2.java
@@ -54,8 +54,6 @@ public class Profiler2 {
     public final CounterStopwatch queryBuildTimer = new CounterStopwatch("query build time");
     public final CounterStopwatch impliesSMTTimer = new CounterStopwatch("impliesSMT time");
 
-    public int countResFuncTopUncached = 0;
-    public int countResFuncRecursiveUncached = 0;
     final Map<FormulaContext.Kind, Z3Profiler> z3Profilers = createZ3Profilers();
 
     private Map<FormulaContext.Kind, Z3Profiler> createZ3Profilers() {
@@ -86,7 +84,7 @@ public class Profiler2 {
             profiler.print();
         }
 
-        System.err.format("  Time and top-level event counts:\n");
+        System.err.format("\n  Time and top-level event counts:\n");
         printTimer("  ", resFuncNanoTimer, "remaining time & # cached", true);
         printTimer("  ", logOverheadTimer, null, true);
         printTimer("  ", impliesSMTTimer, null, true);
@@ -97,17 +95,6 @@ public class Profiler2 {
             System.err.format("\nMax memory : %d MB\n", Runtime.getRuntime().maxMemory() / (1024 * 1024));
         }
         printCacheStats(currentStats, afterExecution, context);
-
-        System.err.format("resolveFunction top-level       : %d\n", resFuncNanoTimer.getCountTop());
-        System.err.format("resolveFunction top-level uncached: %d\n", countResFuncTopUncached);
-        int countCached = resFuncNanoTimer.getCountTop() - countResFuncTopUncached;
-        if (countCached > 0) {
-            System.err.format("resolveFunction top-level cached:   %d\n", countCached);
-        }
-        System.err.format("resolveFunction recursive       : %d\n", resFuncNanoTimer.getCountRecursive());
-        System.err.format("resolveFunction recursive uncached: %d\n", countResFuncRecursiveUncached);
-        System.err.format("resolveFunction recursive cached  : %d\n",
-                resFuncNanoTimer.getCountRecursive() - countResFuncRecursiveUncached);
 
         //Has some overhead. Enable from class Profiler if needed, by setting value below to true.
         if (Profiler.enableProfilingMode.get()) {

--- a/java-backend/src/main/java/org/kframework/backend/java/util/Profiler2.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/Profiler2.java
@@ -35,7 +35,8 @@ public class Profiler2 {
 
     public final CounterStopwatch resFuncNanoTimer = new CounterStopwatch("resolveFunction");
     public final CounterStopwatch evaluateFunctionNanoTimer = new CounterStopwatch("evaluateFunction");
-    public final CounterStopwatch applyAnywhereRulesNanoTimer = new CounterStopwatch("applyAnywhereRules");
+    public final CounterStopwatch applyAnywhereRulesNanoTimer
+            = new CounterStopwatch("applyAnywhereRules", evaluateFunctionNanoTimer.getSharedLevelHolder());
     public final CounterStopwatch logOverheadTimer = new CounterStopwatch("Log");
     public final CounterStopwatch queryBuildTimer = new CounterStopwatch("Z3 query build");
     public final CounterStopwatch impliesSMTTimer = new CounterStopwatch("impliesSMT");

--- a/java-backend/src/main/java/org/kframework/backend/java/util/Z3Profiler.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/Z3Profiler.java
@@ -68,7 +68,7 @@ public class Z3Profiler {
         int cachedQueries = requestCount - queryCount - queryBuildFailureCount;
         int unrecoveredTimeouts = queryCount - nonTimeouts;
         int recoveredTimeouts = totalTimeouts - unrecoveredTimeouts;
-        Profiler2.printTimer("  ", sw, null);
+        Profiler2.printTimer("  ", sw, null, true);
         if (queryCount != 0) {
             if (queryCount != sw.getCountTop()) {
                 System.err.format("    executed queries:     %d\n", queryCount);

--- a/java-backend/src/main/java/org/kframework/backend/java/util/Z3Profiler.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/Z3Profiler.java
@@ -19,7 +19,7 @@ public class Z3Profiler {
     private Map<String, Integer> queryResultCounts = new HashMap<>();
 
     Z3Profiler(String name) {
-        sw = new CounterStopwatch(name);
+        sw = new CounterStopwatch(name + " time");
     }
 
     public void startRun() {
@@ -61,17 +61,18 @@ public class Z3Profiler {
         return lastRunTimeout;
     }
 
-    public int getQueryCount() {
-        return queryCount;
-    }
-
     public void print() {
+        if (queryCount == 0) {
+            return;
+        }
         int cachedQueries = requestCount - queryCount - queryBuildFailureCount;
         int unrecoveredTimeouts = queryCount - nonTimeouts;
         int recoveredTimeouts = totalTimeouts - unrecoveredTimeouts;
-        System.err.format("  %-28s time:  %s\n", sw.getName(), sw);
+        Profiler2.printTimer("  ", sw, null);
         if (queryCount != 0) {
-            System.err.format("    executed queries:     %d\n", queryCount);
+            if (queryCount != sw.getCountTop()) {
+                System.err.format("    executed queries:     %d\n", queryCount);
+            }
             for (String result : Z3Wrapper.Z3_QUERY_RESULTS) {
                 if (queryResultCounts.get(result) != null) {
                     System.err.format("      %-14s:       %d\n", "unsat".equals(result) ? "unsat (proved)" : result,


### PR DESCRIPTION
Now we display detailed statistics on top-level & recursive calls to `resolveFunction`, `applyAnhywhereRules`, and each exit point inside those functions. Example summary at the end of kprove:
```
SPEC PROVED: /mnt/d/verified-smart-contracts-fork/specs/gnosis/checkSignatures-loop-success-middle-spec.k Location(742,5,997,56)
==================================
Execution paths: 1
Longest path: 16 steps
Stats for each phase, time, used memory, implicit main GC time percentage:
Total                 :  105.324 s,	 3097 MB, gc:  4.195 %
  Parsing             :   54.002 s,	  243 MB, gc:  1.378 %
  Init                :   36.177 s,	 3332 MB, gc:  9.912 %
  Execution           :   15.145 s,	 3097 MB, gc:  0.581 %

Init+Execution time:      51.322 s
  query build time                 :    1.207 s,      #        750
  Z3 Regular rule implication time :    0.028 s,      #          1
      unsat (proved):       1
  Z3 Function rule implication time:   14.139 s,      #        485
      sat           :       407
      unsat (proved):       78
    cached queries:       737
    query build failures: 253
  Z3 Spec rule implication time    :    0.027 s,      #          1
      unsat (proved):       1
    query build failures: 1
  Z3 Final implication time        :    0.030 s,      #          1
      unsat (proved):       1
  Z3 Regular rule constraint time  :    0.084 s,      #          3
      sat           :       1
      unsat (proved):       2
  Z3 Spec rule constraint time     :    0.152 s,      #          5
      sat           :       5

  Time and top-level event counts:
  resolveFunctionAndAnywhere time  :   47.580 s,      #     458103
    evaluateFunction time            :   47.080 s,      #       3191
      builtin evaluation               :           ,      #        119
      function rule                    :           ,      #        196
      sort predicate                   :           ,      #          5
      no rule applicable               :           ,      #       2867
      no function rules                :           ,      #          4
    applyAnywhereRules time          :    0.006 s,      #       3385
      no anywhere rules                :           ,      #       3385
    remaining time & # cached        :    0.495 s,      #     451527
  log time                         :    0.050 s,      #         16
  impliesSMT time                  :   18.114 s,      #       1479

  Recursive event counts:
  resolveFunctionAndAnywhere time  :           ,      #   53105314
    evaluateFunction time            :           ,      #     240274
      builtin evaluation               :           ,      #     127474
      function rule                    :           ,      #      94919
      sort predicate                   :           ,      #        553
      no rule applicable               :           ,      #      17266
      no function rules                :           ,      #         61
    applyAnywhereRules time          :           ,      #      48214
      no anywhere rules                :           ,      #      48214
    # cached                         :           ,      #   52816826

Max memory : 8192 MB
==================================
```