### PR TITLE
Java Backend log: --log-func-target, more KItem and global logs

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -9,6 +9,7 @@ import org.kframework.backend.java.symbolic.JavaExecutionOptions;
 import org.kframework.backend.java.symbolic.SMTOperations;
 import org.kframework.backend.java.symbolic.Stage;
 import org.kframework.backend.java.util.FormulaSimplificationCache;
+import org.kframework.backend.java.util.PrettyPrinter;
 import org.kframework.backend.java.util.Profiler2;
 import org.kframework.backend.java.util.StateLog;
 import org.kframework.backend.java.util.ToStringCache;
@@ -18,7 +19,6 @@ import org.kframework.krun.KRunOptions;
 import org.kframework.krun.api.io.FileSystem;
 import org.kframework.main.GlobalOptions;
 import org.kframework.unparser.KPrint;
-import org.kframework.backend.java.util.PrettyPrinter;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.options.SMTOptions;
@@ -106,5 +106,14 @@ public class GlobalContext implements Serializable {
 
     public void setExecutionPhase(boolean executionPhase) {
         isExecutionPhase = executionPhase;
+        if (!executionPhase) {
+            profiler.logParsingTime(this);
+            javaExecutionOptions.logRulesPublic = javaExecutionOptions.logRulesInit;
+            javaExecutionOptions.logFunctionTargetPublic = false;
+        } else {
+            profiler.logInitTime(this);
+            javaExecutionOptions.logRulesPublic = javaExecutionOptions.logRules;
+            javaExecutionOptions.logFunctionTargetPublic = javaExecutionOptions.logFunctionTarget;
+        }
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -597,7 +597,9 @@ public class KItem extends Term implements KItemRepresentation {
 
                     if (result != null) {
                         if (kItem.global.javaExecutionOptions.logFunctionTargetPublic) {
-                            System.err.format("KItem evaluated: %s\n", kItem);
+                            System.err.format(""
+                                    + "KItem evaluated: %s\n"
+                                    + "             to: %s\n", kItem, result);
                         }
                         kItem.profiler.evalFuncRuleCounter.increment();
                         return result;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -434,7 +434,7 @@ public class KItem extends Term implements KItemRepresentation {
                         if (result != null && !result.equals(kItem)) {
                             Term evalResult = result.evaluate(context);
                             if (evalResult != result && context.global().javaExecutionOptions.logRulesPublic) {
-                                System.err.format("\nEvaluated builtin KLabel, nesting %d\n" +
+                                System.err.format("\nEvaluated builtin KLabel, lvl %d\n" +
                                         "-------------------------\n", kItem.profiler.resFuncNanoTimer.getLevel());
                             }
                             kItem.profiler.evalFuncBuiltinCounter.increment();
@@ -512,7 +512,7 @@ public class KItem extends Term implements KItemRepresentation {
                                 solution = matches.get(0);
                             }
                             if (context.global().javaExecutionOptions.logRulesPublic) {
-                                System.err.format("\nApplying function rule, nesting %d\n" +
+                                System.err.format("\nApplying function rule, lvl %d\n" +
                                         "-------------------------\n", kItem.profiler.resFuncNanoTimer.getLevel());
                             }
 
@@ -560,7 +560,7 @@ public class KItem extends Term implements KItemRepresentation {
 
                             if (kItem.global.javaExecutionOptions.logRulesPublic) {
                                 String msg = result != null ? "Rule applied" : "Rule application failed";
-                                System.err.format("\n%s, nesting %d\n", msg,
+                                System.err.format("\n%s, lvl %d\n", msg,
                                         kItem.profiler.resFuncNanoTimer.getLevel());
                                 RuleSourceUtil.printRuleAndSource(rule);
                                 System.err.println("-------------------------");

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -496,7 +496,8 @@ public class KItem extends Term implements KItemRepresentation {
                             }
 
                             Substitution<Variable, Term> solution;
-                            List<Substitution<Variable, Term>> matches = PatternMatcher.match(kItem, rule, context);
+                            List<Substitution<Variable, Term>> matches = PatternMatcher.match(kItem, rule, context,
+                                    "KItem", nestingLevel);
                             if (matches.isEmpty()) {
                                 continue;
                             } else {
@@ -720,7 +721,8 @@ public class KItem extends Term implements KItemRepresentation {
                     }
                     /* anywhere rules should be applied by pattern match rather than unification */
                     Map<Variable, Term> solution;
-                    List<Substitution<Variable, Term>> matches = PatternMatcher.match(this, rule, context);
+                    List<Substitution<Variable, Term>> matches = PatternMatcher.match(this, rule, context,
+                            "KItem anywhere", profiler.applyAnywhereRulesNanoTimer.getLevel());
                     if (matches.isEmpty()) {
                         continue;
                     } else {

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -478,7 +478,7 @@ public class KItem extends Term implements KItemRepresentation {
                     Term result = null;
                     Term owiseResult = null;
                     Rule appliedRule = null;
-                    KItemLog.logStartingEval(kLabelConstant, nestingLevel, kItem.global);
+                    KItemLog.logStartingEval(kLabelConstant, nestingLevel, kItem.global, context);
 
                     // an argument is concrete if it doesn't contain variables or unresolved functions
                     boolean isConcrete = kList.getContents().stream().filter(elem -> !elem.isGround() || !elem.isNormal()).collect(Collectors.toList()).isEmpty();

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
@@ -44,8 +44,18 @@ public class KItemLog {
     static void logApplyingFuncRule(KLabelConstant kLabelConstant, int nestingLevel,
                                     Rule rule, GlobalContext global) {
         if (global.javaExecutionOptions.logRulesPublic) {
-            System.err.format("\n%sKItem lvl %d, %23s: %s, source: %s %s\n", indent(nestingLevel - 1),
+            System.err.format("\n%s KItem lvl %d, %23s: %s, source: %s %s\n", indent(nestingLevel - 1),
                     nestingLevel, "function rule applying", kLabelConstant, rule.getSource(), rule.getLocation());
+        }
+    }
+
+    public static void logEvaluatingConstraints(Term term, int nestingLevel,
+                                                Rule rule, GlobalContext global, String logMsg) {
+        if (global.javaExecutionOptions.logRulesPublic) {
+            org.kframework.kore.KLabel kLabel = term instanceof KItem ? ((KItem) term).klabel() : null;
+            //one extra space for indent
+            System.err.format("%s %s lvl %d, %23s: %s, source: %s %s\n", indent(nestingLevel - 1), logMsg,
+                    nestingLevel, "matched, eval. constr.", kLabel, rule.getSource(), rule.getLocation());
         }
     }
 
@@ -96,7 +106,7 @@ public class KItemLog {
     }
 
     private static void logRuleApplying(KLabelConstant kLabelConstant, int nestingLevel, Rule rule, String msg) {
-        System.err.format("\n%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1), nestingLevel, msg, kLabelConstant);
+        System.err.format("\n%s KItem lvl %d, %23s: %s\n", indent(nestingLevel - 1), nestingLevel, msg, kLabelConstant);
         RuleSourceUtil.printRuleAndSource(rule);
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
@@ -1,0 +1,84 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+package org.kframework.backend.java.kil;
+
+import org.kframework.backend.java.util.RuleSourceUtil;
+
+/**
+ * @author Denis Bogdanas
+ * Created on 07-Apr-19.
+ */
+public class KItemLog {
+    private KItemLog() {}
+
+    static void logBuiltinEval(KLabelConstant kLabelConstant, int nestingLevel, GlobalContext global) {
+        if (global.javaExecutionOptions.logRulesPublic) {
+            System.err.format("\nKItem lvl %d, %23s: %s\n",
+                    nestingLevel, "builtin evaluation", kLabelConstant);
+        }
+    }
+
+    static void logStartingEval(KLabelConstant kLabelConstant, int nestingLevel, GlobalContext global) {
+        if (global.javaExecutionOptions.logRulesPublic) {
+            if (nestingLevel == 1) {
+                System.err.print("\n-------------------------");
+            }
+            System.err.format("\nKItem lvl %d, %23s: %s\n",
+                    nestingLevel, "starting evaluation", kLabelConstant);
+        }
+    }
+
+    static void logApplyingFuncRule(KLabelConstant kLabelConstant, int nestingLevel,
+                                    Rule rule, GlobalContext global) {
+        if (global.javaExecutionOptions.logRulesPublic) {
+            System.err.format("\nKItem lvl %d, %23s: %s, source: %s\n",
+                    nestingLevel, "function rule applying", kLabelConstant, rule.getSource());
+        }
+    }
+
+    static void logRuleApplied(KLabelConstant kLabelConstant, int nestingLevel,
+                               boolean resultNotNull, Rule rule, GlobalContext global) {
+        if (global.javaExecutionOptions.logRulesPublic) {
+            String msg = resultNotNull ? "rule applied" : "rule application failed";
+            logRuleApplying(kLabelConstant, nestingLevel, rule, msg);
+        }
+    }
+
+    static void logEvaluated(KItem kItem, Term result, int nestingLevel) {
+        logEvaluatedImpl(kItem, result, nestingLevel, "evaluated");
+    }
+
+    static void logEvaluatedOwise(KItem kItem, Term owiseResult, int nestingLevel) {
+        logEvaluatedImpl(kItem, owiseResult, nestingLevel, "evaluated (owise)");
+    }
+
+    static void logNoRuleApplicable(KItem kItem, int nestingLevel) {
+        if (kItem.globalContext().javaExecutionOptions.logFunctionTargetPublic) {
+            System.err.format("KItem lvl %d, %23s: %s\n", nestingLevel, "no rule applicable", kItem);
+        }
+    }
+
+    private static void logEvaluatedImpl(KItem kItem, Term result, int nestingLevel, String evaluated) {
+        if (kItem.globalContext().javaExecutionOptions.logRulesPublic) {
+            String formatStr = "" +
+                    "KItem lvl %d, %23s: %s\n"
+                    + "             %23s: %s\n";
+            if (kItem.globalContext().javaExecutionOptions.logFunctionTargetPublic) {
+                System.err.format(formatStr, nestingLevel, evaluated, kItem, "to", result);
+            } else {
+                System.err.format(formatStr, nestingLevel, evaluated, kItem.klabel(), "to",
+                        result instanceof KItem ? ((KItem) result).klabel() : result);
+            }
+        }
+    }
+
+    static void logAnywhereRule(KLabelConstant kLabelConstant, int nestingLevel, Rule rule, GlobalContext global) {
+        if (global.javaExecutionOptions.logRulesPublic) {
+            logRuleApplying(kLabelConstant, nestingLevel, rule, "anywhere rule applied");
+        }
+    }
+
+    private static void logRuleApplying(KLabelConstant kLabelConstant, int nestingLevel, Rule rule, String msg) {
+        System.err.format("\nKItem lvl %d, %23s: %s\n", nestingLevel, msg, kLabelConstant);
+        RuleSourceUtil.printRuleAndSource(rule);
+    }
+}

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
@@ -3,6 +3,9 @@ package org.kframework.backend.java.kil;
 
 import org.kframework.backend.java.util.RuleSourceUtil;
 
+import java.util.ArrayList;
+import java.util.Collections;
+
 /**
  * @author Denis Bogdanas
  * Created on 07-Apr-19.
@@ -10,9 +13,20 @@ import org.kframework.backend.java.util.RuleSourceUtil;
 public class KItemLog {
     private KItemLog() {}
 
+    private static ArrayList<String> indents = new ArrayList<>(Collections.singleton(""));
+
+    private static synchronized String indent(int n) {
+        if (!(n < indents.size())) {
+            for (int i = indents.size(); i <= n; i++) {
+                indents.add(indents.get(i - 1) + "  ");
+            }
+        }
+        return indents.get(n);
+    }
+
     static void logBuiltinEval(KLabelConstant kLabelConstant, int nestingLevel, GlobalContext global) {
         if (global.javaExecutionOptions.logRulesPublic) {
-            System.err.format("\nKItem lvl %d, %23s: %s\n",
+            System.err.format("\n%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1),
                     nestingLevel, "builtin evaluation", kLabelConstant);
         }
     }
@@ -22,7 +36,7 @@ public class KItemLog {
             if (nestingLevel == 1) {
                 System.err.print("\n-------------------------");
             }
-            System.err.format("\nKItem lvl %d, %23s: %s\n",
+            System.err.format("\n%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1),
                     nestingLevel, "starting evaluation", kLabelConstant);
         }
     }
@@ -30,8 +44,8 @@ public class KItemLog {
     static void logApplyingFuncRule(KLabelConstant kLabelConstant, int nestingLevel,
                                     Rule rule, GlobalContext global) {
         if (global.javaExecutionOptions.logRulesPublic) {
-            System.err.format("\nKItem lvl %d, %23s: %s, source: %s\n",
-                    nestingLevel, "function rule applying", kLabelConstant, rule.getSource());
+            System.err.format("\n%sKItem lvl %d, %23s: %s, source: %s %s\n", indent(nestingLevel - 1),
+                    nestingLevel, "function rule applying", kLabelConstant, rule.getSource(), rule.getLocation());
         }
     }
 
@@ -53,19 +67,23 @@ public class KItemLog {
 
     static void logNoRuleApplicable(KItem kItem, int nestingLevel) {
         if (kItem.globalContext().javaExecutionOptions.logFunctionTargetPublic) {
-            System.err.format("KItem lvl %d, %23s: %s\n", nestingLevel, "no rule applicable", kItem);
+            System.err
+                    .format("%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1), nestingLevel, "no rule applicable",
+                            kItem);
         }
     }
 
     private static void logEvaluatedImpl(KItem kItem, Term result, int nestingLevel, String evaluated) {
         if (kItem.globalContext().javaExecutionOptions.logRulesPublic) {
             String formatStr = "" +
-                    "KItem lvl %d, %23s: %s\n"
-                    + "             %23s: %s\n";
+                    "%sKItem lvl %d, %23s: %s\n"
+                    + "%s             %23s: %s\n";
             if (kItem.globalContext().javaExecutionOptions.logFunctionTargetPublic) {
-                System.err.format(formatStr, nestingLevel, evaluated, kItem, "to", result);
+                System.err.format(formatStr, indent(nestingLevel - 1), nestingLevel, evaluated, kItem,
+                        indent(nestingLevel - 1), "to", result);
             } else {
-                System.err.format(formatStr, nestingLevel, evaluated, kItem.klabel(), "to",
+                System.err.format(formatStr, indent(nestingLevel - 1), nestingLevel, evaluated, kItem.klabel(),
+                        indent(nestingLevel - 1), "to",
                         result instanceof KItem ? ((KItem) result).klabel() : result);
             }
         }
@@ -78,7 +96,7 @@ public class KItemLog {
     }
 
     private static void logRuleApplying(KLabelConstant kLabelConstant, int nestingLevel, Rule rule, String msg) {
-        System.err.format("\nKItem lvl %d, %23s: %s\n", nestingLevel, msg, kLabelConstant);
+        System.err.format("\n%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1), nestingLevel, msg, kLabelConstant);
         RuleSourceUtil.printRuleAndSource(rule);
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
@@ -31,13 +31,17 @@ public class KItemLog {
         }
     }
 
-    static void logStartingEval(KLabelConstant kLabelConstant, int nestingLevel, GlobalContext global) {
+    static void logStartingEval(KLabelConstant kLabelConstant, int nestingLevel, GlobalContext global,
+                                TermContext termContext) {
         if (global.javaExecutionOptions.logRulesPublic) {
             if (nestingLevel == 1) {
                 System.err.print("\n-------------------------");
             }
             System.err.format("\n%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1),
                     nestingLevel, "starting evaluation", kLabelConstant);
+            if (termContext.getTopConstraint() == null) {
+                System.err.format("%s%13s%23s  null constraint\n", indent(nestingLevel - 1), "", "");
+            }
         }
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
@@ -675,7 +675,8 @@ public class FastRuleMatcher {
         while (!queue.isEmpty()) {
             BuiltinMap candidate = queue.remove();
             for (Rule rule : global.getDefinition().patternFoldingRules()) {
-                for (Substitution<Variable, Term> substitution : PatternMatcher.match(candidate, rule, context)) {
+                for (Substitution<Variable, Term> substitution : PatternMatcher.match(candidate, rule, context,
+                        "unifyMap", 1)) {
                     BuiltinMap result = (BuiltinMap) rule.rightHandSide().substituteAndEvaluate(substitution, context);
                     if (foldedMaps.add(result)) {
                         queue.add(result);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -187,9 +187,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
         @Override
         public RewriterResult execute(K k, Optional<Integer> depth) {
             rewritingContext.stateLog.open("execute-" + Integer.toString(Math.abs(k.hashCode())));
-            rewritingContext.profiler.logParsingTime(rewritingContext);
             rewritingContext.setExecutionPhase(false);
-            rewritingContext.javaExecutionOptions.logRulesPublic = rewritingContext.javaExecutionOptions.logRulesInit;
             TermContext termContext = TermContext.builder(rewritingContext).freshCounter(initCounterValue).build();
             KOREtoBackendKIL converter = new KOREtoBackendKIL(module, definition, termContext.global(), false);
             ResolveSemanticCasts resolveCasts = new ResolveSemanticCasts(true);
@@ -197,10 +195,8 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
             termContext.setKOREtoBackendKILConverter(converter);
             Term backendKil = converter.convert(macroExpander.expand(resolveCasts.resolve(k))).evaluate(termContext);
             rewritingContext.stateLog.log(StateLog.LogEvent.EXECINIT, backendKil, KApply(KLabels.ML_TRUE));
-            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, transitions, converter);
-            rewritingContext.profiler.logInitTime(rewritingContext);
             rewritingContext.setExecutionPhase(true);
-            rewritingContext.javaExecutionOptions.logRulesPublic = rewritingContext.javaExecutionOptions.logRules;
+            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, transitions, converter);
             RewriterResult result = rewriter.rewrite(new ConstrainedTerm(backendKil, termContext), depth.orElse(-1));
             rewritingContext.stateLog.close();
             return result;
@@ -237,11 +233,8 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
 
         @Override
         public K prove(Module mod, @Nullable Rule boundaryPattern) {
-            //todo kompileOptions.global == null, but shouldn't
             rewritingContext.stateLog.open("prove-" + Integer.toString(Math.abs(mod.hashCode())));
-            rewritingContext.profiler.logParsingTime(rewritingContext);
             rewritingContext.setExecutionPhase(false);
-            rewritingContext.javaExecutionOptions.logRulesPublic = rewritingContext.javaExecutionOptions.logRulesInit;
             List<Rule> rules = stream(mod.rules())
                     .sorted(Comparator.comparingInt(rule -> rule.body().hashCode()))
                     .filter(r -> r.att().contains("specification")).collect(Collectors.toList());
@@ -262,9 +255,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
 
             SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, transitions, converter);
 
-            rewritingContext.profiler.logInitTime(rewritingContext);
             rewritingContext.setExecutionPhase(true);
-            rewritingContext.javaExecutionOptions.logRulesPublic = rewritingContext.javaExecutionOptions.logRules;
             List<ConstrainedTerm> proofResults = javaRules.stream()
                     .filter(r -> !r.att().contains(Attribute.TRUSTED_KEY))
                     .map(r -> {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaExecutionOptions.java
@@ -105,6 +105,10 @@ public final class JavaExecutionOptions {
             "don't have all their side conditions satisfied and are not applied.")
     public boolean logRules = false;
 
+    @Parameter(names="--log-func-target", description="Log all symbolic KItems on which function evaluation produced " +
+            "a different result than original item. Potentially very verbose.")
+    public boolean logFunctionTarget = false;
+
     @Parameter(names="--log-rules-init", description="Log applied rules at initialization phase.")
     public boolean logRulesInit = false;
 
@@ -121,6 +125,7 @@ public final class JavaExecutionOptions {
     public boolean debugFormulas = false;
 
     public boolean logRulesPublic = false;
+    public boolean logFunctionTargetPublic = false;
 
     @Parameter(names = "--log-success", description = "Log success final states. " +
             "By default only failure final states are logged.")

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/MacroExpander.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/MacroExpander.java
@@ -123,7 +123,8 @@ public class MacroExpander extends CopyOnWriteTransformer {
     private Term applyMacroRule(Term term) {
         for (Rule rule : context.definition().macros()) {
             Map<Variable, Term> solution;
-            List<Substitution<Variable, Term>> matches = PatternMatcher.match(term, rule, context);
+            List<Substitution<Variable, Term>> matches = PatternMatcher.match(term, rule, context,
+                    "applyMacroRule", 1);
             if (matches.isEmpty()) {
                 continue;
             } else {

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/PatternMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/PatternMatcher.java
@@ -6,7 +6,19 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.kframework.backend.java.kil.*;
+import org.kframework.backend.java.kil.BuiltinList;
+import org.kframework.backend.java.kil.BuiltinMap;
+import org.kframework.backend.java.kil.BuiltinSet;
+import org.kframework.backend.java.kil.ConcreteCollectionVariable;
+import org.kframework.backend.java.kil.GlobalContext;
+import org.kframework.backend.java.kil.KCollection;
+import org.kframework.backend.java.kil.KItem;
+import org.kframework.backend.java.kil.KItemLog;
+import org.kframework.backend.java.kil.Kind;
+import org.kframework.backend.java.kil.Rule;
+import org.kframework.backend.java.kil.Term;
+import org.kframework.backend.java.kil.TermContext;
+import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.util.RewriteEngineUtils;
 
 import java.util.ArrayList;
@@ -104,17 +116,21 @@ public class PatternMatcher extends AbstractUnifier {
      *            the rule
      * @param context
      *            the term context
+     * @param logMsg for logging
+     * @param nestingLevel for logging
      * @return a list of possible instantiations of the left-hand side of the
      *         rule (each instantiation is represented as a substitution mapping
      *         variables in the pattern to sub-terms in the subject)
      */
-    public static List<Substitution<Variable, Term>> match(Term subject, Rule rule, TermContext context) {
+    public static List<Substitution<Variable, Term>> match(Term subject, Rule rule, TermContext context,
+                                                           String logMsg, int nestingLevel) {
         PatternMatcher matcher = new PatternMatcher(rule.isFunction() || rule.isLemma(), true, context);
 
         if (!matcher.patternMatch(subject, rule.leftHandSide())) {
             return Collections.emptyList();
         }
 
+        KItemLog.logEvaluatingConstraints(subject, nestingLevel, rule, context.global(), logMsg);
         return RewriteEngineUtils.evaluateConditions(rule, matcher.substitutions(), context);
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -183,7 +183,7 @@ public class SymbolicRewriter {
             Rule rule = definition.ruleTable.get(matchResult.ruleIndex);
             global.stateLog.log(StateLog.LogEvent.RULEATTEMPT, rule.toKRewrite(), subject.term(), subject.constraint());
             if (global.javaExecutionOptions.logRulesPublic) {
-                System.err.println("\nRegular rule matched:");
+                System.err.print("\nRegular rule: matched:\n-------------------------\n");
                 RuleSourceUtil.printRuleAndSource(rule);
             }
 
@@ -194,7 +194,7 @@ public class SymbolicRewriter {
             // start the optimized substitution
 
             if (global.javaExecutionOptions.logRulesPublic) {
-                System.err.println("\nBuilding match result\n-------------------------\n");
+                System.err.println("\nRegular rule: building match result\n-------------------------\n");
             }
             // get a map from AST paths to (fine-grained, inner) rewrite RHSs
             assert (matchResult.rewrites.size() > 0);
@@ -211,7 +211,7 @@ public class SymbolicRewriter {
             }
 
             if (global.javaExecutionOptions.logRulesPublic) {
-                System.err.println("\nEvaluating rule application result\n-------------------------\n");
+                System.err.println("\nRegular rule: evaluating rule application result\n-------------------------\n");
             }
             if (!matchResult.isMatching) {
                 theNew = theNew.substituteAndEvaluate(substitution, subject.termContext());
@@ -220,7 +220,7 @@ public class SymbolicRewriter {
             theNew = restoreConfigurationIfNecessary(subject, rule, theNew);
 
             if (global.javaExecutionOptions.logRulesPublic) {
-                System.err.println("\nEvaluating constraint\n-------------------------\n");
+                System.err.println("\nRegular rule: evaluating constraint\n-------------------------\n");
             }
             /* eliminate bindings of the substituted variables */
             ConjunctiveFormula constraint = matchResult.constraint;
@@ -1109,8 +1109,8 @@ public class SymbolicRewriter {
                     new FormulaContext(FormulaContext.Kind.SpecRule, specRule), specRule.matchingSymbols());
             if (constraint != null) {
                 if (global.javaExecutionOptions.logRulesPublic) {
-                    System.err.println("\nSpec rule matched, building result\n" +
-                            "==========================================\n");
+                    System.err.format("\nSpec rule matched, building result for: %s %s\n-------------------------\n",
+                            specRule.getSource(), specRule.getLocation());
                 }
                 global.stateLog.log(StateLog.LogEvent.SRULEATTEMPT, specRule.toKRewrite(), constrainedTerm.term(), constrainedTerm.constraint());
                 ConstrainedTerm result = buildResult(specRule, constraint, null, true, constrainedTerm.termContext(),


### PR DESCRIPTION
Main new features:
- option --log-func-target that prints every KItem that reached function evaluation, along with result of evaluation costomzied by exit point.
- printing mode details of what's going on inside function evaluation.
- printing more details of whats going on as part of one global step. Distinguishing final implication phase, apply spec rule phase and multiple sub-phases as part of applying a regular rule.

Example log fragment:
```
KItem lvl 1,     starting evaluation: #if_#then_#else_#fi_K-EQUAL
 -------------
 KItem lvl 1,  matched, eval. constr.: #if_#then_#else_#fi_K-EQUAL, source: Source(/mnt/d/k5/k-distribution/target/release/k/include/builtin/domains.k) Location(829,8,829,67)

  KItem lvl 2,     starting evaluation: notBool_
  KItem lvl 2,      no rule applicable: notBool_(_<Int__INT-COMMON(X_81:Int,, Int(#"0")))

  Z3 Implication (Function rule implication) failed (cached result):
  ConjunctiveFormula(
    equalities:
      _==K_(_<Int__INT-COMMON(X_81:Int,, Int(#"0")),, Bool(#"true"))
  )
    implies
  ConjunctiveFormula(
    equalities:
      _==K_(_<Int__INT-COMMON(X_81:Int,, Int(#"0")),, Bool(#"false"))
  )
  
  Rule for formula above:
    rule #if C:Bool #then _ #else B2::K #fi => B2 requires notBool C
  	Source: /mnt/d/k5/k-distribution/target/release/k/include/builtin/domains.k Location(829,8,829,67)
  -------------
 -------------
 KItem lvl 1,  matched, eval. constr.: #if_#then_#else_#fi_K-EQUAL, source: Source(/mnt/d/k5/k-distribution/target/release/k/include/builtin/domains.k) Location(828,8,828,59)

 KItem lvl 1,  function rule applying: #if_#then_#else_#fi_K-EQUAL, source: Source(/mnt/d/k5/k-distribution/target/release/k/include/builtin/domains.k) Location(828,8,828,59)

 KItem lvl 1,            rule applied: #if_#then_#else_#fi_K-EQUAL
  rule #if C:Bool #then B1::K #else _ #fi => B1 requires C
	Source: /mnt/d/k5/k-distribution/target/release/k/include/builtin/domains.k Location(828,8,828,59)
KItem lvl 1,               evaluated: #if_#then_#else_#fi_K-EQUAL(_<Int__INT-COMMON(X_81:Int,, Int(#"0")),, Int(#"2"),, Int(#"1"))
                                  to: Int(#"2")
```