### PR TITLE
Java Backend cache: introduced KItem.evaluatedRecursively

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -84,6 +84,7 @@ public class KItem extends Term implements KItemRepresentation {
 
     private BitSet[] childrenDontCareRuleMask = null;
     private final Profiler2 profiler;
+    private boolean evaluatedRecursively = false;
 
     public static KItem of(Term kLabel, Term kList, GlobalContext global) {
         return of(kLabel, kList, global, Att.empty(), null);
@@ -791,6 +792,14 @@ public class KItem extends Term implements KItemRepresentation {
         //return !(kLabel instanceof KLabel) || ((KLabel) kLabel).isFunction();
         return kLabel instanceof KLabel
                 && (((KLabel) kLabel).isFunction() || ((KLabel) kLabel).isPattern());
+    }
+
+    public boolean isEvaluatedRecursively() {
+        return evaluatedRecursively;
+    }
+
+    public void setEvaluatedRecursively(boolean evaluatedRecursively) {
+        this.evaluatedRecursively = evaluatedRecursively;
     }
 
     @Override

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -794,6 +794,10 @@ public class KItem extends Term implements KItemRepresentation {
                 && (((KLabel) kLabel).isFunction() || ((KLabel) kLabel).isPattern());
     }
 
+    /**
+     * @return true if this KItem is ground and has been evaluated recursively, otherwise false.
+     * @see KItem#evaluate(TermContext)
+     */
     public boolean isEvaluatedRecursively() {
         return evaluatedRecursively;
     }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/Evaluator.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/Evaluator.java
@@ -24,7 +24,15 @@ public class Evaluator extends CopyOnWriteTransformer {
 
     @Override
     public JavaSymbolicObject transform(KItem kItem) {
-        return ((KItem) super.transform(kItem)).resolveFunctionAndAnywhere(context);
+        if (kItem.isEvaluatedRecursively()) {
+            return kItem;
+        }
+        Term result = ((KItem) super.transform(kItem)).resolveFunctionAndAnywhere(context);
+        if (result instanceof KItem && result.isGround()) {
+            ((KItem) result).setEvaluatedRecursively(true);
+        }
+
+        return result;
     }
 
     @Override


### PR DESCRIPTION
that prevents recursive traversal of evaluated ground terms.

Tested on VSC: https://github.com/runtimeverification/verified-smart-contracts/pull/225
Total Jenkins suite time 40% less.
