### PR TITLE
Java Backend log: indent logs generated during function evaluation

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/GlobalContext.java
@@ -131,11 +131,17 @@ public class GlobalContext implements Serializable {
     }
 
     public void newLogIndent(String indent) {
+        if (!javaExecutionOptions.logRulesPublic) {
+            return;
+        }
         logStack.push(log);
         log = new IndentingFormatter(systemErrFormatter, indent);
     }
 
     public void restorePreviousLogIndent() {
+        if (!javaExecutionOptions.logRulesPublic) {
+            return;
+        }
         log = logStack.pop();
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -505,11 +505,11 @@ public class KItem extends Term implements KItemRepresentation {
 
                             Substitution<Variable, Term> solution;
                             List<Substitution<Variable, Term>> matches;
-                            kItem.global.openLogWrapper();
+                            kItem.global.newLogIndent(KItemLog.indent(nestingLevel));
                             try {
                                 matches = PatternMatcher.match(kItem, rule, context, "KItem", nestingLevel);
                             } finally {
-                                kItem.global.flushLogWrapper(KItemLog.indent(nestingLevel));
+                                kItem.global.restorePreviousLogIndent();
                             }
                             if (matches.isEmpty()) {
                                 continue;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -431,10 +431,11 @@ public class KItem extends Term implements KItemRepresentation {
             kItem.profiler.evaluateFunctionNanoTimer.start();
             KLabelConstant kLabelConstant = (KLabelConstant) kItem.kLabel;
             Profiler.startTimer(Profiler.getTimerForFunction(kLabelConstant));
+            int nestingLevel = kItem.profiler.evaluateFunctionNanoTimer.getLevel();
+            kItem.global.newLogIndent(KItemLog.indent(nestingLevel - 1));
 
             try {
                 KList kList = (KList) kItem.kList;
-                int nestingLevel = kItem.profiler.resFuncNanoTimer.getLevel();
 
                 if (builtins.get().isBuiltinKLabel(kLabelConstant)) {
                     try {
@@ -504,13 +505,8 @@ public class KItem extends Term implements KItemRepresentation {
                             }
 
                             Substitution<Variable, Term> solution;
-                            List<Substitution<Variable, Term>> matches;
-                            kItem.global.newLogIndent(KItemLog.indent(nestingLevel));
-                            try {
-                                matches = PatternMatcher.match(kItem, rule, context, "KItem", nestingLevel);
-                            } finally {
-                                kItem.global.restorePreviousLogIndent();
-                            }
+                            List<Substitution<Variable, Term>> matches =
+                                    PatternMatcher.match(kItem, rule, context, "KItem", nestingLevel);
                             if (matches.isEmpty()) {
                                 continue;
                             } else {
@@ -617,6 +613,7 @@ public class KItem extends Term implements KItemRepresentation {
                 }
                 return kItem;
             } finally {
+                kItem.global.restorePreviousLogIndent();
                 Profiler.stopTimer(Profiler.getTimerForFunction(kLabelConstant));
                 kItem.profiler.evaluateFunctionNanoTimer.stop();
             }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -495,7 +495,7 @@ public class KItem extends Term implements KItemRepresentation {
                             if (rule == RuleAuditing.getAuditingRule()) {
                                 RuleAuditing.beginAudit();
                             } else if (RuleAuditing.isAuditBegun() && RuleAuditing.getAuditingRule() == null) {
-                                System.err.println("\nAuditing " + rule + "...\n");
+                                context.global().log().format("\nAuditing " + rule + "...\n\n");
                             }
 
                             // a concrete rule is skipped if some argument is not concrete
@@ -504,8 +504,13 @@ public class KItem extends Term implements KItemRepresentation {
                             }
 
                             Substitution<Variable, Term> solution;
-                            List<Substitution<Variable, Term>> matches = PatternMatcher.match(kItem, rule, context,
-                                    "KItem", nestingLevel);
+                            List<Substitution<Variable, Term>> matches;
+                            kItem.global.openLogWrapper();
+                            try {
+                                matches = PatternMatcher.match(kItem, rule, context, "KItem", nestingLevel);
+                            } finally {
+                                kItem.global.flushLogWrapper(KItemLog.indent(nestingLevel));
+                            }
                             if (matches.isEmpty()) {
                                 continue;
                             } else {
@@ -721,7 +726,7 @@ public class KItem extends Term implements KItemRepresentation {
                     if (rule == RuleAuditing.getAuditingRule()) {
                         RuleAuditing.beginAudit();
                     } else if (RuleAuditing.isAuditBegun() && RuleAuditing.getAuditingRule() == null) {
-                        System.err.println("\nAuditing " + rule + "...\n");
+                        context.global().log().format("\nAuditing " + rule + "...\n\n");
                     }
                     /* anywhere rules should be applied by pattern match rather than unification */
                     Map<Variable, Term> solution;

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
@@ -2,10 +2,10 @@
 package org.kframework.backend.java.kil;
 
 import org.kframework.backend.java.util.RuleSourceUtil;
+import org.kframework.utils.IndentingFormatter;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Formatter;
 
 /**
  * @author Denis Bogdanas
@@ -27,7 +27,7 @@ public class KItemLog {
 
     static void logBuiltinEval(KLabelConstant kLabelConstant, int nestingLevel, GlobalContext global) {
         if (global.javaExecutionOptions.logRulesPublic) {
-            global.log().format("\n%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1),
+            global.log().format("\nKItem lvl %d, %23s: %s\n",
                     nestingLevel, "builtin evaluation", kLabelConstant);
         }
     }
@@ -38,10 +38,10 @@ public class KItemLog {
             if (nestingLevel == 1) {
                 global.log().format("\n-------------------------");
             }
-            global.log().format("\n%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1),
+            global.log().format("\nKItem lvl %d, %23s: %s\n",
                     nestingLevel, "starting evaluation", kLabelConstant);
             if (termContext.getTopConstraint() == null) {
-                global.log().format("%s%13s%23s  null constraint\n", indent(nestingLevel - 1), "", "");
+                global.log().format("%13s%23s  null constraint\n", "", "");
             }
         }
     }
@@ -49,7 +49,7 @@ public class KItemLog {
     static void logApplyingFuncRule(KLabelConstant kLabelConstant, int nestingLevel,
                                     Rule rule, GlobalContext global) {
         if (global.javaExecutionOptions.logRulesPublic) {
-            global.log().format("\n%s KItem lvl %d, %23s: %s, source: %s %s\n", indent(nestingLevel - 1),
+            global.log().format("\n KItem lvl %d, %23s: %s, source: %s %s\n",
                     nestingLevel, "function rule applying", kLabelConstant, rule.getSource(), rule.getLocation());
         }
     }
@@ -59,8 +59,8 @@ public class KItemLog {
         if (global.javaExecutionOptions.logRulesPublic) {
             org.kframework.kore.KLabel kLabel = term instanceof KItem ? ((KItem) term).klabel() : null;
             //one extra space for indent
-            global.log().format("%s -------------\n", indent(nestingLevel - 1));
-            global.log().format("%s %s lvl %d, %23s: %s, source: %s %s\n", indent(nestingLevel - 1), logMsg,
+            global.log().format(" -------------\n");
+            global.log().format(" %s lvl %d, %23s: %s, source: %s %s\n", logMsg,
                     nestingLevel, "matched, eval. constr.", kLabel, rule.getSource(), rule.getLocation());
         }
     }
@@ -83,7 +83,7 @@ public class KItemLog {
 
     static void logNoRuleApplicable(KItem kItem, int nestingLevel) {
         if (kItem.globalContext().javaExecutionOptions.logFunctionTargetPublic) {
-            kItem.globalContext().log().format("%sKItem lvl %d, %23s: %s\n", indent(nestingLevel - 1),
+            kItem.globalContext().log().format("KItem lvl %d, %23s: %s\n",
                     nestingLevel, "no rule applicable", kItem);
         }
     }
@@ -91,16 +91,14 @@ public class KItemLog {
     private static void logEvaluatedImpl(KItem kItem, Term result, int nestingLevel, String evaluated) {
         if (kItem.globalContext().javaExecutionOptions.logRulesPublic) {
             String formatStr = "" +
-                    "%sKItem lvl %d, %23s: %s\n"
-                    + "%s             %23s: %s\n";
-            Formatter log = kItem.globalContext().log();
+                    "KItem lvl %d, %23s: %s\n"
+                    + "             %23s: %s\n";
+            IndentingFormatter log = kItem.globalContext().log();
             if (kItem.globalContext().javaExecutionOptions.logFunctionTargetPublic) {
-                log.format(formatStr, indent(nestingLevel - 1), nestingLevel, evaluated, kItem,
-                        indent(nestingLevel - 1), "to", result);
+                log.format(formatStr, nestingLevel, evaluated, kItem, "to", result);
             } else {
-                log.format(formatStr, indent(nestingLevel - 1), nestingLevel, evaluated, kItem.klabel(),
-                        indent(nestingLevel - 1), "to",
-                        result instanceof KItem ? ((KItem) result).klabel() : result);
+                log.format(formatStr, nestingLevel, evaluated, kItem.klabel(),
+                        "to", result instanceof KItem ? ((KItem) result).klabel() : result);
             }
         }
     }
@@ -113,13 +111,13 @@ public class KItemLog {
 
     private static void logRuleApplying(KLabelConstant kLabelConstant, int nestingLevel, Rule rule, String msg,
                                         GlobalContext global) {
-        global.log().format("\n%s KItem lvl %d, %23s: %s\n", indent(nestingLevel - 1), nestingLevel,
+        global.log().format("\n KItem lvl %d, %23s: %s\n", nestingLevel,
                 msg, kLabelConstant);
-        global.openLogWrapper();
+        global.newLogIndent(indent(nestingLevel - 1) + " ");
         try {
             RuleSourceUtil.appendRuleAndSource(rule, global.log());
         } finally {
-            global.flushLogWrapper(indent(nestingLevel - 1) + " ");
+            global.restorePreviousLogIndent();
         }
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItemLog.java
@@ -105,19 +105,18 @@ public class KItemLog {
 
     static void logAnywhereRule(KLabelConstant kLabelConstant, int nestingLevel, Rule rule, GlobalContext global) {
         if (global.javaExecutionOptions.logRulesPublic) {
-            logRuleApplying(kLabelConstant, nestingLevel, rule, "anywhere rule applied", global);
+            global.newLogIndent(indent(nestingLevel - 1) + " ");
+            try {
+                logRuleApplying(kLabelConstant, nestingLevel, rule, "anywhere rule applied", global);
+            } finally {
+                global.restorePreviousLogIndent();
+            }
         }
     }
 
     private static void logRuleApplying(KLabelConstant kLabelConstant, int nestingLevel, Rule rule, String msg,
                                         GlobalContext global) {
-        global.log().format("\n KItem lvl %d, %23s: %s\n", nestingLevel,
-                msg, kLabelConstant);
-        global.newLogIndent(indent(nestingLevel - 1) + " ");
-        try {
-            RuleSourceUtil.appendRuleAndSource(rule, global.log());
-        } finally {
-            global.restorePreviousLogIndent();
-        }
+        global.log().format("\n KItem lvl %d, %23s: %s\n", nestingLevel, msg, kLabelConstant);
+        RuleSourceUtil.appendRuleAndSource(rule, global.log());
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -553,7 +553,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
             Equality equality) {
         if ((RuleAuditing.isAuditBegun() || global.javaExecutionOptions.debugZ3)
                 && !(equality.leftHandSide() instanceof BoolToken && equality.rightHandSide() instanceof BoolToken)) {
-            System.err.format("Unification failure: %s does not unify with %s\n",
+            global.log().format("Unification failure: %s does not unify with %s\n",
                     equality.leftHandSide(), equality.rightHandSide());
         }
         return new ConjunctiveFormula(
@@ -868,7 +868,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
             }
 
             if (global.javaExecutionOptions.debugFormulas) {
-                System.err.format("\nAttempting to prove:\n================= \n\t%s\n  implies \n\t%s\n", left, right);
+                global.log().format("\nAttempting to prove:\n================= \n\t%s\n  implies \n\t%s\n", left, right);
             }
 
             right = right.orientSubstitution(existentialQuantVars);
@@ -876,7 +876,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
             right = right.orientSubstitution(existentialQuantVars);
             if (right.isTrue() || (right.equalities().isEmpty() && existentialQuantVars.containsAll(right.substitution().keySet()))) {
                 if (global.javaExecutionOptions.debugFormulas) {
-                    System.err.println("Implication proved by simplification");
+                    global.log().format("Implication proved by simplification\n");
                 }
                 continue;
             }
@@ -888,7 +888,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                 // TODO (AndreiS): handle KList variables
                 Term condition = ((KList) ite.kList()).get(0);
                 if (global.javaExecutionOptions.debugFormulas) {
-                    System.err.format("Split on %s\n", condition);
+                    global.log().format("Split on %s\n", condition);
                 }
                 TermContext context = TermContext.builder(global).build();
                 implications.add(Pair.of(left.add(condition, BoolToken.TRUE).simplify(context), right));
@@ -903,12 +903,12 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
             global.stateLog.log(StateLog.LogEvent.IMPLICATION, leftWithoutSubst, right);
             if (!impliesSMT(leftWithoutSubst, right, existentialQuantVars, formulaContext)) {
                 if (global.javaExecutionOptions.debugFormulas) {
-                    System.err.println("Failure!");
+                    global.log().format("Failure!\n");
                 }
                 return false;
             } else {
                 if (global.javaExecutionOptions.debugFormulas) {
-                    System.err.println("Proved!");
+                    global.log().format("Proved!\n");
                 }
             }
         }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -480,7 +480,7 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
                 variable = Variable.getAnonVariable(term.sort());
                 termAbstractionMap.put(term, variable);
                 if (globalContext.javaExecutionOptions.debugZ3Queries) {
-                    System.err.format("\t%s ::= %s\n", variable.longName(), term);
+                    globalContext.log().format("\t%s ::= %s\n", variable.longName(), term);
                 }
             } else {
                 throw e;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SMTOperations.java
@@ -6,11 +6,11 @@ import org.kframework.backend.java.kil.Definition;
 import org.kframework.backend.java.kil.Variable;
 import org.kframework.backend.java.util.FormulaContext;
 import org.kframework.backend.java.util.Z3Wrapper;
+import org.kframework.utils.IndentingFormatter;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.options.SMTOptions;
 import org.kframework.utils.options.SMTSolver;
 
-import java.util.Formatter;
 import java.util.Set;
 
 public class SMTOperations {
@@ -41,7 +41,7 @@ public class SMTOperations {
             return false;
         }
 
-        Formatter log = constraint.globalContext().log();
+        IndentingFormatter log = constraint.globalContext().log();
         boolean result = false;
         try {
             constraint.globalContext().profiler.queryBuildTimer.start();
@@ -81,7 +81,7 @@ public class SMTOperations {
             ConjunctiveFormula right,
             Set<Variable> existentialQuantVars, FormulaContext formulaContext) {
         if (smtOptions.smt == SMTSolver.Z3) {
-            Formatter log = left.globalContext().log();
+            IndentingFormatter log = left.globalContext().log();
             try {
                 left.globalContext().profiler.queryBuildTimer.start();
                 CharSequence query;

--- a/java-backend/src/main/java/org/kframework/backend/java/util/FormulaContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/FormulaContext.java
@@ -5,10 +5,10 @@ import com.google.common.collect.ImmutableMap;
 import org.kframework.backend.java.kil.GlobalContext;
 import org.kframework.backend.java.kil.Rule;
 import org.kframework.backend.java.symbolic.ConjunctiveFormula;
+import org.kframework.utils.IndentingFormatter;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import java.util.Formatter;
 import java.util.Map;
 
 /**
@@ -72,7 +72,7 @@ public class FormulaContext {
     }
 
     public void printImplication(ConjunctiveFormula left, ConjunctiveFormula right, Boolean proved, boolean cached) {
-        Formatter log = left.globalContext().log();
+        IndentingFormatter log = left.globalContext().log();
         String cachedMsg = cached ? " (cached result)" : "";
         if (queryBuildFailure) {
             log.format("\nZ3 Implication (%s) RHS dropped (cannot be proved)%s:\n%s\n", kind.label, cachedMsg,
@@ -91,7 +91,7 @@ public class FormulaContext {
     }
 
     public void printUnsat(ConjunctiveFormula formula, boolean unsat, boolean cached) {
-        Formatter log = formula.globalContext().log();
+        IndentingFormatter log = formula.globalContext().log();
         String cachedMsg = cached ? " (cached result)" : "";
         if (unsat) {
             log.format("\nZ3 Constraint (%s) is unsat%s:\n%s\n", kind.label, cachedMsg, formula.toStringMultiline());

--- a/java-backend/src/main/java/org/kframework/backend/java/util/FormulaContext.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/FormulaContext.java
@@ -8,6 +8,7 @@ import org.kframework.backend.java.symbolic.ConjunctiveFormula;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.Formatter;
 import java.util.Map;
 
 /**
@@ -71,34 +72,37 @@ public class FormulaContext {
     }
 
     public void printImplication(ConjunctiveFormula left, ConjunctiveFormula right, Boolean proved, boolean cached) {
+        Formatter log = left.globalContext().log();
         String cachedMsg = cached ? " (cached result)" : "";
         if (queryBuildFailure) {
-            System.err.format("\nZ3 Implication (%s) RHS dropped (cannot be proved)%s:\n%s\n", kind.label, cachedMsg,
+            log.format("\nZ3 Implication (%s) RHS dropped (cannot be proved)%s:\n%s\n", kind.label, cachedMsg,
                     right.toStringMultiline());
         } else if (proved) {
-            System.err.format("\nZ3 Implication (%s) RHS proved%s:\n%s\n", kind.label, cachedMsg, right.toStringMultiline());
+            log.format("\nZ3 Implication (%s) RHS proved%s:\n%s\n", kind.label, cachedMsg, right.toStringMultiline());
         } else {
-            System.err.format("\nZ3 Implication (%s) failed%s:\n%s\n  implies\n%s\n",
+            log.format("\nZ3 Implication (%s) failed%s:\n%s\n  implies\n%s\n",
                     kind.label, cachedMsg, left.toStringMultiline(), right.toStringMultiline());
         }
         if (rule != null) {
-            System.err.println("\nRule for formula above:");
-            RuleSourceUtil.printRuleAndSource(rule);
+            log.format("\nRule for formula above:\n");
+            RuleSourceUtil.appendRuleAndSource(rule, log);
         }
-        System.err.println("==================================");
+        log.format("-------------\n");
     }
 
     public void printUnsat(ConjunctiveFormula formula, boolean unsat, boolean cached) {
+        Formatter log = formula.globalContext().log();
         String cachedMsg = cached ? " (cached result)" : "";
         if (unsat) {
-            System.err.format("\nZ3 Constraint (%s) is unsat%s:\n%s\n", kind.label, cachedMsg, formula.toStringMultiline());
+            log.format("\nZ3 Constraint (%s) is unsat%s:\n%s\n", kind.label, cachedMsg, formula.toStringMultiline());
         } else {
-            System.err.format("\nZ3 Constraint (%s) is assumed sat%s:\n%s\n", kind.label, cachedMsg, formula.toStringMultiline());
+            log.format("\nZ3 Constraint (%s) is assumed sat%s:\n%s\n", kind.label, cachedMsg,
+                    formula.toStringMultiline());
         }
         if (rule != null) {
-            System.err.println("\nRule for formula above:");
-            RuleSourceUtil.printRuleAndSource(rule);
+            log.format("\nRule for formula above:\n");
+            RuleSourceUtil.appendRuleAndSource(rule, log);
         }
-        System.err.println("==================================");
+        log.format("-------------\n");
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/util/RuleSourceUtil.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/RuleSourceUtil.java
@@ -37,8 +37,11 @@ public class RuleSourceUtil {
     }
 
     public static void appendRuleAndSource(Rule rule, Appendable out) {
+        appendRuleAndSource(rule, new Formatter(out));
+    }
+
+    public static void appendRuleAndSource(Rule rule, Formatter formatter) {
         File source = rule.source().isPresent() ? new File(rule.getSource().source()) : null;
-        Formatter formatter = new Formatter(out);
         if (sourceShortEnough(rule)) {
             formatter.format("%s\n", loadSource(rule));
         } else if (rule.source().isPresent()) {
@@ -46,6 +49,6 @@ public class RuleSourceUtil {
         } else {
             formatter.format("Rule with no source. toString() format:\n%s\n", rule.toString());
         }
-        formatter.format("\tSource: %s %s\n\n", source, rule.getLocation());
+        formatter.format("\tSource: %s %s\n", source, rule.getLocation());
     }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/util/RuleSourceUtil.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/RuleSourceUtil.java
@@ -3,6 +3,7 @@ package org.kframework.backend.java.util;
 
 import org.kframework.attributes.Location;
 import org.kframework.backend.java.kil.Rule;
+import org.kframework.utils.IndentingFormatter;
 import org.kframework.utils.file.FileUtil;
 
 import java.io.File;
@@ -41,6 +42,18 @@ public class RuleSourceUtil {
     }
 
     public static void appendRuleAndSource(Rule rule, Formatter formatter) {
+        File source = rule.source().isPresent() ? new File(rule.getSource().source()) : null;
+        if (sourceShortEnough(rule)) {
+            formatter.format("%s\n", loadSource(rule));
+        } else if (rule.source().isPresent()) {
+            formatter.format("rule too long...\n");
+        } else {
+            formatter.format("Rule with no source. toString() format:\n%s\n", rule.toString());
+        }
+        formatter.format("\tSource: %s %s\n", source, rule.getLocation());
+    }
+
+    public static void appendRuleAndSource(Rule rule, IndentingFormatter formatter) {
         File source = rule.source().isPresent() ? new File(rule.getSource().source()) : null;
         if (sourceShortEnough(rule)) {
             formatter.format("%s\n", loadSource(rule));

--- a/kernel/src/main/java/org/kframework/utils/IndentingFormatter.java
+++ b/kernel/src/main/java/org/kframework/utils/IndentingFormatter.java
@@ -1,0 +1,47 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+package org.kframework.utils;
+
+import javax.annotation.Nonnull;
+import java.util.Formatter;
+
+/**
+ * An extension of {@code java.util.Formatter} that indents every new line with specified prefix.
+ *
+ * @author Denis Bogdanas
+ * Created on 14-Apr-19.
+ */
+public class IndentingFormatter {
+
+    public static final String ENDL = "\n";
+    private Formatter formatter;
+    private String endlReplacement;
+
+    public IndentingFormatter(@Nonnull Formatter formatter, @Nonnull String indent) {
+        this.formatter = formatter;
+        this.endlReplacement = indent.isEmpty() ? ENDL : ENDL + indent;
+    }
+
+    public Formatter format(String format, Object... args) {
+        if (endlReplacement.equals(ENDL)) {
+            return formatter.format(format, args);
+        } else {
+            String newFormat = buildNewFormat(format);
+            Object[] newArgs = buildNewArgs(args);
+            return formatter.format(newFormat, newArgs);
+        }
+    }
+
+    public String buildNewFormat(String format) {
+        return format.replaceAll("\\R", endlReplacement);
+    }
+
+    public Object[] buildNewArgs(Object[] args) {
+        Object[] newArgs = new Object[args.length];
+        for (int i = 0; i < args.length; i++) {
+            newArgs[i] = args[i] instanceof String
+                         ? ((String) args[i]).replaceAll("\\R", endlReplacement)
+                         : args[i];
+        }
+        return newArgs;
+    }
+}

--- a/kore/src/main/java/org/kframework/utils/StringUtil.java
+++ b/kore/src/main/java/org/kframework/utils/StringUtil.java
@@ -1,9 +1,8 @@
 // Copyright (c) 2014-2019 K Team. All Rights Reserved.
 package org.kframework.utils;
 
-import org.apache.commons.lang3.StringUtils;
-
 import com.beust.jcommander.JCommander;
+import org.apache.commons.lang3.StringUtils;
 
 import java.util.regex.Pattern;
 
@@ -807,5 +806,22 @@ public class StringUtil {
         if (!inIdent) {
             sb.append("'");
         }
+    }
+
+    public static void replaceAll(StringBuilder builder, String from, String to, boolean includeLastChars) {
+        int index = getNextIndex(builder, from, 0, includeLastChars);
+        while (index != -1) {
+            builder.replace(index, index + from.length(), to);
+            index += to.length(); // Move to the end of the replacement
+            index = getNextIndex(builder, from, index, includeLastChars);
+        }
+    }
+
+    private static int getNextIndex(StringBuilder builder, String from, int index, boolean includeLastChars) {
+        int nextIndex = builder.indexOf(from, index);
+        if (!includeLastChars && nextIndex == builder.length() - from.length()) {
+            nextIndex = -1;
+        }
+        return nextIndex;
     }
 }

--- a/kore/src/main/java/org/kframework/utils/StringUtil.java
+++ b/kore/src/main/java/org/kframework/utils/StringUtil.java
@@ -1,8 +1,9 @@
 // Copyright (c) 2014-2019 K Team. All Rights Reserved.
 package org.kframework.utils;
 
-import com.beust.jcommander.JCommander;
 import org.apache.commons.lang3.StringUtils;
+
+import com.beust.jcommander.JCommander;
 
 import java.util.regex.Pattern;
 
@@ -806,22 +807,5 @@ public class StringUtil {
         if (!inIdent) {
             sb.append("'");
         }
-    }
-
-    public static void replaceAll(StringBuilder builder, String from, String to, boolean includeLastChars) {
-        int index = getNextIndex(builder, from, 0, includeLastChars);
-        while (index != -1) {
-            builder.replace(index, index + from.length(), to);
-            index += to.length(); // Move to the end of the replacement
-            index = getNextIndex(builder, from, index, includeLastChars);
-        }
-    }
-
-    private static int getNextIndex(StringBuilder builder, String from, int index, boolean includeLastChars) {
-        int nextIndex = builder.indexOf(from, index);
-        if (!includeLastChars && nextIndex == builder.length() - from.length()) {
-            nextIndex = -1;
-        }
-        return nextIndex;
     }
 }


### PR DESCRIPTION
according to `evaluateFunction` nesting level

Example log fragment:
```
KItem lvl 1,     starting evaluation: #stackOverflow
 -------------
 KItem lvl 1,  matched, eval. constr.: #stackOverflow, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(367,10,367,86)

 KItem lvl 1,  function rule applying: #stackOverflow, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(367,10,367,86)

  KItem lvl 2,     starting evaluation: #stackDelta
   -------------
   KItem lvl 2,  matched, eval. constr.: #stackDelta, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(410,10,410,66)
  
   KItem lvl 2,  function rule applying: #stackDelta, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(410,10,410,66)
  
    KItem lvl 3,     starting evaluation: #stackAdded
     -------------
     KItem lvl 3,  matched, eval. constr.: #stackAdded, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(401,10,401,42)
    
     KItem lvl 3,  function rule applying: #stackAdded, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(401,10,401,42)
    
     KItem lvl 3,            rule applied: #stackAdded
        rule #stackAdded(PUSH(_,_))      => 1
    	Source: /mnt/d/evm-semantics/.build/java/evm.k Location(401,10,401,42)
     -------------
     KItem lvl 3,  matched, eval. constr.: #stackAdded, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(406,10,406,42)
    
     KItem lvl 3,  function rule applying: #stackAdded, source: Source(/mnt/d/evm-semantics/.build/java/evm.k) Location(406,10,406,42)
    
     KItem lvl 3,            rule applied: #stackAdded
        rule #stackAdded(OP)             => 1 [owise]
    	Source: /mnt/d/evm-semantics/.build/java/evm.k Location(406,10,406,42)
    KItem lvl 3,               evaluated: #stackAdded(PUSH(Int(#"1"),, Int(#"96")))
                                      to: Int(#"1")
    
    KItem lvl 3,      builtin evaluation: _-Int__INT-COMMON
    
   KItem lvl 2,            rule applied: #stackDelta
      rule #stackDelta(OP) => #stackAdded(OP) -Int #stackNeeded(OP)
  	Source: /mnt/d/evm-semantics/.build/java/evm.k Location(410,10,410,66)
  KItem lvl 2,               evaluated: #stackDelta(PUSH(Int(#"1"),, Int(#"96")))
                                    to: Int(#"1")
  
  KItem lvl 2,      builtin evaluation: _+Int_
  
  KItem lvl 2,      builtin evaluation: _>Int__INT-COMMON
  
 KItem lvl 1,            rule applied: #stackOverflow
    rule #stackOverflow (WS, OP) => #sizeWordStack(WS) +Int #stackDelta(OP) >Int 1024
	Source: /mnt/d/evm-semantics/.build/java/evm.k Location(367,10,367,86)
KItem lvl 1,               evaluated: #stackOverflow(.WordStack_EVM-DATA(.KList),, PUSH(Int(#"1"),, Int(#"96")))
                                  to: Bool(#"false")
```
