### PR TITLE
Fix kompile crash with stream cell

### DIFF
--- a/k-distribution/tests/regression-new/Makefile
+++ b/k-distribution/tests/regression-new/Makefile
@@ -44,6 +44,7 @@ SUBDIRS=issue-2273 \
 	cast \
 	help \
 	exit-code-no-gen-top \
+	issue-425 \
 
 
 include ../../include/ktest-group.mak

--- a/k-distribution/tests/regression-new/issue-425/Makefile
+++ b/k-distribution/tests/regression-new/issue-425/Makefile
@@ -1,0 +1,4 @@
+DEF=test
+EXT=test
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/issue-425/test.k
+++ b/k-distribution/tests/regression-new/issue-425/test.k
@@ -1,0 +1,11 @@
+module TEST
+  imports LIST
+  imports STRING
+
+  configuration <T color="yellow">
+                  <k color="green"> $PGM:K </k>
+                  <input color="magenta" stream="stdin"> .List </input>
+                  <output color="Orchid" stream="stdout"> .List </output>
+                </T>
+
+endmodule

--- a/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
@@ -81,7 +81,7 @@ public class ResolveIOStreams {
                     sentences.addAll(getStreamModuleSentences(p));
                 }
             }
-            return Module(m.name(), m.imports(), immutable(sentences), m.att());
+            return Module(m.name(), (Set<Module>)m.imports().$bar(Set(definition.getModule("K-IO").get())), immutable(sentences), m.att());
         }
     }
 


### PR DESCRIPTION
There was an issue where kompile failed when you specified a stream cell in your config but never imported the K-IO module. We now import this module implicitly similarly to how we implicitly import MAP in order to deal with rule initializers or DEFAULT-CONFIGURATION if no config declaration appears in your code.