### PR TITLE
 support for fresh constants in function rules in llvm backend

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -123,10 +123,12 @@ public class KoreBackend implements Backend {
         DefinitionTransformer subsortKItem = DefinitionTransformer.from(Kompile::subsortKItem, "subsort all sorts to KItem");
         DefinitionTransformer expandMacros = DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(m, files, kompileOptions, false).expand(s), "expand macros");
         Function1<Definition, Definition> resolveFreshConstants = d -> DefinitionTransformer.from(m -> GeneratedTopFormat.resolve(new ResolveFreshConstants(d, true).resolve(m)), "resolving !Var variables").apply(d);
+        Function1<Definition, Definition> resolveFreshConstantsInFunctions = d -> DefinitionTransformer.fromSentenceTransformer(new ResolveFreshConstants(d, true)::resolveFunction, "resolving !Var variables in functions").apply(d);
         DefinitionTransformer resolveConfigVar = DefinitionTransformer.fromSentenceTransformer(new ResolveFunctionWithConfig()::resolveConfigVar, "Adding configuration variable to lhs");
         Function1<Definition, Definition> resolveIO = (d -> Kompile.resolveIOStreams(kem, d));
 
         return def -> resolveIO
+                .andThen(resolveFreshConstantsInFunctions)
                 .andThen(resolveFunctionWithConfig)
                 .andThen(resolveFun)
                 .andThen(resolveStrict)

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -301,12 +301,13 @@ public class AddSortInjections {
 
     private Sort lub(Collection<Sort> entries, Sort expectedSort, HasLocation loc) {
         assert !entries.isEmpty();
+        entries = new HashSet<>(entries);
         Collection<Sort> filteredEntries = entries.stream().filter(s -> !s.name().equals(SORTPARAM_NAME)).collect(Collectors.toList());
         if (filteredEntries.isEmpty()) { // if all sorts are parameters, take the first
             return entries.iterator().next();
         }
         Set<Sort> bounds = upperBounds(filteredEntries);
-        if (expectedSort != null && !expectedSort.name().equals(SORTPARAM_NAME) && !expectedSort.equals(Sorts.KItem())) {
+        if (expectedSort != null && !expectedSort.name().equals(SORTPARAM_NAME) && !expectedSort.equals(Sorts.KItem()) && !expectedSort.equals(Sorts.K())) {
             bounds.removeIf(s -> !mod.subsorts().lessThanEq(s, expectedSort));
         }
         Set<Sort> lub = mod.subsorts().minimal(bounds);

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -198,6 +198,13 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
   def isSort(klabel: KLabel, s: Sort) = subsorts.<(sortFor(klabel), s)
 
   lazy val rules: Set[Rule] = sentences collect { case r: Rule => r }
+  lazy val rulesFor: Map[KLabel, Set[Rule]] = rules.groupBy(r => {
+    r.body match {
+      case Unapply.KApply(s, _) => s
+      case Unapply.KRewrite(Unapply.KApply(s, _), _) => s
+      case _ => KORE.KLabel("")
+    }
+  })
   lazy val contexts: Set[Context] = sentences collect { case r: Context => r }
 
   lazy val localRules: Set[Rule] = localSentences collect { case r: Rule => r }
@@ -381,7 +388,7 @@ case class Production(klabel: Option[KLabel], sort: Sort, items: Seq[ProductionI
   lazy val klabelAtt: Option[String] = att.getOption("klabel").orElse(klabel.map(_.name))
 
   override def equals(that: Any) = that match {
-    case p@Production(`klabel`, `sort`, `items`, _) => this.klabelAtt == p.klabelAtt && this.att.getOption("poly") == p.att.getOption("poly") && this.att.getOption("function") == p.att.getOption("function")
+    case p@Production(`klabel`, `sort`, `items`, _) => this.klabelAtt == p.klabelAtt && this.att.getOption("poly") == p.att.getOption("poly") && this.att.getOption("function") == p.att.getOption("function") && this.att.getOption("withConfig") == p.att.getOption("withConfig")
     case _ => false
   }
 


### PR DESCRIPTION
This is not handled in a way that would work for symbolic execution, but it's good enough for the llvm backend so we're going in this direction for now in order to unblock us.