### PR TITLE
Refactor injected options in the haskell backend

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -55,7 +55,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
 
     private final FileUtil files;
     private final CompiledDefinition def;
-    private final KRunOptions options;
+    private final KRunOptions krunOptions;
     private final KompileOptions kompileOptions;
     private final KExceptionManager kem;
     private final HaskellKRunOptions haskellKRunOptions;
@@ -66,7 +66,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
     public HaskellRewriter(
             FileUtil files,
             CompiledDefinition def,
-            KRunOptions kRunOptions,
+            KRunOptions krunOptions,
             KompileOptions kompileOptions,
             KProveOptions kProveOptions,
             InitializeDefinition init,
@@ -77,7 +77,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
         this.def = def;
         this.kem = kem;
         this.haskellKRunOptions = haskellKRunOptions;
-        this.options = kRunOptions;
+        this.krunOptions = krunOptions;
         this.kompileOptions = kompileOptions;
         this.kProveOptions = kProveOptions;
         this.idsToLabels = init.serialized;
@@ -112,18 +112,18 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                         "--module", moduleName,
                         "--pattern", pgmPath,
                         "--output", koreOutputFile.getAbsolutePath()));
-                if (options.depth != null) {
+                if (krunOptions.depth != null) {
                     args.add("--depth");
-                    args.add(options.depth.toString());
+                    args.add(krunOptions.depth.toString());
                 }
-                if (options.experimental.smt.smtPrelude != null) {
+                if (krunOptions.experimental.smt.smtPrelude != null) {
                     args.add("--smt-prelude");
-                    args.add(options.experimental.smt.smtPrelude);
+                    args.add(krunOptions.experimental.smt.smtPrelude);
                 }
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
                     System.out.println(String.join(" ", koreCommand));
-                    options.print.output = OutputModes.NONE;
+                    krunOptions.print.output = OutputModes.NONE;
                     return new RewriterResult(Optional.empty(), Optional.empty(), k);
                 }
                 try {
@@ -209,14 +209,14 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                     args.add("--bound");
                     args.add(bound.get().toString());
                 }
-                if (options.experimental.smt.smtPrelude != null) {
+                if (krunOptions.experimental.smt.smtPrelude != null) {
                     args.add("--smt-prelude");
-                    args.add(options.experimental.smt.smtPrelude);
+                    args.add(krunOptions.experimental.smt.smtPrelude);
                 }
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
                     System.out.println(String.join(" ", koreCommand));
-                    options.print.output = OutputModes.NONE;
+                    krunOptions.print.output = OutputModes.NONE;
                     return initialConfiguration;
                 }
                 try {
@@ -269,9 +269,9 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                     args.addAll(Arrays.asList(
                         "--depth", kProveOptions.depth.toString()));
                 }
-                if (options.experimental.smt.smtPrelude != null) {
+                if (krunOptions.experimental.smt.smtPrelude != null) {
                     args.add("--smt-prelude");
-                    args.add(options.experimental.smt.smtPrelude);
+                    args.add(krunOptions.experimental.smt.smtPrelude);
                 }
                 if (haskellKRunOptions.allPathReachability) {
                     args.add("--all-path-reachability");
@@ -279,10 +279,10 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
                     System.out.println(String.join(" ", koreCommand));
-                    options.print.output = OutputModes.NONE;
+                    krunOptions.print.output = OutputModes.NONE;
                     return boundaryPattern.body();
                 }
-                if (options.global.verbose) {
+                if (krunOptions.global.verbose) {
                     System.err.println("Executing " + args);
                 }
                 try {
@@ -329,7 +329,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
      * @throws InterruptedException
      */
     private int executeCommandBasic(File workingDir, String... command) throws IOException, InterruptedException {
-        if (options.global.verbose) {
+        if (krunOptions.global.verbose) {
             System.err.println("Executing command: " + String.join(" ", Arrays.asList(command)));
         }
         int exit;

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -29,6 +29,7 @@ import org.kframework.parser.kore.Pattern;
 import org.kframework.RewriterResult;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.rewriter.SearchType;
+import org.kframework.unparser.KPrint;
 import org.kframework.unparser.OutputModes;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -56,41 +57,43 @@ import static org.kframework.builtin.BooleanUtils.*;
 @RequestScoped
 public class HaskellRewriter implements Function<Definition, Rewriter> {
 
-    private final FileUtil files;
-    private final CompiledDefinition def;
     private final GlobalOptions globalOptions;
     private final SMTOptions smtOptions;
     private final KRunOptions krunOptions;
     private final KompileOptions kompileOptions;
-    private final KExceptionManager kem;
-    private final HaskellKRunOptions haskellKRunOptions;
     private final KProveOptions kProveOptions;
+    private final HaskellKRunOptions haskellKRunOptions;
+    private final FileUtil files;
+    private final CompiledDefinition def;
+    private final KExceptionManager kem;
+    private final KPrint kprint;
     private final Properties idsToLabels;
 
     @Inject
     public HaskellRewriter(
-            FileUtil files,
-            CompiledDefinition def,
             GlobalOptions globalOptions,
             SMTOptions smtOptions,
             KRunOptions krunOptions,
             KompileOptions kompileOptions,
             KProveOptions kProveOptions,
             InitializeDefinition init,
+            HaskellKRunOptions haskellKRunOptions,
+            FileUtil files,
+            CompiledDefinition def,
             KExceptionManager kem,
-            HaskellKRunOptions haskellKRunOptions
+            KPrint kprint
             ) {
-        this.files = files;
-        this.def = def;
-        this.kem = kem;
         this.globalOptions = globalOptions;
         this.smtOptions = smtOptions;
         this.haskellKRunOptions = haskellKRunOptions;
         this.krunOptions = krunOptions;
         this.kompileOptions = kompileOptions;
         this.kProveOptions = kProveOptions;
+        this.files = files;
+        this.def = def;
+        this.kem = kem;
+        this.kprint = kprint;
         this.idsToLabels = init.serialized;
-
     }
 
     @Override
@@ -123,7 +126,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                         "--output", koreOutputFile.getAbsolutePath()));
                 if (depth.isPresent()) {
                     args.add("--depth");
-                    args.add(krunOptions.depth.toString());
+                    args.add(depth.toString());
                 }
                 if (smtOptions.smtPrelude != null) {
                     args.add("--smt-prelude");
@@ -132,7 +135,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
                     System.out.println(String.join(" ", koreCommand));
-                    krunOptions.print.output = OutputModes.NONE;
+                    kprint.options.output = OutputModes.NONE;
                     return new RewriterResult(Optional.empty(), Optional.empty(), k);
                 }
                 try {
@@ -225,7 +228,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
                     System.out.println(String.join(" ", koreCommand));
-                    krunOptions.print.output = OutputModes.NONE;
+                    kprint.options.output = OutputModes.NONE;
                     return initialConfiguration;
                 }
                 try {
@@ -288,7 +291,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
                     System.out.println(String.join(" ", koreCommand));
-                    krunOptions.print.output = OutputModes.NONE;
+                    kprint.options.output = OutputModes.NONE;
                     return boundaryPattern.body();
                 }
                 if (globalOptions.verbose) {

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -18,7 +18,6 @@ import org.kframework.kore.KORE;
 import org.kframework.kore.KVariable;
 import org.kframework.kore.Sort;
 import org.kframework.kprove.KProveOptions;
-import org.kframework.krun.KRunOptions;
 import org.kframework.krun.RunProcess;
 import org.kframework.main.GlobalOptions;
 import org.kframework.main.Main;
@@ -59,7 +58,6 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
 
     private final GlobalOptions globalOptions;
     private final SMTOptions smtOptions;
-    private final KRunOptions krunOptions;
     private final KompileOptions kompileOptions;
     private final KProveOptions kProveOptions;
     private final HaskellKRunOptions haskellKRunOptions;
@@ -73,7 +71,6 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
     public HaskellRewriter(
             GlobalOptions globalOptions,
             SMTOptions smtOptions,
-            KRunOptions krunOptions,
             KompileOptions kompileOptions,
             KProveOptions kProveOptions,
             InitializeDefinition init,
@@ -86,7 +83,6 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
         this.globalOptions = globalOptions;
         this.smtOptions = smtOptions;
         this.haskellKRunOptions = haskellKRunOptions;
-        this.krunOptions = krunOptions;
         this.kompileOptions = kompileOptions;
         this.kProveOptions = kProveOptions;
         this.files = files;

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -2,7 +2,6 @@
 package org.kframework.backend.haskell;
 
 import com.google.inject.Inject;
-import org.kframework.RewriterResult;
 import org.kframework.attributes.Att;
 import org.kframework.backend.kore.KoreBackend;
 import org.kframework.backend.kore.ModuleToKORE;
@@ -21,11 +20,13 @@ import org.kframework.kore.Sort;
 import org.kframework.kprove.KProveOptions;
 import org.kframework.krun.KRunOptions;
 import org.kframework.krun.RunProcess;
+import org.kframework.main.GlobalOptions;
 import org.kframework.main.Main;
-import org.kframework.parser.kore.Pattern;
 import org.kframework.parser.kore.parser.KoreToK;
 import org.kframework.parser.kore.parser.ParseError;
 import org.kframework.parser.kore.parser.TextToKore;
+import org.kframework.parser.kore.Pattern;
+import org.kframework.RewriterResult;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.rewriter.SearchType;
 import org.kframework.unparser.OutputModes;
@@ -35,6 +36,7 @@ import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.inject.DefinitionScoped;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.StringUtil;
+
 import scala.Tuple2;
 
 import java.io.File;
@@ -55,6 +57,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
 
     private final FileUtil files;
     private final CompiledDefinition def;
+    private final GlobalOptions globalOptions;
     private final KRunOptions krunOptions;
     private final KompileOptions kompileOptions;
     private final KExceptionManager kem;
@@ -66,6 +69,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
     public HaskellRewriter(
             FileUtil files,
             CompiledDefinition def,
+            GlobalOptions globalOptions,
             KRunOptions krunOptions,
             KompileOptions kompileOptions,
             KProveOptions kProveOptions,
@@ -78,6 +82,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
         this.kem = kem;
         this.haskellKRunOptions = haskellKRunOptions;
         this.krunOptions = krunOptions;
+        this.globalOptions = globalOptions;
         this.kompileOptions = kompileOptions;
         this.kProveOptions = kProveOptions;
         this.idsToLabels = init.serialized;
@@ -282,7 +287,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                     krunOptions.print.output = OutputModes.NONE;
                     return boundaryPattern.body();
                 }
-                if (krunOptions.global.verbose) {
+                if (globalOptions.verbose) {
                     System.err.println("Executing " + args);
                 }
                 try {
@@ -329,7 +334,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
      * @throws InterruptedException
      */
     private int executeCommandBasic(File workingDir, String... command) throws IOException, InterruptedException {
-        if (krunOptions.global.verbose) {
+        if (globalOptions.verbose) {
             System.err.println("Executing command: " + String.join(" ", Arrays.asList(command)));
         }
         int exit;

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -122,7 +122,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                         "--output", koreOutputFile.getAbsolutePath()));
                 if (depth.isPresent()) {
                     args.add("--depth");
-                    args.add(depth.toString());
+                    args.add(Integer.toString(depth.get()));
                 }
                 if (smtOptions.smtPrelude != null) {
                     args.add("--smt-prelude");

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -35,6 +35,7 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.inject.DefinitionScoped;
 import org.kframework.utils.inject.RequestScoped;
+import org.kframework.utils.options.SMTOptions;
 import org.kframework.utils.StringUtil;
 
 import scala.Tuple2;
@@ -58,6 +59,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
     private final FileUtil files;
     private final CompiledDefinition def;
     private final GlobalOptions globalOptions;
+    private final SMTOptions smtOptions;
     private final KRunOptions krunOptions;
     private final KompileOptions kompileOptions;
     private final KExceptionManager kem;
@@ -70,6 +72,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
             FileUtil files,
             CompiledDefinition def,
             GlobalOptions globalOptions,
+            SMTOptions smtOptions,
             KRunOptions krunOptions,
             KompileOptions kompileOptions,
             KProveOptions kProveOptions,
@@ -80,9 +83,10 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
         this.files = files;
         this.def = def;
         this.kem = kem;
+        this.globalOptions = globalOptions;
+        this.smtOptions = smtOptions;
         this.haskellKRunOptions = haskellKRunOptions;
         this.krunOptions = krunOptions;
-        this.globalOptions = globalOptions;
         this.kompileOptions = kompileOptions;
         this.kProveOptions = kProveOptions;
         this.idsToLabels = init.serialized;
@@ -121,9 +125,9 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                     args.add("--depth");
                     args.add(krunOptions.depth.toString());
                 }
-                if (krunOptions.experimental.smt.smtPrelude != null) {
+                if (smtOptions.smtPrelude != null) {
                     args.add("--smt-prelude");
-                    args.add(krunOptions.experimental.smt.smtPrelude);
+                    args.add(smtOptions.smtPrelude);
                 }
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
@@ -214,9 +218,9 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                     args.add("--bound");
                     args.add(bound.get().toString());
                 }
-                if (krunOptions.experimental.smt.smtPrelude != null) {
+                if (smtOptions.smtPrelude != null) {
                     args.add("--smt-prelude");
-                    args.add(krunOptions.experimental.smt.smtPrelude);
+                    args.add(smtOptions.smtPrelude);
                 }
                 koreCommand = args.toArray(koreCommand);
                 if (haskellKRunOptions.dryRun) {
@@ -274,9 +278,9 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                     args.addAll(Arrays.asList(
                         "--depth", kProveOptions.depth.toString()));
                 }
-                if (krunOptions.experimental.smt.smtPrelude != null) {
+                if (smtOptions.smtPrelude != null) {
                     args.add("--smt-prelude");
-                    args.add(krunOptions.experimental.smt.smtPrelude);
+                    args.add(smtOptions.smtPrelude);
                 }
                 if (haskellKRunOptions.allPathReachability) {
                     args.add("--all-path-reachability");

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -282,7 +282,9 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                     options.print.output = OutputModes.NONE;
                     return boundaryPattern.body();
                 }
-                System.out.println("Executing " + args);
+                if (options.global.verbose) {
+                    System.err.println("Executing " + args);
+                }
                 try {
                     File korePath = koreDirectory == null ? null : new File(koreDirectory);
                     if (executeCommandBasic(korePath, koreCommand) != 0) {
@@ -327,7 +329,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
      * @throws InterruptedException
      */
     private int executeCommandBasic(File workingDir, String... command) throws IOException, InterruptedException {
-        if (options.global.debug()) {
+        if (options.global.verbose) {
             System.err.println("Executing command: " + String.join(" ", Arrays.asList(command)));
         }
         int exit;

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -121,7 +121,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
                         "--module", moduleName,
                         "--pattern", pgmPath,
                         "--output", koreOutputFile.getAbsolutePath()));
-                if (krunOptions.depth != null) {
+                if (depth.isPresent()) {
                     args.add("--depth");
                     args.add(krunOptions.depth.toString());
                 }


### PR DESCRIPTION
This PR:

- Makes it so haskell backend doesn't print out extra stuff unless you include `--verbose`.
- Injects a `KPrint` into `HaskellRewriter` and uses the options from there.
- Injects `GlobalOptions` and `SMTOptions` into haskell rewriter and uses options directly from there when applicable.
- Correctly passes `depth` parameter instead of looking up in options when invoking haskell backend.