### PR TITLE
fix performance regression

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -67,7 +67,7 @@ public class ExpandMacros {
     private final ResolveFunctionWithConfig transformer;
 
     public ExpandMacros(Module mod, FileUtil files, KompileOptions kompileOptions, boolean reverse) {
-        this(new ResolveFunctionWithConfig(mod), mod, files, kompileOptions, reverse);
+        this(reverse ? null : new ResolveFunctionWithConfig(mod), mod, files, kompileOptions, reverse);
     }
 
     public ExpandMacros(ResolveFunctionWithConfig transformer, Module mod, FileUtil files, KompileOptions kompileOptions, boolean reverse) {


### PR DESCRIPTION
We don't need to initialize the dependencies when we are only processing terms, which means we can save some time here. I noticed it was taking a while since we were constructing an ExpandMacros for every key in a map/set in the final configuration, so this should help a lot to bring performance back to where it was before for unparsing.