### PR TITLE
Overload attribute for overload constructors

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -864,6 +864,7 @@ public class ModuleToKORE {
     private Att addKoreAttributes(Production prod, SetMultimap<KLabel, Rule> functionRules, Set<KLabel> impurities, Set<Production> overloads) {
         boolean isConstructor = !isFunction(prod);
         boolean isFunctional = !isFunction(prod);
+        boolean isOverloaded = false;
         if (prod.att().contains(Attribute.ASSOCIATIVE_KEY) ||
                 prod.att().contains(Attribute.COMMUTATIVE_KEY) ||
                 prod.att().contains(Attribute.IDEMPOTENT_KEY) ||
@@ -872,7 +873,7 @@ public class ModuleToKORE {
         }
         boolean isAnywhere = false;
         if (overloads.contains(prod)) {
-            isConstructor = false;
+            isOverloaded = true;
             isAnywhere = true;
         }
         for (Rule r : functionRules.get(prod.klabel().get())) {
@@ -893,6 +894,9 @@ public class ModuleToKORE {
         }
         if (isAnywhere) {
             att = att.add("anywhere");
+        }
+        if (isOverloaded) {
+            att = att.add("overload");
         }
         return att;
     }


### PR DESCRIPTION
I can add an `overloaded-constructor` attribute instead if it does not make sense to use the `constructor` attribute here, but the only difference between this and a "normal" constructor is whether `inj` works as some sort of constructor, too.