### PR TITLE
kprove: refactoring. Renamed and moved spliceModule()

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -127,6 +127,7 @@ public class JavaBackend implements Backend {
                 .andThen(ModuleTransformer.fromRuleBodyTransformer(NormalizeKSeq.self(), "normalize kseq"))
                 .andThen(mod -> JavaBackend.markRegularRules(def, mod))
                 .andThen(ModuleTransformer.fromSentenceTransformer(new AddConfigurationRecoveryFlags()::apply, "add refers_THIS_CONFIGURATION_marker"))
+                .andThen(restoreDefinitionModulesTransformer(def))
                 .apply(m);
     }
 

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -189,6 +189,7 @@ public class KoreBackend implements Backend {
                 .andThen(resolveFreshConstants)
                 .andThen(concretizeCells)
                 .andThen(subsortKItem)
+                .andThen(restoreDefinitionModulesTransformer(def))
                 .apply(m);
     }
 

--- a/kernel/src/main/java/org/kframework/compile/Backend.java
+++ b/kernel/src/main/java/org/kframework/compile/Backend.java
@@ -3,10 +3,8 @@ package org.kframework.compile;
 
 import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
-import org.kframework.definition.Rule;
-import org.kframework.definition.Sentence;
+import org.kframework.definition.ModuleTransformer;
 import org.kframework.kompile.CompiledDefinition;
-import org.kframework.kompile.Kompile;
 
 import java.util.Set;
 import java.util.function.Function;
@@ -23,4 +21,11 @@ public interface Backend {
     Function<Module, Module> specificationSteps(Definition def);
 
     Set<String> excludedModuleTags();
+
+    default ModuleTransformer restoreDefinitionModulesTransformer(Definition kompiledDefinition) {
+        return ModuleTransformer.from(mod -> kompiledDefinition.getModule(mod.name()).isDefined()
+                                             ? kompiledDefinition.getModule(mod.name()).get()
+                                             : mod,
+                "restore definition modules to same state as in definition");
+    }
 }

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -102,7 +102,6 @@ public class KProve {
         Module defModule = getModule(defModuleName, modulesMap, compiledDefinition.getParsedDefinition());
         Module specModule = getModule(specModuleName, modulesMap, compiledDefinition.getParsedDefinition());
         specModule = backend.specificationSteps(compiledDefinition.kompiledDefinition).apply(specModule);
-        specModule = spliceModule(specModule, compiledDefinition.kompiledDefinition);
         Definition combinedDef = Definition.apply(defModule, compiledDefinition.getParsedDefinition().entryModules(), compiledDefinition.getParsedDefinition().att());
         Definition compiled = compileDefinition(backend, combinedDef);
         return Tuple2.apply(compiled, specModule);
@@ -115,10 +114,6 @@ public class KProve {
             cache.put(combinedDef, compiled);
         }
         return compiled;
-    }
-
-    private static Module spliceModule(Module specModule, Definition kompiledDefinition) {
-        return ModuleTransformer.from(mod -> kompiledDefinition.getModule(mod.name()).isDefined() ? kompiledDefinition.getModule(mod.name()).get() : mod, "splice imports of specification module").apply(specModule);
     }
 
     /**


### PR DESCRIPTION
to actual specification steps in each backend, where it belongs.

Prerequisite for Spec rules automaton.
