### PR TITLE
kseq and dotk are Kore constructors

### DIFF
--- a/k-distribution/include/kore/prelude.kore
+++ b/k-distribution/include/kore/prelude.kore
@@ -6,9 +6,9 @@ endmodule []
 module KSEQ
   import BASIC-K []
 
-  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} []
+  symbol kseq{}(SortKItem{}, SortK{}) : SortK{} [constructor{}()]
   symbol append{}(SortK{}, SortK{}) : SortK{} [function{}()]
-  symbol dotk{}() : SortK{} []
+  symbol dotk{}() : SortK{} [constructor{}()]
 
   axiom{R}
     \equals{SortK{},R}(


### PR DESCRIPTION
We currently have special cases in the Haskell backend to make `kseq` and `dotk` into constructors. I would like to remove those special cases. Also, if we ever change the encoding of heating and cooling rules, these might not be constructors anymore. (I don't know if we'll ever do that, but the idea has been tossed around in the past.)