### PR TITLE
java backend: Partial work on automaton for spec rules

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Definition.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Definition.java
@@ -187,7 +187,7 @@ public class Definition extends JavaSymbolicObject {
     }
 
     private static final Set<String> automatonAttributes
-            = Sets.newHashSet(JavaBackend.MAIN_AUTOMATON);
+            = Sets.newHashSet(JavaBackend.MAIN_AUTOMATON, JavaBackend.SPEC_AUTOMATON);
 
     /**
      * Converts the org.kframework.Rules to backend Rules, also plugging in the automaton rule

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Definition.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Definition.java
@@ -80,6 +80,10 @@ public class Definition extends JavaSymbolicObject {
 
     private final List<Rule> rules = Lists.newArrayList();
     private final List<Rule> macros = Lists.newArrayList();
+    private final List<Rule> specRules = new ArrayList<>();
+
+    @SuppressWarnings("unused") //for debug
+    public final List<Rule> specRulesPublic = Collections.unmodifiableList(specRules);
     private final Multimap<KLabelConstant, Rule> functionRules = ArrayListMultimap.create();
     private final Multimap<KLabelConstant, Rule> sortPredicateRules = HashMultimap.create();
     private final Multimap<KLabelConstant, Rule> anywhereRules = ArrayListMultimap.create();
@@ -294,6 +298,9 @@ public class Definition extends JavaSymbolicObject {
             anywhereRules.put(rule.anywhereKLabel(), rule);
         } else {
             rules.add(rule);
+            if (rule.att().contains(Att.specification())) {
+                specRules.add(rule);
+            }
         }
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/InnerRHSRewrite.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/InnerRHSRewrite.java
@@ -39,7 +39,7 @@ public class InnerRHSRewrite extends Term {
 
     @Override
     public boolean isExactSort() {
-        throw new UnsupportedOperationException();
+        return true;
     }
 
     @Override
@@ -49,7 +49,7 @@ public class InnerRHSRewrite extends Term {
 
     @Override
     public Sort sort() {
-        throw new UnsupportedOperationException();
+        return Sort.BOTTOM;
     }
 
     @Override

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/InnerRHSRewrite.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/InnerRHSRewrite.java
@@ -61,4 +61,9 @@ public class InnerRHSRewrite extends Term {
     public void accept(Visitor visitor) {
         visitor.visit(this);
     }
+
+    @Override
+    public String toString() {
+        return "InnerRHSRewrite{ " + Arrays.toString(theRHS) + " }";
+    }
 }

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.Multiset;
 import com.google.common.collect.Multisets;
 import com.google.common.collect.Sets;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.kframework.attributes.Att;
@@ -16,6 +17,7 @@ import org.kframework.backend.java.kil.BuiltinList;
 import org.kframework.backend.java.kil.BuiltinMap;
 import org.kframework.backend.java.kil.BuiltinSet;
 import org.kframework.backend.java.kil.ConstrainedTerm;
+import org.kframework.backend.java.kil.Definition;
 import org.kframework.backend.java.kil.GlobalContext;
 import org.kframework.backend.java.kil.InnerRHSRewrite;
 import org.kframework.backend.java.kil.KItem;
@@ -58,6 +60,7 @@ import static org.kframework.Collections.*;
  */
 public class FastRuleMatcher {
 
+    private final Definition definition;
     private ConjunctiveFormula[] constraints;
     private final int ruleCount;
     private BitSet ruleMask;
@@ -82,9 +85,18 @@ public class FastRuleMatcher {
         return new FastRuleMatcher(context.global(), 1).matchSinglePattern(subject, pattern, context);
     }
 
+    public FastRuleMatcher(GlobalContext global) {
+        this(global, global.getDefinition().ruleTable.size());
+    }
+
     public FastRuleMatcher(GlobalContext global, int ruleCount) {
+        this(global, ruleCount, global.getDefinition());
+    }
+
+    public FastRuleMatcher(GlobalContext global, int ruleCount, Definition definition) {
         this.global = global;
         this.ruleCount = ruleCount;
+        this.definition = definition;
         constraints = new ConjunctiveFormula[this.ruleCount];
         ruleMask = makeAllRuleBits(ruleCount);
     }
@@ -108,25 +120,22 @@ public class FastRuleMatcher {
             List<String> transitions,
             boolean proveFlag,
             TermContext context, int step) {
-
-        ruleMask.stream().forEach(i -> constraints[i] = ConjunctiveFormula.of(context.global()));
-        empty = BitSet.apply(ruleCount);
-
         if (global.javaExecutionOptions.logRulesPublic) {
             System.err.format("\nRegular rule automaton phase, step %d\n" +
                     "==========================================\n", step);
         }
-        Term automatonLHS = global.getDefinition().mainAutomaton().leftHandSide();
-        BitSet theMatchingRules = matchAndLog(subject.term(), automatonLHS, ruleMask, List(), false);
+        Rule automaton = definition.mainAutomaton();
+        List<Pair<Rule, Integer>> automatonMatchedRules = matchWithAutomaton(subject, automaton);
 
         if (global.javaExecutionOptions.logRulesPublic) {
-            System.err.format("\nRegular rule attempting to match phase, step %d\n" +
-                    "==========================================\n", step);
+            System.err.format("\nRegular rule application, rules matched by automaton: %d\n" +
+                    "------------------------------------------\n", automatonMatchedRules.size());
         }
         List<RuleMatchResult> structuralResults = new ArrayList<>();
         List<RuleMatchResult> transitionResults = new ArrayList<>();
-        for (int i = theMatchingRules.nextSetBit(0); i >= 0; i = theMatchingRules.nextSetBit(i + 1)) {
-            Rule rule = global.getDefinition().ruleTable.get(i);
+        for (Pair<Rule, Integer> match : automatonMatchedRules) {
+            Rule rule = match.getLeft();
+            int i = match.getRight();
             // skip over IO rules when in prove rules
             if (proveFlag && rule.att().contains("stream")) {
                 continue;
@@ -151,7 +160,7 @@ public class FastRuleMatcher {
                     constraints[i],
                     subject.constraint(),
                     patternConstraint,
-                    Sets.union(getLeftHandSide(automatonLHS, i).variableSet(), patternConstraint.variableSet()).stream()
+                    Sets.union(getLeftHandSide(automaton.leftHandSide(), i).variableSet(), patternConstraint.variableSet()).stream()
                             .filter(v -> !v.name().equals(KOREtoBackendKIL.THE_VARIABLE))
                             .collect(Collectors.toSet()),
                     context, formulaContext);
@@ -182,16 +191,20 @@ public class FastRuleMatcher {
         }
     }
 
-    public List<Rule> matchSpecRule(ConstrainedTerm subject, List<Rule> rules, Rule automaton, TermContext context) {
-        ruleMask.stream().forEach(i -> constraints[i] = ConjunctiveFormula.of(context.global()));
+    /**
+     * @return rules matching the subject
+     */
+    public List<Pair<Rule, Integer>> matchWithAutomaton(ConstrainedTerm subject, Rule automaton) {
+        ruleMask.stream().forEach(i -> constraints[i] = ConjunctiveFormula.of(subject.termContext().global()));
         empty = BitSet.apply(ruleCount);
-        BitSet matchingRuleBits = matchAndLog(subject.term(), automaton.leftHandSide(), ruleMask, List(), false);
+        BitSet matchingRuleBits =
+                matchAndLog(subject.term(), automaton.leftHandSide(), ruleMask, List(), false);
 
-        List<Rule> matchingRules = new ArrayList<>();
+        List<Pair<Rule, Integer>> result = new ArrayList<>();
         for (int i = matchingRuleBits.nextSetBit(0); i >= 0; i = matchingRuleBits.nextSetBit(i + 1)) {
-            matchingRules.add(rules.get(i));
+            result.add(new ImmutablePair<>(definition.ruleTable.get(i), i));
         }
-        return matchingRules;
+        return result;
     }
 
     public static class RuleMatchResult {
@@ -580,7 +593,7 @@ public class FastRuleMatcher {
             return ruleMask;
         }
 
-        if (!global.getDefinition().subsorts().isSubsortedEq(variable.sort(), term.sort())) {
+        if (!definition.subsorts().isSubsortedEq(variable.sort(), term.sort())) {
             return empty;
         }
 
@@ -690,7 +703,7 @@ public class FastRuleMatcher {
         queue.add(map);
         while (!queue.isEmpty()) {
             BuiltinMap candidate = queue.remove();
-            for (Rule rule : global.getDefinition().patternFoldingRules()) {
+            for (Rule rule : definition.patternFoldingRules()) {
                 for (Substitution<Variable, Term> substitution : PatternMatcher.match(candidate, rule, context,
                         "unifyMap", 1)) {
                     BuiltinMap result = (BuiltinMap) rule.rightHandSide().substituteAndEvaluate(substitution, context);

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
@@ -13,6 +13,7 @@ import org.apache.commons.lang3.tuple.Triple;
 import org.kframework.attributes.Att;
 import org.kframework.backend.java.builtins.BoolToken;
 import org.kframework.backend.java.compile.KOREtoBackendKIL;
+import org.kframework.backend.java.kil.Bottom;
 import org.kframework.backend.java.kil.BuiltinList;
 import org.kframework.backend.java.kil.BuiltinMap;
 import org.kframework.backend.java.kil.BuiltinSet;
@@ -643,7 +644,8 @@ public class FastRuleMatcher {
                 return (Term) ruleAutomatonDisjunction.disjunctions().stream()
                         .filter(p -> p.getRight().get(i))
                         .map(Pair::getLeft)
-                        .findAny().get()
+                        //If automaton doesn't include this rule, return BOTTOM, that will remove this rule from BitSet.
+                        .findAny().orElse(Bottom.BOTTOM)
                         .accept(this);
             }
 
@@ -666,7 +668,8 @@ public class FastRuleMatcher {
                 return (Term) ruleAutomatonDisjunction.disjunctions().stream()
                         .filter(p -> p.getRight().get(i))
                         .map(Pair::getLeft)
-                        .findAny().get()
+                        //If automaton doesn't include this rule, return BOTTOM, that will remove this rule from BitSet.
+                        .findAny().orElse(Bottom.BOTTOM)
                         .accept(this);
             }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/FastRuleMatcher.java
@@ -374,8 +374,14 @@ public class FastRuleMatcher {
             BitSet theNewMask = matchAndLog(subject, (Term) rw.klist().items().get(0), ruleMask, path, logFailures);
 
             for (int i = theNewMask.nextSetBit(0); i >= 0; i = theNewMask.nextSetBit(i + 1)) {
-                if (innerRHSRewrite.theRHS[i] != null) {
-                    constraints[i] = constraints[i].add(new LocalRewriteTerm(path.reverse(), innerRHSRewrite.theRHS[i]), BoolToken.TRUE);
+                if (i < innerRHSRewrite.theRHS.length) {
+                    if (innerRHSRewrite.theRHS[i] != null) {
+                        constraints[i] = constraints[i]
+                                .add(new LocalRewriteTerm(path.reverse(), innerRHSRewrite.theRHS[i]), BoolToken.TRUE);
+                    }
+                } else {
+                    //rule index i is not handled by this automaton.
+                    theNewMask.clear(i);
                 }
             }
             return theNewMask;

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -40,6 +40,7 @@ import java.util.function.Function;
 public class JavaBackend implements Backend {
 
     public static final String MAIN_AUTOMATON = "mainAutomaton";
+    public static final String SPEC_AUTOMATON = "specAutomaton";
 
     private final KExceptionManager kem;
     private final FileUtil files;
@@ -130,6 +131,7 @@ public class JavaBackend implements Backend {
                 .andThen(mod -> JavaBackend.markSpecRules(def, mod))
                 .andThen(ModuleTransformer.fromSentenceTransformer(new AddConfigurationRecoveryFlags()::apply, "add refers_THIS_CONFIGURATION_marker"))
                 .andThen(restoreDefinitionModulesTransformer(def))
+                .andThen(ModuleTransformer.from(new MergeRules(SPEC_AUTOMATON, Att.specification())::apply, "merge spec rules into one rule with or clauses"))
                 .apply(m);
     }
 

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -1097,15 +1097,18 @@ public class SymbolicRewriter {
             System.err.format("\nSpec rule application phase, step %d\n" +
                     "==========================================\n", step);
         }
-        List<Pair<Rule, Integer>> automatonMatchedRules =
+        //Work in progress: spec rules automaton. Use in for loop below.
+        /*List<Pair<Rule, Integer>> automatonMatchedRules =
                 theFastMatcher.matchWithAutomaton(constrainedTerm, definition.specAutomaton());
 
         if (global.javaExecutionOptions.logRulesPublic && !automatonMatchedRules.isEmpty()) {
             System.err.format("\nSpec rule application, rules matched by automaton: %d\n" +
                     "------------------------------------------\n", automatonMatchedRules.size());
-        }
-        for (Pair<Rule, Integer> match : automatonMatchedRules) {
-            Rule specRule = match.getLeft();
+        }*/
+
+        //for (Pair<Rule, Integer> match : automatonMatchedRules) {
+        for (Rule specRule : definition.specRulesPublic) {
+            //Rule specRule = match.getLeft();
             ConstrainedTerm pattern = specRule.createLhsPattern(constrainedTerm.termContext());
             ConjunctiveFormula constraint = constrainedTerm.matchImplies(pattern, true, false,
                     new FormulaContext(FormulaContext.Kind.SpecRule, specRule, global), specRule.matchingSymbols());

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -76,7 +76,7 @@ public class SymbolicRewriter {
         this.constructor = constructor;
         this.definition = global.getDefinition();
         this.transitions = transitions;
-        this.theFastMatcher = new FastRuleMatcher(global, definition.ruleTable.size());
+        this.theFastMatcher = new FastRuleMatcher(global);
         this.transition = true;
         this.global = global;
         parseLogCells();
@@ -169,8 +169,10 @@ public class SymbolicRewriter {
         global.stateLog.log(StateLog.LogEvent.NODE, subject.term(), subject.constraint());
         List<ConstrainedTerm> results = new ArrayList<>();
         if (definition.mainAutomaton() == null) {
+            //If there are no regular rules, do nothing.
             return results;
         }
+
         List<FastRuleMatcher.RuleMatchResult> matches = theFastMatcher.matchRulePattern(
                 subject,
                 narrowing,
@@ -623,7 +625,7 @@ public class SymbolicRewriter {
     public List<ConstrainedTerm> proveRule(
             Rule rule, ConstrainedTerm initialTerm,
             ConstrainedTerm targetTerm,
-            List<Rule> specRules, Rule specAutomaton, KExceptionManager kem,
+            KExceptionManager kem,
             @Nullable Rule boundaryPattern) {
         List<ConstrainedTerm> proofResults = new ArrayList<>();
         List<ConstrainedTerm> successResults = new ArrayList<>();
@@ -708,7 +710,7 @@ public class SymbolicRewriter {
 
                     //Attempt to apply a spec rule, except on first step.
                     if (step > 1) {
-                        ConstrainedTerm result = applySpecRules(term, specRules, specAutomaton, step);
+                        ConstrainedTerm result = applySpecRules(term, step);
                         if (result != null) {
                             nextStepLogEnabled = true;
                             logStep(step, v, term, true, alreadyLogged, initialTerm);
@@ -1090,22 +1092,20 @@ public class SymbolicRewriter {
     /**
      * Applies the first applicable specification rule and returns the result.
      */
-    private ConstrainedTerm applySpecRules(ConstrainedTerm constrainedTerm, List<Rule> specRules, Rule specAutomaton,
-                                           int step) {
+    private ConstrainedTerm applySpecRules(ConstrainedTerm constrainedTerm, int step) {
         if (global.javaExecutionOptions.logRulesPublic) {
             System.err.format("\nSpec rule application phase, step %d\n" +
                     "==========================================\n", step);
         }
-
-        FastRuleMatcher specMatcher = new FastRuleMatcher(global, specRules.size());
-        List<Rule> automatonMatchedRules = specMatcher.matchSpecRule(constrainedTerm, specRules, specAutomaton,
-                constrainedTerm.termContext());
+        List<Pair<Rule, Integer>> automatonMatchedRules =
+                theFastMatcher.matchWithAutomaton(constrainedTerm, definition.specAutomaton());
 
         if (global.javaExecutionOptions.logRulesPublic && !automatonMatchedRules.isEmpty()) {
             System.err.format("\nSpec rule application, rules matched by automaton: %d\n" +
                     "------------------------------------------\n", automatonMatchedRules.size());
         }
-        for (Rule specRule : automatonMatchedRules) {
+        for (Pair<Rule, Integer> match : automatonMatchedRules) {
+            Rule specRule = match.getLeft();
             ConstrainedTerm pattern = specRule.createLhsPattern(constrainedTerm.termContext());
             ConjunctiveFormula constraint = constrainedTerm.matchImplies(pattern, true, false,
                     new FormulaContext(FormulaContext.Kind.SpecRule, specRule, global), specRule.matchingSymbols());

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -87,8 +87,13 @@ public class SymbolicRewriter {
     }
 
     public RewriterResult rewrite(ConstrainedTerm constrainedTerm, int bound) {
-        stopwatch.start();
         ConstrainedTerm initTerm = constrainedTerm;
+        if (prettyInitTerm != null) {
+            System.err.println("\nInitial term\n=====================\n");
+            printTermAndConstraint(initTerm, prettyInitTerm, initTerm);
+        }
+
+        stopwatch.start();
         int step = 0;
         prevStats = new TimeMemoryEntry(false);
 


### PR DESCRIPTION
Enabling refactorings in different PR: #541 
VSC build: https://github.com/runtimeverification/verified-smart-contracts/pull/247

Attempt to enable automaton for spec rules. Disabled after I realized this requires more extensive changes in pre-processing steps that we cannot afford right now. Still refactorings here clean up the code and are useful to keep.

Core idea: add spec rules and their automaton to the java backend definition. This won't interfere with regular rule evaluation because regular rules have their own automaton and cannot match spec rules, even if they are not otherwise distinguished in the definition.

Most of the work was various refactorings/code cleanup to make this possible.

I also removed the cache from `InitializeRewriter.InitializeDefinition`, because `InitializeDefinition` is a request-based object managed by Guice, so it will be instantiated anew each time it is requested. Cache is thus useless.

@dwightguth ping