### PR TITLE
fix bug in -ccopt

### DIFF
--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
@@ -2,15 +2,23 @@
 package org.kframework.backend.llvm;
 
 import com.beust.jcommander.Parameter;
+import com.beust.jcommander.IStringConverter;
 import org.kframework.utils.inject.RequestScoped;
 
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.List;
 
 @RequestScoped
 public class LLVMKompileOptions {
 
-    @Parameter(names="-ccopt", description="Add a command line option to the compiler invocation for the llvm backend.")
+    @Parameter(names="-ccopt", description="Add a command line option to the compiler invocation for the llvm backend.", listConverter=SingletonListConverter.class)
     public List<String> ccopts = new ArrayList<>();
 
+    public static class SingletonListConverter implements IStringConverter<List<String>> {
+        @Override
+        public List<String> convert(String str) {
+            return Arrays.asList(str);
+        }
+    }
 }


### PR DESCRIPTION
apparently jcommander by default allows you to split options passed via lists on commas, which is not what we want here as the comma has meaning to clang.