### PR TITLE
Temporary roll back of set var axioms

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -423,16 +423,22 @@ module INT-SYMBOLIC [symbolic, kore]
    * Definability conditions for _/Int_ and _%Int_
    */
 
+  rule #Ceil(I1:Int /Int I2:Int) => {(I2 =/=Int 0) #Equals true} [anywhere]
+/* TODO(traiansf): The rule above should change to the version below once we implement set variables.
   rule
     #Ceil(@I1:Int /Int @I2:Int)
   =>
     {(@I2 =/=Int 0) #Equals true} #And #Ceil(@I1) #And #Ceil(@I2)
   [anywhere]
+*/
+  rule #Ceil(I1:Int %Int I2:Int) => {(I2 =/=Int 0) #Equals true} [anywhere]
+/* TODO(traiansf): The rule above should change to the version below once we implement set variables.
   rule
     #Ceil(@I1:Int %Int @I2:Int)
   =>
     {(@I2 =/=Int 0) #Equals true} #And #Ceil(@I1) #And #Ceil(@I2)
   [anywhere]
+*/
 endmodule
 
 module INT


### PR DESCRIPTION
Since it takes longer to update the backend to handle set variables properly, we decided to roll back the K rules containing set variables for now.