### PR TITLE
Automatically generate tools in bin dir of package from prefix.

### DIFF
--- a/PKGBUILD
+++ b/PKGBUILD
@@ -39,6 +39,6 @@ check() {
 
 package() {
 	cd ..
-	DESTDIR="$pkgdir/usr/" src/main/scripts/package
+	DESTDIR="$pkgdir" PREFIX="/usr" src/main/scripts/package
 	install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
 }

--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,7 @@ override_dh_auto_build:
 	mvn package -DskipTests
 
 override_dh_auto_install:
-	DESTDIR=debian/kframework/usr src/main/scripts/package
+	DESTDIR=debian/kframework PREFIX=/usr src/main/scripts/package
 
 override_dh_strip:
 	dh_strip -Xliballoc.a -Xlibarithmetic.a -XlibAST.a -Xlibconfigurationparser.a -XlibParser.a -Xlibstrings.a -Xlibmeta.a -Xlibio.a

--- a/k-distribution/src/main/scripts/distro-bin/k-bin-to-text
+++ b/k-distribution/src/main/scripts/distro-bin/k-bin-to-text
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/k-bin-to-text "$@"

--- a/k-distribution/src/main/scripts/distro-bin/kast
+++ b/k-distribution/src/main/scripts/distro-bin/kast
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/kast "$@"

--- a/k-distribution/src/main/scripts/distro-bin/kbmc
+++ b/k-distribution/src/main/scripts/distro-bin/kbmc
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/kbmc "$@"

--- a/k-distribution/src/main/scripts/distro-bin/kcovr
+++ b/k-distribution/src/main/scripts/distro-bin/kcovr
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/kcovr "$@"

--- a/k-distribution/src/main/scripts/distro-bin/kdep
+++ b/k-distribution/src/main/scripts/distro-bin/kdep
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/kdep "$@"

--- a/k-distribution/src/main/scripts/distro-bin/keq
+++ b/k-distribution/src/main/scripts/distro-bin/keq
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/keq "$@"

--- a/k-distribution/src/main/scripts/distro-bin/kompile
+++ b/k-distribution/src/main/scripts/distro-bin/kompile
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/kompile "$@"

--- a/k-distribution/src/main/scripts/distro-bin/kprove
+++ b/k-distribution/src/main/scripts/distro-bin/kprove
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/kprove "$@"

--- a/k-distribution/src/main/scripts/distro-bin/krun
+++ b/k-distribution/src/main/scripts/distro-bin/krun
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/krun "$@"

--- a/k-distribution/src/main/scripts/distro-bin/kserver
+++ b/k-distribution/src/main/scripts/distro-bin/kserver
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/kserver "$@"

--- a/k-distribution/src/main/scripts/distro-bin/stop-kserver
+++ b/k-distribution/src/main/scripts/distro-bin/stop-kserver
@@ -1,2 +1,0 @@
-#!/bin/sh
-/usr/lib/kframework/bin/stop-kserver "$@"

--- a/src/main/scripts/package
+++ b/src/main/scripts/package
@@ -8,5 +8,3 @@ for tool in k-bin-to-text kast kbmc kcovr kdep keq kompile kprove krun kserver s
   echo "$PREFIX/lib/kframework/bin/$tool \"\$@\"" > "$path"
   chmod a+x "$path"
 done
-cp k-distribution/src/main/scripts/distro-bin/* $DESTDIR/bin
-

--- a/src/main/scripts/package
+++ b/src/main/scripts/package
@@ -1,6 +1,12 @@
 #!/bin/bash
-mkdir -p $DESTDIR/bin
-mkdir -p $DESTDIR/lib/kframework
-cp -R k-distribution/target/release/k/* $DESTDIR/lib/kframework
+mkdir -p $DESTDIR$PREFIX/bin
+mkdir -p $DESTDIR$PREFIX/lib/kframework
+cp -R k-distribution/target/release/k/* $DESTDIR$PREFIX/lib/kframework
+for tool in k-bin-to-text kast kbmc kcovr kdep keq kompile kprove krun kserver stop-kserver; do
+  path=$DESTDIR$PREFIX/bin/$tool
+  echo "#!/bin/sh" > "$path"
+  echo "$PREFIX/lib/kframework/bin/$tool \"\$@\"" > "$path"
+  chmod a+x "$path"
+done
 cp k-distribution/src/main/scripts/distro-bin/* $DESTDIR/bin
 


### PR DESCRIPTION
this should fix the issue where the path in the installed bin script to the actual bin script is incorrect on mac os.