### PR TITLE
remove xenial apt packaging. xenial does not have llvm 8 by default.

### DIFF
--- a/install-k
+++ b/install-k
@@ -10,8 +10,6 @@ case $ID in
 	ubuntu)
 		CODENAME=$UBUNTU_CODENAME
 		case $CODENAME in
-			xenial)
-				;;
 			bionic)
 				;;
 			*)


### PR DESCRIPTION
If you want to build K on Ubuntu 16.04, either run mvn package
-Dllvm.backend.skip to disable the llvm backend, or else install llvm 8
from apt.llvm.org.