### PR TITLE
Use same Stack flags in Docker and Maven

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -24,7 +24,7 @@ ENV LC_ALL=C.UTF-8
 ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
 ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
 RUN    cd /home/user/.tmp-haskell \
-    && stack build --only-snapshot --test --library-profiling
+    && stack build --only-snapshot
 
 ADD pom.xml /home/user/.tmp-maven/
 ADD ktree/pom.xml /home/user/.tmp-maven/ktree/

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -25,7 +25,7 @@ ENV LC_ALL=C.UTF-8
 ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
 ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
 RUN    cd /home/user/.tmp-haskell \
-    && stack build --only-snapshot --test --bench --no-haddock-deps --haddock --library-profiling
+    && stack build --only-snapshot
 
 ADD pom.xml /home/user/.tmp-maven/
 ADD ktree/pom.xml /home/user/.tmp-maven/ktree/


### PR DESCRIPTION
This should solve the caching problem, yet allow Stack to be installed by the
system package manager.