### PR TITLE
Regression test example demonstrating https://github.com/kframework/k/issues/708

### DIFF
--- a/k-distribution/tests/regression-new/sizeVar/1.test
+++ b/k-distribution/tests/regression-new/sizeVar/1.test
@@ -1,0 +1,1 @@
+function size

--- a/k-distribution/tests/regression-new/sizeVar/1.test.out
+++ b/k-distribution/tests/regression-new/sizeVar/1.test.out
@@ -1,0 +1,1 @@
+<k> function size </k>

--- a/k-distribution/tests/regression-new/sizeVar/2.test
+++ b/k-distribution/tests/regression-new/sizeVar/2.test
@@ -1,0 +1,1 @@
+function siz

--- a/k-distribution/tests/regression-new/sizeVar/2.test.out
+++ b/k-distribution/tests/regression-new/sizeVar/2.test.out
@@ -1,0 +1,1 @@
+<k> function siz </k>

--- a/k-distribution/tests/regression-new/sizeVar/Makefile
+++ b/k-distribution/tests/regression-new/sizeVar/Makefile
@@ -1,0 +1,6 @@
+DEF=test
+EXT=test
+TESTDIR=.
+KOMPILE_BACKEND=java
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/sizeVar/test.k
+++ b/k-distribution/tests/regression-new/sizeVar/test.k
@@ -1,0 +1,6 @@
+// Copyright (c) 2013-2019 K Team. All Rights Reserved.
+module TEST
+imports ID
+syntax Int ::= "function" Id
+
+endmodule


### PR DESCRIPTION
Here's a minimal example replicating the issue described in https://github.com/kframework/k/issues/708.

Running this locally, 1.test fails with
```
cat 1.test.in 2>/dev/null | ~/k/k-distribution/bin/krun 1.test   -d . | diff - 1.test.out
[Error] Inner Parser: Parse error: unexpected character 's'.
	Source(<command line: -cPGM>)
	Location(1,10,1,11)
0a1
> <k> function size </k>
make: *** [1.test] Error 1
```