### PR TITLE
checks: map access in a complex context should need cast, but doesn't

### DIFF
--- a/k-distribution/tests/regression-new/checks/mapAccessWantsCast.k
+++ b/k-distribution/tests/regression-new/checks/mapAccessWantsCast.k
@@ -1,0 +1,17 @@
+module MAPACCESSWANTSCAST
+  imports DOMAINS
+
+configuration <k> $PGM:K </k> <map> .Map </map>
+
+  syntax Bytes   ::= String | Bytes32
+  syntax Bytes32 ::= String | Hash
+  syntax Hash    ::= String
+  syntax BytesList ::= List{Bytes, ""}
+
+  syntax Bytes ::= BytesList "[" Int "]"                              [function]
+
+  syntax Hash ::= mapGet ( Int ) [function]
+  rule [[ mapGet( I ) => MAP[ I ] ]]
+    <map> MAP </map>
+
+endmodule

--- a/k-distribution/tests/regression-new/checks/mapAccessWantsCast.k.out
+++ b/k-distribution/tests/regression-new/checks/mapAccessWantsCast.k.out
@@ -1,0 +1,1 @@
+[Error] Compiler:


### PR DESCRIPTION
Leads to backend crash.