### PR TITLE
Infer definition module when proving specifications

### DIFF
--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/if-const-propa-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/if-const-propa-spec.k
@@ -16,7 +16,6 @@ endmodule
 
 module IF-CONST-PROPA-SPEC
 
-imports MAIN
 imports SYNC-POINT-CANDIDATES
 
 syntax Id ::= "n" [token]

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/if-failure-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/if-failure-spec.k
@@ -16,7 +16,6 @@ endmodule
 
 module IF-FAILURE-SPEC
 
-imports MAIN
 imports SYNC-POINT-CANDIDATES
 
 syntax Id ::= "n" [token]

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/if-swap-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/if-swap-spec.k
@@ -16,7 +16,6 @@ endmodule
 
 module IF-SWAP-SPEC
 
-imports MAIN
 imports SYNC-POINT-CANDIDATES
 
 syntax Id ::= "n" [token]

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-failure-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-failure-spec.k
@@ -30,7 +30,6 @@ endmodule
 
 module WHILE-FAILURE-SPEC
 
-imports MAIN
 imports SYNC-POINT-CANDIDATES
 
 // wrong loop unrolling (`<` should have been used instead of `<=`)

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-simple-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-simple-spec.k
@@ -26,7 +26,6 @@ endmodule
 
 module WHILE-SIMPLE-SPEC
 
-imports MAIN
 imports SYNC-POINT-CANDIDATES
 
 syntax Id ::= "n" [token]

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-simple2-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-simple2-spec.k
@@ -26,7 +26,6 @@ endmodule
 
 module WHILE-SIMPLE2-SPEC
 
-imports MAIN
 imports SYNC-POINT-CANDIDATES
 
 syntax Id ::= "n" [token]

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-unroll-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-imp/while-unroll-spec.k
@@ -30,7 +30,6 @@ endmodule
 
 module WHILE-UNROLL-SPEC
 
-imports MAIN
 imports SYNC-POINT-CANDIDATES
 
 // loop unrolling

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/Makefile
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/Makefile
@@ -3,6 +3,5 @@ EXT=main
 TESTDIR=.
 KOMPILE_BACKEND=java
 KOMPILE_FLAGS=
-KPROVE_FLAGS=-m VERIFICATION
 
 include ../../../../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/simple-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/simple-spec.k
@@ -1,9 +1,3 @@
-module VERIFICATION
-
-imports MAIN
-
-endmodule
-
 module SYNC-POINT-CANDIDATES
 
 imports MAIN
@@ -25,7 +19,6 @@ endmodule
 
 module SIMPLE-SPEC
 
-imports VERIFICATION
 imports SYNC-POINT-CANDIDATES
 
 rule

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/sum-concrete-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/sum-concrete-spec.k
@@ -1,9 +1,3 @@
-module VERIFICATION
-
-imports MAIN
-
-endmodule
-
 module SYNC-POINT-CANDIDATES
 
 imports MAIN
@@ -27,7 +21,6 @@ endmodule
 
 module SUM-CONCRETE-SPEC
 
-imports VERIFICATION
 imports SYNC-POINT-CANDIDATES
 
 rule

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/sum-symbolic-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/sum-symbolic-spec.k
@@ -18,7 +18,7 @@ endmodule
 
 module SYNC-POINT-CANDIDATES
 
-imports MAIN
+imports VERIFICATION
 
 syntax Id ::= "n"   [token]
             | "sum" [token]
@@ -50,7 +50,6 @@ endmodule
 
 module SUM-SYMBOLIC-SPEC
 
-imports VERIFICATION
 imports SYNC-POINT-CANDIDATES
 
 rule

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -28,7 +28,6 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.function.Function;
 
-
 /**
  * Class that implements the "--prove" option.
  */
@@ -93,8 +92,8 @@ public class KProve {
         specModule = backend.specificationSteps(compiledDefinition.kompiledDefinition).apply(specModule);
 
         if (defModuleName == null) {
-            if (specModule.imports().size() == 1) {
-                defModuleName = specModule.imports().iterator().next().name();
+            if (specModule.userImportedModuleNames().size() == 1) {
+                defModuleName = specModule.userImportedModuleNames().iterator().next();
             } else {
                 throw KEMException.criticalError("Definition module must either be specified as --def-module or as the singular import of the specification module.");
             }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -106,6 +106,10 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
 
   lazy val importedModuleNames: Set[String] = importedModules.map(_.name)
 
+  lazy val allModulesNames : Set[String] = (imports map  {_.name}) + name
+
+  lazy val userImportedModuleNames : Set[String] = (imports map {_.name}).collect({ case iName if ! (iName contains "$") => iName })
+
   lazy val productions: Set[Production] = sentences collect { case p: Production => p }
 
   lazy val sortedProductions: Seq[Production] = productions.toSeq.sorted
@@ -177,8 +181,6 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
     else
       Production(None, s, Seq(), Att.empty.add("token"))
   }
-
-  lazy val allModulesNames : Set[String] = (imports map  {_.name}) + name
 
   def importedSentencesExcept(m: Module): Set[Sentence] =
     imports flatMap { i => if (m.allModulesNames contains i.name) Set.empty[Sentence] else i.localSentences }


### PR DESCRIPTION
When proving we need two modules, the "spec module" and the "def module". The def module will be taken as axioms to be used in proving the claims in the spec module.

Currently, if the user does not supply the spec module, the filename passed on the command line is used to infer the spec module. This seems reasonable.

If the user does not supply the def module, we currently use the kompiled definitions `mainModule`. This may seem reasonable when no lemmas are being added to the definition, but all our real-world proofs have lemma files in addition.

This PR changes the logic so that if the user does not manually provide `--def-module`, the `mainModule` is not used as the default. Instead, it will inspect the spec module and see if there is a singular import, if so, it will use that imported module as the def module.

In KEVM/KWasm, for example, this would largely remove the need to ever supply `-m MODULE_NAME` on the command line, which has caused at least 2 RV devs to waste a day each trying to make the prover work, and is confusing for new users.