### PR TITLE
Weaker configuration constraints for more flexible composition

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -156,7 +156,7 @@ public class JavaBackend implements Backend {
             if (r.body() instanceof KApply) {
                 KLabel klabel = ((KApply) r.body()).klabel();
                 if (d.mainModule().sortFor().contains(klabel) //is false for rules in specification modules not part of semantics
-                        && d.mainModule().sortFor().apply(klabel).equals(configInfo.topCell())) {
+                        && d.mainModule().sortFor().apply(klabel).equals(configInfo.getRootCell())) {
                     return Rule.apply(r.body(), r.requires(), r.ensures(), r.att().add(att));
                 }
             }

--- a/k-distribution/tests/regression-new/configuration-composition/Makefile
+++ b/k-distribution/tests/regression-new/configuration-composition/Makefile
@@ -1,0 +1,6 @@
+DEF=config-comp
+EXT=ccomp
+TESTDIR=.
+KOMPILE_BACKEND=llvm
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/configuration-composition/config-comp.k
+++ b/k-distribution/tests/regression-new/configuration-composition/config-comp.k
@@ -1,0 +1,66 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+
+module CONFIG-COMP
+    imports CONFIG-COMP-1
+    imports CONFIG-COMP-2
+
+    configuration
+      <example>
+        <common/>
+        <module1/>
+        <module2/>
+      </example>
+endmodule
+
+module CONFIG-COMP-COMMON
+    imports LIST
+
+    configuration
+      <common>
+        <k> $PGM:Cmds </k>
+        <output> .List </output>
+      </common>
+
+    syntax Cmd
+    syntax Cmds ::= Cmd Cmds
+                  | ".Cmds"
+endmodule
+
+module CONFIG-COMP-1
+    imports CONFIG-COMP-COMMON
+    imports INT
+
+    configuration
+      <module1>
+        <accumulator> 0 </accumulator>
+      </module1>
+
+    syntax Int ::= get() [function]
+ // -------------------------------
+    rule [[ get() => ACCUMULATOR ]]
+         <accumulator> ACCUMULATOR </accumulator>
+
+    syntax Cmd ::= "Inc"
+ // --------------------
+    rule <k> Inc => . ... </k>
+         <accumulator> I => I +Int 1 </accumulator>
+endmodule
+
+module CONFIG-COMP-2
+    imports CONFIG-COMP-COMMON
+
+    configuration
+      <module2>
+        <stack> .List </stack>
+      </module2>
+
+    syntax Cmd ::= "push" Int
+                 | "pop"
+ // -------------------------
+    rule <k> push I => . ... </k>
+         <stack> (.List => ListItem( I )) ... </stack>
+
+    rule <k> pop => . ... </k>
+         <output> ... (.List => ListItem( I )) </output>
+         <stack> (ListItem( I ) => .List) ... </stack>
+endmodule

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
@@ -244,7 +244,7 @@ public class ResolveFreshConstants {
                 RuleGrammarGenerator gen = new RuleGrammarGenerator(def);
                 ParseInModule mod = RuleGrammarGenerator.getCombinedGrammar(gen.getConfigGrammar(m), true);
                 ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(m);
-                Sort topCellSort = configInfo.topCell();
+                Sort topCellSort = configInfo.getRootCell();
                 KLabel topCellLabel = configInfo.getCellLabel(topCellSort);
                 Production prod = m.productionsFor().apply(topCellLabel).head();
                 KToken cellName = KToken(prod.att().get("cellName"), Sort("#CellName"));

--- a/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
@@ -62,7 +62,7 @@ public class ResolveFunctionWithConfig {
         topCell = Sorts.GeneratedTopCell();
         topCellLabel = KLabels.GENERATED_TOP_CELL;
       } else {
-        topCell = info.topCell();
+        topCell = info.getRootCell();
         topCellLabel = info.getCellLabel(topCell);
       }
       CONFIG_VAR = KVariable("_Configuration", Att().add(Sort.class, topCell).add("withConfig"));

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -128,7 +128,7 @@ public class Kompile {
 
         ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(kompiledDefinition.mainModule());
 
-        return new CompiledDefinition(kompileOptions, parsedDef, kompiledDefinition, files, kem, configInfo.getDefaultCell(configInfo.topCell()).klabel());
+        return new CompiledDefinition(kompileOptions, parsedDef, kompiledDefinition, files, kem, configInfo.getDefaultCell(configInfo.getRootCell()).klabel());
     }
 
     public Definition parseDefinition(File definitionFile, String mainModuleName, String mainProgramsModule, Set<String> excludedModuleTags) {

--- a/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
+++ b/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
@@ -86,8 +86,9 @@ class ConfigurationInfoFromModule(val m: Module) extends ConfigurationInfo {
     throw KEMException.compilerError("Too many top cells:" + topCells)
 
   val topCell: Sort = topCells.head
-  private val sortedSorts: Seq[Sort] = tsort(edges).toSeq
-  val levels: Map[Sort, Int] = edges.toList.sortWith((l, r) => sortedSorts.indexOf(l._1) < sortedSorts.indexOf(r._1)).foldLeft(Map(topCell -> 0)) {
+  private val sortedSorts: Seq[Sort]         = tsort(edges).toSeq
+  private val sortedEdges: Seq[(Sort, Sort)] = edges.toList.sortWith((l, r) => sortedSorts.indexOf(l._1) < sortedSorts.indexOf(r._1))
+  val levels: Map[Sort, Int] = sortedEdges.foldLeft(Map(topCell -> 0)) {
     case (m: Map[Sort, Int], (from: Sort, to: Sort)) =>
       m + (to -> (m(from) + 1))
   }

--- a/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
+++ b/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
@@ -74,21 +74,14 @@ class ConfigurationInfoFromModule(val m: Module) extends ConfigurationInfo {
 
   private val edgesPoset: POSet[Sort] = POSet(edges)
 
-  private val topCellsIncludingStrategyCell = cellSorts.diff(edges.map(_._2))
-
-  private lazy val topCells =
-    if (topCellsIncludingStrategyCell.size > 1)
-      topCellsIncludingStrategyCell.filterNot(s => s == KORE.Sort("SCell") || s == KORE.Sort("KCell"))
-    else
-      topCellsIncludingStrategyCell
+  private lazy val topCells = cellSorts.diff(edges.map(_._2))
 
   if (topCells.size > 1)
     throw KEMException.compilerError("Too many top cells:" + topCells)
 
-  val topCell: Sort = topCells.head
   private val sortedSorts: Seq[Sort]         = tsort(edges).toSeq
   private val sortedEdges: Seq[(Sort, Sort)] = edges.toList.sortWith((l, r) => sortedSorts.indexOf(l._1) < sortedSorts.indexOf(r._1))
-  val levels: Map[Sort, Int] = sortedEdges.foldLeft(Map(topCell -> 0)) {
+  val levels: Map[Sort, Int] = sortedEdges.foldLeft(topCells.map((_, 0)).toMap) {
     case (m: Map[Sort, Int], (from: Sort, to: Sort)) =>
       m + (to -> (m(from) + 1))
   }

--- a/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
+++ b/kore/src/main/scala/org/kframework/compile/ConfigurationInfoFromModule.scala
@@ -76,9 +76,6 @@ class ConfigurationInfoFromModule(val m: Module) extends ConfigurationInfo {
 
   private lazy val topCells = cellSorts.diff(edges.map(_._2))
 
-  if (topCells.size > 1)
-    throw KEMException.compilerError("Too many top cells:" + topCells)
-
   private val sortedSorts: Seq[Sort]         = tsort(edges).toSeq
   private val sortedEdges: Seq[(Sort, Sort)] = edges.toList.sortWith((l, r) => sortedSorts.indexOf(l._1) < sortedSorts.indexOf(r._1))
   val levels: Map[Sort, Int] = sortedEdges.foldLeft(topCells.map((_, 0)).toMap) {
@@ -133,7 +130,12 @@ class ConfigurationInfoFromModule(val m: Module) extends ConfigurationInfo {
   override def getCellFragmentLabel(k : Sort): KLabel = cellFragmentLabel(k)
   override def getCellAbsentLabel(k: Sort): KLabel = cellAbsentLabel(k)
 
-  override def getRootCell: Sort = topCell
+  override def getRootCell: Sort = {
+    if (topCells.size > 1)
+      throw KEMException.compilerError("Too many top cells for module " + m.name + ": " + topCells)
+    topCells.head
+  }
+
   override def getComputationCell: Sort = mainCell
   override def getCellSorts: util.Set[Sort] = cellSorts.asJava
 


### PR DESCRIPTION
-   Only check that there is a unique top cell when the calling context explicitly requests for the top cell (by moving the check into `getRootCell` and getting rid of variable `topCell`).
-   Rule out the case that there are multiple productions for the same configuration item directly (perhaps this is redundant with a check elsewhere over the syntax?)
-    No need to tree `<k>` and `<s>` cell specially in ConfigurationInformation because multiple top cells allowed.