### PR TITLE
Remove some mvn warnings

### DIFF
--- a/kore/src/main/scala/org/kframework/compile/NormalizeAssoc.scala
+++ b/kore/src/main/scala/org/kframework/compile/NormalizeAssoc.scala
@@ -2,7 +2,6 @@ package org.kframework.compile
 
 import org.kframework.Collections._
 import org.kframework.attributes.Att
-import org.kframework.compile.RewriteToTop
 import org.kframework.definition.{Module, Rule, Sentence}
 import org.kframework.kore._
 

--- a/kore/src/main/scala/org/kframework/kore/interface.scala
+++ b/kore/src/main/scala/org/kframework/kore/interface.scala
@@ -3,7 +3,6 @@ package org.kframework.kore
 import java.util.Optional
 
 import org.kframework.attributes._
-import org.kframework.kore.ADT.{KApply, KList}
 import org.kframework.unparser.ToKast
 
 import scala.collection.JavaConverters._
@@ -70,7 +69,7 @@ trait KLabel {
   }
   override def hashCode = name.hashCode * 29 + params.hashCode
 
-  def apply(ks: K*) = KApply(this, KList(ks.toList))   
+  def apply(ks: K*) = ADT.KApply(this, ADT.KList(ks.toList))
 }
 
 object KLabelOrdering extends Ordering[KLabel] {

--- a/kore/src/main/scala/org/kframework/kore/interface.scala
+++ b/kore/src/main/scala/org/kframework/kore/interface.scala
@@ -54,7 +54,7 @@ object K {
         case (_, _:KRewrite) => -1
         case (_:InjectedKLabel, _) => 1
         case (_, _:InjectedKLabel) => -1
-        case (_, _) => throw KEMException.criticalError("Cannot order these terms:\n" + a.toString() + "\n" + b.toString())
+        case (_, _) => throw KEMException.internalError("Cannot order these terms:\n" + a.toString() + "\n" + b.toString())
       }
     }
   }

--- a/kore/src/main/scala/org/kframework/kore/interface.scala
+++ b/kore/src/main/scala/org/kframework/kore/interface.scala
@@ -4,6 +4,7 @@ import java.util.Optional
 
 import org.kframework.attributes._
 import org.kframework.unparser.ToKast
+import org.kframework.utils.errorsystem.KEMException
 
 import scala.collection.JavaConverters._
 
@@ -53,6 +54,7 @@ object K {
         case (_, _:KRewrite) => -1
         case (_:InjectedKLabel, _) => 1
         case (_, _:InjectedKLabel) => -1
+        case (_, _) => throw KEMException.criticalError("Cannot order these terms:\n" + a.toString() + "\n" + b.toString())
       }
     }
   }


### PR DESCRIPTION
The remaining warnings are either about the assembly process (copying things into place), or in the llvm-backend repository code.

Also the warning in POSet about using JavaConversions vs JavaConverters, I couldn't figure out in a short amount of time, so I gave up.