### PR TITLE
More robust (un)parsing for PRETTY and PROGRAM

### DIFF
--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -106,19 +106,17 @@ public class KastFrontEnd extends FrontEnd {
                 }
             }
 
-            Module unparsingMod;
             if (options.module == null) {
-                options.module = def.mainSyntaxModuleName();
                 switch (options.input) {
                     case KORE:
-                        unparsingMod = def.languageParsingModule();
+                        options.module = def.languageParsingModule().name();
                         break;
                     default:
-                        unparsingMod = def.kompiledDefinition.getModule(def.mainSyntaxModuleName()).get();
+                        options.module = def.mainSyntaxModuleName();
+                        break;
                 }
-            } else {
-                unparsingMod = def.kompiledDefinition.getModule(options.module).get();
             }
+            Module unparsingMod = def.kompiledDefinition.getModule(options.module).get();
 
             Option<Module> maybeMod = def.kompiledDefinition.getModule(options.module);
             if (maybeMod.isEmpty()) {

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -105,6 +105,7 @@ public class KastFrontEnd extends FrontEnd {
                     sort = def.programStartSymbol;
                 }
             }
+
             Module unparsingMod;
             if (options.module == null) {
                 options.module = def.mainSyntaxModuleName();
@@ -118,7 +119,8 @@ public class KastFrontEnd extends FrontEnd {
             } else {
                 unparsingMod = def.kompiledDefinition.getModule(options.module).get();
             }
-            Option<Module> maybeMod = def.programParsingModuleFor(options.module, kem);
+
+            Option<Module> maybeMod = def.kompiledDefinition.getModule(options.module);
             if (maybeMod.isEmpty()) {
                 throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
             }

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -95,7 +95,7 @@ public class KastFrontEnd extends FrontEnd {
 
             CompiledDefinition def = compiledDef.get();
             KPrint kprint = new KPrint(kem, files.get(), ttyInfo, options.print, compiledDef.get());
-            KRead kread = new KRead(kem, files.get());
+            KRead kread = new KRead(kem, files.get(), options.input);
 
             org.kframework.kore.Sort sort = options.sort;
             if (sort == null) {
@@ -124,7 +124,7 @@ public class KastFrontEnd extends FrontEnd {
             }
             Module mod = maybeMod.get();
 
-            K parsed = kread.prettyRead(mod, sort, def, source, FileUtil.read(stringToParse), options.input);
+            K parsed = kread.prettyRead(mod, sort, def, source, FileUtil.read(stringToParse));
 
             if (options.expandMacros) {
                 parsed = ExpandMacros.forNonSentences(compiledMod, files.get(), def.kompileOptions, false).expand(parsed);

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -105,32 +105,32 @@ public class KastFrontEnd extends FrontEnd {
                     sort = def.programStartSymbol;
                 }
             }
-            Module compiledMod;
+            Module unparsingMod;
             if (options.module == null) {
                 options.module = def.mainSyntaxModuleName();
                 switch (options.input) {
-                case KORE:
-                    compiledMod = def.languageParsingModule();
-                    break;
-                default:
-                    compiledMod = def.kompiledDefinition.getModule(def.mainSyntaxModuleName()).get();
+                    case KORE:
+                        unparsingMod = def.languageParsingModule();
+                        break;
+                    default:
+                        unparsingMod = def.kompiledDefinition.getModule(def.mainSyntaxModuleName()).get();
                 }
             } else {
-                compiledMod = def.kompiledDefinition.getModule(options.module).get();
+                unparsingMod = def.kompiledDefinition.getModule(options.module).get();
             }
             Option<Module> maybeMod = def.programParsingModuleFor(options.module, kem);
             if (maybeMod.isEmpty()) {
                 throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
             }
-            Module mod = maybeMod.get();
+            Module parsingMod = maybeMod.get();
 
-            K parsed = kread.prettyRead(mod, sort, def, source, FileUtil.read(stringToParse));
+            K parsed = kread.prettyRead(parsingMod, sort, def, source, FileUtil.read(stringToParse));
 
             if (options.expandMacros) {
-                parsed = ExpandMacros.forNonSentences(compiledMod, files.get(), def.kompileOptions, false).expand(parsed);
+                parsed = ExpandMacros.forNonSentences(unparsingMod, files.get(), def.kompileOptions, false).expand(parsed);
             }
 
-            System.out.println(new String(kprint.prettyPrint(def, compiledMod, parsed), StandardCharsets.UTF_8));
+            System.out.println(new String(kprint.prettyPrint(def, unparsingMod, parsed), StandardCharsets.UTF_8));
             sw.printTotal("Total");
             return 0;
         } finally {

--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -117,7 +117,7 @@ public final class KastOptions {
     public boolean expandMacros = false;
 
     @Parameter(names={"--input", "-i"}, converter=InputModeConverter.class,
-            description="How to read kast input in. <mode> is either [program|binary|kast|json|kore].")
+            description="How to read kast input in. <mode> is either [pretty|program|binary|kast|json|kore].")
     public InputModes input = InputModes.PROGRAM;
 
     public static class InputModeConverter extends BaseEnumConverter<InputModes> {

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -279,7 +279,6 @@ public class Kompile {
         Module languageParsingModule = Constructors.Module("LANGUAGE-PARSING",
                 Set(d.mainModule(),
                         d.getModule(d.att().get(Att.syntaxModule())).get(),
-                        d.getModule("K-TERM").get(),
                         d.getModule(RuleGrammarGenerator.ID_PROGRAM_PARSING).get()), Set(), Att());
         allModules.add(languageParsingModule);
         return Constructors.Definition(d.mainModule(), immutable(allModules), d.att());

--- a/kernel/src/main/java/org/kframework/parser/InputModes.java
+++ b/kernel/src/main/java/org/kframework/parser/InputModes.java
@@ -2,5 +2,5 @@
 package org.kframework.parser;
 
 public enum InputModes {
-    PROGRAM, BINARY, JSON, KAST, KORE;
+    PRETTY, PROGRAM, BINARY, JSON, KAST, KORE;
 }

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -50,7 +50,8 @@ public class KRead {
             case KORE:
                 return new KoreParser(files.resolveKoreToKLabelsFile(), mod.sortAttributesFor()).parseString(stringToParse);
             case PROGRAM:
-                return def.getParser(mod, sort, kem).apply(stringToParse, source);
+                Module programParsingMod = def.programParsingModuleFor(mod.name(), kem).get();
+                return def.getParser(programParsingMod, sort, kem).apply(stringToParse, source);
             case KAST:
                 return KastParser.parse(stringToParse, source);
             case BINARY:

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -27,13 +27,20 @@ public class KRead {
 
     private final KExceptionManager kem;
     private final FileUtil files;
+    private final InputModes input;
 
     public KRead(
             KExceptionManager kem,
-            FileUtil files
+            FileUtil files,
+            InputModes input
     ) {
         this.kem = kem;
         this.files = files;
+        this.input = input;
+    }
+
+    public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse) {
+        return prettyRead(mod, sort, def, source, stringToParse, this.input);
     }
 
     public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse, InputModes inputMode) {
@@ -51,6 +58,10 @@ public class KRead {
             default:
                 throw KEMException.criticalError("Unsupported input mode: " + inputMode);
         }
+    }
+
+    public K deserialize(String stringToParse) {
+        return deserialize(stringToParse, this.input);
     }
 
     public static K deserialize(String stringToParse, InputModes inputMode) {

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -47,31 +47,32 @@ public class KRead {
         switch (inputMode) {
             case BINARY:
             case JSON:
-                return deserialize(stringToParse, inputMode);
+            case KAST:
+                return deserialize(stringToParse, inputMode, source);
             case KORE:
                 return new KoreParser(files.resolveKoreToKLabelsFile(), mod.sortAttributesFor()).parseString(stringToParse);
             case PROGRAM:
                 Module programParsingMod = def.programParsingModuleFor(mod.name(), kem).get();
                 return def.getParser(programParsingMod, sort, kem).apply(stringToParse, source);
-            case KAST:
-                return KastParser.parse(stringToParse, source);
             default:
                 throw KEMException.criticalError("Unsupported input mode: " + inputMode);
         }
     }
 
-    public K deserialize(String stringToParse) {
-        return deserialize(stringToParse, this.input);
+    public K deserialize(String stringToParse, Source source) {
+        return deserialize(stringToParse, this.input, source);
     }
 
-    public static K deserialize(String stringToParse, InputModes inputMode) {
+    public static K deserialize(String stringToParse, InputModes inputMode, Source source) {
         switch (inputMode) {
             case BINARY:
                 return BinaryParser.parse(stringToParse.getBytes());
             case JSON:
                 return JsonParser.parse(stringToParse);
+            case KAST:
+                return KastParser.parse(stringToParse, source);
             default:
-                throw KEMException.criticalError("Unsupported input mode: " + inputMode);
+                throw KEMException.criticalError("Unsupported input mode for deserialization: " + inputMode);
         }
     }
 

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -45,6 +45,7 @@ public class KRead {
 
     public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse, InputModes inputMode) {
         switch (inputMode) {
+            case BINARY:
             case JSON:
                 return deserialize(stringToParse, inputMode);
             case KORE:
@@ -54,8 +55,6 @@ public class KRead {
                 return def.getParser(programParsingMod, sort, kem).apply(stringToParse, source);
             case KAST:
                 return KastParser.parse(stringToParse, source);
-            case BINARY:
-                return BinaryParser.parse(stringToParse.getBytes());
             default:
                 throw KEMException.criticalError("Unsupported input mode: " + inputMode);
         }
@@ -67,6 +66,8 @@ public class KRead {
 
     public static K deserialize(String stringToParse, InputModes inputMode) {
         switch (inputMode) {
+            case BINARY:
+                return BinaryParser.parse(stringToParse.getBytes());
             case JSON:
                 return JsonParser.parse(stringToParse);
             default:

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -54,6 +54,10 @@ public class KRead {
             case PROGRAM:
                 Module programParsingMod = def.programParsingModuleFor(mod.name(), kem).get();
                 return def.getParser(programParsingMod, sort, kem).apply(stringToParse, source);
+            case PRETTY:
+                Module kTermMod = def.kompiledDefinition.getModule("K-TERM").get();
+                Module prettyParsingMod = mod.addImport(kTermMod).changeName(mod.name() + "$PRETTY");
+                return def.getParser(prettyParsingMod, sort, kem).apply(stringToParse, source);
             default:
                 throw KEMException.criticalError("Unsupported input mode: " + inputMode);
         }

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -56,7 +56,7 @@ public class KRead {
                 return def.getParser(programParsingMod, sort, kem).apply(stringToParse, source);
             case PRETTY:
                 Module kTermMod = def.kompiledDefinition.getModule("K-TERM").get();
-                Module prettyParsingMod = mod.addImport(kTermMod).changeName(mod.name() + "$PRETTY");
+                Module prettyParsingMod = mod.wrappingModule(mod.name() + "$PRETTY").addImport(kTermMod);
                 return def.getParser(prettyParsingMod, sort, kem).apply(stringToParse, source);
             default:
                 throw KEMException.criticalError("Unsupported input mode: " + inputMode);

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -150,7 +150,7 @@ public class KPrint {
             case JSON:
             case PRETTY: {
                 Module kTermMod = def.getModule("K-TERM").get();
-                Module prettyParsingMod = module.addImport(kTermMod).changeName(module.name() + "$PRETTY");
+                Module prettyParsingMod = module.wrappingModule(module.name() + "$PRETTY").addImport(kTermMod);
                 Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(prettyParsingMod, false).getExtensionModule();
                 K result = abstractTerm(module, orig);
                 return (unparseTerm(result, unparsingModule, colorize) + "\n").getBytes();

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -148,8 +148,13 @@ public class KPrint {
             case NONE:
             case BINARY:
             case JSON:
-            case PRETTY:
-                return prettyPrint(module, orig, colorize, outputMode);
+            case PRETTY: {
+                Module kTermMod = def.getModule("K-TERM").get();
+                Module prettyParsingMod = module.addImport(kTermMod).changeName(module.name() + "$PRETTY");
+                Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(prettyParsingMod, false).getExtensionModule();
+                K result = abstractTerm(module, orig);
+                return (unparseTerm(result, unparsingModule, colorize) + "\n").getBytes();
+            }
             case KORE:
                 if (!compiledDefinition.isPresent()) {
                     throw KEMException.criticalError("KORE output requires a compiled definition.");
@@ -174,10 +179,7 @@ public class KPrint {
             case JSON:
             case LATEX:
                 return serialize(result, outputMode);
-            case PRETTY: {
-                Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(module, false).getExtensionModule();
-                return (unparseTerm(result, unparsingModule, colorize) + "\n").getBytes();
-            } default:
+            default:
                 throw KEMException.criticalError("Unsupported output mode without a Definition: " + outputMode);
         }
     }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -144,21 +144,24 @@ public class KPrint {
     }
 
     public byte[] prettyPrint(Definition def, Module module, K orig, ColorSetting colorize, OutputModes outputMode) {
-        K result = abstractTerm(module, orig);
+        K result;
         switch (outputMode) {
             case KAST:
             case NONE:
             case BINARY:
             case JSON:
             case LATEX:
+                result = abstractTerm(module, orig);
                 return serialize(result, outputMode);
             case PRETTY: {
                 Module kTermMod = def.getModule("K-TERM").get();
                 Module prettyParsingMod = module.wrappingModule(module.name() + "$PRETTY").addImport(kTermMod);
                 Module unparsingModule = RuleGrammarGenerator.getCombinedGrammar(prettyParsingMod, false).getExtensionModule();
+                result = abstractTerm(unparsingModule, orig);
                 return (unparseTerm(result, unparsingModule, colorize) + "\n").getBytes();
             }
             case KORE:
+                result = abstractTerm(module, orig);
                 if (!compiledDefinition.isPresent()) {
                     throw KEMException.criticalError("KORE output requires a compiled definition.");
                 }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -149,8 +149,8 @@ public class KPrint {
             case KAST:
             case NONE:
             case BINARY:
-            case LATEX:
             case JSON:
+            case LATEX:
                 return serialize(result, outputMode);
             case PRETTY: {
                 Module kTermMod = def.getModule("K-TERM").get();

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -102,7 +102,8 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
     _.importedModules
   })
 
-  def addImport(m : Module) : Module = new Module(name, imports + m, localSentences, att)
+  def addImport(m : Module)        : Module = new Module(name, imports + m, localSentences, att)
+  def changeName(newName : String) : Module = new Module(newName, imports, localSentences, att)
 
   lazy val importedModuleNames: Set[String] = importedModules.map(_.name)
 

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -102,8 +102,8 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
     _.importedModules
   })
 
-  def addImport(m : Module)        : Module = new Module(name, imports + m, localSentences, att)
-  def changeName(newName : String) : Module = new Module(newName, imports, localSentences, att)
+  def addImport(m : Module) : Module = new Module(name, imports + m, localSentences, att)
+  def wrappingModule(newName : String) : Module = new Module(newName, Set(this), Set(), Att.empty)
 
   lazy val importedModuleNames: Set[String] = importedModules.map(_.name)
 


### PR DESCRIPTION
Here we make sure to use the same module for parsing/expanding macros/unparsing, instead of switching between modules. By default, it's the languageParsingModule(), which is what KRun defaults to as well for unparsing.

This is a change in behavior for Kast, but if the tests pass and the beacon-chain repo works better with this commit, I see no reason to not merge it.