### PR TITLE
Kast unparsing module defaults to languageParsingModule

### DIFF
--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -247,6 +247,11 @@ def buildSymbolTable(definition):
     return symbolTable
 
 def prettyPrintKast(kast, symbolTable):
+    """Print out KAST terms/outer syntax.
+
+    -   Input: KAST term.
+    -   Output: Best-effort string representation of KAST term.
+    """
     if kast is None or kast == {}:
         return ""
     if isKVariable(kast):
@@ -272,6 +277,8 @@ def prettyPrintKast(kast, symbolTable):
         unparsedKSequence = "\n~> ".join(unparsedItems)
         if len(unparsedItems) > 1:
             unparsedKSequence = "    " + unparsedKSequence
+        else:
+            unparsedKSequence = '.'
         return unparsedKSequence
     if isKRule(kast):
         body     = "\n     ".join(prettyPrintKast(kast["body"], symbolTable).split("\n"))

--- a/k-distribution/src/main/scripts/lib/pyk/kastManip.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kastManip.py
@@ -21,6 +21,10 @@ def match(pattern, kast):
             if subst is None:
                 return None
         return subst
+    if isKRewrite(pattern) and isKRewrite(kast):
+        lhsSubst = match(pattern['lhs'], kast['lhs'])
+        rhsSubst = match(pattern['rhs'], kast['rhs'])
+        return combineDicts(lhsSubst, rhsSubst)
     return None
 
 def collectBottomUp(kast, callback):

--- a/k-distribution/src/main/scripts/lib/pyk/kastManip.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kastManip.py
@@ -194,6 +194,18 @@ def inlineCellMaps(kast):
         return _kast
     return traverseBottomUp(kast, _inlineCellMaps)
 
+def removeSemanticCasts(kast):
+    """Remove injected `#SemanticCast*` nodes in AST.
+
+    -   Input: kast (possibly) containing automatically injected `#SemanticCast*` KApply nodes.
+    -   Output: kast without the `#SemanticCast*` nodes.
+    """
+    def _removeSemanticCasts(_kast):
+        if isKApply(_kast) and len(_kast['args']) == 1 and _kast['label'].startswith('#SemanticCast'):
+            return _kast['args'][0]
+        return _kast
+    return traverseBottomUp(kast, _removeSemanticCasts)
+
 def uselessVarsToDots(kast, requires = None, ensures = None):
 
     numOccurances = {}
@@ -252,6 +264,7 @@ def minimizeRule(rule):
         ruleRequires = simplifyBool(mlPredToBool(ruleRequires))
 
     ruleBody = inlineCellMaps(ruleBody)
+    ruleBody = removeSemanticCasts(ruleBody)
     ruleBody = uselessVarsToDots(ruleBody, requires = ruleRequires, ensures = ruleEnsures)
     ruleBody = collapseDots(ruleBody)
 

--- a/k-distribution/src/main/scripts/lib/pyk/kastManip.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kastManip.py
@@ -175,6 +175,13 @@ def pushDownRewrites(kast):
             and len(lhs["args"]) == len(rhs["args"]):
                     newArgs = [ KRewrite(lArg, rArg) for (lArg, rArg) in zip(lhs["args"], rhs["args"]) ]
                     return KApply(lhs["label"], newArgs)
+            if isKSequence(lhs) and isKSequence(rhs) and len(lhs['items']) > 0 and len(rhs['items']) > 0:
+                if lhs['items'][0] == rhs['items'][0]:
+                    lowerRewrite = KRewrite(KSequence(lhs['items'][1:]), KSequence(rhs['items'][1:]))
+                    return KSequence([lhs['items'][0], lowerRewrite])
+                if lhs['items'][-1] == rhs['items'][-1]:
+                    lowerRewrite = KRewrite(KSequence(lhs['items'][0:-1]), KSequence(rhs['items'][0:-1]))
+                    return KSequence([lowerRewrite, lhs['items'][-1]])
         return _kast
     return traverseTopDown(kast, _pushDownRewrites)
 

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -105,17 +105,17 @@ public class KastFrontEnd extends FrontEnd {
                     sort = def.programStartSymbol;
                 }
             }
-            Module unparsingMod;
+
             if (options.module == null) {
                 options.module = def.languageParsingModule().name();
-                unparsingMod = def.languageParsingModule();
-            } else {
-                Option<Module> maybeUnparsingMod = def.kompiledDefinition.getModule(options.module);
-                if (maybeUnparsingMod.isEmpty()) {
-                    throw KEMException.innerParserError("Module " + options.module + " not found.");
-                }
-                unparsingMod = maybeUnparsingMod.get();
             }
+
+            Option<Module> maybeUnparsingMod = def.kompiledDefinition.getModule(options.module);
+            if (maybeUnparsingMod.isEmpty()) {
+                throw KEMException.innerParserError("Module " + options.module + " not found.");
+            }
+            Module unparsingMod = maybeUnparsingMod.get();
+
             Option<Module> maybeMod = def.programParsingModuleFor(options.module, kem);
             if (maybeMod.isEmpty()) {
                 throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -107,14 +107,8 @@ public class KastFrontEnd extends FrontEnd {
             }
             Module unparsingMod;
             if (options.module == null) {
-                options.module = def.mainSyntaxModuleName();
-                switch (options.input) {
-                    case KORE:
-                        unparsingMod = def.languageParsingModule();
-                        break;
-                    default:
-                        unparsingMod = def.kompiledDefinition.getModule(def.mainSyntaxModuleName()).get();
-                }
+                options.module = def.languageParsingModule().name();
+                unparsingMod = def.languageParsingModule();
             } else {
                 Option<Module> maybeUnparsingMod = def.kompiledDefinition.getModule(options.module);
                 if (maybeUnparsingMod.isEmpty()) {

--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -116,18 +116,16 @@ public class KastFrontEnd extends FrontEnd {
             }
             Module unparsingMod = maybeUnparsingMod.get();
 
-            Option<Module> maybeMod = def.programParsingModuleFor(options.module, kem);
-            if (maybeMod.isEmpty()) {
+            Option<Module> maybeParsingMod = def.programParsingModuleFor(options.module, kem);
+            if (maybeParsingMod.isEmpty()) {
                 throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
             }
-            Module parsingMod = maybeMod.get();
+            Module parsingMod = maybeParsingMod.get();
 
             K parsed = kread.prettyRead(parsingMod, sort, def, source, FileUtil.read(stringToParse));
-
             if (options.expandMacros) {
                 parsed = ExpandMacros.forNonSentences(unparsingMod, files.get(), def.kompileOptions, false).expand(parsed);
             }
-
             System.out.println(new String(kprint.prettyPrint(def, unparsingMod, parsed), StandardCharsets.UTF_8));
             sw.printTotal("Total");
             return 0;


### PR DESCRIPTION
-    In all cases (not just KORE output) we default to languageParsingModule for `kast`
-    Refactor control flow now that less conditionals are present.
-    Rename variables.
-    Much more efficient writing to file in `pyk` library for JSON serialization.