### PR TITLE
Emit json definitions when kompiling

### DIFF
--- a/k-distribution/src/main/scripts/lib/pyk/__init__.py
+++ b/k-distribution/src/main/scripts/lib/pyk/__init__.py
@@ -44,13 +44,13 @@ def kprove(definition, inputFile, kproveArgs = [], teeOutput = True, kRelease = 
 
 def kastJSON(definition, inputJSON, kastArgs = [], teeOutput = True, kRelease = None):
     with tempfile.NamedTemporaryFile(mode = 'w') as tempf:
-        json.dump(inputJSON, tempf)
+        tempf.write(json.dumps(inputJSON))
         tempf.flush()
         return kast(definition, tempf.name, kastArgs = kastArgs, teeOutput = teeOutput, kRelease = kRelease)
 
 def krunJSON(definition, inputJSON, krunArgs = [], teeOutput = True, kRelease = None):
     with tempfile.NamedTemporaryFile(mode = 'w') as tempf:
-        json.dump(inputJSON, tempf)
+        tempf.write(json.dumps(inputJSON))
         tempf.flush()
         (rC, out, err) = krun(definition, tempf.name, krunArgs = krunArgs + ['--output', 'json', '--parser', 'cat'], teeOutput = teeOutput, kRelease = kRelease)
         out = None if out == '' else json.loads(out)['term']

--- a/k-distribution/src/main/scripts/lib/pyk/kastManip.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kastManip.py
@@ -120,6 +120,19 @@ def flattenLabel(label, kast):
         return [ c for cs in constraints for c in cs ]
     return [kast]
 
+def splitConfigFrom(configuration):
+    initial_substitution = {}
+    _mkCellVar = lambda label: label.replace('-', '_').replace('<', '').replace('>', '').upper() + '_CELL'
+    def _replaceWithVar(k):
+        if pyk.isKApply(k) and pyk.isCellKLabel(k['label']):
+            if len(k['args']) == 1 and not (pyk.isKApply(k['args'][0]) and pyk.isCellKLabel(k['args'][0]['label'])):
+                config_var = _mkCellVar(k['label'])
+                initial_substitution[config_var] = k['args'][0]
+                return KApply(k['label'], [KVariable(config_var)])
+        return k
+    symbolic_config = pyk.traverseBottomUp(configuration, _replaceWithVar)
+    return (symbolic_config, initial_substitution)
+
 def collapseDots(kast):
     def _collapseDots(_kast):
         if isKApply(_kast):

--- a/k-distribution/tests/regression-new/imp-json/Makefile
+++ b/k-distribution/tests/regression-new/imp-json/Makefile
@@ -1,0 +1,7 @@
+DEF=imp
+EXT=imp
+TESTDIR=.
+KOMPILE_BACKEND?=llvm
+KOMPILE_FLAGS=--emit-json
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/imp-json/imp.k
+++ b/k-distribution/tests/regression-new/imp-json/imp.k
@@ -1,0 +1,205 @@
+// Copyright (c) 2014-2019 K Team. All Rights Reserved.
+
+/*!
+\setlength{\parindent}{1em}
+\title{IMP}
+\author{Grigore Ro\c{s}u (\texttt{grosu@illinois.edu})}
+\organization{University of Illinois at Urbana-Champaign}
+*/
+
+/*@ \section{Abstract}
+This is the \K semantic definition of the classic IMP language.
+IMP is considered a folklore language, without an official inventor,
+and has been used in many textbooks and papers, often with slight
+syntactic variations and often without being called IMP\@.  It includes
+the most basic imperative language constructs, namely basic constructs
+for arithmetic and Boolean expressions, and variable assignment,
+conditional, while loop and sequential composition constructs for statements.
+*/
+
+module IMP-SYNTAX
+  imports DOMAINS-SYNTAX
+/*@ \section{Syntax}
+This module defines the syntax of IMP\@.
+Note that \texttt{<=} is sequentially strict and has a \LaTeX\ attribute
+making it display as $\leq$, and that \texttt{\&\&} is strict only in its first
+argument, because we want to give it a short-circuit semantics. */
+
+  syntax AExp  ::= Int | Id
+                 | "-" Int                    [format(%1%2)]
+                 | AExp "/" AExp              [left, strict, color(pink)]
+                 > AExp "+" AExp              [left, strict, color(pink)]
+                 | "(" AExp ")"               [bracket]
+  syntax BExp  ::= Bool
+                 | AExp "<=" AExp             [seqstrict, latex({#1}\leq{#2}), color(pink)]
+                 | "!" BExp                   [strict, color(pink)]
+                 > BExp "&&" BExp             [left, strict(1), color(pink)]
+                 | "(" BExp ")"               [bracket]
+  syntax Block ::= "{" "}"
+                 | "{" Stmt "}"               [format(%1%i%n%2%d%n%3)]
+  syntax Stmt  ::= Block
+                 | Id "=" AExp ";"            [strict(2), color(pink), format(%1 %2 %3%4)]
+                 | "if" "(" BExp ")"
+                   Block "else" Block         [strict(1), colors(yellow, white, white, yellow), format(%1 %2%3%4 %5 %6 %7)]
+                 | "while" "(" BExp ")" Block [colors(yellow,white,white), format(%1 %2%3%4 %5)]
+                 > Stmt Stmt                  [left, format(%1%n%2)]
+
+/*@ An IMP program declares a set of variables and then executes a
+statement in the state obtained after initializing all those variables
+to 0.  \K provides builtin support for generic syntactic lists:
+$\textit{List}\{\textit{Nonterminal},\textit{terminal}\}$ stands for
+\textit{terminal}-separated lists of \textit{Nonterminal} elements. */
+
+  syntax Pgm ::= "int" Ids ";" Stmt           [format(%1 %2%3%n%4), colors(yellow,pink)]
+  syntax Ids ::= List{Id,","} [format(%1%2 %3)]
+endmodule
+
+/*@ We are done with the definition of IMP's syntax.  Make sure
+that you write and parse several interesting programs before you move to the
+semantics.  */
+
+module IMP
+  imports IMP-SYNTAX
+  imports INT
+  imports BOOL
+  imports MAP
+/*@ \section{Semantics}
+This module defines the semantics of IMP\@.
+Before you start adding semantic rules to a \K definition, you need to
+define the basic semantic infrastructure consisting of definitions for
+{\em results} and the {\em configuration}.  */
+
+/*@ \subsection{Values and results}
+IMP only has two types of values, or results of computations: integers
+and Booleans.  We here use the \K builtin variants for both of them. */
+
+  syntax KResult ::= Int | Bool
+
+/*@ \subsection{Configuration}
+The configuration of IMP is trivial: it only contains two cells, one
+for the computation and another for the state.  For good encapsulation
+and clarity, we place the two cells inside another cell, the ``top'' cell
+which is labeled \textsf{T}. */
+
+  configuration <T color="yellow">
+                  <k color="green"> $PGM:Pgm </k>
+                  <state color="red"> .Map </state>
+                </T>
+
+/*@ The configuration variable $\${\it PGM}$ tells the \K tool where to
+place the program.  More precisely, the command
+``\texttt{krun program}'' parses the program and places the resulting
+\K abstract syntax tree in the \textsf{k} cell before invoking the
+semantic rules described in the sequel.  The ``$\kdot$'' in the
+\textsf{state} cell, written \texttt{.Map} in ASCII in the
+\texttt{imp.k} file, is \K's way to say ``nothing''.  Technically, it
+is a constant which is the unit, or identity, of all maps in \K
+(similar dot units exist for other \K structures, such as lists, sets,
+multi-sets, etc.).  */
+
+/*@ \subsection{Arithmetic expressions}
+The \K semantics of each arithmetic construct is defined below. */
+
+/*@ \subsubsection{Variable lookup}
+A program variable $X$ is looked up in the state by matching a binding
+of the form $X \mapsto I$ in the state cell.  If such a binding does not
+exist, then the rewriting process will get stuck.  Thus our semantics of
+IMP disallows uses of uninitialized variables.  Note that the variable
+to be looked up is the first task in the \textsf{k} cell (the cell is
+closed to the left and torn to the right), while the binding can be
+anywhere in the \textsf{state} cell (the cell is torn at both sides). */
+
+  rule <k> X:Id => I ...</k> <state>... X |-> I ...</state>
+
+/*@ \subsubsection{Arithmetic operators}
+There is nothing special about these, but recall that \K's configuration
+abstraction mechanism is at work here!  That means that the rewrites in the
+rules below all happen at the beginning of the \textsf{k} cell.  */
+
+  rule I1 / I2 => I1 /Int I2  requires I2 =/=Int 0
+  rule I1 + I2 => I1 +Int I2
+  rule - I1 => 0 -Int I1
+
+/*@ \subsection{Boolean expressions}
+The rules below are straightforward.  Note the short-circuited semantics
+of \texttt{\&\&}; this is the reason we annotated the syntax of
+\texttt{\&\&} with the \K attribute \texttt{strict(1)} instead of
+\texttt{strict}. */
+
+  rule I1 <= I2 => I1 <=Int I2
+  rule ! T => notBool T
+  rule true && B => B
+  rule false && _ => false
+
+/*@ \subsection{Blocks and Statements}
+There is one rule per statement construct except for the conditional,
+which needs two rules. */
+
+/*@ \subsubsection{Blocks}
+The empty block \texttt{\{\}} is simply dissolved.  The $\kdot$ below is the
+unit of the computation list structure $K$, that is, the empty task.
+Similarly, the non-empty blocks are dissolved and replaced by their statement
+contents, thus effectively giving them a bracket semantics; we can afford to
+do this only because we have no block-local variable declarations yet in IMP.
+Since we tagged the rules below as "structural", the \K tool structurally
+erases the block constructs from the computation structure, without
+considering their erasure as computational steps in the resulting transition
+systems.  You can make these rules computational (dropping the attribute
+\texttt{structural}) if you do want these to count as computational steps. */
+
+  rule {} => .   [structural]
+  rule {S} => S  [structural]
+
+/*@ \subsubsection{Assignment}
+The assigned variable is updated in the state.  The variable is expected
+to be declared, otherwise the semantics will get stuck.  At the same time,
+the assignment is dissolved. */
+
+  rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
+
+/*@ \subsubsection{Sequential composition}
+Sequential composition is simply structurally translated into \K's
+builtin task sequentialization operation.  You can make this rule
+computational (i.e., remove the \texttt{structural} attribute) if you
+want it to count as a computational step.  Recall that the semantics
+of a program in a programming language defined in \K is the transition
+system obtained from the initial configuration holding that program
+and counting only the steps corresponding to computational rules as
+transitions (i.e., hiding the structural rules as unobservable, or
+internal steps). */
+
+  rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
+
+/*@ \subsubsection{Conditional}
+The conditional statement has two semantic cases, corresponding to
+when its condition evaluates to \texttt{true} or to \texttt{false}.
+Recall that the conditional was annotated with the attribute
+\texttt{strict(1)} in the syntax module above, so only its first
+argument is allowed to be evaluated. */
+
+  rule if (true)  S else _ => S
+  rule if (false) _ else S => S
+
+/*@ \subsubsection{While loop}
+We give the semantics of the \texttt{while} loop by unrolling.
+Note that we preferred to make the rule below structural. */
+
+  rule while (B) S => if (B) {S while (B) S} else {}  [structural]
+
+/*@ \subsection{Programs}
+The semantics of an IMP program is that its body statement is executed
+in a state initializing all its global variables to 0.  Since \K's
+syntactic lists are internally interpreted as cons-lists (i.e., lists
+constructed with a head element followed by a tail list), we need to
+distinguish two cases, one when the list has at least one element and
+another when the list is empty.  In the first case we initialize the
+variable to 0 in the state, but only when the variable is not already
+declared (all variables are global and distinct in IMP).  We prefer to
+make the second rule structural, thinking of dissolving the residual
+empty \texttt{int;} declaration as a structural cleanup rather than as
+a computational step. */
+
+  rule <k> int (X,Xs => Xs);_ </k> <state> Rho:Map (.Map => X|->0) </state>
+    requires notBool (X in keys(Rho))
+  rule int .Ids; S => S  [structural]
+endmodule

--- a/k-distribution/tests/regression-new/imp-json/imp.k
+++ b/k-distribution/tests/regression-new/imp-json/imp.k
@@ -34,12 +34,6 @@ module IMP
 
   syntax KResult ::= Int | Bool
 
-/*@ \subsection{Configuration}
-The configuration of IMP is trivial: it only contains two cells, one
-for the computation and another for the state.  For good encapsulation
-and clarity, we place the two cells inside another cell, the ``top'' cell
-which is labeled \textsf{T}. */
-
   configuration <T color="yellow">
                   <k color="green"> $PGM:Pgm </k>
                   <state color="red"> .Map </state>

--- a/k-distribution/tests/regression-new/imp-json/imp.k
+++ b/k-distribution/tests/regression-new/imp-json/imp.k
@@ -1,29 +1,7 @@
 // Copyright (c) 2014-2019 K Team. All Rights Reserved.
 
-/*!
-\setlength{\parindent}{1em}
-\title{IMP}
-\author{Grigore Ro\c{s}u (\texttt{grosu@illinois.edu})}
-\organization{University of Illinois at Urbana-Champaign}
-*/
-
-/*@ \section{Abstract}
-This is the \K semantic definition of the classic IMP language.
-IMP is considered a folklore language, without an official inventor,
-and has been used in many textbooks and papers, often with slight
-syntactic variations and often without being called IMP\@.  It includes
-the most basic imperative language constructs, namely basic constructs
-for arithmetic and Boolean expressions, and variable assignment,
-conditional, while loop and sequential composition constructs for statements.
-*/
-
 module IMP-SYNTAX
   imports DOMAINS-SYNTAX
-/*@ \section{Syntax}
-This module defines the syntax of IMP\@.
-Note that \texttt{<=} is sequentially strict and has a \LaTeX\ attribute
-making it display as $\leq$, and that \texttt{\&\&} is strict only in its first
-argument, because we want to give it a short-circuit semantics. */
 
   syntax AExp  ::= Int | Id
                  | "-" Int                    [format(%1%2)]
@@ -44,34 +22,15 @@ argument, because we want to give it a short-circuit semantics. */
                  | "while" "(" BExp ")" Block [colors(yellow,white,white), format(%1 %2%3%4 %5)]
                  > Stmt Stmt                  [left, format(%1%n%2)]
 
-/*@ An IMP program declares a set of variables and then executes a
-statement in the state obtained after initializing all those variables
-to 0.  \K provides builtin support for generic syntactic lists:
-$\textit{List}\{\textit{Nonterminal},\textit{terminal}\}$ stands for
-\textit{terminal}-separated lists of \textit{Nonterminal} elements. */
-
   syntax Pgm ::= "int" Ids ";" Stmt           [format(%1 %2%3%n%4), colors(yellow,pink)]
   syntax Ids ::= List{Id,","} [format(%1%2 %3)]
 endmodule
-
-/*@ We are done with the definition of IMP's syntax.  Make sure
-that you write and parse several interesting programs before you move to the
-semantics.  */
 
 module IMP
   imports IMP-SYNTAX
   imports INT
   imports BOOL
   imports MAP
-/*@ \section{Semantics}
-This module defines the semantics of IMP\@.
-Before you start adding semantic rules to a \K definition, you need to
-define the basic semantic infrastructure consisting of definitions for
-{\em results} and the {\em configuration}.  */
-
-/*@ \subsection{Values and results}
-IMP only has two types of values, or results of computations: integers
-and Booleans.  We here use the \K builtin variants for both of them. */
 
   syntax KResult ::= Int | Bool
 
@@ -86,118 +45,28 @@ which is labeled \textsf{T}. */
                   <state color="red"> .Map </state>
                 </T>
 
-/*@ The configuration variable $\${\it PGM}$ tells the \K tool where to
-place the program.  More precisely, the command
-``\texttt{krun program}'' parses the program and places the resulting
-\K abstract syntax tree in the \textsf{k} cell before invoking the
-semantic rules described in the sequel.  The ``$\kdot$'' in the
-\textsf{state} cell, written \texttt{.Map} in ASCII in the
-\texttt{imp.k} file, is \K's way to say ``nothing''.  Technically, it
-is a constant which is the unit, or identity, of all maps in \K
-(similar dot units exist for other \K structures, such as lists, sets,
-multi-sets, etc.).  */
-
-/*@ \subsection{Arithmetic expressions}
-The \K semantics of each arithmetic construct is defined below. */
-
-/*@ \subsubsection{Variable lookup}
-A program variable $X$ is looked up in the state by matching a binding
-of the form $X \mapsto I$ in the state cell.  If such a binding does not
-exist, then the rewriting process will get stuck.  Thus our semantics of
-IMP disallows uses of uninitialized variables.  Note that the variable
-to be looked up is the first task in the \textsf{k} cell (the cell is
-closed to the left and torn to the right), while the binding can be
-anywhere in the \textsf{state} cell (the cell is torn at both sides). */
-
   rule <k> X:Id => I ...</k> <state>... X |-> I ...</state>
-
-/*@ \subsubsection{Arithmetic operators}
-There is nothing special about these, but recall that \K's configuration
-abstraction mechanism is at work here!  That means that the rewrites in the
-rules below all happen at the beginning of the \textsf{k} cell.  */
 
   rule I1 / I2 => I1 /Int I2  requires I2 =/=Int 0
   rule I1 + I2 => I1 +Int I2
   rule - I1 => 0 -Int I1
-
-/*@ \subsection{Boolean expressions}
-The rules below are straightforward.  Note the short-circuited semantics
-of \texttt{\&\&}; this is the reason we annotated the syntax of
-\texttt{\&\&} with the \K attribute \texttt{strict(1)} instead of
-\texttt{strict}. */
 
   rule I1 <= I2 => I1 <=Int I2
   rule ! T => notBool T
   rule true && B => B
   rule false && _ => false
 
-/*@ \subsection{Blocks and Statements}
-There is one rule per statement construct except for the conditional,
-which needs two rules. */
-
-/*@ \subsubsection{Blocks}
-The empty block \texttt{\{\}} is simply dissolved.  The $\kdot$ below is the
-unit of the computation list structure $K$, that is, the empty task.
-Similarly, the non-empty blocks are dissolved and replaced by their statement
-contents, thus effectively giving them a bracket semantics; we can afford to
-do this only because we have no block-local variable declarations yet in IMP.
-Since we tagged the rules below as "structural", the \K tool structurally
-erases the block constructs from the computation structure, without
-considering their erasure as computational steps in the resulting transition
-systems.  You can make these rules computational (dropping the attribute
-\texttt{structural}) if you do want these to count as computational steps. */
-
   rule {} => .   [structural]
   rule {S} => S  [structural]
 
-/*@ \subsubsection{Assignment}
-The assigned variable is updated in the state.  The variable is expected
-to be declared, otherwise the semantics will get stuck.  At the same time,
-the assignment is dissolved. */
-
   rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
 
-/*@ \subsubsection{Sequential composition}
-Sequential composition is simply structurally translated into \K's
-builtin task sequentialization operation.  You can make this rule
-computational (i.e., remove the \texttt{structural} attribute) if you
-want it to count as a computational step.  Recall that the semantics
-of a program in a programming language defined in \K is the transition
-system obtained from the initial configuration holding that program
-and counting only the steps corresponding to computational rules as
-transitions (i.e., hiding the structural rules as unobservable, or
-internal steps). */
-
   rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
-
-/*@ \subsubsection{Conditional}
-The conditional statement has two semantic cases, corresponding to
-when its condition evaluates to \texttt{true} or to \texttt{false}.
-Recall that the conditional was annotated with the attribute
-\texttt{strict(1)} in the syntax module above, so only its first
-argument is allowed to be evaluated. */
 
   rule if (true)  S else _ => S
   rule if (false) _ else S => S
 
-/*@ \subsubsection{While loop}
-We give the semantics of the \texttt{while} loop by unrolling.
-Note that we preferred to make the rule below structural. */
-
   rule while (B) S => if (B) {S while (B) S} else {}  [structural]
-
-/*@ \subsection{Programs}
-The semantics of an IMP program is that its body statement is executed
-in a state initializing all its global variables to 0.  Since \K's
-syntactic lists are internally interpreted as cons-lists (i.e., lists
-constructed with a head element followed by a tail list), we need to
-distinguish two cases, one when the list has at least one element and
-another when the list is empty.  In the first case we initialize the
-variable to 0 in the state, but only when the variable is not already
-declared (all variables are global and distinct in IMP).  We prefer to
-make the second rule structural, thinking of dissolving the residual
-empty \texttt{int;} declaration as a structural cleanup rather than as
-a computational step. */
 
   rule <k> int (X,Xs => Xs);_ </k> <state> Rho:Map (.Map => X|->0) </state>
     requires notBool (X in keys(Rho))

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -147,7 +147,7 @@ public class Kompile {
     public Definition parseDefinition(File definitionFile, String mainModuleName, String mainProgramsModule, Set<String> excludedModuleTags) {
         switch (kompileOptions.input) {
             case JSON:
-                return JsonParser.parseDef(files.load(definitionFile));
+                return JsonParser.parseDefinition(files.load(definitionFile));
             case PRETTY:
                 return definitionParsing.parseDefinitionAndResolveBubbles(definitionFile, mainModuleName, mainProgramsModule, excludedModuleTags);
             default:

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -23,6 +23,8 @@ import org.kframework.definition.Module;
 import org.kframework.kore.Sort;
 import org.kframework.parser.concrete2kore.ParserUtils;
 import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
+import org.kframework.parser.json.JsonParser;
+import org.kframework.unparser.OutputModes;
 import org.kframework.utils.Stopwatch;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -132,6 +134,9 @@ public class Kompile {
     }
 
     public Definition parseDefinition(File definitionFile, String mainModuleName, String mainProgramsModule, Set<String> excludedModuleTags) {
+        if (kompileOptions.input == OutputModes.JSON) {
+            return JsonParser.parseDef(files.load(definitionFile));
+        }
         return definitionParsing.parseDefinitionAndResolveBubbles(definitionFile, mainModuleName, mainProgramsModule, excludedModuleTags);
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -23,8 +23,6 @@ import org.kframework.definition.Module;
 import org.kframework.kore.Sort;
 import org.kframework.parser.concrete2kore.ParserUtils;
 import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
-import org.kframework.parser.json.JsonParser;
-import org.kframework.unparser.OutputModes;
 import org.kframework.unparser.ToJson;
 import org.kframework.utils.Stopwatch;
 import org.kframework.utils.errorsystem.KEMException;
@@ -145,14 +143,7 @@ public class Kompile {
     }
 
     public Definition parseDefinition(File definitionFile, String mainModuleName, String mainProgramsModule, Set<String> excludedModuleTags) {
-        switch (kompileOptions.input) {
-            case JSON:
-                return JsonParser.parseDefinition(files.load(definitionFile));
-            case PRETTY:
-                return definitionParsing.parseDefinitionAndResolveBubbles(definitionFile, mainModuleName, mainProgramsModule, excludedModuleTags);
-            default:
-                throw KEMException.criticalError("Unsupported input mode for definition parsing: " + kompileOptions.input);
-        }
+        return definitionParsing.parseDefinitionAndResolveBubbles(definitionFile, mainModuleName, mainProgramsModule, excludedModuleTags);
     }
 
     private static Module filterStreamModules(Module input) {

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -145,10 +145,14 @@ public class Kompile {
     }
 
     public Definition parseDefinition(File definitionFile, String mainModuleName, String mainProgramsModule, Set<String> excludedModuleTags) {
-        if (kompileOptions.input == OutputModes.JSON) {
-            return JsonParser.parseDef(files.load(definitionFile));
+        switch (kompileOptions.input) {
+            case JSON:
+                return JsonParser.parseDef(files.load(definitionFile));
+            case PRETTY:
+                return definitionParsing.parseDefinitionAndResolveBubbles(definitionFile, mainModuleName, mainProgramsModule, excludedModuleTags);
+            default:
+                throw KEMException.criticalError("Unsupported input mode for definition parsing: " + kompileOptions.input);
         }
-        return definitionParsing.parseDefinitionAndResolveBubbles(definitionFile, mainModuleName, mainProgramsModule, excludedModuleTags);
     }
 
     private static Module filterStreamModules(Module input) {

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -128,7 +128,7 @@ public class Kompile {
         files.saveToKompiled("compiled.txt", kompiledDefinition.toString());
         sw.printIntermediate("Apply compile pipeline");
 
-        if (kompileOptions.emitJson) {
+        if (kompileOptions.experimental.emitJson) {
             try {
                 files.saveToKompiled("parsed.json",   new String(ToJson.apply(parsedDef),          "UTF-8"));
                 files.saveToKompiled("compiled.json", new String(ToJson.apply(kompiledDefinition), "UTF-8"));

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -25,6 +25,7 @@ import org.kframework.parser.concrete2kore.ParserUtils;
 import org.kframework.parser.concrete2kore.generator.RuleGrammarGenerator;
 import org.kframework.parser.json.JsonParser;
 import org.kframework.unparser.OutputModes;
+import org.kframework.unparser.ToJson;
 import org.kframework.utils.Stopwatch;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -33,6 +34,7 @@ import org.kframework.utils.file.JarInfo;
 import scala.Function1;
 
 import java.io.File;
+import java.io.UnsupportedEncodingException;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
@@ -127,6 +129,15 @@ public class Kompile {
 
         files.saveToKompiled("compiled.txt", kompiledDefinition.toString());
         sw.printIntermediate("Apply compile pipeline");
+
+        if (kompileOptions.emitJson) {
+            try {
+                files.saveToKompiled("parsed.json",   new String(ToJson.apply(parsedDef),          "UTF-8"));
+                files.saveToKompiled("compiled.json", new String(ToJson.apply(kompiledDefinition), "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                throw KEMException.criticalError("Unsupported encoding `UTF-8` when saving JSON definition.");
+            }
+        }
 
         ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(kompiledDefinition.mainModule());
 

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -102,6 +102,9 @@ public class KompileOptions implements Serializable {
         }
     }
 
+    @Parameter(names="--emit-json", description="Emit JSON serialized version of parsed and kompiled definitions.")
+    public boolean emitJson = false;
+
     public static final class Experimental implements Serializable {
 
         // Experimental options

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -98,9 +98,6 @@ public class KompileOptions implements Serializable {
         }
     }
 
-    @Parameter(names="--emit-json", description="Emit JSON serialized version of parsed and kompiled definitions.")
-    public boolean emitJson = false;
-
     public static final class Experimental implements Serializable {
 
         // Experimental options
@@ -130,5 +127,8 @@ public class KompileOptions implements Serializable {
 
         @Parameter(names="--cache-file", description="Location of parse cache file. Default is $KOMPILED_DIR/cache.bin.")
         public String cacheFile;
+
+        @Parameter(names="--emit-json", description="Emit JSON serialized version of parsed and kompiled definitions.")
+        public boolean emitJson = false;
     }
 }

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -86,10 +86,6 @@ public class KompileOptions implements Serializable {
         return backend.equals("kore") || backend.equals("haskell") || backend.equals("llvm");
     }
 
-    @Parameter(names={"--input", "-i"}, converter=OutputModeConverter.class,
-            description="Format to read definition in. <mode> is either [pretty|json].")
-    public OutputModes input = OutputModes.PRETTY;
-
     public static class OutputModeConverter extends BaseEnumConverter<OutputModes> {
 
         public OutputModeConverter(String optionName) {

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -4,12 +4,15 @@ package org.kframework.kompile;
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.ParametersDelegate;
 import org.apache.commons.io.FilenameUtils;
+
 import org.kframework.backend.Backends;
 import org.kframework.main.GlobalOptions;
+import org.kframework.unparser.OutputModes;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
+import org.kframework.utils.options.BaseEnumConverter;
 import org.kframework.utils.options.StringListConverter;
 
 import java.io.Serializable;
@@ -81,6 +84,22 @@ public class KompileOptions implements Serializable {
 
     public boolean isKore() {
         return backend.equals("kore") || backend.equals("haskell") || backend.equals("llvm");
+    }
+
+    @Parameter(names={"--input", "-i"}, converter=OutputModeConverter.class,
+            description="Format to read definition in. <mode> is either [pretty|json].")
+    public OutputModes input = OutputModes.PRETTY;
+
+    public static class OutputModeConverter extends BaseEnumConverter<OutputModes> {
+
+        public OutputModeConverter(String optionName) {
+            super(optionName);
+        }
+
+        @Override
+        public Class<OutputModes> enumClass() {
+            return OutputModes.class;
+        }
     }
 
     public static final class Experimental implements Serializable {

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -1,6 +1,13 @@
 // Copyright (c) 2018-2019 K Team. All Rights Reserved.
 package org.kframework.parser.json;
 
+import org.kframework.attributes.Att;
+import org.kframework.definition.Context;
+import org.kframework.definition.Definition;
+import org.kframework.definition.Module;
+import org.kframework.definition.ModuleComment;
+import org.kframework.definition.Rule;
+import org.kframework.definition.Sentence;
 import org.kframework.kore.K;
 import org.kframework.kore.KLabel;
 import static org.kframework.kore.KORE.KLabel;
@@ -18,25 +25,173 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.io.StringReader;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.json.Json;
 import javax.json.JsonArray;
 import javax.json.JsonObject;
 import javax.json.JsonReader;
 
+import scala.collection.JavaConverters;
+
 /**
  * Parses a Json term into the KORE data structures.
  */
 public class JsonParser {
 
-    public static final String KTOKEN         = "KToken"
-                             , KAPPLY         = "KApply"
-                             , KSEQUENCE      = "KSequence"
-                             , KVARIABLE      = "KVariable"
-                             , KREWRITE       = "KRewrite"
-                             , KAS            = "KAs"
-                             , INJECTEDKLABEL = "InjectedKLabel"
+    public static final String KDEFINITION          = "KDefinition"
+                             , KATT                 = "KAtt"
+                             , KCONFIGURATION       = "KConfiguration"
+                             , KBUBBLE              = "KBubble"
+                             , KMODULE              = "KModule"
+                             , KCONTEXT             = "KContext"
+                             , KRULE                = "KRule"
+                             , KMODULECOMMENT       = "KModuleComment"
+                             , KSYNTAXPRIORITY      = "KSyntaxPriority"
+                             , KSYNTAXASSOCIATIVITY = "KSyntaxAssociativity"
+                             , KTOKEN               = "KToken"
+                             , KSYNTAXSORT          = "KSyntaxSort"
+                             , KPRODUCTION          = "KProduction"
+                             , KAPPLY               = "KApply"
+                             , KSEQUENCE            = "KSequence"
+                             , KVARIABLE            = "KVariable"
+                             , KREWRITE             = "KRewrite"
+                             , KAS                  = "KAs"
+                             , INJECTEDKLABEL       = "InjectedKLabel"
                              ;
+
+/////////////////////////////
+// Parsing Definition Json //
+/////////////////////////////
+
+    public static Definition parseDef(byte[] data) {
+        try {
+            return parseDef(new String(data, "UTF-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new AssertionError("UTF-8 encoding not supported");
+        }
+    }
+
+    public static Definition parseDef(String data) {
+        JsonReader reader = Json.createReader(new StringReader(data));
+        return parseJsonDef(reader.readObject());
+    }
+
+    public static Definition parseJsonDef(JsonObject data) {
+        try {
+            if (! (data.containsKey("format") && data.containsKey("version") && data.containsKey("term"))) {
+                throw KEMException.criticalError("Must have `format`, `version`, and `term` fields in serialized Json!");
+            }
+            if (! data.getString("format").equals("KAST")) {
+                throw KEMException.criticalError("Only can deserialize 'KAST' format Json! Found: " + data.getString("format"));
+            }
+            if (data.getInt("version") != 1) {
+                throw KEMException.criticalError("Only can deserialize KAST version '1'! Found: " + data.getInt("version"));
+            }
+            return toDef(data.getJsonObject("term"));
+        } catch (IOException e) {
+            throw KEMException.criticalError("Could not read Definition term from json", e);
+        }
+    }
+
+    public static Definition toDef(JsonObject data) throws IOException {
+        if (! data.getString("node").equals(KDEFINITION))
+            throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
+
+        Module mainModule = toMod(data.getJsonObject("mainModule"));
+        JsonArray mods = data.getJsonArray("entryModules");
+        Module[] modArray = toMods(mods.size(), mods);
+        Set<Module> entryModules = new HashSet<>(Arrays.asList(modArray));
+        return new Definition(mainModule, JavaConverters.asScalaSet(entryModules), toAtt(data.getJsonObject("att")));
+    }
+
+/////////////////////////
+// Parsing Module Json //
+/////////////////////////
+
+    public static Module toMod(JsonObject data) throws IOException {
+        if (! data.getString("node").equals(KMODULE))
+            throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
+
+        String name = data.getString("name");
+
+        JsonArray mods = data.getJsonArray("imports");
+        Module[] modArray = toMods(mods.size(), mods);
+        Set<Module> modImports = new HashSet<>(Arrays.asList(modArray));
+
+        JsonArray sens = data.getJsonArray("localSentences");
+        Sentence[] senArray = toSens(sens.size(), sens);
+        Set<Sentence> localSentences = new HashSet<>(Arrays.asList(senArray));
+
+        return new Module(name, JavaConverters.asScalaSet(modImports), JavaConverters.asScalaSet(localSentences), toAtt(data.getJsonObject("att")));
+    }
+
+    private static Module[] toMods(int arity, JsonArray data) throws IOException {
+        Module[] items = new Module[arity];
+        for (int i = 0; i < arity; i++) {
+            items[i] = toMod(data.getValuesAs(JsonObject.class).get(i));
+        }
+        return items;
+    }
+
+///////////////////////////
+// Parsing Sentence Json //
+///////////////////////////
+
+    public static Sentence toSen(JsonObject data) throws IOException {
+        switch(data.getString("node")) {
+            case KCONTEXT: {
+                K body = toK(data.getJsonObject("body"));
+                K requires = toK(data.getJsonObject("requires"));
+                Att att = toAtt(data.getJsonObject("att"));
+                return new Context(body, requires, att);
+            }
+            case KRULE: {
+                K body = toK(data.getJsonObject("body"));
+                K requires = toK(data.getJsonObject("requires"));
+                K ensures = toK(data.getJsonObject("ensures"));
+                Att att = toAtt(data.getJsonObject("att"));
+                return new Rule(body, requires, ensures, att);
+            }
+            case KMODULECOMMENT:{
+                String comment = data.getString("comment");
+                Att att = toAtt(data.getJsonObject("att"));
+                return new ModuleComment(comment, att);
+            }
+            case KSYNTAXPRIORITY: {
+                
+            }
+            case KSYNTAXASSOCIATIVITY: {
+                
+            }
+            default:
+                throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
+        }
+    }
+
+    private static Sentence[] toSens(int arity, JsonArray data) throws IOException {
+        Sentence[] items = new Sentence[arity];
+        for (int i = 0; i < arity; i++) {
+            items[i] = toSen(data.getValuesAs(JsonObject.class).get(i));
+        }
+        return items;
+    }
+
+//////////////////////
+// Parsing Att Json //
+//////////////////////
+
+    public static Att toAtt(JsonObject data) throws IOException {
+        if (! data.getString("node").equals(KATT))
+            throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
+
+        return Att.empty();
+    }
+
+////////////////////
+// Parsing K Json //
+////////////////////
 
     public static K parse(byte[] data) {
         try {

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -75,6 +75,7 @@ public class JsonParser {
                              , KDEFINITION          = "KDefinition"
                              , KNONTERMINAL         = "KNonTerminal"
                              , KMODULE              = "KModule"
+                             , KFLATMODULE          = "KFlatModule"
                              , KMODULECOMMENT       = "KModuleComment"
                              , KPRODUCTION          = "KProduction"
                              , KREGEXTERMINAL       = "KRegexTerminal"
@@ -144,8 +145,8 @@ public class JsonParser {
 // Parsing Module Json //
 /////////////////////////
 
-    public static FlatModule toMod(JsonObject data) throws IOException {
-        if (! data.getString("node").equals(KMODULE))
+    public static FlatModule toFlatModule(JsonObject data) throws IOException {
+        if (! data.getString("node").equals(KFLATMODULE))
             throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
 
         String name = data.getString("name");
@@ -165,7 +166,7 @@ public class JsonParser {
     private static FlatModule[] toMods(int arity, JsonArray data) throws IOException {
         FlatModule[] items = new FlatModule[arity];
         for (int i = 0; i < arity; i++) {
-            items[i] = toMod(data.getValuesAs(JsonObject.class).get(i));
+            items[i] = toFlatModule(data.getValuesAs(JsonObject.class).get(i));
         }
         return items;
     }
@@ -200,7 +201,7 @@ public class JsonParser {
                 return new SyntaxPriority(toPriorities(priorities.size(), priorities), att);
             }
             case KSYNTAXASSOCIATIVITY: {
-                
+
             }
             case KCONFIGURATION: {
 

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -31,6 +31,7 @@ import org.kframework.kore.mini.KRewrite;
 import org.kframework.kore.mini.KSequence;
 import org.kframework.kore.mini.KToken;
 import org.kframework.kore.mini.KVariable;
+import org.kframework.kore.Sort;
 import org.kframework.parser.outer.Outer;
 import org.kframework.utils.errorsystem.KEMException;
 
@@ -174,21 +175,21 @@ public class JsonParser {
     public static Sentence toSentence(JsonObject data) throws IOException {
         switch(data.getString("node")) {
             case KCONTEXT: {
-                K body = toK(data.getJsonObject("body"));
+                K body     = toK(data.getJsonObject("body"));
                 K requires = toK(data.getJsonObject("requires"));
-                Att att = toAtt(data.getJsonObject("att"));
+                Att att    = toAtt(data.getJsonObject("att"));
                 return new Context(body, requires, att);
             }
             case KRULE: {
-                K body = toK(data.getJsonObject("body"));
+                K body     = toK(data.getJsonObject("body"));
                 K requires = toK(data.getJsonObject("requires"));
-                K ensures = toK(data.getJsonObject("ensures"));
-                Att att = toAtt(data.getJsonObject("att"));
+                K ensures  = toK(data.getJsonObject("ensures"));
+                Att att    = toAtt(data.getJsonObject("att"));
                 return new Rule(body, requires, ensures, att);
             }
             case KMODULECOMMENT:{
                 String comment = data.getString("comment");
-                Att att = toAtt(data.getJsonObject("att"));
+                Att att        = toAtt(data.getJsonObject("att"));
                 return new ModuleComment(comment, att);
             }
             case KSYNTAXPRIORITY: {
@@ -209,13 +210,21 @@ public class JsonParser {
                 return new SyntaxAssociativity(assoc, tags, att);
             }
             case KCONFIGURATION: {
-
+                K body    = toK(data.getJsonObject("body"));
+                K ensures = toK(data.getJsonObject("ensures"));
+                Att att   = toAtt(data.getJsonObject("att"));
+                return new Configuration(body, ensures, att);
             }
             case KSYNTAXSORT: {
-
+                Sort sort = toSort(data.getJsonObject("sort"));
+                Att att   = toAtt(data.getJsonObject("att"));
+                return new SyntaxSort(sort, att);
             }
             case KBUBBLE: {
-
+                String sentenceType = data.getString("sentenceType");
+                String contents     = data.getString("contents");
+                Att att             = toAtt(data.getJsonObject("att"));
+                return new Bubble(sentenceType, contents, att);
             }
             case KPRODUCTION: {
                 return new ModuleComment("Dummy comment", Att.empty());
@@ -229,6 +238,12 @@ public class JsonParser {
         Set<Tag> tags = new HashSet<>();
         data.getValuesAs(JsonString.class).forEach(s -> tags.add(new Tag(s.getString())));
         return JavaConverters.asScalaSet(tags);
+    }
+
+    private static Sort toSort(JsonObject data) {
+        if (! data.getString("node").equals(KSORT))
+            throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
+        return KORE.Sort(data.getString("name"));
     }
 
 //////////////////////

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -134,7 +134,7 @@ public class JsonParser {
         Set<FlatModule> entryModules = new HashSet<>(Arrays.asList(modArray));
         Map<String,Module> koreModules = new HashMap<>();
 
-        FlatModule mainFlatMod = entryModules.stream().filter(mod -> mod.hasName(mainModuleName)).findFirst().get();
+        FlatModule mainFlatMod = entryModules.stream().filter(mod -> mod.name().equals(mainModuleName)).findFirst().get();
         Module mainMod = mainFlatMod.toModule(immutable(entryModules), JavaConverters.mapAsScalaMapConverter(koreModules).asScala(), Seq());
 
         return new Definition(mainMod, immutable(new HashSet<>(koreModules.values())), toAtt(data.getJsonObject("att")));

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -199,7 +199,14 @@ public class JsonParser {
                 return new SyntaxPriority(JavaConverters.iterableAsScalaIterableConverter(syntaxPriorities).asScala().toSeq(), att);
             }
             case KSYNTAXASSOCIATIVITY: {
-
+                String assocString = data.getString("assoc");
+                scala.Enumeration.Value assoc = assocString == "Left"     ? Associativity.Left()
+                                              : assocString == "Right"    ? Associativity.Right()
+                                              : assocString == "NonAssoc" ? Associativity.NonAssoc()
+                                              : Associativity.Unspecified();
+                scala.collection.Set<Tag> tags = toTags(data.getJsonArray("tags"));
+                Att att = toAtt(data.getJsonObject("att"));
+                return new SyntaxAssociativity(assoc, tags, att);
             }
             case KCONFIGURATION: {
 

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -96,15 +96,15 @@ public class JsonParser {
 // Parsing Definition Json //
 /////////////////////////////
 
-    public static Definition parseDef(byte[] data) {
+    public static Definition parseDefinition(byte[] data) {
         try {
-            return parseDef(new String(data, "UTF-8"));
+            return parseDefinition(new String(data, "UTF-8"));
         } catch (UnsupportedEncodingException e) {
             throw new AssertionError("UTF-8 encoding not supported");
         }
     }
 
-    public static Definition parseDef(String data) {
+    public static Definition parseDefinition(String data) {
         JsonReader reader = Json.createReader(new StringReader(data));
         return parseJsonDef(reader.readObject());
     }

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -131,7 +131,7 @@ public class JsonParser {
             throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
 
         String mainModuleName = data.getString("mainModule");
-        JsonArray mods = data.getJsonArray("entryModules");
+        JsonArray mods = data.getJsonArray("modules");
         Set<FlatModule> entryModules = new HashSet<>();
         for (JsonObject m: mods.getValuesAs(JsonObject.class)) {
             entryModules.add(toFlatModule(m));

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -1,6 +1,21 @@
 // Copyright (c) 2015-2019 K Team. All Rights Reserved.
 package org.kframework.unparser;
 
+import org.kframework.attributes.Att;
+import org.kframework.definition.Associativity;
+import org.kframework.definition.Bubble;
+import org.kframework.definition.Context;
+import org.kframework.definition.Configuration;
+import org.kframework.definition.Definition;
+import org.kframework.definition.Module;
+import org.kframework.definition.ModuleComment;
+import org.kframework.definition.Production;
+import org.kframework.definition.Rule;
+import org.kframework.definition.Sentence;
+import org.kframework.definition.SyntaxAssociativity;
+import org.kframework.definition.SyntaxPriority;
+import org.kframework.definition.SyntaxSort;
+import org.kframework.definition.Tag;
 import org.kframework.kore.InjectedKLabel;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
@@ -30,10 +45,222 @@ import javax.json.JsonObjectBuilder;
 import javax.json.JsonWriter;
 import javax.json.JsonStructure;
 
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+import scala.collection.Set;
+import scala.Enumeration;
+
 /**
  * Writes a KAST term to the KAST Json format.
  */
 public class ToJson {
+
+    private DataOutputStream data;
+    private ToJson(DataOutputStream data) {
+        this.data = data;
+    }
+
+///////////////////////////////
+// ToJson Definition Objects //
+///////////////////////////////
+
+    public static byte[] apply(Definition def) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            DataOutputStream data = new DataOutputStream(out);
+            JsonWriter jsonWriter = Json.createWriter(data);
+
+            JsonObjectBuilder term = Json.createObjectBuilder();
+            term.add("format", "KAST");
+            term.add("version", 1);
+            term.add("term", toJson(def));
+
+            jsonWriter.write(term.build());
+            jsonWriter.close();
+            data.close();
+        } catch (IOException e) {
+            throw KEMException.criticalError("Could not write Definition to Json", e);
+        }
+        return out.toByteArray();
+    }
+
+    public static JsonStructure toJson(Definition def) {
+        JsonObjectBuilder jdef = Json.createObjectBuilder();
+
+        JsonArrayBuilder mods = Json.createArrayBuilder();
+        for (Module m : JavaConverters.setAsJavaSet(def.modules())) {
+            mods.add(toJson(m));
+        }
+
+        jdef.add("node", JsonParser.KDEFINITION);
+        jdef.add("mainModule", def.mainModule().name());
+        jdef.add("entryModules", mods);
+        jdef.add("att", toJson(def.att()));
+
+        return jdef.build();
+    }
+
+    public static JsonStructure toJson(Att att) {
+        JsonObjectBuilder jatt = Json.createObjectBuilder();
+        jatt.add("node", JsonParser.KATT);
+        jatt.add("att", att.toString());
+
+        return jatt.build();
+    }
+
+///////////////////////////
+// ToJson Module Objects //
+///////////////////////////
+
+    public static JsonStructure toJson(Module mod) {
+        JsonObjectBuilder jmod = Json.createObjectBuilder();
+
+        jmod.add("node", JsonParser.KMODULE);
+
+        JsonArrayBuilder imports = Json.createArrayBuilder();
+        for (String s: JavaConverters.setAsJavaSet(mod.importedModuleNames())) {
+            imports.add(s);
+        }
+
+        JsonArrayBuilder sentences = Json.createArrayBuilder();
+        for (Sentence s: JavaConverters.setAsJavaSet(mod.localSentences())) {
+            sentences.add(toJson(s));
+        }
+
+        jmod.add("name", mod.name());
+        jmod.add("imports", imports);
+        jmod.add("localSentences", sentences);
+        jmod.add("att", toJson(mod.att()));
+
+        return jmod.build();
+    }
+
+/////////////////////////////
+// ToJSon Sentence Objects //
+/////////////////////////////
+
+    public static JsonStructure toJson(Sentence sen) {
+        if (sen instanceof Context)             return toJson((Context) sen);
+        if (sen instanceof Rule)                return toJson((Rule) sen);
+        if (sen instanceof ModuleComment)       return toJson((ModuleComment) sen);
+        if (sen instanceof SyntaxPriority)      return toJson((SyntaxPriority) sen);
+        if (sen instanceof SyntaxAssociativity) return toJson((SyntaxAssociativity) sen);
+        if (sen instanceof Configuration)       return toJson((Configuration) sen);
+        if (sen instanceof Bubble)              return toJson((Bubble) sen);
+        if (sen instanceof SyntaxSort)          return toJson((SyntaxSort) sen);
+        if (sen instanceof Production)          return toJson((Production) sen);
+
+        JsonObjectBuilder jsen = Json.createObjectBuilder();
+        jsen.add("node", "badsentence");
+        return jsen.build();
+    }
+
+    public static JsonStructure toJson(Context con) {
+        JsonObjectBuilder jcon = Json.createObjectBuilder();
+
+        jcon.add("node", JsonParser.KCONTEXT);
+        jcon.add("body", toJson(con.body()));
+        jcon.add("requires", toJson(con.requires()));
+        jcon.add("att", toJson(con.att()));
+
+        return jcon.build();
+    }
+
+    public static JsonStructure toJson(Rule rule) {
+        JsonObjectBuilder jrule = Json.createObjectBuilder();
+
+        jrule.add("node", JsonParser.KRULE);
+        jrule.add("body", toJson(rule.body()));
+        jrule.add("requires", toJson(rule.requires()));
+        jrule.add("ensures", toJson(rule.ensures()));
+        jrule.add("att", toJson(rule.att()));
+
+        return jrule.build();
+    }
+
+    public static JsonStructure toJson(ModuleComment mcom) {
+        JsonObjectBuilder jmcom = Json.createObjectBuilder();
+
+        jmcom.add("node", JsonParser.KMODULECOMMENT);
+        jmcom.add("comment", mcom.comment());
+        jmcom.add("att", toJson(mcom.att()));
+
+        return jmcom.build();
+    }
+
+    public static JsonStructure toJson(SyntaxPriority syn) {
+        JsonObjectBuilder jsyn = Json.createObjectBuilder();
+
+        jsyn.add("node", JsonParser.KSYNTAXPRIORITY);
+
+        Seq<Set<Tag>> priSeq = syn.priorities();
+        JsonArrayBuilder priArray = Json.createArrayBuilder();
+        for (Set<Tag> pri : JavaConverters.seqAsJavaList(priSeq)) {
+            JsonArrayBuilder tagArray = Json.createArrayBuilder();
+            for (Tag t : JavaConverters.setAsJavaSet(pri)) {
+                tagArray.add(t.name());
+            }
+            priArray.add(tagArray);
+        }
+        jsyn.add("priorities", priArray);
+
+        jsyn.add("att", toJson(syn.att()));
+
+        return jsyn.build();
+    }
+
+    public static JsonStructure toJson(SyntaxAssociativity syn) {
+        JsonObjectBuilder jsyn = Json.createObjectBuilder();
+
+        jsyn.add("node", JsonParser.KSYNTAXASSOCIATIVITY);
+        jsyn.add("assoc", syn.assoc().toString());
+
+        JsonArrayBuilder tagArray = Json.createArrayBuilder();
+        for (Tag t : JavaConverters.setAsJavaSet(syn.tags())) {
+            tagArray.add(t.name());
+        }
+        jsyn.add("tags", tagArray);
+
+        jsyn.add("att", toJson(syn.att()));
+
+        return jsyn.build();
+    }
+
+    public static JsonStructure toJson(Configuration con) {
+        JsonObjectBuilder jcon = Json.createObjectBuilder();
+
+        jcon.add("node", JsonParser.KCONFIGURATION);
+
+        return jcon.build();
+    }
+
+    public static JsonStructure toJson(Bubble bub) {
+        JsonObjectBuilder jbub = Json.createObjectBuilder();
+
+        jbub.add("node", JsonParser.KBUBBLE);
+
+        return jbub.build();
+    }
+
+    public static JsonStructure toJson(SyntaxSort sort) {
+        JsonObjectBuilder jsort = Json.createObjectBuilder();
+
+        jsort.add("node", JsonParser.KSYNTAXSORT);
+
+        return jsort.build();
+    }
+
+    public static JsonStructure toJson(Production pro) {
+        JsonObjectBuilder jpro = Json.createObjectBuilder();
+
+        jpro.add("node", JsonParser.KPRODUCTION);
+
+        return jpro.build();
+    }
+
+//////////////////////
+// ToJson K Objects //
+//////////////////////
 
     public static void apply(OutputStream out, K k) {
         try {
@@ -57,11 +284,6 @@ public class ToJson {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         apply(out, k);
         return out.toByteArray();
-    }
-
-    private DataOutputStream data;
-    private ToJson(DataOutputStream data) {
-        this.data = data;
     }
 
     private static JsonStructure toJson(K k) {

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -102,7 +102,7 @@ public class ToJson {
 
         jdef.add("node", JsonParser.KDEFINITION);
         jdef.add("mainModule", def.mainModule().name());
-        jdef.add("entryModules", mods);
+        jdef.add("modules", mods);
         jdef.add("att", toJson(def.att()));
 
         return jdef.build();

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -127,7 +127,7 @@ public class ToJson {
     public static JsonStructure toJson(FlatModule mod) {
         JsonObjectBuilder jmod = Json.createObjectBuilder();
 
-        jmod.add("node", JsonParser.KMODULE);
+        jmod.add("node", JsonParser.KFLATMODULE);
 
         JsonArrayBuilder imports = Json.createArrayBuilder();
         mod.imports().foreach(i -> imports.add(i));

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -9,6 +9,7 @@ import org.kframework.definition.Configuration;
 import org.kframework.definition.Definition;
 import org.kframework.definition.NonTerminal;
 import org.kframework.definition.Module;
+import org.kframework.definition.FlatModule;
 import org.kframework.definition.ModuleComment;
 import org.kframework.definition.Production;
 import org.kframework.definition.ProductionItem;
@@ -120,19 +121,19 @@ public class ToJson {
 ///////////////////////////
 
     public static JsonStructure toJson(Module mod) {
+        return toJson(mod.flattened());
+    }
+
+    public static JsonStructure toJson(FlatModule mod) {
         JsonObjectBuilder jmod = Json.createObjectBuilder();
 
         jmod.add("node", JsonParser.KMODULE);
 
         JsonArrayBuilder imports = Json.createArrayBuilder();
-        for (String s: JavaConverters.setAsJavaSet(mod.importedModuleNames())) {
-            imports.add(s);
-        }
+        mod.imports().foreach(i -> imports.add(i));
 
         JsonArrayBuilder sentences = Json.createArrayBuilder();
-        for (Sentence s: JavaConverters.setAsJavaSet(mod.localSentences())) {
-            sentences.add(toJson(s));
-        }
+        mod.localSentences().foreach(s -> sentences.add(toJson(s)));
 
         jmod.add("name", mod.name());
         jmod.add("imports", imports);

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -271,37 +271,39 @@ public class ToJson {
             jpro.add("klabel", klabel.get().name());
         }
 
-        Seq<ProductionItem> items = pro.items();
         JsonArrayBuilder productionItems = Json.createArrayBuilder();
-        for (ProductionItem p : JavaConverters.seqAsJavaList(items)) {
-            JsonObjectBuilder obj = Json.createObjectBuilder();
-
-            if (p instanceof NonTerminal) {
-                NonTerminal t = (NonTerminal) p;
-                obj.add("node", JsonParser.KNONTERMINAL);
-                obj.add("sort", toJson(t.sort()));
-                Option<String> name = t.name();
-                if (! name.isEmpty())
-                    obj.add("name", name.get());
-            } else if (p instanceof RegexTerminal) {
-                RegexTerminal t = (RegexTerminal) p;
-                obj.add("node", JsonParser.KREGEXTERMINAL);
-                obj.add("precedeRegex", t.precedeRegex());
-                obj.add("regex", t.regex());
-                obj.add("followRegex", t.followRegex());
-            } else if (p instanceof Terminal) {
-                Terminal t = (Terminal) p;
-                obj.add("node", JsonParser.KTERMINAL);
-                obj.add("value", t.value());
-            }
-
-            productionItems.add(obj.build());
-        }
+        JavaConverters.seqAsJavaList(pro.items()).forEach(p -> productionItems.add(toJson(p)));
+        jpro.add("productionItems", productionItems.build());
 
         jpro.add("sort", toJson(pro.sort()));
         jpro.add("att", toJson(pro.att()));
 
         return jpro.build();
+    }
+
+    public static JsonObject toJson(ProductionItem prod) {
+        JsonObjectBuilder jsonProduction = Json.createObjectBuilder();
+
+        if (prod instanceof NonTerminal) {
+            NonTerminal t = (NonTerminal) prod;
+            jsonProduction.add("node", JsonParser.KNONTERMINAL);
+            jsonProduction.add("sort", toJson(t.sort()));
+            Option<String> name = t.name();
+            if (! name.isEmpty())
+                jsonProduction.add("name", name.get());
+        } else if (prod instanceof RegexTerminal) {
+            RegexTerminal t = (RegexTerminal) prod;
+            jsonProduction.add("node", JsonParser.KREGEXTERMINAL);
+            jsonProduction.add("precedeRegex", t.precedeRegex());
+            jsonProduction.add("regex", t.regex());
+            jsonProduction.add("followRegex", t.followRegex());
+        } else if (prod instanceof Terminal) {
+            Terminal t = (Terminal) prod;
+            jsonProduction.add("node", JsonParser.KTERMINAL);
+            jsonProduction.add("value", t.value());
+        }
+
+        return jsonProduction.build();
     }
 
     public static JsonStructure toJson(Sort sort) {

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -201,13 +201,10 @@ public class ToJson {
 
         jsyn.add("node", JsonParser.KSYNTAXPRIORITY);
 
-        Seq<Set<Tag>> priSeq = syn.priorities();
         JsonArrayBuilder priArray = Json.createArrayBuilder();
-        for (Set<Tag> pri : JavaConverters.seqAsJavaList(priSeq)) {
+        for (Set<Tag> pri : JavaConverters.seqAsJavaList(syn.priorities())) {
             JsonArrayBuilder tagArray = Json.createArrayBuilder();
-            for (Tag t : JavaConverters.setAsJavaSet(pri)) {
-                tagArray.add(t.name());
-            }
+            pri.foreach(t -> tagArray.add(t.name()));
             priArray.add(tagArray);
         }
         jsyn.add("priorities", priArray);
@@ -224,9 +221,7 @@ public class ToJson {
         jsyn.add("assoc", syn.assoc().toString());
 
         JsonArrayBuilder tagArray = Json.createArrayBuilder();
-        for (Tag t : JavaConverters.setAsJavaSet(syn.tags())) {
-            tagArray.add(t.name());
-        }
+        syn.tags().foreach(t -> tagArray.add(t.name()));
         jsyn.add("tags", tagArray);
 
         jsyn.add("att", toJson(syn.att()));

--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -114,6 +114,4 @@ case class FlatModule(name: String, imports: Set[String], localSentences: Set[Se
 
     newModule
   }
-
-  def hasName(name: String) : Boolean = this.name == name
 }

--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -114,4 +114,6 @@ case class FlatModule(name: String, imports: Set[String], localSentences: Set[Se
 
     newModule
   }
+
+  def hasName(name: String) : Boolean = this.name == name
 }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -84,6 +84,12 @@ object Module {
   def apply(name: String, unresolvedLocalSentences: Set[Sentence]): Module = {
     new Module(name, Set(), unresolvedLocalSentences, Att.empty)
   }
+
+  def apply(name: String, unresolvedLocalSentences: Set[Sentence], att: Att): Module = {
+    new Module(name, Set(), unresolvedLocalSentences, att)
+  }
+
+  def withName(name: String, modules: Set[Module]): Option[Module] = modules.find(M => M.name.equals(name))
 }
 
 case class Module(val name: String, val imports: Set[Module], localSentences: Set[Sentence], @(Nonnull@param) val att: Att = Att.empty)

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -84,12 +84,6 @@ object Module {
   def apply(name: String, unresolvedLocalSentences: Set[Sentence]): Module = {
     new Module(name, Set(), unresolvedLocalSentences, Att.empty)
   }
-
-  def apply(name: String, unresolvedLocalSentences: Set[Sentence], att: Att): Module = {
-    new Module(name, Set(), unresolvedLocalSentences, att)
-  }
-
-  def withName(name: String, modules: Set[Module]): Option[Module] = modules.find(M => M.name.equals(name))
 }
 
 case class Module(val name: String, val imports: Set[Module], localSentences: Set[Sentence], @(Nonnull@param) val att: Att = Att.empty)

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -313,16 +313,8 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
     case m: Module => m.name == name && m.sentences == sentences
   }
 
-  def toFlatModules() : (String, Set[FlatModule]) = {
-    var flatSelf = new FlatModule(name, importedModuleNames, sentences, att)
-    var flatModules = Set(flatSelf) ++
-      (imports.size match {
-        case 0 => Set()
-        case _ => imports.map(m => m.toFlatModules._2).flatten
-      })
-    (name, flatModules)
-  }
-
+  def flattened()   : FlatModule                = new FlatModule(name, importedModuleNames, sentences, att)
+  def flatModules() : (String, Set[FlatModule]) = (name, Set(flattened) ++ imports.map(m => m.flatModules._2).flatten)
 }
 
 object Import {

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -313,7 +313,7 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
     case m: Module => m.name == name && m.sentences == sentences
   }
 
-  def flattened()   : FlatModule                = new FlatModule(name, importedModuleNames, sentences, att)
+  def flattened()   : FlatModule                = new FlatModule(name, imports.map(m => m.name), sentences, att)
   def flatModules() : (String, Set[FlatModule]) = (name, Set(flattened) ++ imports.map(m => m.flatModules._2).flatten)
 }
 


### PR DESCRIPTION
-   Improvements to `pyk` serialization to files when running `{krun,kast,kprove}JSON` functions.
-   Add function which splits configuration from substitution to pyk.
-   Add definition JSON serialization/deserialization methods.
-   Add `--emit-json` option to Kompile which emits the json serialized definition to the `-kompiled` directory (and test of it).