### PR TITLE
haskell-backend: Build in parallel

### DIFF
--- a/haskell-backend/pom.xml
+++ b/haskell-backend/pom.xml
@@ -42,10 +42,12 @@
               <target>
                 <exec executable="stack" dir="${project.basedir}/src/main/native/haskell-backend" failonerror="true">
                   <arg value="build" />
+                  <arg value="--only-dependencies" />
                 </exec>
                 <mkdir dir="${project.build.directory}/stack-install" />
                 <exec executable="stack" dir="${project.basedir}/src/main/native/haskell-backend" failonerror="true">
                   <arg value="install" />
+                  <arg value="--ghc-options=-j" />
                   <arg value="--local-bin-path" />
                   <arg value="${project.build.directory}/stack-install" />
                 </exec>


### PR DESCRIPTION
This brings the build time for the Haskell backend down from 3m14s to 2m40s on my machine, with all dependency packages cached.