### PR TITLE
Always generate unique id map

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -138,7 +138,8 @@ public class KoreBackend implements Backend {
         Function1<Definition, Definition> resolveFreshConstants = d -> DefinitionTransformer.from(m -> GeneratedTopFormat.resolve(new ResolveFreshConstants(d, true).resolve(m)), "resolving !Var variables").apply(d);
         GenerateCoverage cov = new GenerateCoverage(kompileOptions.coverage, files);
         Function1<Definition, Definition> genCoverage = d -> DefinitionTransformer.fromRuleBodyTransformerWithRule((r, body) -> cov.gen(r, body, d.mainModule()), "generate coverage instrumentation").apply(d);
-        DefinitionTransformer numberSentences = DefinitionTransformer.fromSentenceTransformer(new NumberSentences()::number, "number sentences uniquely");
+        NumberSentences numSents = new NumberSentences(files);
+        DefinitionTransformer numberSentences = DefinitionTransformer.fromSentenceTransformer(numSents::number, "number sentences uniquely");
         Function1<Definition, Definition> resolveConfigVar = d -> DefinitionTransformer.fromSentenceTransformer(new ResolveFunctionWithConfig(d, true)::resolveConfigVar, "Adding configuration variable to lhs").apply(d);
         Function1<Definition, Definition> resolveIO = (d -> Kompile.resolveIOStreams(kem, d));
 
@@ -149,6 +150,7 @@ public class KoreBackend implements Backend {
                 .andThen(resolveAnonVars)
                 .andThen(d -> new ResolveContexts(kompileOptions).resolve(d))
                 .andThen(numberSentences)
+                .andThen(d -> { numSents.close(); return d; })
                 .andThen(resolveHeatCoolAttribute)
                 .andThen(resolveSemanticCasts)
                 .andThen(subsortKItem)
@@ -164,7 +166,6 @@ public class KoreBackend implements Backend {
                 .andThen(d -> Strategy.addStrategyRuleToMainModule(def.mainModule().name()).apply(d))
                 .andThen(ConcretizeCells::transformDefinition)
                 .andThen(genCoverage)
-                .andThen(d -> { cov.close(); return d; })
                 .andThen(Kompile::addSemanticsModule)
                 .andThen(resolveConfigVar)
                 .andThen(addCoolLikeAtt)

--- a/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
@@ -1,7 +1,6 @@
 // Copyright (c) 2018-2019 K Team. All Rights Reserved.
 package org.kframework.compile;
 
-import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
 import org.kframework.builtin.Sorts;
 import org.kframework.compile.RewriteToTop;
@@ -10,31 +9,17 @@ import org.kframework.definition.Rule;
 import org.kframework.kore.K;
 import org.kframework.kore.Sort;
 import org.kframework.utils.StringUtil;
-import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.file.FileUtil;
-import org.kframework.utils.file.JarInfo;
-
-import java.io.BufferedWriter;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.PrintWriter;
 
 import static org.kframework.kore.KORE.*;
 
-public class GenerateCoverage implements AutoCloseable {
+public class GenerateCoverage {
     private final boolean cover;
     private final FileUtil files;
-    private final PrintWriter allRulesFile;
 
     public GenerateCoverage(boolean cover, FileUtil files) {
         this.cover = cover;
         this.files = files;
-        files.resolveKompiled(".").mkdirs();
-        try {
-            allRulesFile = new PrintWriter(new BufferedWriter(new FileWriter(files.resolveKompiled("allRules.txt").getAbsolutePath())));
-        } catch (IOException e) {
-            throw KEMException.internalError("Could not write list of rules to coverage document.", e);
-        }
     }
 
     public K gen(Rule r, K body, Module mod) {
@@ -43,17 +28,8 @@ public class GenerateCoverage implements AutoCloseable {
         }
         K left = RewriteToTop.toLeft(body);
         K right = RewriteToTop.toRight(body);
-        String file = r.att().get(Source.class).source();
-        if (file.startsWith(JarInfo.getKBase())) {
-            return body;
-        }
-        int line = r.att().get(Location.class).startLine();
-        int col = r.att().get(Location.class).startColumn();
-        String loc = file + ":" + line + ":" + col;
         String id = r.att().get("UNIQUE_ID");
-        allRulesFile.print(id);
-        allRulesFile.print(" ");
-        allRulesFile.println(loc);
+
         if (ExpandMacros.isMacro(r)) {
             //handled by macro expander
             return body;
@@ -72,10 +48,5 @@ public class GenerateCoverage implements AutoCloseable {
         }
 
         return KRewrite(left, k);
-    }
-
-    @Override
-    public void close() {
-      allRulesFile.close();
     }
 }

--- a/kernel/src/main/java/org/kframework/compile/NumberSentences.java
+++ b/kernel/src/main/java/org/kframework/compile/NumberSentences.java
@@ -11,6 +11,8 @@ import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.JarInfo;
 
+import java.util.Optional;
+
 import java.io.BufferedWriter;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -33,9 +35,15 @@ public class NumberSentences implements AutoCloseable {
 
     public Sentence number(Sentence s) {
         String id = ruleHash(s.withAtt(Att.empty()));
-        String file = s.att().get(Source.class).source();
-        int line = s.att().get(Location.class).startLine();
-        int col = s.att().get(Location.class).startColumn();
+        Optional<Source> optFile = s.att().getOptional(Source.class);
+        Optional<Location> optLine = s.att().getOptional(Location.class);
+        Optional<Location> optCol = s.att().getOptional(Location.class);
+        if (! (optFile.isPresent() && optLine.isPresent() && optCol.isPresent())) {
+            return s;
+        }
+        String file = optFile.get().source();
+        int line = optLine.get().startLine();
+        int col = optCol.get().startColumn();
         String loc = file + ":" + line + ":" + col;
         allRulesFile.print(id);
         allRulesFile.print(" ");

--- a/kernel/src/main/java/org/kframework/compile/NumberSentences.java
+++ b/kernel/src/main/java/org/kframework/compile/NumberSentences.java
@@ -7,6 +7,7 @@ import org.kframework.attributes.Att;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Sentence;
+import org.kframework.definition.Rule;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.JarInfo;
@@ -34,6 +35,9 @@ public class NumberSentences implements AutoCloseable {
     }
 
     public Sentence number(Sentence s) {
+        if (!(s instanceof Rule)) {
+            return s;
+        }
         String id = ruleHash(s.withAtt(Att.empty()));
         Optional<Source> optFile = s.att().getOptional(Source.class);
         Optional<Location> optLine = s.att().getOptional(Location.class);

--- a/kernel/src/main/java/org/kframework/compile/NumberSentences.java
+++ b/kernel/src/main/java/org/kframework/compile/NumberSentences.java
@@ -4,18 +4,55 @@ package org.kframework.compile;
 import org.bouncycastle.jcajce.provider.digest.SHA3;
 import org.bouncycastle.util.encoders.Hex;
 import org.kframework.attributes.Att;
+import org.kframework.attributes.Location;
+import org.kframework.attributes.Source;
 import org.kframework.definition.Sentence;
+import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.file.FileUtil;
+import org.kframework.utils.file.JarInfo;
 
-public class NumberSentences {
+import java.io.BufferedWriter;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class NumberSentences implements AutoCloseable {
+
+    private final FileUtil files;
+    private final PrintWriter allRulesFile;
+
+    public NumberSentences(FileUtil files) {
+        this.files = files;
+        files.resolveKompiled(".").mkdirs();
+        try {
+            allRulesFile = new PrintWriter(new BufferedWriter(new FileWriter(files.resolveKompiled("allRules.txt").getAbsolutePath())));
+        } catch (IOException e) {
+            throw KEMException.internalError("Could not write list of rules to coverage document.", e);
+        }
+    }
+
     public Sentence number(Sentence s) {
-      return s.withAtt(s.att().add("UNIQUE_ID", ruleHash(s.withAtt(Att.empty()))));
+        String id = ruleHash(s.withAtt(Att.empty()));
+        String file = s.att().get(Source.class).source();
+        int line = s.att().get(Location.class).startLine();
+        int col = s.att().get(Location.class).startColumn();
+        String loc = file + ":" + line + ":" + col;
+        allRulesFile.print(id);
+        allRulesFile.print(" ");
+        allRulesFile.println(loc);
+        return s.withAtt(s.att().add("UNIQUE_ID", id));
     }
 
     private String ruleHash(Sentence s) {
-      String text = new NormalizeVariables().normalize(s).toString();
-      SHA3.Digest256 sha3engine = new SHA3.Digest256();
-      byte[] digest = sha3engine.digest(text.getBytes());
-      String digestString = Hex.toHexString(digest);
-      return digestString;
+        String text = new NormalizeVariables().normalize(s).toString();
+        SHA3.Digest256 sha3engine = new SHA3.Digest256();
+        byte[] digest = sha3engine.digest(text.getBytes());
+        String digestString = Hex.toHexString(digest);
+        return digestString;
+    }
+
+    @Override
+    public void close() {
+      allRulesFile.close();
     }
 }


### PR DESCRIPTION
Fixes: runtimeverification/firefly#36

-   Move the logic for generating `allRules.txt` over to `NumberSentences` so it always happens.
-   Fail gracefully when a given sentence doesn't have source information.