### PR TITLE
Structured JSON serialized attributes

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -288,10 +288,14 @@ public class JsonParser {
 //////////////////////
 
     public static Att toAtt(JsonObject data) throws IOException {
-        if (! data.getString("node").equals(KATT))
-            throw KEMException.criticalError("Unexpected node found in KAST Json term: " + data.getString("node"));
-
-        return Att.empty();
+        if (! (data.getString("node").equals(KATT) && data.containsKey("att")))
+            throw KEMException.criticalError("Unexpected node found in KAST Json term when unparsing KATT: " + data.getString("node"));
+        JsonObject attMap = data.getJsonObject("att");
+        Att newAtt = Att.empty();
+        for (String key: attMap.keySet()) {
+            newAtt = newAtt.add(key, attMap.getString(key));
+        }
+        return newAtt;
     }
 
 ////////////////////

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -116,7 +116,7 @@ public class ToJson {
 
         JsonObjectBuilder jattKeys = Json.createObjectBuilder();
         for (Tuple2<String,String> key: JavaConverters.seqAsJavaList(att.att().keys().toSeq())) {
-            jattKeys.add(key._1(), att.get(key._1()));
+            jattKeys.add(key._1(), att.att().get(key).get().toString());
         }
         jatt.add("att", jattKeys.build());
 

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -55,6 +55,7 @@ import javax.json.JsonStructure;
 
 import scala.Enumeration;
 import scala.Option;
+import scala.Tuple2;
 import scala.collection.JavaConverters;
 import scala.collection.Seq;
 import scala.collection.Set;
@@ -112,7 +113,12 @@ public class ToJson {
     public static JsonStructure toJson(Att att) {
         JsonObjectBuilder jatt = Json.createObjectBuilder();
         jatt.add("node", JsonParser.KATT);
-        jatt.add("att", att.toString());
+
+        JsonObjectBuilder jattKeys = Json.createObjectBuilder();
+        for (Tuple2<String,String> key: JavaConverters.seqAsJavaList(att.att().keys().toSeq())) {
+            jattKeys.add(key._1(), att.get(key._1()));
+        }
+        jatt.add("att", jattKeys.build());
 
         return jatt.build();
     }


### PR DESCRIPTION
-   Serialize attributes in more structured manner.
-   Corresponding deserializer.

It's not perfect, because we're not preserving class information, but it's much better than calling `toString` on serialization and ignoring the attributes on deserialization.