### PR TITLE
Remaining json serialization for pyk

### DIFF
--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -90,7 +90,7 @@ def isKBubble(k):
     return k['node'] == 'KBubble'
 
 def KModuleComment(comment, att = None):
-    return { "node": "KModuleComment", "commonte": comment, "att": att }
+    return { "node": "KModuleComment", "comment": comment, "att": att }
 
 def isKModuleComment(k):
     return k['node'] == 'KModuleComment'

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -83,11 +83,65 @@ def KRule(rule, requires = None, ensures = None, att = None):
 def isKRule(k):
     return k["node"] == "KRule"
 
-def KImport(kimport):
-    return { "node": "KImport", "import": kimport }
+def KBubble(sentenceType, contents, att = None):
+    return { "node": "KBubble", "sentenceType": sentenceType, "contents": contents, "att": att }
 
-def isKImport(k):
-    return k["node"] == "KImport"
+def isKBubble(k):
+    return k['node'] == 'KBubble'
+
+def KModuleComment(comment, att = None):
+    return { "node": "KModuleComment", "commonte": comment, "att": att }
+
+def isKModuleComment(k):
+    return k['node'] == 'KModuleComment'
+
+def KProduction(productionItems, sort, att = None):
+    return { "node": "KProduction", "productionItems": productionItems, "sort": sort, "att": att }
+
+def isKProduction(k):
+    return k['node'] == 'KProduction'
+
+def KNonTerminal(sort):
+    return { "node": "KNonTerminal", "sort": sort }
+
+def isKNonTerminal(k):
+    return k['node'] == 'KNonTerminal'
+
+def KTerminal(value):
+    return { "node": "KTerminal", "value": value}
+
+def isKTerminal(k):
+    return k['node'] == 'KTerminal'
+
+def KRegexTerminal(regex, precedeRegex = None, followRegex = None):
+    return { "node": "KRegexTerminal", "regex": regex, "precedeRegex": precedeRegex, "followRegex": followRegex }
+
+def isKRegexTerminal(k):
+    return k['node'] == 'KRegexTerminal'
+
+def KSort(name):
+    return { "node": "KSort", "name": name }
+
+def isKSort(k):
+    return k['node'] == 'KSort'
+
+def KSyntaxAssociativity(assoc, tags = [], att = None):
+    return { "node": "KSyntaxAssociativity", "assoc": assoc, "tags": tags, "att": att }
+
+def isKSyntaxAssociativity(k):
+    return k['node'] == 'KSyntaxAssociativity'
+
+def KSyntaxPriority(priorities = [], att = None):
+    return { "node": "KSyntaxPriority", "priorities": priorities, "att": att }
+
+def isKSyntaxPriority(k):
+    return k['node'] == 'KSyntaxPriority'
+
+def KSyntaxSort(sort, att = None):
+    return { "node": "KSyntaxSort", "sort": sort, "att": att }
+
+def isKSyntaxSort(k):
+    return k['node'] == 'KSyntaxSort'
 
 def KFlatModule(name, imports, localSentences, att = None):
     return { "node": "KFlatModule", "name": name, "imports": imports, "localSentences": localSentences, "att": att }
@@ -261,11 +315,9 @@ def prettyPrintKast(kast, symbolTable):
             return kastStr
         else:
             return kastStr + "(" + str(kast["value"]) + ")"
-    if isKImport(kast):
-        return "imports " + kast["import"]
     if isKFlatModule(kast):
         name = kast["name"]
-        imports = "\n".join([prettyPrintKast(kimport, symbolTable) for kimport in kast["imports"]])
+        imports = "\n".join(['import ' + kimport for kimport in kast["imports"]])
         localSentences = "\n\n".join([prettyPrintKast(sent, symbolTable) for sent in kast["localSentences"]])
         contents = imports + "\n\n" + localSentences
         return "module " + name                    + "\n    " \

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -71,8 +71,8 @@ def KAtt(key, value):
 def isKAtt(k):
     return k["node"] == "KAtt"
 
-def KRule(rule, requires = None, ensures = None, atts = None):
-    return { "node": "KRule", "body": rule, "requires": requires, "ensures": ensures, "atts": atts }
+def KRule(rule, requires = None, ensures = None, att = None):
+    return { "node": "KRule", "body": rule, "requires": requires, "ensures": ensures, "att": att }
 
 def isKRule(k):
     return k["node"] == "KRule"
@@ -83,8 +83,8 @@ def KImport(kimport):
 def isKImport(k):
     return k["node"] == "KImport"
 
-def KFlatModule(name, imports, localSentences, atts = None):
-    return { "node": "KFlatModule", "name": name, "imports": imports, "localSentences": localSentences, "atts": atts }
+def KFlatModule(name, imports, localSentences, att = None):
+    return { "node": "KFlatModule", "name": name, "imports": imports, "localSentences": localSentences, "att": att }
 
 def isKFlatModule(k):
     return k["node"] == "KFlatModule"
@@ -95,8 +95,8 @@ def KRequire(krequire):
 def isKRequire(k):
     return k["node"] == "KRequire"
 
-def KDefinition(mainModule, modules, requires = None, atts = None):
-    return { "node": "KDefinition", "mainModule": mainModule, "modules": modules, "requires": requires, "atts": atts }
+def KDefinition(mainModule, modules, requires = None, att = None):
+    return { "node": "KDefinition", "mainModule": mainModule, "modules": modules, "requires": requires, "att": att }
 
 def isKDefinition(k):
     return k["node"] == "KDefinition"
@@ -104,14 +104,14 @@ def isKDefinition(k):
 def isCellKLabel(label):
     return len(label) > 1 and label[0] == "<" and label[-1] == ">"
 
-def addAttributes(kast, atts):
+def addAttributes(kast, att):
     if isKRule(kast):
         newAtts = []
-        if kast["atts"] is None:
-            newAtts = atts
+        if kast["att"] is None:
+            newAtts = att
         else:
-            newAtts.extend(kast["atts"])
-        return KRule(kast["rule"], requires = kast["requires"], ensures = kast["ensures"], atts = newAtts)
+            newAtts.extend(kast["att"])
+        return KRule(kast["body"], requires = kast["requires"], ensures = kast["ensures"], att = newAtts)
     else:
         notif("Don't know how to add attributes to KAST!")
         print(kast)
@@ -232,7 +232,7 @@ def prettyPrintKast(kast, symbolTable):
             unparsedKSequence = "    " + unparsedKSequence
         return unparsedKSequence
     if isKRule(kast):
-        body     = "\n     ".join(prettyPrintKast(kast["rule"], symbolTable).split("\n"))
+        body     = "\n     ".join(prettyPrintKast(kast["body"], symbolTable).split("\n"))
         ruleStr = "rule " + body
         requiresStr = ""
         ensuresStr  = ""
@@ -243,8 +243,8 @@ def prettyPrintKast(kast, symbolTable):
         if kast["ensures"] is not None:
             ensuresStr = prettyPrintKast(kast["ensures"], symbolTable)
             ensuresStr = "\n  ensures " + "\n  ".join(ensuresStr.split("\n"))
-        if kast["atts"] is not None:
-            attsStr = ", ".join([prettyPrintKast(att, symbolTable) for att in kast["atts"]])
+        if kast["att"] is not None:
+            attsStr = ", ".join([prettyPrintKast(att, symbolTable) for att in kast["att"]])
             attsStr = "\n  [" + attsStr + "]"
         return ruleStr + requiresStr + ensuresStr + attsStr
     if isKAtt(kast):

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -65,6 +65,12 @@ def KToken(token, sort):
 def isKToken(k):
     return k["node"] == "KToken"
 
+def KRewrite(lhs, rhs, att = None):
+    return { "node": "KRewrite", "lhs": lhs, "rhs": rhs, "att": att }
+
+def isKRewrite(k):
+    return k["node"] == "KRewrite"
+
 def KAtt(key, value):
     return {"node": "KAtt", "key": key, "value": value}
 
@@ -117,7 +123,6 @@ def addAttributes(kast, att):
         print(kast)
         sys.exit(1)
 
-klabelRewrite = "#KRewrite"
 klabelCells   = "#KCells"
 klabelEmptyK  = "#EmptyK"
 
@@ -159,8 +164,7 @@ def underbarUnparsing(symbol):
 def indent(input):
     return "\n".join(["  " + l for l in input.split("\n")])
 
-K_builtin_labels = { klabelRewrite : binOpStr("=>")
-                   , klabelCells   : (lambda *args: "\n".join(args))
+K_builtin_labels = { klabelCells   : (lambda *args: "\n".join(args))
                    , klabelEmptyK  : (lambda : ".")
                    }
 
@@ -225,6 +229,10 @@ def prettyPrintKast(kast, symbolTable):
             return cellStr.rstrip()
         unparser = appliedLabelStr(label) if label not in symbolTable else symbolTable[label]
         return unparser(*unparsedArgs)
+    if isKRewrite(kast):
+        lhsStr = prettyPrintKast(kast["lhs"], symbolTable)
+        rhsStr = prettyPrintKast(kast["rhs"], symbolTable)
+        return lhsStr + " => " + rhsStr
     if isKSequence(kast):
         unparsedItems = [ prettyPrintKast(item, symbolTable) for item in kast['items'] ]
         unparsedKSequence = "\n~> ".join(unparsedItems)

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -308,11 +308,12 @@ def prettyPrintKast(kast, symbolTable):
             attsStr = "\n  [" + attsStr + "]"
         return ruleStr + requiresStr + ensuresStr + attsStr
     if isKAtt(kast):
-        kastStr = kast["key"]
-        if kast["value"] == True:
-            return kastStr
-        else:
-            return kastStr + "(" + str(kast["value"]) + ")"
+        if len(kast['att']) == 0:
+            return ''
+        attStr = ''
+        for att in kast['att'].keys():
+            attStr += att + '(' + kast['att'][att] + ')'
+        return '[' + attStr + ']'
     if isKFlatModule(kast):
         name = kast["name"]
         imports = "\n".join(['import ' + kimport for kimport in kast["imports"]])

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -71,8 +71,8 @@ def KRewrite(lhs, rhs, att = None):
 def isKRewrite(k):
     return k["node"] == "KRewrite"
 
-def KAtt(key, value):
-    return {"node": "KAtt", "key": key, "value": value}
+def KAtt(atts = {}):
+    return {"node": "KAtt", "att": atts}
 
 def isKAtt(k):
     return k["node"] == "KAtt"
@@ -165,16 +165,14 @@ def isCellKLabel(label):
     return len(label) > 1 and label[0] == "<" and label[-1] == ">"
 
 def addAttributes(kast, att):
+    if isKAtt(kast):
+        return KAtt(combineDicts(att, kast['att']))
     if isKRule(kast):
-        newAtts = []
-        if kast["att"] is None:
-            newAtts = att
-        else:
-            newAtts.extend(kast["att"])
-        return KRule(kast["body"], requires = kast["requires"], ensures = kast["ensures"], att = newAtts)
+        return KRule(kast['body'], requires = kast['requires'], ensures = kast['ensures'], att = addAttributes(kast['att'], att))
     else:
-        notif("Don't know how to add attributes to KAST!")
-        print(kast)
+        notif('Do not know how to add attributes to KAST!')
+        sys.stderr.write(kast)
+        sys.stderr.flush()
         sys.exit(1)
 
 klabelCells   = "#KCells"

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -72,7 +72,7 @@ def isKAtt(k):
     return k["node"] == "KAtt"
 
 def KRule(rule, requires = None, ensures = None, atts = None):
-    return { "node": "KRule", "rule": rule, "requires": requires, "ensures": ensures, "atts": atts }
+    return { "node": "KRule", "body": rule, "requires": requires, "ensures": ensures, "atts": atts }
 
 def isKRule(k):
     return k["node"] == "KRule"

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -286,7 +286,7 @@ def prettyPrintKast(kast, symbolTable):
     if isKRewrite(kast):
         lhsStr = prettyPrintKast(kast["lhs"], symbolTable)
         rhsStr = prettyPrintKast(kast["rhs"], symbolTable)
-        return lhsStr + " => " + rhsStr
+        return "( " + lhsStr + " => " + rhsStr + " )"
     if isKSequence(kast):
         unparsedItems = [ prettyPrintKast(item, symbolTable) for item in kast['items'] ]
         unparsedKSequence = "\n~> ".join(unparsedItems)

--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -296,16 +296,13 @@ def prettyPrintKast(kast, symbolTable):
         ruleStr = "rule " + body
         requiresStr = ""
         ensuresStr  = ""
-        attsStr     = ""
+        attsStr     = prettyPrintKast(kast['att'], symbolTable)
         if kast["requires"] is not None:
             requiresStr = prettyPrintKast(kast["requires"], symbolTable)
             requiresStr = "\n  requires " + "\n   ".join(requiresStr.split("\n"))
         if kast["ensures"] is not None:
             ensuresStr = prettyPrintKast(kast["ensures"], symbolTable)
             ensuresStr = "\n  ensures " + "\n  ".join(ensuresStr.split("\n"))
-        if kast["att"] is not None:
-            attsStr = ", ".join([prettyPrintKast(att, symbolTable) for att in kast["att"]])
-            attsStr = "\n  [" + attsStr + "]"
         return ruleStr + requiresStr + ensuresStr + attsStr
     if isKAtt(kast):
         if len(kast['att']) == 0:

--- a/k-distribution/src/main/scripts/lib/pyk/kastManip.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kastManip.py
@@ -213,10 +213,10 @@ def uselessVarsToDots(kast, requires = None, ensures = None):
     return traverseBottomUp(kast, _collapseUselessVars)
 
 def minimizeRule(rule):
-    ruleBody     = rule["rule"]
+    ruleBody     = rule["body"]
     ruleRequires = rule["requires"]
     ruleEnsures  = rule["ensures"]
-    ruleAtts     = rule["atts"]
+    ruleAtts     = rule["att"]
 
     if ruleRequires is not None:
         constraints = flattenLabel("_andBool_", ruleRequires)
@@ -246,7 +246,7 @@ def minimizeRule(rule):
     if (ruleRequires == KToken("true", "Bool")):
         ruleRequires = None
 
-    return KRule(ruleBody, requires = ruleRequires, ensures = ruleEnsures, atts = ruleAtts)
+    return KRule(ruleBody, requires = ruleRequires, ensures = ruleEnsures, att = ruleAtts)
 
 def readKastTerm(termPath):
     with open(termPath, "r") as termFile:

--- a/k-distribution/src/main/scripts/lib/pyk/kastManip.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kastManip.py
@@ -148,27 +148,28 @@ def collapseDots(kast):
             args  = _kast["args"]
             if isCellKLabel(label) and len(args) == 1 and args[0] == ktokenDots:
                 return ktokenDots
-            if label == klabelRewrite and args[0] == ktokenDots:
-                return ktokenDots
             newArgs = [ arg for arg in args if arg != ktokenDots ]
             if isCellKLabel(label) and len(newArgs) == 0:
                 return ktokenDots
             if len(newArgs) < len(args):
                 newArgs.append(ktokenDots)
             return KApply(label, newArgs)
+        elif isKRewrite(_kast):
+            if _kast["lhs"] == ktokenDots:
+                return ktokenDots
         return _kast
     return traverseBottomUp(kast, _collapseDots)
 
 def pushDownRewrites(kast):
     def _pushDownRewrites(_kast):
-        if isKApply(_kast) and _kast["label"] == klabelRewrite:
-            lhs = _kast["args"][0]
-            rhs = _kast["args"][1]
+        if isKRewrite(_kast):
+            lhs = _kast["lhs"]
+            rhs = _kast["rhs"]
             if lhs == rhs:
                 return lhs
             if  isKApply(lhs) and isKApply(rhs) and lhs["label"] == rhs["label"] and isCellKLabel(lhs["label"]) \
             and len(lhs["args"]) == len(rhs["args"]):
-                    newArgs = [ KApply(klabelRewrite, [lArg, rArg]) for (lArg, rArg) in zip(lhs["args"], rhs["args"]) ]
+                    newArgs = [ KRewrite(lArg, rArg) for (lArg, rArg) in zip(lhs["args"], rhs["args"]) ]
                     return KApply(lhs["label"], newArgs)
         return _kast
     return traverseTopDown(kast, _pushDownRewrites)

--- a/k-distribution/src/main/scripts/lib/pyk/kastManip.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kastManip.py
@@ -121,6 +121,14 @@ def flattenLabel(label, kast):
     return [kast]
 
 def splitConfigFrom(configuration):
+    """Split the substitution from a given configuration.
+
+    Given an input configuration `config`, will return a tuple `(symbolic_config, subst)`, where:
+
+        1.  `config == substitute(symbolic_config, subst)`
+        2.  `symbolic_config` is the same configuration structure, but where the contents of leaf cells is replaced with a fresh KVariable.
+        3.  `subst` is the substitution for the generated KVariables back to the original configuration contents.
+    """
     initial_substitution = {}
     _mkCellVar = lambda label: label.replace('-', '_').replace('<', '').replace('>', '').upper() + '_CELL'
     def _replaceWithVar(k):

--- a/k-distribution/tests/pyk/build-config.py
+++ b/k-distribution/tests/pyk/build-config.py
@@ -22,7 +22,7 @@ kast_term = readKastTerm(sys.argv[1])
 if isKRule(kast_term):
     kast_term = minimizeRule(kast_term)
     defn_name = sys.argv[1][:-5].split("/")[1]
-    mod = KFlatModule(defn_name.upper(), [KImport("IMP")], [kast_term])
+    mod = KFlatModule(defn_name.upper(), ["IMP"], [kast_term])
     kast_term = KDefinition(defn_name, [mod], requires = [KRequire("imp")])
 elif isKApply(kast_term):
     kast_term = simplifyBool(kast_term)

--- a/k-distribution/tests/pyk/proof-tests/simple-add-spec.json
+++ b/k-distribution/tests/pyk/proof-tests/simple-add-spec.json
@@ -3,55 +3,35 @@
   "version": 1,
   "term": {
     "node": "KRule",
-    "rule":
-      {
+    "body": {
+      "node": "KRewrite",
+      "lhs": {
         "node": "KApply",
-        "label": "#KRewrite",
+        "label": "<T>",
         "variable": false,
         "arity": 2,
         "args": [
           {
             "node": "KApply",
-            "label": "<T>",
+            "label": "<k>",
             "variable": false,
-            "arity": 2,
+            "arity": 1,
             "args": [
               {
                 "node": "KApply",
-                "label": "<k>",
+                "label": "_+_",
                 "variable": false,
-                "arity": 1,
-                "args": [
-                  {
-                    "node": "KApply",
-                    "label": "_+_",
-                    "variable": false,
-                    "arity": 2,
-                    "args": [
-                      {
-                        "node": "KVariable",
-                        "name": "X:Int",
-                        "originalName": "X:Int"
-                      },
-                      {
-                        "node": "KVariable",
-                        "name": "Y:Int",
-                        "originalName": "Y:Int"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "node": "KApply",
-                "label": "<state>",
-                "variable": false,
-                "arity": 1,
+                "arity": 2,
                 "args": [
                   {
                     "node": "KVariable",
-                    "name": "STATE:Map",
-                    "originalName": "STATE:Map"
+                    "name": "X:Int",
+                    "originalName": "X:Int"
+                  },
+                  {
+                    "node": "KVariable",
+                    "name": "Y:Int",
+                    "originalName": "Y:Int"
                   }
                 ]
               }
@@ -59,73 +39,86 @@
           },
           {
             "node": "KApply",
-            "label": "<T>",
+            "label": "<state>",
             "variable": false,
-            "arity": 2,
+            "arity": 1,
             "args": [
               {
-                "node": "KApply",
-                "label": "<k>",
-                "variable": false,
-                "arity": 1,
-                "args": [
-                  {
-                    "node": "KApply",
-                    "label": "_+Int_",
-                    "variable": false,
-                    "arity": 2,
-                    "args": [
-                      {
-                        "node": "KVariable",
-                        "name": "X:Int",
-                        "originalName": "X:Int"
-                      },
-                      {
-                        "node": "KVariable",
-                        "name": "Y:Int",
-                        "originalName": "Y:Int"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "node": "KApply",
-                "label": "<state>",
-                "variable": false,
-                "arity": 1,
-                "args": [
-                  {
-                    "node": "KVariable",
-                    "name": "STATE:Map",
-                    "originalName": "STATE:Map"
-                  }
-                ]
+                "node": "KVariable",
+                "name": "STATE:Map",
+                "originalName": "STATE:Map"
               }
             ]
           }
         ]
       },
-    "requires":
-      {
+      "rhs": {
         "node": "KApply",
-        "label": "_andBool_",
+        "label": "<T>",
         "variable": false,
         "arity": 2,
         "args": [
           {
-            "node": "KToken",
-            "sort": "Bool",
-            "token": "true"
+            "node": "KApply",
+            "label": "<k>",
+            "variable": false,
+            "arity": 1,
+            "args": [
+              {
+                "node": "KApply",
+                "label": "_+Int_",
+                "variable": false,
+                "arity": 2,
+                "args": [
+                  {
+                    "node": "KVariable",
+                    "name": "X:Int",
+                    "originalName": "X:Int"
+                  },
+                  {
+                    "node": "KVariable",
+                    "name": "Y:Int",
+                    "originalName": "Y:Int"
+                  }
+                ]
+              }
+            ]
           },
           {
-            "node": "KToken",
-            "sort": "Bool",
-            "token": "true"
+            "node": "KApply",
+            "label": "<state>",
+            "variable": false,
+            "arity": 1,
+            "args": [
+              {
+                "node": "KVariable",
+                "name": "STATE:Map",
+                "originalName": "STATE:Map"
+              }
+            ]
           }
         ]
-      },
+      }
+    },
+    "requires": {
+      "node": "KApply",
+      "label": "_andBool_",
+      "variable": false,
+      "arity": 2,
+      "args": [
+        {
+          "node": "KToken",
+          "sort": "Bool",
+          "token": "true"
+        },
+        {
+          "node": "KToken",
+          "sort": "Bool",
+          "token": "true"
+        }
+      ]
+    },
     "ensures": null,
-    "atts": null
+    "att": null
   }
 }


### PR DESCRIPTION
Currently we only support a subset of the JSON nodes which the k frontend can put out for a given definition.

-   Add the remaining nodes (mostly having to do with sentences/productions).
-   Remove the KImport node, which doesn't get its own representation in KAST.
-   Changes `KApply(klabelRewrite, ...) => KRewrite`, since rewrites get their own node in the KAST json format output by the existing frontend.