### PR TITLE
Fix a pretty serious bug in sort inference + better debugging info

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
@@ -202,6 +202,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
             VarKey fails = null;
             Collection<Sort> constraint = null;
             for (Multimap<VarKey, Sort> variant : vars2.vars) {
+                boolean success = true;
                 // take each solution and do GLB on every variable
                 Multimap<VarKey, Sort> solution = HashMultimap.create();
                 for (VarKey key : variant.keySet()) {
@@ -210,14 +211,14 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
                     if (mins.size() == 0) {
                         fails = key;
                         constraint = values;
-                        solution.clear();
+                        success = false;
                         break;
                     } else {
                         solution.putAll(key, subsorts.maximal(mins));
                     }
                 }
                 // I found a solution that fits everywhere, then store it for disambiguation
-                if (!solution.isEmpty())
+                if (success)
                     solutions.add(solution);
             }
             if (!vars2.vars.isEmpty()) {
@@ -628,6 +629,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
 
         public CollectExpectedVariablesVisitor(Set<VarKey> declaredNames) {
             this.declaredNames = declaredNames;
+            vars.add(HashMultimap.create());
         }
 
         @Override
@@ -644,14 +646,10 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
                         clone.putAll(elem2);
                         newVars.add(clone);
                     }
-                    if (viz.vars.size() == 0)
-                        newVars.addAll(vars);
                 }
-                if (vars.size() == 0)
-                    newVars.addAll(viz.vars);
             }
-            if (!newVars.isEmpty())
-                vars = newVars;
+            vars.clear();
+            vars.addAll(newVars);
             return node;
         }
 

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
@@ -585,6 +585,8 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
             info.addAll(res._2());
             if (res._1().isLeft())
                 errors.addAll(res._1().left().get());
+            else
+                tc = tc.with(i, res._1.right().get());
         }
         if (errors.isEmpty())
             return Tuple2.apply(Right.apply(tc), info);
@@ -606,6 +608,8 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
             Either<Set<ParseFailedException>, Term> res = apply.apply(tc.get(i - 1));
             if (res.isLeft()) {
                 errors.addAll(res.left().get());
+            } else {
+              tc = tc.with(i, res.right().get());
             }
         }
         if (errors.isEmpty())

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
@@ -200,6 +200,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
 
             Set<Multimap<VarKey, Sort>> solutions = new HashSet<>();
             VarKey fails = null;
+            Collection<Sort> constraint = null;
             for (Multimap<VarKey, Sort> variant : vars2.vars) {
                 // take each solution and do GLB on every variable
                 Multimap<VarKey, Sort> solution = HashMultimap.create();
@@ -208,6 +209,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
                     Set<Sort> mins = lowerBounds(values);
                     if (mins.size() == 0) {
                         fails = key;
+                        constraint = values;
                         solution.clear();
                         break;
                     } else {
@@ -220,8 +222,8 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
             }
             if (!vars2.vars.isEmpty()) {
                 if (solutions.size() == 0) {
-                    assert fails != null;
-                    String msg = "Could not infer a sort for variable " + fails + " to match every location.";
+                    assert fails != null && constraint != null;
+                    String msg = "Could not infer a sort for variable " + fails + " to match every location. Expected sorts: " + constraint;
                     KException kex = new KException(ExceptionType.ERROR, KExceptionGroup.CRITICAL, msg, loc.source().orElse(null), loc.location().orElse(null));
                     return simpleError(Sets.newHashSet(new VariableTypeClashException(kex)));
                 }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
@@ -586,7 +586,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
             if (res._1().isLeft())
                 errors.addAll(res._1().left().get());
             else
-                tc = tc.with(i, res._1.right().get());
+                tc = tc.with(i - 1, res._1.right().get());
         }
         if (errors.isEmpty())
             return Tuple2.apply(Right.apply(tc), info);
@@ -609,7 +609,7 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
             if (res.isLeft()) {
                 errors.addAll(res.left().get());
             } else {
-              tc = tc.with(i, res.right().get());
+              tc = tc.with(i - 1, res.right().get());
             }
         }
         if (errors.isEmpty())


### PR DESCRIPTION
This is the first of many smaller PRs that I am making because the work I've done on parametric productions turned out to be quite invasive and I'm trying to break it into smaller diffs.

Basically this fixes a bug where we were not correctly computing the full range of possible sorts for variables in nested ambiguities and thus triggering inference incorrectly to the wrong sort.