### PR TITLE
refactor some places to use Sentence.withAtt

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -64,7 +64,7 @@ public class JavaBackend implements Backend {
         }
         Production prod = (Production)sentence;
         if (prod.klabel().isDefined() && KLabels.ListItem.equals(prod.klabel().get())) {
-            return Production(prod.sort(), prod.items(), prod.att().remove("function"));
+            return prod.withAtt(prod.att().remove("function"));
         }
         return prod;
     }

--- a/kernel/src/main/java/org/kframework/compile/GeneratedTopFormat.java
+++ b/kernel/src/main/java/org/kframework/compile/GeneratedTopFormat.java
@@ -44,7 +44,7 @@ public class GeneratedTopFormat {
                 }
                 format.append("%d%n%").append(cellPositions.get(j - 1) + 1);
             }
-            return Production(prod.klabel(), prod.sort(), prod.items(), prod.att().add("format", format.toString()));
+            return prod.withAtt(prod.att().add("format", format.toString()));
         }
         return prod;
     }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/ResolveOverloadedTerminators.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/ResolveOverloadedTerminators.java
@@ -43,7 +43,7 @@ public class ResolveOverloadedTerminators extends SetsTransformerWithErrors<Pars
                 return Left.apply(Sets.newHashSet(new ParseFailedException(ex)));
             }
             Production prod = candidates.iterator().next();
-            prod = Production(prod.klabel(), prod.sort(), prod.items(), prod.att()
+            prod = prod.withAtt(prod.att()
                     .add(Constants.ORIGINAL_PRD, Production.class, tc.production()));
             return super.apply(TermCons.apply(tc.items(), prod, tc.location(), tc.source()));
         }


### PR DESCRIPTION
This is one of many smaller PRs that I am making because the work I've done on parametric productions turned out to be quite invasive and I'm trying to break it into smaller diffs.

Here we refactor some places to use Sentence.withAtt so that we will not have to modify those places if new fields of productions get added.