### PR TITLE
Update to latest llvm backend

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 ARG BASE_IMAGE
 
 RUN apt-get update && \
-    apt-get install -y git debhelper maven openjdk-11-jdk cmake libboost-test-dev libyaml-dev libjemalloc-dev flex bison `if [ "$BASE_IMAGE" = "debian:buster" ]; then echo clang-7 llvm-7-tools lld-7; else echo clang-8 llvm-8-tools lld-8; fi` zlib1g-dev libgmp-dev libmpfr-dev gcc z3 libz3-dev opam pkg-config curl python3
+    apt-get install -y git debhelper maven openjdk-11-jdk cmake libboost-test-dev libyaml-dev libjemalloc-dev flex `if [ "$BASE_IMAGE" = "debian:buster" ]; then echo clang-7 llvm-7-tools lld-7; else echo clang-8 llvm-8-tools lld-8; fi` zlib1g-dev libgmp-dev libmpfr-dev gcc z3 libz3-dev opam pkg-config curl python3
 RUN curl -sSL https://get.haskellstack.org/ | sh      
 
 ARG USER_ID=1000

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ On Ubuntu:
 
 ```
 git submodule update --init --recursive
-sudo apt-get install build-essential m4 openjdk-8-jdk libgmp-dev libmpfr-dev pkg-config flex z3 libz3-dev maven opam python3 cmake gcc clang-8 lld-8 llvm-8-tools zlib1g-dev bison libboost-test-dev libyaml-dev libjemalloc-dev
+sudo apt-get install build-essential m4 openjdk-8-jdk libgmp-dev libmpfr-dev pkg-config flex z3 libz3-dev maven opam python3 cmake gcc clang-8 lld-8 llvm-8-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 

--- a/debian/control.debian
+++ b/debian/control.debian
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: debhelper (>=9), maven, openjdk-11-jdk, cmake, libboost-test-dev, libyaml-dev, libjemalloc-dev, flex, bison, clang-7, zlib1g-dev, libgmp-dev, libmpfr-dev
+Build-Depends: debhelper (>=9), maven, openjdk-11-jdk, cmake, libboost-test-dev, libyaml-dev, libjemalloc-dev, flex, clang-7, zlib1g-dev, libgmp-dev, libmpfr-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/kframework/k
 

--- a/debian/control.ubuntu
+++ b/debian/control.ubuntu
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: debhelper (>=9), maven, openjdk-11-jdk, cmake, libboost-test-dev, libyaml-dev, libjemalloc-dev, flex, bison, clang-8, zlib1g-dev, libgmp-dev, libmpfr-dev
+Build-Depends: debhelper (>=9), maven, openjdk-11-jdk, cmake, libboost-test-dev, libyaml-dev, libjemalloc-dev, flex, clang-8, zlib1g-dev, libgmp-dev, libmpfr-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/kframework/k
 

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
@@ -78,7 +78,7 @@ public class LLVMRewriter implements Function<Definition, Rewriter> {
                 K withMacros = macroExpander.expand(k);
                 K kWithInjections = new AddSortInjections(mod).addInjections(withMacros);
                 converter.convert(kWithInjections);
-                String koreOutput = "[initial-configuration{}(" + converter.toString() + ")]\n\nmodule TMP\nendmodule []\n";
+                String koreOutput = converter.toString();
                 files.saveToTemp("pgm.kore", koreOutput);
                 String pgmPath = files.resolveTemp("pgm.kore").getAbsolutePath();
                 File koreOutputFile = files.resolveTemp("result.kore");

--- a/pom.xml
+++ b/pom.xml
@@ -362,7 +362,7 @@
         <native.exe.type>uexe</native.exe.type>
         <native.exe.extension />
 	<native.script.extension />
-	<prefix.path>/usr/local/opt/llvm/;/usr/local/opt/bison;/usr/local/opt/flex;/usr/local/opt/libffi</prefix.path>
+	<prefix.path>/usr/local/opt/llvm/;/usr/local/opt/flex;/usr/local/opt/libffi</prefix.path>
       </properties>
     </profile>
     <profile>

--- a/src/main/scripts/brew-install-deps
+++ b/src/main/scripts/brew-install-deps
@@ -1,7 +1,7 @@
 #!/bin/bash -ex
 
 brew update
-brew install maven cmake boost libyaml jemalloc llvm gmp mpfr z3 opam pkg-config bison flex
+brew install maven cmake boost libyaml jemalloc llvm gmp mpfr z3 opam pkg-config flex
 
 curl -sSL https://get.haskellstack.org/ | sh
 


### PR DESCRIPTION
This should contain the latest llvm backend that has fixed its remaining memory leaks and removed its dependency on Bison.