### PR TITLE
Auto update dependents of K frontend

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -122,7 +122,7 @@ pipeline {
             stage('Build and Package on Debian Buster') {
               when {
                 anyOf {
-                  not { changeRequest() }
+                  branch 'master'
                   changelog '.*^\\[build-system\\] .+$'
                   changeset 'Jenkinsfile'
                   changeset 'Dockerfile'
@@ -186,7 +186,7 @@ pipeline {
             stage('Build and Package on Arch Linux') {
               when {
                 anyOf {
-                  not { changeRequest() }
+                  branch 'master'
                   changelog '.*^\\[build-system\\] .+$'
                   changeset 'Jenkinsfile'
                   changeset 'Dockerfile'
@@ -251,7 +251,7 @@ pipeline {
         stage('Build and Package on Mac OS') {
           when {
             anyOf {
-              not { changeRequest() }
+              branch 'master'
               changelog '.*^\\[build-system\\] .+$'
               changeset 'Jenkinsfile'
               changeset 'Dockerfile'
@@ -343,7 +343,6 @@ pipeline {
         }
       }
       when {
-        not { changeRequest() }
         branch 'master'
         beforeAgent true
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -40,6 +40,13 @@ pipeline {
         stash name: "src", includes: "kframework-5.0.0-src.tar.gz"
       }
     }
+    stage('Update Submodules (non-release)') {
+      when { branch 'master' }
+      steps {
+        build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'ehildenb'), booleanParam(name: 'UPDATE_DEPS_KWASM' , value: true)], propagate: false, wait: false
+        build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'malturki'), booleanParam(name: 'UPDATE_DEPS_BEACON', value: true)], propagate: false, wait: false
+      }
+    }
     stage('Build and Package K') {
       failFast true
       parallel {
@@ -407,6 +414,13 @@ pipeline {
                   , channel: '#k'                                    \
                   , message: "Deploy Phase Failed: ${env.BUILD_URL}"
         }
+      }
+    }
+    stage('Update Submodules (release)') {
+      when { branch 'master' }
+      steps {
+        build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'ehildenb'), booleanParam(name: 'UPDATE_DEPS_KEVM'   , value: true)], propagate: false, wait: false
+        build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'ttuegel') , booleanParam(name: 'UPDATE_DEPS_HASKELL', value: true)], propagate: false, wait: false
       }
     }
   }


### PR DESCRIPTION
This auto-updates the following dependents of K frontend on pushes to K master:

-   KEVM
-   KWasm
-   Haskell Backend
-   Beacon Chain Project

Note that KEVM and Haskell backend updates will _only_ go through if the release goes through.