### PR TITLE
Switch to using `hub` command for releases

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -10,6 +10,7 @@ RUN    pacman -Syyu --noconfirm \
                     curl        \
                     git         \
                     gmp         \
+                    hub         \
                     jdk-openjdk \
                     jemalloc    \
                     libyaml     \

--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -19,6 +19,7 @@ RUN    pacman -Syyu --noconfirm \
                     maven       \
                     mpfr        \
                     opam        \
+                    openssh     \
                     python      \
                     stack       \
                     z3          \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,14 +54,14 @@ pipeline {
         stage('Build and Package K on Linux') {
           stages {
             stage('Build Platform Independent K Binary') {
-              //when {
-              //  anyOf {
-              //    branch 'master'
-              //    changelog '.*^\\[build-system\\] .+$'
-              //    changeset 'Jenkinsfile'
-              //    changeset 'Dockerfile'
-              //  }
-              //}
+              when {
+                anyOf {
+                  branch 'master'
+                  changelog '.*^\\[build-system\\] .+$'
+                  changeset 'Jenkinsfile'
+                  changeset 'Dockerfile'
+                }
+              }
               agent {
                 dockerfile {
                   filename 'Dockerfile.debian'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -45,6 +45,7 @@ pipeline {
       steps {
         build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'ehildenb'), booleanParam(name: 'UPDATE_DEPS_KWASM' , value: true)], propagate: false, wait: false
         build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'malturki'), booleanParam(name: 'UPDATE_DEPS_BEACON', value: true)], propagate: false, wait: false
+        build job: 'rv-devops/master', parameters: [string(name: 'PR_REVIEWER', value: 'ehildenb'), booleanParam(name: 'UPDATE_DEPS_MCD'   , value: true)], propagate: false, wait: false
       }
     }
     stage('Build and Package K') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -344,8 +344,8 @@ pipeline {
     stage('Deploy') {
       agent {
         dockerfile {
-          filename 'Dockerfile.debian'
-          additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g) --build-arg BASE_IMAGE=ubuntu:bionic'
+          filename 'Dockerfile.arch'
+          additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
           reuseNode true
         }
       }
@@ -381,20 +381,17 @@ pipeline {
             echo 'Deploying K...'
             mvn --batch-mode clean
             mvn --batch-mode install -DskipKTest -Dcheckstyle.skip
-            COMMIT=$(git rev-parse --short HEAD)
-            DESCRIPTION="$(cat k-distribution/INSTALL.md | ./src/main/scripts/prepare-release-notes)"
-            RESPONSE=`curl --data '{"tag_name": "nightly-'$COMMIT'","name": "Nightly build of K framework at commit '$COMMIT'","body": "'"$DESCRIPTION"'", "draft": true,"prerelease": true}' https://api.github.com/repos/kframework/k/releases?access_token=$GITHUB_TOKEN`
-            ID=`echo "$RESPONSE" | grep '"id": [0-9]*,' -o | head -1 | grep '[0-9]*' -o`
-            BOTTLE_NAME=`cd mojave && echo kframework--5.0.0.mojave.bottle*.tar.gz | sed 's!kframework--!kframework-!'`
-            LOCAL_BOTTLE_NAME=`echo mojave/kframework--5.0.0.mojave.bottle*.tar.gz`
-            curl --data-binary @kframework-5.0.0-src.tar.gz -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/gzip" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework-5.0.0-src.tar.gz&label=Source+tar.gz'
-            curl --data-binary @k-distribution/target/k-nightly.tar.gz -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/gzip" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=nightly.tar.gz&label=Platform-Indepdendent+K+binary'
-            curl --data-binary @bionic/kframework_5.0.0_amd64.deb -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/vnd.debian.binary-package" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework_5.0.0_amd64_bionic.deb&label=Ubuntu+Bionic+Debian+Package'
-            curl --data-binary @buster/kframework_5.0.0_amd64.deb -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/vnd.debian.binary-package" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework_5.0.0_amd64_buster.deb&label=Debian+Buster+Debian+Package'
-            # curl --data-binary @arch/kframework-5.0.0-1-x86_64.pkg.tar.xz -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/x-xz" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework-5.0.0-1-x86_64.pkg.tar.xz&label=Arch+Linux+Pacman+Package'
-            curl --data-binary @$LOCAL_BOTTLE_NAME -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/gzip" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name='$BOTTLE_NAME'&label=Mac+OS+X+Mojave+Homebrew+Bottle'
-            curl -X PATCH --data '{"draft": false}' https://api.github.com/repos/kframework/k/releases/$ID?access_token=$GITHUB_TOKEN
-            curl --data '{"state": "success","target_url": "'$BUILD_URL'","description": "Build succeeded."}' https://api.github.com/repos/kframework/k/statuses/$(git rev-parse origin/master)?access_token=$GITHUB_TOKEN
+            release_tag="v${VERSION}-$(git rev-parse --short HEAD)"
+            mv bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
+            mv buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
+            hub release create                                                                                           \
+                --attach kframework-${VERSION}-src.tar.gz"#Source tar.gz"                                                \
+                --attach bionic/kframework_${VERSION}_amd64_bionic.deb"#Ubuntu Bionic (18.04) Package"                   \
+                --attach buster/kframework_${VERSION}_amd64_buster.deb"#Debian Buster (10) Package"                      \
+                --attach mojave/kframework--${VERSION}.mojave.bottle*.tar.gz"#Mac OS X Homebrew Bottle"                  \
+                --attach k-distribution/target/k-nightly.tar.gz"#Platform Indepdendent K Binary"                         \
+                --file "k-distribution/INSTALL.md" "${release_tag}"
+                # --attach arch/kframework-${VERSION}/package/kframework-git-${VERSION}-1-x86_64.pkg.tar.xz"#Arch Package" \
           '''
         }
         dir("homebrew-k") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -411,16 +411,16 @@ pipeline {
         }
         sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
           sh '''
-            echo 'Deploying K...'
             release_tag="v${VERSION}-$(git rev-parse --short HEAD)"
             mv bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
             mv buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
-            hub release create                                                                          \
-                --attach kframework-${VERSION}-src.tar.gz"#Source tar.gz"                               \
-                --attach bionic/kframework_${VERSION}_amd64_bionic.deb"#Ubuntu Bionic (18.04) Package"  \
-                --attach buster/kframework_${VERSION}_amd64_buster.deb"#Debian Buster (10) Package"     \
-                --attach mojave/kframework--${VERSION}.mojave.bottle*.tar.gz"#Mac OS X Homebrew Bottle" \
-                --attach k-nightly.tar.gz"#Platform Indepdendent K Binary"                              \
+            LOCAL_BOTTLE_NAME=$(echo mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)
+            hub release create                                                                         \
+                --attach kframework-${VERSION}-src.tar.gz"#Source tar.gz"                              \
+                --attach bionic/kframework_${VERSION}_amd64_bionic.deb"#Ubuntu Bionic (18.04) Package" \
+                --attach buster/kframework_${VERSION}_amd64_buster.deb"#Debian Buster (10) Package"    \
+                --attach $LOCAL_BOTTLE_NAME"#Mac OS X Homebrew Bottle"                                 \
+                --attach k-nightly.tar.gz"#Platform Indepdendent K Binary"                             \
                 --file "k-distribution/INSTALL.md" "${release_tag}"
                 # --attach arch/kframework-${VERSION}/package/kframework-git-${VERSION}-1-x86_64.pkg.tar.xz"#Arch Package" \
           '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -71,20 +71,20 @@ pipeline {
                         }
                       }
                     }
-                    stage('Build and Test K') {
-                      steps {
-                        sh '''
-                          echo 'Setting up environment...'
-                          eval `opam config env`
-                          echo 'Building K...'
-                          mvn --batch-mode verify -U
-                          echo 'Starting kserver...'
-                          k-distribution/target/release/k/bin/spawn-kserver kserver.log
-                          cd k-exercises/tutorial
-                          make -j`nproc`
-                        '''
-                      }
-                    }
+                    //stage('Build and Test K') {
+                    //  steps {
+                    //    sh '''
+                    //      echo 'Setting up environment...'
+                    //      eval `opam config env`
+                    //      echo 'Building K...'
+                    //      mvn --batch-mode verify -U
+                    //      echo 'Starting kserver...'
+                    //      k-distribution/target/release/k/bin/spawn-kserver kserver.log
+                    //      cd k-exercises/tutorial
+                    //      make -j`nproc`
+                    //    '''
+                    //  }
+                    //}
                     stage('Build Debian Package') {
                       steps {
                         dir('kframework-5.0.0') {
@@ -98,44 +98,44 @@ pipeline {
                       }
                     }
                   }
-                  post {
-                    always {
-                      sh 'k-distribution/target/release/k/bin/stop-kserver || true'
-                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                    }
-                  }
+                  //post {
+                  //  always {
+                  //    sh 'k-distribution/target/release/k/bin/stop-kserver || true'
+                  //    archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                  //  }
+                  //}
                 }
-                stage('Test Debian Package') {
-                  agent {
-                    docker {
-                      image 'ubuntu:bionic'
-                      args '-u 0'
-                      reuseNode true
-                    }
-                  }
-                  options { skipDefaultCheckout() }
-                  steps {
-                    unstash "bionic"
-                    sh 'src/main/scripts/test-in-container-debian'
-                  }
-                  post {
-                    always {
-                      sh 'stop-kserver || true'
-                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                    }
-                  }
-                }
+                //stage('Test Debian Package') {
+                //  agent {
+                //    docker {
+                //      image 'ubuntu:bionic'
+                //      args '-u 0'
+                //      reuseNode true
+                //    }
+                //  }
+                //  options { skipDefaultCheckout() }
+                //  steps {
+                //    unstash "bionic"
+                //    sh 'src/main/scripts/test-in-container-debian'
+                //  }
+                //  post {
+                //    always {
+                //      sh 'stop-kserver || true'
+                //      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                //    }
+                //  }
+                //}
               }
             }
             stage('Build and Package on Debian Buster') {
-              when {
-                anyOf {
-                  branch 'master'
-                  changelog '.*^\\[build-system\\] .+$'
-                  changeset 'Jenkinsfile'
-                  changeset 'Dockerfile'
-                }
-              }
+              //when {
+              //  anyOf {
+              //    branch 'master'
+              //    changelog '.*^\\[build-system\\] .+$'
+              //    changeset 'Jenkinsfile'
+              //    changeset 'Dockerfile'
+              //  }
+              //}
               stages {
                 stage('Build on Debian Buster') {
                   agent {
@@ -160,28 +160,28 @@ pipeline {
                     }
                   }
                 }
-                stage('Test Debian Package') {
-                  agent {
-                    docker {
-                      image 'debian:buster'
-                      args '-u 0'
-                      reuseNode true
-                    }
-                  }
-                  options { skipDefaultCheckout() }
-                  steps {
-                    unstash "buster"
-                    sh '''
-                      src/main/scripts/test-in-container-debian
-                    '''
-                  }
-                  post {
-                    always {
-                      sh 'stop-kserver || true'
-                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                    }
-                  }
-                }
+                //stage('Test Debian Package') {
+                //  agent {
+                //    docker {
+                //      image 'debian:buster'
+                //      args '-u 0'
+                //      reuseNode true
+                //    }
+                //  }
+                //  options { skipDefaultCheckout() }
+                //  steps {
+                //    unstash "buster"
+                //    sh '''
+                //      src/main/scripts/test-in-container-debian
+                //    '''
+                //  }
+                //  post {
+                //    always {
+                //      sh 'stop-kserver || true'
+                //      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                //    }
+                //  }
+                //}
               }
               post {
                 failure {
@@ -257,14 +257,14 @@ pipeline {
           }
         }
         stage('Build and Package on Mac OS') {
-          when {
-            anyOf {
-              branch 'master'
-              changelog '.*^\\[build-system\\] .+$'
-              changeset 'Jenkinsfile'
-              changeset 'Dockerfile'
-            }
-          }
+          //when {
+          //  anyOf {
+          //    branch 'master'
+          //    changelog '.*^\\[build-system\\] .+$'
+          //    changeset 'Jenkinsfile'
+          //    changeset 'Dockerfile'
+          //  }
+          //}
           stages {
             stage('Build on Mac OS') {
               stages {
@@ -285,51 +285,51 @@ pipeline {
                     }
                   }
                 }
-                stage("Test Homebrew Bottle") {
-                  agent {
-                    label 'anka'
-                  }
-                  steps {
-                    dir('homebrew-k') {
-                      git url: 'git@github.com:kframework/homebrew-k.git', branch: 'brew-release-kframework'
-                      unstash "mojave"
-                      sh '''
-                        ${WORKSPACE}/src/main/scripts/brew-install-bottle
-                      '''
-                    }
-                    sh '''
-                      cp -R /usr/local/lib/kframework/tutorial ~
-                      WD=`pwd`
-                      cd
-                      echo 'Starting kserver...'
-                      /usr/local/lib/kframework/bin/spawn-kserver $WD/kserver.log
-                      cd tutorial
-                      echo 'Testing tutorial in user environment...'
-                      make -j`sysctl -n hw.ncpu`
-                      cd ~
-                      echo "module TEST imports BOOL endmodule" > test.k
-                      kompile test.k --backend llvm
-                      kompile test.k --backend haskell
-                    '''
-                    dir('homebrew-k') {
-                      sh '''
-                        ${WORKSPACE}/src/main/scripts/brew-update-to-final
-                      '''
-                    }
-                  }
-                  post {
-                    always {
-                      sh 'stop-kserver || true'
-                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                    }
-                  }
-                }
+                //stage("Test Homebrew Bottle") {
+                //  agent {
+                //    label 'anka'
+                //  }
+                //  steps {
+                //    dir('homebrew-k') {
+                //      git url: 'git@github.com:kframework/homebrew-k.git', branch: 'brew-release-kframework'
+                //      unstash "mojave"
+                //      sh '''
+                //        ${WORKSPACE}/src/main/scripts/brew-install-bottle
+                //      '''
+                //    }
+                //    sh '''
+                //      cp -R /usr/local/lib/kframework/tutorial ~
+                //      WD=`pwd`
+                //      cd
+                //      echo 'Starting kserver...'
+                //      /usr/local/lib/kframework/bin/spawn-kserver $WD/kserver.log
+                //      cd tutorial
+                //      echo 'Testing tutorial in user environment...'
+                //      make -j`sysctl -n hw.ncpu`
+                //      cd ~
+                //      echo "module TEST imports BOOL endmodule" > test.k
+                //      kompile test.k --backend llvm
+                //      kompile test.k --backend haskell
+                //    '''
+                //    dir('homebrew-k') {
+                //      sh '''
+                //        ${WORKSPACE}/src/main/scripts/brew-update-to-final
+                //      '''
+                //    }
+                //  }
+                //  post {
+                //    always {
+                //      sh 'stop-kserver || true'
+                //      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                //    }
+                //  }
+                //}
               }
-              post {
-                always {
-                  archiveArtifacts artifacts: 'kserver.log,k-distribution/target/kserver.log', allowEmptyArchive: true
-                }
-              }
+              //post {
+              //  always {
+              //    archiveArtifacts artifacts: 'kserver.log,k-distribution/target/kserver.log', allowEmptyArchive: true
+              //  }
+              //}
             }
           }
           post {
@@ -350,10 +350,10 @@ pipeline {
           reuseNode true
         }
       }
-      when {
-        branch 'master'
-        beforeAgent true
-      }
+      //when {
+      //  branch 'master'
+      //  beforeAgent true
+      //}
       environment {
         AWS_ACCESS_KEY_ID     = credentials('aws-access-key-id')
         AWS_SECRET_ACCESS_KEY = credentials('aws-secret-access-key')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -54,14 +54,14 @@ pipeline {
         stage('Build and Package K on Linux') {
           stages {
             stage('Build Platform Independent K Binary') {
-              when {
-                anyOf {
-                  branch 'master'
-                  changelog '.*^\\[build-system\\] .+$'
-                  changeset 'Jenkinsfile'
-                  changeset 'Dockerfile'
-                }
-              }
+              //when {
+              //  anyOf {
+              //    branch 'master'
+              //    changelog '.*^\\[build-system\\] .+$'
+              //    changeset 'Jenkinsfile'
+              //    changeset 'Dockerfile'
+              //  }
+              //}
               agent {
                 dockerfile {
                   filename 'Dockerfile.debian'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,20 +104,20 @@ pipeline {
                         }
                       }
                     }
-                    //stage('Build and Test K') {
-                    //  steps {
-                    //    sh '''
-                    //      echo 'Setting up environment...'
-                    //      eval `opam config env`
-                    //      echo 'Building K...'
-                    //      mvn --batch-mode verify -U
-                    //      echo 'Starting kserver...'
-                    //      k-distribution/target/release/k/bin/spawn-kserver kserver.log
-                    //      cd k-exercises/tutorial
-                    //      make -j`nproc`
-                    //    '''
-                    //  }
-                    //}
+                    stage('Build and Test K') {
+                      steps {
+                        sh '''
+                          echo 'Setting up environment...'
+                          eval `opam config env`
+                          echo 'Building K...'
+                          mvn --batch-mode verify -U
+                          echo 'Starting kserver...'
+                          k-distribution/target/release/k/bin/spawn-kserver kserver.log
+                          cd k-exercises/tutorial
+                          make -j`nproc`
+                        '''
+                      }
+                    }
                     stage('Build Debian Package') {
                       steps {
                         dir('kframework-5.0.0') {
@@ -131,44 +131,44 @@ pipeline {
                       }
                     }
                   }
-                  //post {
-                  //  always {
-                  //    sh 'k-distribution/target/release/k/bin/stop-kserver || true'
-                  //    archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                  //  }
-                  //}
+                  post {
+                    always {
+                      sh 'k-distribution/target/release/k/bin/stop-kserver || true'
+                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                    }
+                  }
                 }
-                //stage('Test Debian Package') {
-                //  agent {
-                //    docker {
-                //      image 'ubuntu:bionic'
-                //      args '-u 0'
-                //      reuseNode true
-                //    }
-                //  }
-                //  options { skipDefaultCheckout() }
-                //  steps {
-                //    unstash "bionic"
-                //    sh 'src/main/scripts/test-in-container-debian'
-                //  }
-                //  post {
-                //    always {
-                //      sh 'stop-kserver || true'
-                //      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                //    }
-                //  }
-                //}
+                stage('Test Debian Package') {
+                  agent {
+                    docker {
+                      image 'ubuntu:bionic'
+                      args '-u 0'
+                      reuseNode true
+                    }
+                  }
+                  options { skipDefaultCheckout() }
+                  steps {
+                    unstash "bionic"
+                    sh 'src/main/scripts/test-in-container-debian'
+                  }
+                  post {
+                    always {
+                      sh 'stop-kserver || true'
+                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                    }
+                  }
+                }
               }
             }
             stage('Build and Package on Debian Buster') {
-              //when {
-              //  anyOf {
-              //    branch 'master'
-              //    changelog '.*^\\[build-system\\] .+$'
-              //    changeset 'Jenkinsfile'
-              //    changeset 'Dockerfile'
-              //  }
-              //}
+              when {
+                anyOf {
+                  branch 'master'
+                  changelog '.*^\\[build-system\\] .+$'
+                  changeset 'Jenkinsfile'
+                  changeset 'Dockerfile'
+                }
+              }
               stages {
                 stage('Build on Debian Buster') {
                   agent {
@@ -193,28 +193,28 @@ pipeline {
                     }
                   }
                 }
-                //stage('Test Debian Package') {
-                //  agent {
-                //    docker {
-                //      image 'debian:buster'
-                //      args '-u 0'
-                //      reuseNode true
-                //    }
-                //  }
-                //  options { skipDefaultCheckout() }
-                //  steps {
-                //    unstash "buster"
-                //    sh '''
-                //      src/main/scripts/test-in-container-debian
-                //    '''
-                //  }
-                //  post {
-                //    always {
-                //      sh 'stop-kserver || true'
-                //      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                //    }
-                //  }
-                //}
+                stage('Test Debian Package') {
+                  agent {
+                    docker {
+                      image 'debian:buster'
+                      args '-u 0'
+                      reuseNode true
+                    }
+                  }
+                  options { skipDefaultCheckout() }
+                  steps {
+                    unstash "buster"
+                    sh '''
+                      src/main/scripts/test-in-container-debian
+                    '''
+                  }
+                  post {
+                    always {
+                      sh 'stop-kserver || true'
+                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                    }
+                  }
+                }
               }
               post {
                 failure {
@@ -290,14 +290,14 @@ pipeline {
           }
         }
         stage('Build and Package on Mac OS') {
-          //when {
-          //  anyOf {
-          //    branch 'master'
-          //    changelog '.*^\\[build-system\\] .+$'
-          //    changeset 'Jenkinsfile'
-          //    changeset 'Dockerfile'
-          //  }
-          //}
+          when {
+            anyOf {
+              branch 'master'
+              changelog '.*^\\[build-system\\] .+$'
+              changeset 'Jenkinsfile'
+              changeset 'Dockerfile'
+            }
+          }
           stages {
             stage('Build on Mac OS') {
               stages {
@@ -318,51 +318,51 @@ pipeline {
                     }
                   }
                 }
-                //stage("Test Homebrew Bottle") {
-                //  agent {
-                //    label 'anka'
-                //  }
-                //  steps {
-                //    dir('homebrew-k') {
-                //      git url: 'git@github.com:kframework/homebrew-k.git', branch: 'brew-release-kframework'
-                //      unstash "mojave"
-                //      sh '''
-                //        ${WORKSPACE}/src/main/scripts/brew-install-bottle
-                //      '''
-                //    }
-                //    sh '''
-                //      cp -R /usr/local/lib/kframework/tutorial ~
-                //      WD=`pwd`
-                //      cd
-                //      echo 'Starting kserver...'
-                //      /usr/local/lib/kframework/bin/spawn-kserver $WD/kserver.log
-                //      cd tutorial
-                //      echo 'Testing tutorial in user environment...'
-                //      make -j`sysctl -n hw.ncpu`
-                //      cd ~
-                //      echo "module TEST imports BOOL endmodule" > test.k
-                //      kompile test.k --backend llvm
-                //      kompile test.k --backend haskell
-                //    '''
-                //    dir('homebrew-k') {
-                //      sh '''
-                //        ${WORKSPACE}/src/main/scripts/brew-update-to-final
-                //      '''
-                //    }
-                //  }
-                //  post {
-                //    always {
-                //      sh 'stop-kserver || true'
-                //      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                //    }
-                //  }
-                //}
+                stage("Test Homebrew Bottle") {
+                  agent {
+                    label 'anka'
+                  }
+                  steps {
+                    dir('homebrew-k') {
+                      git url: 'git@github.com:kframework/homebrew-k.git', branch: 'brew-release-kframework'
+                      unstash "mojave"
+                      sh '''
+                        ${WORKSPACE}/src/main/scripts/brew-install-bottle
+                      '''
+                    }
+                    sh '''
+                      cp -R /usr/local/lib/kframework/tutorial ~
+                      WD=`pwd`
+                      cd
+                      echo 'Starting kserver...'
+                      /usr/local/lib/kframework/bin/spawn-kserver $WD/kserver.log
+                      cd tutorial
+                      echo 'Testing tutorial in user environment...'
+                      make -j`sysctl -n hw.ncpu`
+                      cd ~
+                      echo "module TEST imports BOOL endmodule" > test.k
+                      kompile test.k --backend llvm
+                      kompile test.k --backend haskell
+                    '''
+                    dir('homebrew-k') {
+                      sh '''
+                        ${WORKSPACE}/src/main/scripts/brew-update-to-final
+                      '''
+                    }
+                  }
+                  post {
+                    always {
+                      sh 'stop-kserver || true'
+                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+                    }
+                  }
+                }
               }
-              //post {
-              //  always {
-              //    archiveArtifacts artifacts: 'kserver.log,k-distribution/target/kserver.log', allowEmptyArchive: true
-              //  }
-              //}
+              post {
+                always {
+                  archiveArtifacts artifacts: 'kserver.log,k-distribution/target/kserver.log', allowEmptyArchive: true
+                }
+              }
             }
           }
           post {
@@ -383,10 +383,10 @@ pipeline {
           reuseNode true
         }
       }
-      //when {
-      //  branch 'master'
-      //  beforeAgent true
-      //}
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       environment {
         AWS_ACCESS_KEY_ID     = credentials('aws-access-key-id')
         AWS_SECRET_ACCESS_KEY = credentials('aws-secret-access-key')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -415,13 +415,16 @@ pipeline {
             mv bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
             mv buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
             LOCAL_BOTTLE_NAME=$(echo mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)
+            echo "K Framework Release $release_tag"  > release.md
+            echo ""                                 >> release.md
+            cat k-distribution/INSTALL.md           >> release.md
             hub release create                                                                         \
                 --attach kframework-${VERSION}-src.tar.gz"#Source tar.gz"                              \
                 --attach bionic/kframework_${VERSION}_amd64_bionic.deb"#Ubuntu Bionic (18.04) Package" \
                 --attach buster/kframework_${VERSION}_amd64_buster.deb"#Debian Buster (10) Package"    \
                 --attach $LOCAL_BOTTLE_NAME"#Mac OS X Homebrew Bottle"                                 \
                 --attach k-nightly.tar.gz"#Platform Indepdendent K Binary"                             \
-                --file "k-distribution/INSTALL.md" "${release_tag}"
+                --file release.md "${release_tag}"
                 # --attach arch/kframework-${VERSION}/package/kframework-git-${VERSION}-1-x86_64.pkg.tar.xz"#Arch Package" \
           '''
         }

--- a/src/main/scripts/prepare-release-notes
+++ b/src/main/scripts/prepare-release-notes
@@ -1,3 +1,0 @@
-#!/usr/bin/env bash
-
-sed ':a;$!{N;ba}; s/\n/\\n/g' | sed 's/"/\\"/g'


### PR DESCRIPTION
GitHub provides the `hub` command for simplifying the Release process. This PR:

-   Switches to using the `hub` command instead of bare `curl`.
-   Updates the `k-distribution/INSTALL.md` for nicer formatting and more instructions.