### PR TITLE
Adding kast option keepAmb

### DIFF
--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -128,7 +128,7 @@ public class KastFrontEnd extends FrontEnd {
             }
             Module parsingMod = maybeMod.get();
 
-            K parsed = kread.prettyRead(parsingMod, sort, def, source, FileUtil.read(stringToParse));
+            K parsed = kread.prettyRead(parsingMod, sort, def, source, FileUtil.read(stringToParse), options.keepAmb);
 
             if (options.expandMacros) {
                 parsed = ExpandMacros.forNonSentences(unparsingMod, files.get(), def.kompileOptions, false).expand(parsed);

--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -116,6 +116,9 @@ public final class KastOptions {
     @Parameter(names="--expand-macros", description="Also expand macros in the parsed string.")
     public boolean expandMacros = false;
 
+    @Parameter(names="--keep-amb", description="When parsing programs, keep ambiguities and print them.")
+    public boolean keepAmb = false;
+
     @Parameter(names={"--input", "-i"}, converter=InputModeConverter.class,
             description="How to read kast input in. <mode> is either [program|binary|kast|json|kore].")
     public InputModes input = InputModes.PROGRAM;

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -429,7 +429,7 @@ public class DefinitionParsing {
                 return Stream.of(parse.getParse());
             }
         }
-        result = parser.parseString(b.contents(), START_SYMBOL, scanner, source, startLine, startColumn, true, b.att().contains("anywhere"));
+        result = parser.parseString(b.contents(), START_SYMBOL, scanner, source, startLine, startColumn, true, b.att().contains("anywhere"), false);
         parsedBubbles.getAndIncrement();
         if (kem.options.warnings2errors && !result._2().isEmpty()) {
           for (KEMException err : result._2()) {

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -39,11 +39,11 @@ public class KRead {
         this.input = input;
     }
 
-    public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse) {
-        return prettyRead(mod, sort, def, source, stringToParse, this.input);
+    public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse, boolean keepAmb) {
+        return prettyRead(mod, sort, def, source, stringToParse, this.input, keepAmb);
     }
 
-    public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse, InputModes inputMode) {
+    public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse, InputModes inputMode, boolean keepAmb) {
         switch (inputMode) {
             case BINARY:
             case JSON:
@@ -52,7 +52,7 @@ public class KRead {
             case KORE:
                 return new KoreParser(mod.sortAttributesFor()).parseString(stringToParse);
             case PROGRAM:
-                return def.getParser(mod, sort, kem).apply(stringToParse, source);
+                return def.getParser(mod, sort, kem, keepAmb).apply(stringToParse, source);
             default:
                 throw KEMException.criticalError("Unsupported input mode: " + inputMode);
         }

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/ParseInModule.java
@@ -116,7 +116,14 @@ public class ParseInModule implements Serializable, AutoCloseable {
     public Tuple2<Either<Set<ParseFailedException>, K>, Set<ParseFailedException>>
             parseString(String input, Sort startSymbol, Source source) {
         try (Scanner scanner = getScanner()) {
-            return parseString(input, startSymbol, scanner, source, 1, 1, true, false);
+            return parseString(input, startSymbol, scanner, source, 1, 1, true, false, false);
+        }
+    }
+
+    public Tuple2<Either<Set<ParseFailedException>, K>, Set<ParseFailedException>>
+            parseStringKeepAmb(String input, Sort startSymbol, Source source) {
+        try (Scanner scanner = getScanner()) {
+            return parseString(input, startSymbol, scanner, source, 1, 1, true, false, true);
         }
     }
 
@@ -139,9 +146,9 @@ public class ParseInModule implements Serializable, AutoCloseable {
     }
 
     public Tuple2<Either<Set<ParseFailedException>, K>, Set<ParseFailedException>>
-        parseString(String input, Sort startSymbol, Scanner scanner, Source source, int startLine, int startColumn, boolean inferSortChecks, boolean isAnywhere) {
+        parseString(String input, Sort startSymbol, Scanner scanner, Source source, int startLine, int startColumn, boolean inferSortChecks, boolean isAnywhere, boolean keepAmb) {
         final Tuple2<Either<Set<ParseFailedException>, Term>, Set<ParseFailedException>> result
-                = parseStringTerm(input, startSymbol, scanner, source, startLine, startColumn, inferSortChecks, isAnywhere);
+                = parseStringTerm(input, startSymbol, scanner, source, startLine, startColumn, inferSortChecks, isAnywhere, keepAmb);
         Either<Set<ParseFailedException>, K> parseInfo;
         if (result._1().isLeft()) {
             parseInfo = Left.apply(result._1().left().get());
@@ -168,7 +175,7 @@ public class ParseInModule implements Serializable, AutoCloseable {
      * @return
      */
     private Tuple2<Either<Set<ParseFailedException>, Term>, Set<ParseFailedException>>
-            parseStringTerm(String input, Sort startSymbol, Scanner scanner, Source source, int startLine, int startColumn, boolean inferSortChecks, boolean isAnywhere) {
+            parseStringTerm(String input, Sort startSymbol, Scanner scanner, Source source, int startLine, int startColumn, boolean inferSortChecks, boolean isAnywhere, boolean keepAmb) {
         scanner = getGrammar(scanner);
 
         long start = 0;
@@ -221,14 +228,16 @@ public class ParseInModule implements Serializable, AutoCloseable {
             if (rez.isLeft())
                 return new Tuple2<>(rez, warn);
             rez3 = new PushAmbiguitiesDownAndPreferAvoid(disambModule.overloads()).apply(rez.right().get());
-            rez = new AmbFilterError(strict && inferSortChecks).apply(rez3);
-            if (rez.isLeft())
-                return new Tuple2<>(rez, warn);
-            rez2 = new AddEmptyLists(disambModule).apply(rez.right().get());
-            warn = Sets.union(rez2._2(), warn);
-            if (rez2._1().isLeft())
-                return rez2;
-            rez3 = new RemoveBracketVisitor().apply(rez2._1().right().get());
+            if (!keepAmb) {
+                rez = new AmbFilterError(strict && inferSortChecks).apply(rez3);
+                if (rez.isLeft())
+                    return new Tuple2<>(rez, warn);
+                rez2 = new AddEmptyLists(disambModule).apply(rez.right().get());
+                warn = Sets.union(rez2._2(), warn);
+                if (rez2._1().isLeft())
+                    return rez2;
+                rez3 = new RemoveBracketVisitor().apply(rez2._1().right().get());
+            }
 
             return new Tuple2<>(Right.apply(rez3), warn);
         } finally {

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -212,17 +212,19 @@ public class KPrint {
                 if (k.klabel() instanceof KVariable) {
                     return super.apply(k);
                 }
-                Att att = unparsingModule.attributesFor().apply(KLabel(k.klabel().name()));
-                if (att.contains("comm") && att.contains("assoc") && att.contains("unit")) {
-                    List<K> items = new ArrayList<>(Assoc.flatten(k.klabel(), k.klist().items(), KLabel(att.get("unit"))));
-                    List<Tuple2<String, K>> printed = new ArrayList<>();
-                    for (K item : items) {
-                        String s = unparseInternal(unparsingModule, apply(item), ColorSetting.OFF);
-                        printed.add(Tuple2.apply(s, item));
+                if (!k.klabel().name().equals("amb")) {
+                    Att att = unparsingModule.attributesFor().apply(KLabel(k.klabel().name()));
+                    if (att.contains("comm") && att.contains("assoc") && att.contains("unit")) {
+                        List<K> items = new ArrayList<>(Assoc.flatten(k.klabel(), k.klist().items(), KLabel(att.get("unit"))));
+                        List<Tuple2<String, K>> printed = new ArrayList<>();
+                        for (K item : items) {
+                            String s = unparseInternal(unparsingModule, apply(item), ColorSetting.OFF);
+                            printed.add(Tuple2.apply(s, item));
+                        }
+                        printed.sort(Comparator.comparing(Tuple2::_1, new AlphanumComparator()));
+                        items = printed.stream().map(Tuple2::_2).map(this::apply).collect(Collectors.toList());
+                        return items.stream().reduce((k1, k2) -> KApply(k.klabel(), k1, k2)).orElse(KApply(KLabel(att.get("unit"))));
                     }
-                    printed.sort(Comparator.comparing(Tuple2::_1, new AlphanumComparator()));
-                    items = printed.stream().map(Tuple2::_2).map(this::apply).collect(Collectors.toList());
-                    return items.stream().reduce((k1, k2) -> KApply(k.klabel(), k1, k2)).orElse(KApply(KLabel(att.get("unit"))));
                 }
                 return super.apply(k);
             }


### PR DESCRIPTION
Since we made ambiguities report as errors, I'm adding this option to kast to visualize ambiguous programs better.