### PR TITLE
Fix bug in sort inference in beacon chain

### DIFF
--- a/k-distribution/tests/regression-new/fun-ocaml/fun-test.k
+++ b/k-distribution/tests/regression-new/fun-ocaml/fun-test.k
@@ -66,4 +66,11 @@ rule useNestedBarInt()
   rule [[ funIntListAndConfig() => #fun(V1 => 0)(.IntList) ]]
     <cell> M </cell>
 
+  syntax KItem ::= Int
+  syntax Int ::= funSortTest(Int) [function]
+  rule funSortTest(I)
+    => #fun(BALANCE
+    => #fun(ROOT
+    => BALANCE +Int ROOT)(I))(I)
+
 endmodule

--- a/k-distribution/tests/regression-new/fun-ocaml/funSort.test
+++ b/k-distribution/tests/regression-new/fun-ocaml/funSort.test
@@ -1,0 +1,1 @@
+funSortTest(1)

--- a/k-distribution/tests/regression-new/fun-ocaml/funSort.test.out
+++ b/k-distribution/tests/regression-new/fun-ocaml/funSort.test.out
@@ -1,0 +1,8 @@
+<generatedTop>
+  <k>
+    2
+  </k>
+  <cell>
+    .Map
+  </cell>
+</generatedTop>

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
@@ -501,7 +501,8 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
                             || (isFunctionRule(tc, isAnywhere)) && j == 0)) {
                         Term t = tc.get(0);
                         boolean strictSortEquality = tc.production().klabel().get().name().equals("#SyntacticCast") || tc.production().klabel().get().name().equals("#InnerCast");
-                        Either<Set<ParseFailedException>, Term> rez = new ApplyTypeCheck2(getSortOfCast(tc), true, strictSortEquality, strictSortEquality && inferSortChecks).apply(t);
+                        boolean hasCast = tc.production().klabel().get().name().startsWith("#SemanticCastTo");
+                        Either<Set<ParseFailedException>, Term> rez = new ApplyTypeCheck2(getSortOfCast(tc), true, strictSortEquality, !hasCast && inferSortChecks).apply(t);
                         if (rez.isLeft())
                             return rez;
                         tc = tc.with(0, rez.right().get());


### PR DESCRIPTION
This bug was not directly caused by the changes to polymorphic productions. It seems to relate to the interaction between sort inference and function rules. However, it was inadvertantly exposed by those changes and caused some variables to be inferred in some places in the rule as sort K and other places as another sort, which made the definition generated by the frontend invalid and silently corrupted the llvm backend's term representation at runtime. We may want to think about running the haskell backend's verifier of kore definitions from within llvm-kompile so we catch this issue sooner, but that can wait.

@malturki Can you please confirm whether or not this fixes the problems you were having with the beacon chain spec?