### PR TITLE
Maven: Use --batch-mode for CI

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -34,4 +34,4 @@ ADD java-backend/pom.xml /home/user/.tmp-maven/java-backend/
 ADD k-distribution/pom.xml /home/user/.tmp-maven/k-distribution/
 ADD kore/pom.xml /home/user/.tmp-maven/kore/
 RUN    cd /home/user/.tmp-maven \
-    && mvn dependency:go-offline 
+    && mvn --batch-mode dependency:go-offline 

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -35,4 +35,4 @@ ADD java-backend/pom.xml /home/user/.tmp-maven/java-backend/
 ADD k-distribution/pom.xml /home/user/.tmp-maven/k-distribution/
 ADD kore/pom.xml /home/user/.tmp-maven/kore/
 RUN    cd /home/user/.tmp-maven \
-    && mvn dependency:go-offline 
+    && mvn --batch-mode dependency:go-offline 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -76,7 +76,7 @@ pipeline {
                           echo 'Setting up environment...'
                           eval `opam config env`
                           echo 'Building K...'
-                          mvn verify -U
+                          mvn --batch-mode verify -U
                           echo 'Starting kserver...'
                           k-distribution/target/release/k/bin/spawn-kserver kserver.log
                           cd k-exercises/tutorial
@@ -382,8 +382,8 @@ pipeline {
             echo 'Setting up environment...'
             eval `opam config env`
             echo 'Deploying K...'
-            mvn clean
-            mvn install -DskipKTest -Dcheckstyle.skip
+            mvn --batch-mode clean
+            mvn --batch-mode install -DskipKTest -Dcheckstyle.skip
             COMMIT=$(git rev-parse --short HEAD)
             DESCRIPTION='This is the nightly release of the K framework. To install, download the appropriate binary package and install using your package manager. You can install a debian package via `sudo apt-get install ./kframework_5.0.0_amd64_$ID.deb` for the appropriate version codename $ID. You can install on Arch Linux using `sudo pacman -S ./kframework-5.0.0-1-x86_64.pkg.tar.xz`. If your OS is not supported, you can download and extract the \\"Platform-Independent K binary\\", and follow the instructions in INSTALL.md within the target directory. Note however that this will not support the Haskell or LLVM Backends. On Windows, start by installing [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) with Ubuntu (or an Ubuntu VM), after which you can install like Ubuntu. K requires gcc and other Linux libraries to run, and building on native Windows, Cygwin, or MINGW is not supported.'
             RESPONSE=`curl --data '{"tag_name": "nightly-'$COMMIT'","name": "Nightly build of K framework at commit '$COMMIT'","body": "'"$DESCRIPTION"'", "draft": true,"prerelease": true}' https://api.github.com/repos/kframework/k/releases?access_token=$GITHUB_TOKEN`

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -30,7 +30,7 @@ prepare() {
 
 build() {
 	cd ..
-	mvn package -DskipTests -Dllvm.backend.prefix=/usr/lib/kframework -Dllvm.backend.destdir="$srcdir"
+	mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=/usr/lib/kframework -Dllvm.backend.destdir="$srcdir"
 }
 
 check() {

--- a/debian/rules
+++ b/debian/rules
@@ -18,7 +18,7 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=-stackprotector
 	dh $@ 
 
 override_dh_auto_build:
-	mvn package -DskipTests -Dllvm.backend.prefix=/usr/lib/kframework -Dllvm.backend.destdir=$(shell pwd)/debian/kframework
+	mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=/usr/lib/kframework -Dllvm.backend.destdir=$(shell pwd)/debian/kframework
 
 override_dh_auto_install:
 	DESTDIR=$(shell pwd)/debian/kframework PREFIX=/usr src/main/scripts/package


### PR DESCRIPTION
The `--batch-mode` option makes logs significantly more readable by preventing
Maven from printing progress updates that don't display correctly.