### PR TITLE
Disable arch, update INSTALL.md

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -385,7 +385,7 @@ pipeline {
             mvn --batch-mode clean
             mvn --batch-mode install -DskipKTest -Dcheckstyle.skip
             COMMIT=$(git rev-parse --short HEAD)
-            DESCRIPTION='This is the nightly release of the K framework. To install, download the appropriate binary package and install using your package manager. You can install a debian package via `sudo apt-get install ./kframework_5.0.0_amd64_$ID.deb` for the appropriate version codename $ID. You can install on Arch Linux using `sudo pacman -S ./kframework-5.0.0-1-x86_64.pkg.tar.xz`. If your OS is not supported, you can download and extract the \\"Platform-Independent K binary\\", and follow the instructions in INSTALL.md within the target directory. Note however that this will not support the Haskell or LLVM Backends. On Windows, start by installing [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) with Ubuntu (or an Ubuntu VM), after which you can install like Ubuntu. K requires gcc and other Linux libraries to run, and building on native Windows, Cygwin, or MINGW is not supported.'
+            DESCRIPTION="$(cat k-distribution/INSTALL.md)"
             RESPONSE=`curl --data '{"tag_name": "nightly-'$COMMIT'","name": "Nightly build of K framework at commit '$COMMIT'","body": "'"$DESCRIPTION"'", "draft": true,"prerelease": true}' https://api.github.com/repos/kframework/k/releases?access_token=$GITHUB_TOKEN`
             ID=`echo "$RESPONSE" | grep '"id": [0-9]*,' -o | head -1 | grep '[0-9]*' -o`
             BOTTLE_NAME=`cd mojave && echo kframework--5.0.0.mojave.bottle*.tar.gz | sed 's!kframework--!kframework-!'`

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -190,69 +190,69 @@ pipeline {
                 }
               }
             }
-            stage('Build and Package on Arch Linux') {
-              when {
-                anyOf {
-                  branch 'master'
-                  changelog '.*^\\[build-system\\] .+$'
-                  changeset 'Jenkinsfile'
-                  changeset 'Dockerfile'
-                }
-              }
-              stages {
-                stage('Build on Arch Linux') {
-                  agent {
-                    dockerfile {
-                      filename 'Dockerfile.arch'
-                      additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
-                      reuseNode true
-                    }
-                  }
-                  stages {
-                    stage('Build Pacman Package') {
-                      steps {
-                        checkout scm
-                        sh '''
-                          makepkg
-                        '''
-                        stash name: "arch", includes: "kframework-5.0.0-1-x86_64.pkg.tar.xz"
-                      }
-                    }
-                  }
-                }
-                stage('Test Arch Package') {
-                  agent {
-                    docker {
-                      image 'archlinux/base'
-                      args '-u 0'
-                      reuseNode true
-                    }
-                  }
-                  options { skipDefaultCheckout() }
-                  steps {
-                    unstash "arch"
-                    sh '''
-                      pacman -Syyu --noconfirm
-                      pacman -U --noconfirm kframework-5.0.0-1-x86_64.pkg.tar.xz
-                      src/main/scripts/test-in-container
-                    '''
-                  }
-                  post {
-                    always {
-                      sh 'stop-kserver || true'
-                      archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
-                    }
-                  }
-                }
-              }
-              post {
-                failure {
-                  slackSend color: '#cb2431'                                         \
-                          , channel: '#k'                                            \
-                          , message: "Arch Linux Packaging Failed: ${env.BUILD_URL}"
-                }
-              }
-            }
+            //stage('Build and Package on Arch Linux') {
+            //  when {
+            //    anyOf {
+            //      branch 'master'
+            //      changelog '.*^\\[build-system\\] .+$'
+            //      changeset 'Jenkinsfile'
+            //      changeset 'Dockerfile'
+            //    }
+            //  }
+            //  stages {
+            //    stage('Build on Arch Linux') {
+            //      agent {
+            //        dockerfile {
+            //          filename 'Dockerfile.arch'
+            //          additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
+            //          reuseNode true
+            //        }
+            //      }
+            //      stages {
+            //        stage('Build Pacman Package') {
+            //          steps {
+            //            checkout scm
+            //            sh '''
+            //              makepkg
+            //            '''
+            //            stash name: "arch", includes: "kframework-5.0.0-1-x86_64.pkg.tar.xz"
+            //          }
+            //        }
+            //      }
+            //    }
+            //    stage('Test Arch Package') {
+            //      agent {
+            //        docker {
+            //          image 'archlinux/base'
+            //          args '-u 0'
+            //          reuseNode true
+            //        }
+            //      }
+            //      options { skipDefaultCheckout() }
+            //      steps {
+            //        unstash "arch"
+            //        sh '''
+            //          pacman -Syyu --noconfirm
+            //          pacman -U --noconfirm kframework-5.0.0-1-x86_64.pkg.tar.xz
+            //          src/main/scripts/test-in-container
+            //        '''
+            //      }
+            //      post {
+            //        always {
+            //          sh 'stop-kserver || true'
+            //          archiveArtifacts 'kserver.log,k-distribution/target/kserver.log'
+            //        }
+            //      }
+            //    }
+            //  }
+            //  post {
+            //    failure {
+            //      slackSend color: '#cb2431'                                         \
+            //              , channel: '#k'                                            \
+            //              , message: "Arch Linux Packaging Failed: ${env.BUILD_URL}"
+            //    }
+            //  }
+            //}
           }
         }
         stage('Build and Package on Mac OS') {
@@ -367,9 +367,9 @@ pipeline {
         dir("buster") {
           unstash "buster"
         }
-        dir("arch") {
-          unstash "arch"
-        }
+        //dir("arch") {
+        //  unstash "arch"
+        //}
         dir("mojave") {
           unstash "mojave"
         }
@@ -394,7 +394,7 @@ pipeline {
             curl --data-binary @k-distribution/target/k-nightly.tar.gz -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/gzip" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=nightly.tar.gz&label=Platform-Indepdendent+K+binary'
             curl --data-binary @bionic/kframework_5.0.0_amd64.deb -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/vnd.debian.binary-package" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework_5.0.0_amd64_bionic.deb&label=Ubuntu+Bionic+Debian+Package'
             curl --data-binary @buster/kframework_5.0.0_amd64.deb -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/vnd.debian.binary-package" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework_5.0.0_amd64_buster.deb&label=Debian+Buster+Debian+Package'
-            curl --data-binary @arch/kframework-5.0.0-1-x86_64.pkg.tar.xz -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/x-xz" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework-5.0.0-1-x86_64.pkg.tar.xz&label=Arch+Linux+Pacman+Package'
+            # curl --data-binary @arch/kframework-5.0.0-1-x86_64.pkg.tar.xz -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/x-xz" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name=kframework-5.0.0-1-x86_64.pkg.tar.xz&label=Arch+Linux+Pacman+Package'
             curl --data-binary @$LOCAL_BOTTLE_NAME -H "Authorization: token $GITHUB_TOKEN" -H "Content-Type: application/gzip" https://uploads.github.com/repos/kframework/k/releases/$ID/assets?'name='$BOTTLE_NAME'&label=Mac+OS+X+Mojave+Homebrew+Bottle'
             curl -X PATCH --data '{"draft": false}' https://api.github.com/repos/kframework/k/releases/$ID?access_token=$GITHUB_TOKEN
             curl --data '{"state": "success","target_url": "'$BUILD_URL'","description": "Build succeeded."}' https://api.github.com/repos/kframework/k/statuses/$(git rev-parse origin/master)?access_token=$GITHUB_TOKEN

--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -1,42 +1,108 @@
-<!-- Copyright (c) 2012-2019 K Team. All Rights Reserved. -->
-Here are instructions for installing K from the release tar.gz archive. If you have installed via the distro package, you do not need to follow these instructinos
+Installing K Framework Package
+==============================
 
+We currently strive to provide packages for the following platforms:
+
+-   Ubuntu Bionic (18.04)
+-   Debian Buster
+-   Arch Linux
+-   MacOS X Mojave
+-   Platform Independent K Binary
+
+**NOTE**: We do not currently support running K on native Windows. To use K on
+Windows, you are encouraged to install
+[Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
+and follow the instructions for Ubuntu Bionic.
+
+Download Packages
+-----------------
+
+Download the appropriate package from the GitHub, via the
+[Releases](https://github.com/kframework/k/releases) page.
+Releases are generated as often as possible from `master` build.
+
+Install Packages
+----------------
+
+For version `X.Y.Z`, disto `DISTRO`, and package ID `ID`, the following
+instructions tell you how to install on each system.
+
+### Ubuntu Bionic (18.04)/Debian Buster
+
+```sh
+sudo apt install ./kframework_X.Y.Z_amd64_DISTRO.deb
+```
+
+### Arch Linux
+
+```sh
+sudo pacman -U kframework-X.Y.Z-ID-x86_64.pkg.tar.xz
+```
+
+### MacOS X Mojave
+
+Tap the `kframework/k` bottle then install (with build number `BN`):
+
+```sh
+brew tap kframework/k "file:///$(pwd)"
+brew install kframework--X.Y.Z.ID.bottle.BN.tar.gz -v
+```
+
+### Platform Independent K Binary
+
+The platform independent K binary is a best-attempt at making a portable
+distribution of K. When possible, prefer the platform specific packages.
 We have only tested this on Ubuntu, although it may work on other distributions.
-Appropriate installation instructions and bug reports are welcome from contributors.
+Appropriate installation instructions and bug reports are welcome from
+contributors.
 
-1. Prerequisites:
-  * Package dependencies:
-    `sudo apt-get update; sudo apt-get install build-essential m4 openjdk-8-jre libgmp-dev libmpfr-dev pkg-config flex z3 libz3-dev unzip python3`
+1.  Install Prerequisites:
 
-2. Install:
-  * Move this directory, once extracted, to your preferred location.  For convenient usage,
-    update your $PATH with <preferred-location>/k/bin.
+    ```sh
+    sudo apt-get update
+    sudo apt-get install build-essential m4 openjdk-8-jre libgmp-dev libmpfr-dev pkg-config flex z3 libz3-dev unzip python3
+    ```
 
-3. OCAML (not required by K tutorial):
-  * To use the OCAML backend requires an installation of the OCAML package
+2.  Unpack the binary (will place in subdirectory `k`), move to preferred install location:
+
+    ```sh
+    tar -xvf kframework-X.Y.Z-ID-x86_64.pkg.tar.gz
+    mv k /PATH/TO/INSTALL/k
+    ```
+
+3.  Update your `PATH` (using the `k` directory extracted to above):
+
+    ```sh
+    export PATH=$PATH:/PATH/TO/INSTALL/k/bin
+    ```
+
+4.  Install OCaml (Optional):
+
+    **NOTE**: It is *strongly* recommended that you use the LLVM backend
+    instead of the OCaml backend. The OCaml backend is being sunsetted.
+
+    To use the OCAML backend requires an installation of the OCAML package
     manager OPAM. Instructions on installing OPAM are available here:
-    https://opam.ocaml.org/doc/Install.html
-    You should install on Windows by following the instructions for the
-    Linux distribution you installed for Windows Subsystem for Linux.
-    
-  * Once opam is installed, you can prepare the installation to run
-    the OCAML backend by running the "k-configure-opam" script found
-    in the bin directory. You will also need to run ``eval `opam config env` ``
-    afterwards to update your environment.
+    <https://opam.ocaml.org/doc/Install.html>.
+    You should install on Windows by following the instructions for the Linux
+    distribution you installed for Windows Subsystem for Linux.
+
+    Once opam is installed, you can prepare the installation to run the OCAML
+    backend by running:
+
+    ```
+    k-configure-opam
+    eval $(opam config env)
+    ```
+
+    `k-configure-opam` is in the `k/bin` directory, and the `eval` command sets
+    up your OCaml environment.
 
 4. Test:
-  * Go to one of the examples (say k/tutorial/2_languages/1_simple/1_untyped/).
-    Assuming k/bin is in your $PATH, you can compile and test a definition by running
-    the `make` command.
-    To execute a program you can use e.g. `krun tests/diverse/factorial.simple`.
-    K supports both the OCAML backend for concrete execution (by default) and
-    also the Java backend for symbolic execution and program verification (with
-    `kompile --backend java`.
 
---------------------------------------------------------------------------
-
-Note: We do not currently support running K on native Windows. To use K on
-Windows, you are encouraged to install
-[Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
-
---------------------------------------------------------------------------
+   Go to one of the examples (say `k/tutorial/2_languages/1_simple/1_untyped/`).
+   Assuming k/bin is in your $PATH, you can compile and test a definition by
+   running the `make` command. To execute a program you can use e.g.
+   `krun tests/diverse/factorial.simple`. K supports both the LLVM/OCaml
+   backends for concrete execution and the Haskell/Java backend for symbolic
+   execution and program verification (with `kompile --backend [haskell|java]`).

--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -94,7 +94,7 @@ contributors.
 4. Test:
 
    Go to one of the examples (say `k/tutorial/2_languages/1_simple/1_untyped/`).
-   Assuming k/bin is in your $PATH, you can compile and test a definition by
+   Assuming `k/bin` is in your `$PATH`, you can compile and test a definition by
    running the `make` command. To execute a program you can use e.g.
    `krun tests/diverse/factorial.simple`. K supports both the LLVM/OCaml
    backends for concrete execution and the Haskell/Java backend for symbolic

--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -5,7 +5,6 @@ We currently strive to provide packages for the following platforms:
 
 -   Ubuntu Bionic (18.04)
 -   Debian Buster
--   Arch Linux
 -   MacOS X Mojave
 -   Platform Independent K Binary
 
@@ -31,12 +30,6 @@ instructions tell you how to install on each system.
 
 ```sh
 sudo apt install ./kframework_X.Y.Z_amd64_DISTRO.deb
-```
-
-### Arch Linux
-
-```sh
-sudo pacman -U kframework-X.Y.Z-ID-x86_64.pkg.tar.xz
 ```
 
 ### MacOS X Mojave


### PR DESCRIPTION
This PR does 3 things:

-   Disable Arch Linux packaging process (waiting for fixes to LLVM backend for Arch).
-   Uses `INSTALL.md` for `DESCRIPTION` in GitHub packaging process.
-   Updates `INSTALL.md` for formatting and stufff.