### PR TITLE
Fix another issue with sort inference

### DIFF
--- a/k-distribution/tests/regression-new/fun-ocaml/fun-test.k
+++ b/k-distribution/tests/regression-new/fun-ocaml/fun-test.k
@@ -73,4 +73,32 @@ rule useNestedBarInt()
     => #fun(ROOT
     => BALANCE +Int ROOT)(I))(I)
 
+  syntax KItem ::= Hash
+  syntax Hash ::= funSortTest2() [function]
+  rule funSortTest2()
+    => #fun(EPOCH
+    => #fun(CommitteesPerSlot
+    => #fun(OFFSET
+    => #fun(SHARD
+    => #fun(FirstCommittee
+    => #fun(MaxRandomByte
+    => #fun(SEED
+    => #fun(I
+    => funSortTest2Aux(EPOCH, CommitteesPerSlot, OFFSET, SHARD, FirstCommittee, MaxRandomByte, SEED, I)
+       )(0)
+       )(get_seed(EPOCH))
+       )(0)
+       )(0)
+       )(0)
+       )(0)
+       )(0)
+       )(0)
+
+  syntax Hash ::= funSortTest2Aux(Int, Int, Int, Int, Int, Int, h: Hash, Int) [function]
+  rule funSortTest2Aux(... h: H) => H
+
+  syntax Hash ::= "foo"
+  syntax Hash ::= "get_seed" "(" Int ")" [function]
+  rule get_seed(_) => foo
+
 endmodule

--- a/k-distribution/tests/regression-new/fun-ocaml/funSort2.test
+++ b/k-distribution/tests/regression-new/fun-ocaml/funSort2.test
@@ -1,0 +1,1 @@
+funSortTest2()

--- a/k-distribution/tests/regression-new/fun-ocaml/funSort2.test.out
+++ b/k-distribution/tests/regression-new/fun-ocaml/funSort2.test.out
@@ -1,0 +1,8 @@
+<generatedTop>
+  <k>
+    foo
+  </k>
+  <cell>
+    .Map
+  </cell>
+</generatedTop>

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/VariableTypeInferenceFilter.java
@@ -510,7 +510,10 @@ public class VariableTypeInferenceFilter extends SetsGeneralTransformer<ParseFai
                     } else {
                         Term t = tc.get(j);
                         Sort s = ((NonTerminal) tc.production().items().apply(i)).sort();
-                        if (!tc.production().isSortVariable(s)) {
+                        if (!tc.production().isSortVariable(s) || !s.equals(tc.production().sort())) {
+                            if (tc.production().isSortVariable(s)) {
+                              s = Sorts.K();
+                            }
                             Either<Set<ParseFailedException>, Term> rez = new ApplyTypeCheck2(s, false, false, inferSortChecks).apply(t);
                             if (rez.isLeft())
                                 return rez;


### PR DESCRIPTION
We had a bug where we were not inferring casts in the direct children of polymorphic productions if the children are polymorphic in one another but not in the return sort. This should fix that case.