### PR TITLE
disable warning about useless top level rules unless asked for

### DIFF
--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -43,7 +43,7 @@ public class LLVMBackend extends KoreBackend {
         files.saveToKompiled("definition.kore", kore);
         FileUtils.deleteQuietly(files.resolveKompiled("dt"));
         MutableInt warnings = new MutableInt();
-        Matching.writeDecisionTreeToFile(files.resolveKompiled("definition.kore"), options.heuristic, files.resolveKompiled("dt"), Matching.getThreshold(getThreshold(options)), ex -> {
+        Matching.writeDecisionTreeToFile(files.resolveKompiled("definition.kore"), options.heuristic, files.resolveKompiled("dt"), Matching.getThreshold(getThreshold(options)), options.warnUseless, ex -> {
           kem.addKException(ex);
           warnings.increment();
           return null;

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
@@ -33,4 +33,7 @@ public class LLVMKompileOptions {
 
     @Parameter(names="--no-llvm-kompile", description="Do not invoke llvm-kompile. Useful if you want to do it yourself when building with the LLVM backend.")
     public boolean noLLVMKompile;
+
+    @Parameter(names="-Wuseless", description="Warn about useless top-level rules. This can be quite time-consuming to compute if the semantics is particularly large, so it is disabled by default.")
+    public boolean warnUseless;
 }


### PR DESCRIPTION
We do this because it turns out to be quite expensive to compute
and I don't currently have the resources to sink into optimizing
it properly. You can still run it via an option. Unless the semantics is extremely large, it seems to perform okay, but some semantics seem to encounter some exponential case.