### PR TITLE
Improve llvm backend optimization flags

### DIFF
--- a/k-distribution/tests/regression-new/context-alias/1.test.out
+++ b/k-distribution/tests/regression-new/context-alias/1.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    1 + ( 1 + 1 ) ~> #freezer_;_TEST0_ ( )
+    1 + ( 1 + 1 ) ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/10.test.out
+++ b/k-distribution/tests/regression-new/context-alias/10.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    0 - ( 1 :+ 1 ) ~> #freezer_;_TEST0_ ( )
+    0 - ( 1 :+ 1 ) ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/1b.test.out
+++ b/k-distribution/tests/regression-new/context-alias/1b.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    ( 1 + 1 ) + 1 ~> #freezer_;_TEST0_ ( )
+    ( 1 + 1 ) + 1 ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/3.test.out
+++ b/k-distribution/tests/regression-new/context-alias/3.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    x = ( 1 + 1 ) ~> #freezer_;_TEST0_ ( )
+    x = ( 1 + 1 ) ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/3b.test.out
+++ b/k-distribution/tests/regression-new/context-alias/3b.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    ( x = 1 ) + 1 ~> #freezer_;_TEST0_ ( )
+    ( x = 1 ) + 1 ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/5b.test.out
+++ b/k-distribution/tests/regression-new/context-alias/5b.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    ( x := 1 ) + 1 ~> #freezer_;_TEST0_ ( )
+    ( x := 1 ) + 1 ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/7.test.out
+++ b/k-distribution/tests/regression-new/context-alias/7.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    ( x = 2 ) ->+ x = 3 ~> #freezer_;_TEST0_ ( )
+    ( x = 2 ) ->+ x = 3 ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/7b.test.out
+++ b/k-distribution/tests/regression-new/context-alias/7b.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    x = ( 2 ->+ x = 3 ) ~> #freezer_;_TEST0_ ( )
+    x = ( 2 ->+ x = 3 ) ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/9.test.out
+++ b/k-distribution/tests/regression-new/context-alias/9.test.out
@@ -1,6 +1,6 @@
 <generatedTop>
   <k>
-    ( 1 + 1 ) - 1 ~> #freezer_;_TEST0_ ( )
+    ( 1 + 1 ) - 1 ~> #freezer_;_TEST_Stmt_Expr0_ ( )
   </k>
   <shouldHeat>
     false

--- a/k-distribution/tests/regression-new/context-alias/Makefile
+++ b/k-distribution/tests/regression-new/context-alias/Makefile
@@ -1,5 +1,6 @@
 DEF=test
 EXT=test
 TESTDIR=.
+KOMPILE_BACKEND=llvm
 
 include ../../../include/ktest.mak

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -70,7 +70,7 @@ public class KoreBackend implements Backend {
             KompileOptions kompileOptions,
             FileUtil files,
             KExceptionManager kem) {
-        this(kompileOptions, files, kem, EnumSet.of(HEAT_RESULT), false);
+        this(kompileOptions, files, kem, kompileOptions.optimize2 || kompileOptions.optimize3 ? EnumSet.of(HEAT_RESULT) : EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION), false);
     }
 
     public KoreBackend(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem, EnumSet<ResolveHeatCoolAttribute.Mode> heatCoolConditions, boolean heatCoolEquations) {

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -79,6 +79,9 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--hook-namespaces", listConverter=StringListConverter.class, description="<string> is a whitespace-separated list of namespaces to include in the hooks defined in the definition")
     public List<String> hookNamespaces = Collections.emptyList();
 
+    @Parameter(names="-O1", description="Optimize in ways that improve performance and code size, but interfere with debugging and increase compilation time slightly.")
+    public boolean optimize1;
+
     @Parameter(names="-O2", description="Optimize further in ways that improve performance and code size, but interfere with debugging more and increase compilation time somewhat.")
     public boolean optimize2;
 

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -79,6 +79,12 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--hook-namespaces", listConverter=StringListConverter.class, description="<string> is a whitespace-separated list of namespaces to include in the hooks defined in the definition")
     public List<String> hookNamespaces = Collections.emptyList();
 
+    @Parameter(names="-O2", description="Optimize further in ways that improve performance and code size, but interfere with debugging more and increase compilation time somewhat.")
+    public boolean optimize2;
+
+    @Parameter(names="-O3", description="Optimize aggressively in ways that significantly improve performance, but interfere with debugging significantly and also increase compilation time and code size substantially.")
+    public boolean optimize3;
+
     @ParametersDelegate
     public Experimental experimental = new Experimental();
 

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -64,6 +64,9 @@ public class LLVMBackend extends KoreBackend {
         args.add("main");
         args.add("-o");
         args.add("interpreter");
+        if (kompileOptions.optimize1) args.add("-O1");
+        if (kompileOptions.optimize2) args.add("-O2");
+        if (kompileOptions.optimize3) args.add("-O2"); // clang -O3 does not make the llvm backend any faster
         args.addAll(options.ccopts);
         try {
             Process p = pb.command(args).directory(files.resolveKompiled(".")).inheritIO().start();

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -24,6 +24,7 @@ public class LLVMBackend extends KoreBackend {
 
     private final LLVMKompileOptions options;
     private final KExceptionManager kem;
+    private final KompileOptions kompileOptions;
 
     @Inject
     public LLVMBackend(
@@ -33,6 +34,7 @@ public class LLVMBackend extends KoreBackend {
             LLVMKompileOptions options) {
         super(kompileOptions, files, kem);
         this.options = options;
+        this.kompileOptions = kompileOptions;
         this.kem = kem;
     }
 
@@ -43,7 +45,7 @@ public class LLVMBackend extends KoreBackend {
         files.saveToKompiled("definition.kore", kore);
         FileUtils.deleteQuietly(files.resolveKompiled("dt"));
         MutableInt warnings = new MutableInt();
-        Matching.writeDecisionTreeToFile(files.resolveKompiled("definition.kore"), options.heuristic, files.resolveKompiled("dt"), Matching.getThreshold(getThreshold(options)), options.warnUseless, ex -> {
+        Matching.writeDecisionTreeToFile(files.resolveKompiled("definition.kore"), options.heuristic, files.resolveKompiled("dt"), Matching.getThreshold(getThreshold()), options.warnUseless, ex -> {
           kem.addKException(ex);
           warnings.increment();
           return null;
@@ -74,8 +76,8 @@ public class LLVMBackend extends KoreBackend {
         }
     }
 
-    private static String getThreshold(LLVMKompileOptions options) {
-        if (!options.iterated) {
+    private String getThreshold() {
+        if (!options.iterated && !kompileOptions.optimize3) {
             return "0";
         }
         return options.iteratedThreshold;

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlBackend.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlBackend.java
@@ -88,7 +88,7 @@ public class OcamlBackend implements Backend {
                 String sharedLibExt;
                 String flag;
                 String ext;
-                if (options.ocamlopt()) {
+                if (kompileOptions.optimize2 || kompileOptions.optimize3) {
                     args.add(0, ocamlfind);
                     args.add(1, "ocamlopt");
                     args.add("-inline");
@@ -121,7 +121,7 @@ public class OcamlBackend implements Backend {
                 args.addAll(Arrays.asList("-g", flag, "-o", "realdef." + sharedLibExt, "realdef." + ext));
                 args.addAll(3, options.packages.stream().flatMap(pkg -> Stream.of("-package", pkg)).collect(Collectors.toList()));
                 args.add(0, ocamlfind);
-                if (options.ocamlopt()) {
+                if (kompileOptions.optimize2 || kompileOptions.optimize3) {
                     args.add(1, "ocamlopt");
                 } else {
                     args.add(1, "ocamlc");

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlOptions.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlOptions.java
@@ -35,12 +35,6 @@ public class OcamlOptions implements Serializable {
     @Parameter(names="--ocaml-serialize-config", listConverter=StringListConverter.class, description="<string> is a whitespace-separated list of configuration variables to precompute the value of")
     public List<String> serializeConfig = Collections.emptyList();
 
-    @Parameter(names="-O2", description="Optimize in ways that improve performance, but intere with debugging and increase compilation time and code size slightly.")
-    public boolean optimize2;
-
-    @Parameter(names="-O3", description="Optimize aggressively in ways that significantly improve performance, but also increase compilation time and code size.")
-    public boolean optimize3;
-
     @Parameter(names="-Og", description="Optimize as much as possible without interfering with debugging experience.")
     public boolean optimizeG;
 
@@ -49,7 +43,4 @@ public class OcamlOptions implements Serializable {
 
     @Parameter(names="--check-races", description="Checks for races among regular rules.")
     public boolean checkRaces;
-
-    public boolean ocamlopt() { return optimize2 || optimize3; }
-    public boolean optimizeStep() { return optimize3 || optimizeG; }
 }

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlRewriter.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlRewriter.java
@@ -338,7 +338,7 @@ public class OcamlRewriter implements Function<Definition, Rewriter> {
         args.addAll(options.experimental.nativeLibraries.stream().flatMap(lib -> Stream.of("-cclib", lib)).collect(Collectors.toList()));
         args.addAll(Arrays.asList(objectFiles));
         String ocamlfind = OcamlBackend.getOcamlFind(files);
-        if (converter.options.ocamlopt()) {
+        if (converter.kompileOptions.optimize2 || converter.kompileOptions.optimize3) {
             args.add(0, ocamlfind);
             args.add(1, "ocamlopt");
             if (!converter.options.noLinkPrelude) {


### PR DESCRIPTION
There are now 3 additional flags to kompile for the llvm backend:

1. Default: no optimizations
1. -O1: passes -O1 to llvm-kompile
2. -O2: passes -O2 to llvm-kompile but also disables the side condition on cooling rules
3. -O3: passes -O2 to llvm-kompile and disables side condition on cooling rules, and also enables iterated pattern matching.