### PR TITLE
Remove "String" as builtin type in Z3

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/KILtoSMTLib.java
@@ -48,7 +48,6 @@ public class    KILtoSMTLib extends CopyOnWriteTransformer {
             Sort.INT,
             Sort.BIT_VECTOR,
             Sort.of(Sorts.Float()),
-            Sort.of(Sorts.String()),
             Sort.of(KORE.Sort("IntSet")),
             Sort.of(KORE.Sort("MIntSet")),
             Sort.of(KORE.Sort("FloatSet")),


### PR DESCRIPTION
Emitting the function `(declare-fun string2wasmstring (String) WasmStringToken)`  causes an error saying there is no `String` sort. Declaring it explicitly fixes the problem.

Perhaps we should also delete the *string theory* set of builtin functions?