### PR TITLE
apply function rules in order

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/KItem.java
@@ -34,6 +34,7 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 
 import java.io.IOException;
 import java.io.ObjectOutputStream;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -494,9 +495,12 @@ public class KItem extends Term implements KItemRepresentation {
                     Rule appliedRule = null;
                     KItemLog.logStartingEval(kLabelConstant, nestingLevel, kItem.global, context);
 
+                    List<Rule> sortedRulesForKLabel = new ArrayList<>(rulesForKLabel);
+                    sortedRulesForKLabel.sort(Rule::compareTo);
+
                     // an argument is concrete if it doesn't contain variables or unresolved functions
                     boolean isConcrete = kList.getContents().stream().filter(elem -> !elem.isGround() || !elem.isNormal()).collect(Collectors.toList()).isEmpty();
-                    for (Rule rule : rulesForKLabel) {
+                    for (Rule rule : sortedRulesForKLabel) {
                         try {
                             if (rule == RuleAuditing.getAuditingRule()) {
                                 RuleAuditing.beginAudit();

--- a/java-backend/src/main/java/org/kframework/backend/java/kil/Rule.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/kil/Rule.java
@@ -7,6 +7,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import org.apache.commons.collections15.list.UnmodifiableList;
 import org.kframework.attributes.Att;
+import org.kframework.attributes.Location;
+import org.kframework.attributes.Source;
 import org.kframework.backend.java.builtins.BoolToken;
 import org.kframework.backend.java.rewritemachine.GenerateRHSInstructions;
 import org.kframework.backend.java.rewritemachine.RHSInstruction;
@@ -350,5 +352,23 @@ public class Rule extends JavaSymbolicObject<Rule> implements HasAtt {
     @Override
     public void accept(Visitor visitor) {
         visitor.visit(this);
+    }
+
+    public int compareTo(Rule anotherRule) {
+        Location loc1 = this.getLocation();
+        Location loc2 = anotherRule.getLocation();
+        String src1 = this.source().toString();
+        String src2 = anotherRule.source().toString();
+        int cmp = src1.compareTo(src2);
+        if (cmp == 0) {
+            if (loc1 != null && loc2 != null) {
+                cmp = loc1.startLine() - loc2.startLine();
+            } else if (loc1 != null) {
+                cmp = -1;
+            } else if (loc2 != null) {
+                cmp = 1;
+            }
+        }
+        return cmp;
     }
 }


### PR DESCRIPTION
Sort function rules by their locations before applying. This helps avoid using #notKLabel in lemmas.

Performance overhead is not much.  Or, we can consider to cache the sorted list, if needed.