### PR TITLE
Java Backend: improved simplification of equalities

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/ConjunctiveFormula.java
@@ -468,7 +468,7 @@ public class ConjunctiveFormula extends Term implements CollectionInternalRepres
                     Equality oldEquality = equality; //for debug
                     Term leftHandSide = oldEquality.leftHandSide().substituteAndEvaluate(substitution, context);
                     Term rightHandSide = oldEquality.rightHandSide().substituteAndEvaluate(substitution, context);
-                    equality = new Equality(leftHandSide, rightHandSide, global);
+                    equality = new Equality(leftHandSide, rightHandSide, global).simplify();
                     //noinspection StatementWithEmptyBody
                     if (equality.isTrue()) {
                         // delete


### PR DESCRIPTION
Allows ==K term evaluation through regular rules before builtin simplification is applied.