### PR TITLE
domains.k: MAP imports BOOL and INT

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -90,6 +90,8 @@ module ARRAY
 endmodule
 
 module MAP
+  imports BOOL-SYNTAX
+  imports INT-SYNTAX
   imports LIST
   imports SET
 


### PR DESCRIPTION
If the BOOL and INT modules are not imported into MAP, then the declaration of
Bool- and Int-valued functions in that module defines new Int and Bool sorts
that are not hooked to the builtin domains in Kore.