### PR TITLE
FST serializer: fixes to intermittent, concurrency failures

### DIFF
--- a/k-distribution/src/main/scripts/lib/checkJava
+++ b/k-distribution/src/main/scripts/lib/checkJava
@@ -40,7 +40,9 @@ else
     if [ $ARCH -eq 64 ]; then
       TIERED=-XX:+TieredCompilation
     fi
-    export K_OPTS="-Xms64m -Xmx4096m -Xss32m $TIERED $K_OPTS"
+    # FST serializer v2.56 works properly only with ParallelGC. And ParallelGC should be faster for K anyway.
+    # https://github.com/RuedigerMoeller/fast-serialization/issues/274
+    export K_OPTS="-Xms64m -Xmx4096m -Xss32m -XX:+UseParallelGC $TIERED $K_OPTS"
     JAVA="java -Dfile.encoding=UTF-8 -Djava.awt.headless=true $K_OPTS -ea -cp \"$(dirname "$BASH_SOURCE")/java/*\""
   fi
 fi


### PR DESCRIPTION
Without this PR K Jenkins fails in ~20% of runs. When definition cache will be merged, it is expected to fail more often.
Proof, 15 K builds passed on Jenkins: https://github.com/kframework/k/pull/1034

References:
https://github.com/RuedigerMoeller/fast-serialization/issues/274