### PR TITLE
kernel/KastFrontEnd: make sure to flush output

### DIFF
--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -144,6 +144,7 @@ public class KastFrontEnd extends FrontEnd {
               }
 
               System.out.print(new String(kprint.get().prettyPrint(def, unparsingMod, parsed), StandardCharsets.UTF_8));
+              System.out.flush();
             }
             sw.printTotal("Total");
             return 0;


### PR DESCRIPTION
Creates a problem in Polkadot repo where only part of the (very large) JSON output is being grabbed by the step after calling `kast`.