### PR TITLE
fix bug involving interaction of function context and macros

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -220,6 +220,9 @@ public class ExpandMacros {
                                 public K apply(KVariable k) {
                                     K result = subst.get(k);
                                     if (result == null) {
+                                      if (k.name().equals("_Configuration")) {
+                                        return k;
+                                      }
                                       result = newDotVariable(k.att());
                                       subst.put(k, result);
                                     }

--- a/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
@@ -233,9 +233,6 @@ public class ResolveFunctionWithConfig {
     }
 
     public Sentence resolve(Module m, Sentence s) {
-        if (ExpandMacros.isMacro(s)) {
-            return s;
-        }
         if (s instanceof Rule) {
             return resolve((Rule) s, m);
         } else if (s instanceof Context) {


### PR DESCRIPTION
This fixes a bug in the C semantics, but I couldn't figure out how to reproduce the issue in a standalone K definition, so that's why there isn't a regression test...