### PR TITLE
domains.k: Do not import K-REFLECTION

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -18,7 +18,6 @@ module DOMAINS
   imports K-IO
   imports MAP
   imports SET
-  imports K-REFLECTION
 endmodule
 
 module ARRAY-SYNTAX


### PR DESCRIPTION
The module K-REFLECTION is not supported by the Haskell backend, and it is an
error if it is imported. Specifically, `#isConcrete` must not be in scope.