### PR TITLE
default value of core.abbrev is different on Mac OS, leading to 404

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -405,7 +405,7 @@ pipeline {
         }
         sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
           sh '''
-            release_tag="v${VERSION}-$(git rev-parse --short HEAD)"
+            release_tag="v${VERSION}-$(git rev-parse --short=7 HEAD)"
             mv bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
             mv buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
             LOCAL_BOTTLE_NAME=$(echo mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)

--- a/src/main/scripts/brew-update-to-final
+++ b/src/main/scripts/brew-update-to-final
@@ -1,5 +1,5 @@
 #!/bin/sh -exu
-REV=$(cd .. && git rev-parse --short HEAD)
+REV=$(cd .. && git rev-parse --short=7 HEAD)
 sed -i "" -e 's!^  url ".*"$!  url "'$ROOT_URL/v$VERSION-$REV/$PACKAGE-$VERSION-src'.tar.gz"!' \
     Formula/$PACKAGE.rb
 git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 3"

--- a/src/main/scripts/brew-update-to-local-bottle
+++ b/src/main/scripts/brew-update-to-local-bottle
@@ -1,5 +1,5 @@
 #!/bin/sh -exu
-REV=$(cd .. && git rev-parse --short HEAD)
+REV=$(cd .. && git rev-parse --short=7 HEAD)
 brew bottle --json $PACKAGE --root-url="$ROOT_URL/v$VERSION-$REV/"
 cat *.bottle.json
 brew bottle --merge --write --no-commit *.bottle.json


### PR DESCRIPTION
error

I believe this should fix, probably, #1078 once the release happens after being merged, [but I'm not 100% sure. At the very least it is harmless though.