### PR TITLE
Filter substitutions of anonymous variables

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -96,7 +96,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
         this.kem = kem;
         this.smtOptions = smtOptions;
         this.hookProvider = HookProvider.get(kem);
-        this.transitions = kompileOptions.transition;
+        this.transitions = kompileOptions.experimental.transition;
         this.krunOptions = krunOptions;
         this.kproveOptions = kproveOptions;
         this.kompileOptions = kompileOptions;

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -106,7 +106,7 @@ public class KoreBackend extends AbstractBackend {
     @Override
     public Function<Definition, Definition> steps() {
         Function1<Definition, Definition> resolveStrict = d -> DefinitionTransformer.from(new ResolveStrict(kompileOptions, d)::resolve, "resolving strict and seqstrict attributes").apply(d);
-        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.transition), heatCoolConditions)::resolve, "resolving heat and cool attributes");
+        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.experimental.transition), heatCoolConditions)::resolve, "resolving heat and cool attributes");
         DefinitionTransformer resolveAnonVars = DefinitionTransformer.fromSentenceTransformer(new ResolveAnonVar()::resolve, "resolving \"_\" vars");
         DefinitionTransformer guardOrs = DefinitionTransformer.fromSentenceTransformer(new GuardOrPatterns(true)::resolve, "resolving or patterns");
         DefinitionTransformer resolveSemanticCasts =

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -190,7 +190,7 @@ public class Kompile {
 
     public static Function<Definition, Definition> defaultSteps(KompileOptions kompileOptions, KExceptionManager kem, FileUtil files) {
         Function1<Definition, Definition> resolveStrict = d -> DefinitionTransformer.from(new ResolveStrict(kompileOptions, d)::resolve, "resolving strict and seqstrict attributes").apply(d);
-        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.transition), EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION))::resolve, "resolving heat and cool attributes");
+        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.experimental.transition), EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION))::resolve, "resolving heat and cool attributes");
         DefinitionTransformer resolveAnonVars = DefinitionTransformer.fromSentenceTransformer(new ResolveAnonVar()::resolve, "resolving \"_\" vars");
         DefinitionTransformer guardOrs = DefinitionTransformer.fromSentenceTransformer(new GuardOrPatterns(false)::resolve, "resolving or patterns");
         DefinitionTransformer resolveSemanticCasts =

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -61,11 +61,6 @@ public class KompileOptions implements Serializable {
         return syntaxModule;
     }
 
-    @Parameter(names="--transition", listConverter=StringListConverter.class, description="<string> is a whitespace-separated list of tags designating rules to become transitions.")
-    public List<String> transition = Collections.singletonList(DEFAULT_TRANSITION);
-
-    public static final String DEFAULT_TRANSITION = "transition";
-
     @Parameter(names="--non-strict", description="Do not add runtime sort checks for every variable's inferred sort. Only has an effect with `--backend ocaml`.")
     private boolean nonStrict;
 
@@ -136,5 +131,10 @@ public class KompileOptions implements Serializable {
 
         @Parameter(names="--gen-bison-parser", description="Emit bison parser for the PGM configuration variable within the syntax module of your definition into the kompiled definition.")
         public boolean genBisonParser;
+
+        @Parameter(names="--transition", listConverter=StringListConverter.class, description="<string> is a whitespace-separated list of tags designating rules to become transitions.")
+        public List<String> transition = Collections.singletonList(DEFAULT_TRANSITION);
+
+        public static final String DEFAULT_TRANSITION = "transition";
     }
 }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -291,7 +291,7 @@ public class KPrint {
       KApply kapp = (KApply)term;
       if (kapp.klabel().head().equals(KLabels.ML_EQUALS)) {
         if (!(kapp.items().get(0) instanceof KVariable) &&
-            (!(kapp.items().get(0) instanceof KApply) || 
+            (!(kapp.items().get(0) instanceof KApply) ||
              !mod.attributesFor().apply(((KApply)kapp.items().get(0)).klabel()).contains(Attribute.FUNCTION_KEY))) {
           return Optional.of(term);
         }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -3,9 +3,12 @@ package org.kframework.unparser;
 
 import com.davekoelle.AlphanumComparator;
 import com.google.inject.Inject;
+import com.google.common.collect.Multiset;
+import com.google.common.collect.HashMultiset;
 import jline.internal.Nullable;
 import org.kframework.attributes.Att;
 import org.kframework.backend.kore.ModuleToKORE;
+import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Sorts;
 import org.kframework.compile.AddSortInjections;
 import org.kframework.compile.ExpandMacros;
@@ -16,9 +19,11 @@ import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.Assoc;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
+import org.kframework.kore.KLabel;
 import org.kframework.kore.KVariable;
 import org.kframework.kore.Sort;
 import org.kframework.kore.TransformK;
+import org.kframework.kore.VisitK;
 import org.kframework.main.GlobalOptions;
 import org.kframework.parser.ProductionReference;
 import org.kframework.parser.Term;
@@ -37,8 +42,11 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -204,7 +212,8 @@ public class KPrint {
     }
 
     public K abstractTerm(Module mod, K term) {
-        K origNames         = options.restoreOriginalNames ? restoreOriginalNameIfPresent(term) : term;
+        K filteredSubst     = options.noFilterSubstitution || !kompileOptions.isKore() ? term : filterSubst(term);
+        K origNames         = options.restoreOriginalNames ? restoreOriginalNameIfPresent(filteredSubst) : filteredSubst;
         K collectionsSorted = options.noSortCollections    ? origNames : sortCollections(mod, origNames);
         //non-determinism is still possible if associative/commutative collection terms start with anonymous vars
         K alphaRenamed      = options.noAlphaRenaming      ? collectionsSorted : alphaRename(collectionsSorted);
@@ -212,6 +221,87 @@ public class KPrint {
         K flattenedTerm     = flattenTerms(mod, squashedTerm);
 
         return flattenedTerm;
+    }
+
+    public Set<KVariable> vars(K term) {
+      return new HashSet<>(multivars(term));
+    }
+
+    public Multiset<KVariable> multivars(K term) {
+      Multiset<KVariable> vars = HashMultiset.create();
+      new VisitK() {
+        @Override
+        public void apply(KVariable var) {
+          vars.add(var);
+        }
+      }.apply(term);
+      return vars;
+    }
+
+    public K filterSubst(K term) {
+      if (!(term instanceof KApply)) {
+        return term;
+      }
+      KApply kapp = (KApply)term;
+      if (kapp.klabel().head().equals(KLabels.ML_AND)) {
+        return filterConjunction(kapp);
+      } else if (kapp.klabel().head().equals(KLabels.ML_OR)) {
+        KLabel unit = KLabel(KLabels.ML_FALSE.name(), kapp.klabel().params().apply(0));
+        List<K> disjuncts = Assoc.flatten(kapp.klabel(), kapp.items(), unit);
+        return disjuncts.stream()
+                .map(this::filterConjunction)
+                .distinct()
+                .reduce((k1, k2) -> KApply(kapp.klabel(), k1, k2))
+                .orElse(KApply(unit));
+      } else if (kapp.klabel().head().equals(KLabels.ML_EQUALS)) {
+        KLabel unit = KLabel(KLabels.ML_TRUE.name(), kapp.klabel().params().apply(0));
+        return filterEquality(kapp, multivars(kapp)).orElse(KApply(unit));
+      } else {
+        return term;
+      }
+    }
+
+    public K filterConjunction(K term) {
+      if (!(term instanceof KApply)) {
+        return term;
+      }
+      KApply kapp = (KApply)term;
+      if (kapp.klabel().head().equals(KLabels.ML_AND)) {
+        KLabel unit = KLabel(KLabels.ML_TRUE.name(), kapp.klabel().params().apply(0));
+        List<K> conjuncts = Assoc.flatten(kapp.klabel(), kapp.items(), unit);
+        return conjuncts.stream()
+                .map(d -> filterEquality(d, multivars(kapp)))
+                .filter(Optional::isPresent)
+                .map(Optional::get)
+                .reduce((k1, k2) -> KApply(kapp.klabel(), k1, k2))
+                .orElse(KApply(unit));
+      } else if (kapp.klabel().head().equals(KLabels.ML_EQUALS)) {
+        KLabel unit = KLabel(KLabels.ML_TRUE.name(), kapp.klabel().params().apply(0));
+        return filterEquality(kapp, multivars(kapp)).orElse(KApply(unit));
+      } else {
+        return term;
+      }
+    }
+
+    public Optional<K> filterEquality(K term, Multiset<KVariable> vars) {
+      if (!(term instanceof KApply)) {
+        return Optional.of(term);
+      }
+      KApply kapp = (KApply)term;
+      if (kapp.klabel().head().equals(KLabels.ML_EQUALS)) {
+        Set<KVariable> leftVars = vars(kapp.items().get(0));
+        if (leftVars.stream().filter(v -> !v.att().contains("anonymous")).findAny().isPresent()) {
+          return Optional.of(term);
+        }
+        for (KVariable var : leftVars) {
+          if (vars.count(var) != 1) {
+            return Optional.of(term);
+          }
+        }
+        return Optional.empty();
+      } else {
+        return Optional.of(term);
+      }
     }
 
     private K sortCollections(Module mod, K input) {

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -96,8 +96,11 @@ public class PrintOptions {
     @Parameter(names={"--output-tokast"}, listConverter=StringListConverter.class, description="KLabels to output as KAST tokens.")
     public List<String> tokastKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--no-alpha-renaming"}, listConverter=StringListConverter.class, description="KLabels to output as KAST tokens.")
+    @Parameter(names={"--no-alpha-renaming"}, listConverter=StringListConverter.class, description="Do not alpha rename anonymous variables in output.")
     public boolean noAlphaRenaming = false;
+
+    @Parameter(names={"--no-substitution-filtering"}, listConverter=StringListConverter.class, description="Do not remove conjuncts of anonymous variables from substitution in output.")
+    public boolean noFilterSubstitution = false;
 
     @Parameter(names={"--restore-original-names"}, listConverter=StringListConverter.class, description="Restore original variable names when provided by attributes.")
     public boolean restoreOriginalNames = false;

--- a/kernel/src/test/java/org/kframework/kompile/KompileOptionsTest.java
+++ b/kernel/src/test/java/org/kframework/kompile/KompileOptionsTest.java
@@ -69,8 +69,8 @@ public class KompileOptionsTest {
     @Test
     public void testTransitionSpaceSeparator() {
         parse("--transition", "foo bar", "foo.k");
-        assertEquals(2, options.transition.size());
-        assertTrue(options.transition.contains("foo"));
-        assertTrue(options.transition.contains("bar"));
+        assertEquals(2, options.experimental.transition.size());
+        assertTrue(options.experimental.transition.contains("foo"));
+        assertTrue(options.experimental.transition.contains("bar"));
     }
 }


### PR DESCRIPTION
This is a reopening of #1068 without the controversial --superstrict option. After discussing with Patrick, we have decided that it's not a priority for the company currently to keep those additional behaviors that it would provide.