### PR TITLE
restrict cool like attribute properly

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/AddCoolLikeAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/AddCoolLikeAtt.java
@@ -55,7 +55,7 @@ public class AddCoolLikeAtt {
                 if (mod.attributesFor().get(k.klabel()).getOrElse(() -> Att.empty()).contains("maincell")) {
                     if (k.items().get(0) instanceof KSequence) {
                         KSequence seq = (KSequence) k.items().get(0);
-                        if (seq.items().size() > 0 && seq.items().get(0) instanceof KVariable) {
+                        if (seq.items().size() > 1 && seq.items().get(0) instanceof KVariable) {
                             return true;
                         }
                     }
@@ -67,7 +67,7 @@ public class AddCoolLikeAtt {
             public Boolean merge(Boolean a, Boolean b) {
                 return a || b;
             }
-        }.apply(body)) {
+        }.apply(RewriteToTop.toLeft(body))) {
           return att.add("cool-like");
         }
         return att;


### PR DESCRIPTION
This attribute is intended to tell the llvm backend that a rule has a K cell on the LHS that has a variable at the top and some pattern underneath that variable, like a cooling rule. However, we did not sufficiently restrict this compilation pass, so we were getting a bunch of rules tagged as cool-like because of their rhs or because they had only a variable inside the K cell. This interferes with the decision tree algorithm and  was making the C semantics generate too large of a decision tree to be tractable. So here we restrict the condition that adds the attribute somewhat, and we see an over 50% reduction in the size of the decision tree on one of the C semantics.