### PR TITLE
Consider the priority attribute for claims

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -688,12 +688,15 @@ public class ModuleToKORE {
         convert(definition.name(), sb);
         sb.append(" []\n");
         sb.append("\n\n// claims\n");
+        HashMap<String, Boolean> consideredAttributes = new HashMap<>();
+        consideredAttributes.put("priority", true);
+
         for (Sentence sentence : iterable(spec.sentencesExcept(definition))) {
             assert sentence instanceof Rule || sentence instanceof ModuleComment
                 : "Unexpected non-rule claim " + sentence.toString();
             if (sentence instanceof Rule) {
                 convertRule((Rule) sentence, 0, false, topCellSortStr,
-                        new HashMap<>(), HashMultimap.create(), new HashMap<>(), ArrayListMultimap.create(),
+                        consideredAttributes, HashMultimap.create(), new HashMap<>(), ArrayListMultimap.create(),
                         sentenceType, sb);
             }
         }


### PR DESCRIPTION
This is needed in order for the `priority` attribute (more precisely, its value) to be visible in the generated `.kore`.

Related question for @dwightguth : I don't remember the rationale for `consideredAttributes` when generating KORE.   Does this date back to the time when we were declaring attributes? if so, is it relevant anymore?