### PR TITLE
fix bug in AddEmptyLists where lub sort cannot be determined

### DIFF
--- a/k-distribution/tests/regression-new/lub/Makefile
+++ b/k-distribution/tests/regression-new/lub/Makefile
@@ -1,0 +1,4 @@
+DEF=test
+EXT=test
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/lub/test.k
+++ b/k-distribution/tests/regression-new/lub/test.k
@@ -1,0 +1,15 @@
+module TEST
+  imports DOMAINS
+
+  syntax IntPtr ::= PtrValue
+  syntax PtrValue ::= SymLoc
+  syntax SymLoc
+  syntax IntPtr ::= EncodedPtr
+  syntax BitValue ::= EncodedPtr
+  syntax Encodable ::= PtrValue
+  syntax BitValueOrEncodable ::= BitValue | Encodable
+
+  syntax EncodedPtr ::= encodedPtr(PtrValue)
+  syntax Bool ::= sameBase(IntPtr, IntPtr) [function]
+  rule sameBase(_, (encodedPtr(S:SymLoc) => S))
+endmodule

--- a/k-distribution/tests/regression-new/lub2/Makefile
+++ b/k-distribution/tests/regression-new/lub2/Makefile
@@ -1,0 +1,4 @@
+DEF=test
+EXT=test
+
+include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/lub2/test.k
+++ b/k-distribution/tests/regression-new/lub2/test.k
@@ -1,0 +1,9 @@
+module TEST
+  imports BOOL
+  imports K-EQUAL
+
+  syntax KItem ::= foo() | bar()
+
+  rule <k> foo() => #if true #then bar() #else .K #fi ~> bar() ...</k>
+
+endmodule

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -148,6 +148,7 @@ public class KoreBackend extends AbstractBackend {
                 .andThen(resolveFreshConstants)
                 .andThen(generateSortPredicateSyntax)
                 .andThen(generateSortProjections)
+                .andThen(subsortKItem)
                 .andThen(d -> new Strategy(kompileOptions.experimental.heatCoolStrategies).addStrategyCellToRulesTransformer(d).apply(d))
                 .andThen(d -> Strategy.addStrategyRuleToMainModule(def.mainModule().name()).apply(d))
                 .andThen(ConcretizeCells::transformDefinition)

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -52,6 +52,7 @@ public class AddSortInjections {
     private int freshSortParamCounter = 0;
     private Set<String> sortParams = new HashSet<>();
     public static final String SORTPARAM_NAME = "#SortParam";
+    private boolean isLHS = false;
 
     public AddSortInjections(Module mod) {
         this.mod = mod;
@@ -193,7 +194,10 @@ public class AddSortInjections {
             return KApply(substituted.klabel().get(), KList(children), att);
         } else if (term instanceof KRewrite) {
             KRewrite rew = (KRewrite) term;
-            return KRewrite(internalAddSortInjections(rew.left(), actualSort), internalAddSortInjections(rew.right(), actualSort), att);
+            isLHS = true;
+            K lhs = internalAddSortInjections(rew.left(), actualSort);
+            isLHS = false;
+            return KRewrite(lhs, internalAddSortInjections(rew.right(), actualSort), att);
         } else if (term instanceof KVariable) {
             return KVariable(((KVariable) term).name(), att);
         } else if (term instanceof KToken) {

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -209,7 +209,7 @@ public class AddSortInjections {
             List<K> children = new ArrayList<>();
             for (int i = 0; i < kseq.size(); i++) {
                 K child = kseq.items().get(i);
-                Sort childSort = sort(child, Sorts.KItem());
+                Sort childSort = sort(child, isLHS ? Sorts.KItem() : Sorts.K());
                 if (childSort.equals(Sorts.K())) {
                     children.add(internalAddSortInjections(child, Sorts.K()));
                 } else {

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -254,7 +254,7 @@ public class AddSortInjections {
                 if (subst.get(param) == null) {
                     args.add(fresh.get(i));
                 } else {
-                    args.add(lub(subst.get(param), null, loc, mod));
+                    args.add(lub(subst.get(param), fresh.get(i), loc, mod));
                 }
                 i++;
             }
@@ -341,7 +341,7 @@ public class AddSortInjections {
                     if (subst.get(param) == null) {
                         args.add(fresh.get(i));
                     } else {
-                        args.add(lub(subst.get(param), null, kapp, mod));
+                        args.add(lub(subst.get(param), fresh.get(i), kapp, mod));
                     }
                     i++;
                 }
@@ -420,7 +420,7 @@ public class AddSortInjections {
             return entries.iterator().next();
         }
         Set<Sort> bounds = upperBounds(filteredEntries, mod);
-        if (expectedSort != null && !expectedSort.name().equals(SORTPARAM_NAME) && !expectedSort.equals(Sorts.KItem()) && !expectedSort.equals(Sorts.K())) {
+        if (expectedSort != null && !expectedSort.name().equals(SORTPARAM_NAME)) {
             bounds.removeIf(s -> !mod.subsorts().lessThanEq(s, expectedSort));
         }
         Set<Sort> lub = mod.subsorts().minimal(bounds);

--- a/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AddEmptyLists.java
+++ b/kernel/src/main/java/org/kframework/parser/concrete2kore/disambiguation/AddEmptyLists.java
@@ -63,6 +63,10 @@ public class AddEmptyLists extends SetsGeneralTransformer<KEMException, KEMExcep
         this.expectedSort = expectedSort;
     }
 
+    // instead of calling super.apply in the apply function below, we should
+    // call this function, because super.apply does not correctly set the
+    // expected sort before recursing, which means that we end up with
+    // the wrong sort computations otherwise
     private Tuple2<Either<Set<KEMException>, Term>, Set<KEMException>> superApply(TermCons tc) {
         Set<KEMException> warns = new HashSet<>();
         TermCons orig = tc;


### PR DESCRIPTION
Previously we were getting an error in certain sort graphs saying that the least upper bound sort could not be determined, even though only one lub sort could actually appear in that location based on its expected sort. Here we correctly filter the lub by the expected sort, which we were not previously doing.