### PR TITLE
src/main/scripts/package: also include kore* executables

### DIFF
--- a/src/main/scripts/package
+++ b/src/main/scripts/package
@@ -3,7 +3,7 @@ mkdir -p $DESTDIR$PREFIX/bin
 mkdir -p $DESTDIR$PREFIX/lib/kframework
 cp -R k-distribution/target/release/k/* $DESTDIR$PREFIX/lib/kframework
 ( cd llvm-backend/target/build && make install )
-for tool in k-bin-to-text kast kbmc kcovr kdep keq kompile kprove krun kserver stop-kserver; do
+for tool in k-bin-to-text kast kbmc kcovr kdep keq kompile kprove krun kserver stop-kserver kore-exec kore-format kore-parser kore-profiler kore-repl; do
   path=$DESTDIR$PREFIX/bin/$tool
   echo "#!/bin/sh" > "$path"
   echo "$PREFIX/lib/kframework/bin/$tool \"\$@\"" >> "$path"


### PR DESCRIPTION
Currently the debian-installed package does not make the `kore-*` executables available.

This copies them into place.