### PR TITLE
k-distribution/substitution: move syntax for KVAR to KVAR-SYNTAX module

### DIFF
--- a/k-distribution/include/builtin/substitution.k
+++ b/k-distribution/include/builtin/substitution.k
@@ -11,22 +11,22 @@ endmodule
 
 module KVAR-SYNTAX
   syntax KVar [token, hook(KVAR.KVar)]
+  syntax KVar ::= String2KVar (String) [function, functional, hook(STRING.string2var)]
+                | freshKVar(Int)       [freshGenerator, function, functional]
 endmodule
 
 module KVAR
   imports KVAR-SYNTAX
   imports KVAR-SYMBOLIC
+  imports STRING
+
+  syntax KItem ::= "#parseToken"  "(" String "," String ")"  [function, klabel(#parseKVar), hook(STRING.parseToken)]
+  rule String2KVar(S:String) => {#parseToken("KVar", S)}:>KVar
+  rule freshKVar(I:Int) => String2KVar("_" +String Int2String(I))
 endmodule
 
 module KVAR-SYMBOLIC [symbolic, kast]
   imports KVAR-SYNTAX
-  imports STRING
-
-  syntax KVar ::= String2KVar (String) [function, functional, hook(STRING.string2var)]
-  syntax KVar ::= freshKVar(Int)    [freshGenerator, function, functional]
-  syntax KItem  ::= "#parseToken"  "(" String "," String ")"  [function, klabel(#parseKVar), hook(STRING.parseToken)]
-  rule String2KVar(S:String) => {#parseToken("KVar", S)}:>KVar
-  rule freshKVar(I:Int) => String2KVar("_" +String Int2String(I))
 endmodule
 
 module SUBSTITUTION


### PR DESCRIPTION
Fixes: #1186