### PR TITLE
In keys collection fix

### DIFF
--- a/k-distribution/tests/regression-new/cell_map/Makefile
+++ b/k-distribution/tests/regression-new/cell_map/Makefile
@@ -1,6 +1,5 @@
 DEF=test
 EXT=test
 TESTDIR=.
-KOMPILE_BACKEND?=java
 
 include ../../../include/ktest.mak

--- a/k-distribution/tests/regression-new/cell_map/pgm.test
+++ b/k-distribution/tests/regression-new/cell_map/pgm.test
@@ -2,4 +2,6 @@ insert(0, 1);
 insert(1, 1);
 update(0, 0);
 remove(1);
+present(0);
+present(1);
 get(0)

--- a/k-distribution/tests/regression-new/cell_map/pgm.test.out
+++ b/k-distribution/tests/regression-new/cell_map/pgm.test.out
@@ -14,4 +14,5 @@
       </value>
     </entry>
   </map>
+  <vals> ListItem(true) ListItem(false) ListItem(1) </vals>
 </generatedTop>

--- a/k-distribution/tests/regression-new/cell_map/pgm.test.out
+++ b/k-distribution/tests/regression-new/cell_map/pgm.test.out
@@ -1,11 +1,12 @@
 <generatedTop>
   <k>
-    0
+    .
   </k>
+  <vals>
+    ListItem(true) ListItem(false) ListItem(0)
+  </vals>
   <map>
-    <key>
-      0
-    </key> |-> <entry>
+    <entry>
       <key>
         0
       </key>
@@ -14,5 +15,4 @@
       </value>
     </entry>
   </map>
-  <vals> ListItem(true) ListItem(false) ListItem(1) </vals>
 </generatedTop>

--- a/k-distribution/tests/regression-new/cell_map/test.k
+++ b/k-distribution/tests/regression-new/cell_map/test.k
@@ -43,7 +43,7 @@ module TEST
   rule
     <k> present(I) => . ... </k>
     <map> MAP </map>
-    <vals> ... (.List => ListItem(<entry> <key> I </key> <value> 0 </value> </entry> in_keys(MAP))) </vals>
+    <vals> ... (.List => ListItem(<key> I </key> in_keys(MAP))) </vals>
 
   rule <k> S1; S2 => S1 ~> S2 ... </k>
 endmodule

--- a/k-distribution/tests/regression-new/cell_map/test.k
+++ b/k-distribution/tests/regression-new/cell_map/test.k
@@ -43,7 +43,7 @@ module TEST
   rule
     <k> present(I) => . ... </k>
     <map> MAP </map>
-    <vals> ... (.List => ListItem(<key> I </key> in_keys(<map> MAP </map>))) </vals>
+    <vals> ... (.List => ListItem(<entry> <key> I </key> <value> 0 </value> </entry> in_keys(MAP))) </vals>
 
   rule <k> S1; S2 => S1 ~> S2 ... </k>
 endmodule

--- a/k-distribution/tests/regression-new/cell_map/test.k
+++ b/k-distribution/tests/regression-new/cell_map/test.k
@@ -3,6 +3,7 @@ module TEST
 
   configuration
     <k> $PGM:Stmt </k>
+    <vals> .List </vals>
     <map>
       <entry multiplicity="*" type="Map">
         <key> .K </key>
@@ -14,24 +15,35 @@ module TEST
                 | insert(Int, Int)
                 | remove(Int)
                 | update(Int, Int)
+                | present(Int)
                 | Stmt ";" Stmt [left]
   rule
-    <k> get(Key) => Value ...</k>
+    <k> get(Key) => . ...</k>
     <key> Key </key>
     <value> Value:Int </value>
+    <vals> ... (.List => ListItem(Value)) </vals>
+
   rule
     <k> insert(Key, Value) => .K ...</k>
     <map>...
       .Bag => <entry> <key> Key </key> <value> Value </value> </entry>
     ...</map>
+
   rule
     <k> remove(Key) => .K ...</k>
     <map>...
       <entry> <key> Key </key> <value> _ </value> </entry> => .Bag
     ...</map>
+
   rule
     <k> update(Key, Value) => .K ...</k>
     <key> Key </key>
     <value> _ => Value </value>
-  rule S1; S2 => S1 ~> S2
+
+  rule
+    <k> present(I) => . ... </k>
+    <map> MAP </map>
+    <vals> ... (.List => ListItem(<key> I </key> in_keys(<map> MAP </map>))) </vals>
+
+  rule <k> S1; S2 => S1 ~> S2 ... </k>
 endmodule

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -461,7 +461,7 @@ public class GenerateSentencesFromConfigDecl {
             sentences.add(bagUnit);
             sentences.add(bag);
             if (type.equals("Map")) {
-                sentences.add(Production(KLabel(bagSort.name() + ":in_keys"), Sorts.Bool(), Seq(NonTerminal(sort), Terminal("in_keys"), Terminal("("), NonTerminal(bagSort), Terminal(")")), Att().add(Att.HOOK(), "MAP.in_keys").add(Att.FUNCTION()).add("functional")));
+                sentences.add(Production(KLabel(bagSort.name() + ":in_keys"), Sorts.Bool(), Seq(NonTerminal(childSorts.get(0)), Terminal("in_keys"), Terminal("("), NonTerminal(bagSort), Terminal(")")), Att().add(Att.HOOK(), "MAP.in_keys").add(Att.FUNCTION()).add("functional")));
             }
             // rule initCell => .CellBag
             // -or-


### PR DESCRIPTION
Fixes #1199 

This adds tests of the `in_keys` construct, but the tests are not passing right now because of #1199.