### PR TITLE
Jenkinsfile: timeout on initial build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,7 +94,7 @@ pipeline {
                       }
                     }
                     stage('Build and Test K') {
-                      options { timeout(time: 40, unit: 'MINUTES') }
+                      options { timeout(time: 45, unit: 'MINUTES') }
                       steps {
                         sh '''
                           echo 'Setting up environment...'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -94,6 +94,7 @@ pipeline {
                       }
                     }
                     stage('Build and Test K') {
+                      options { timeout(time: 40, unit: 'MINUTES') }
                       steps {
                         sh '''
                           echo 'Setting up environment...'


### PR DESCRIPTION
We've had several PRs go for days at a time unchecked because of infinite loops caused in the testing phase. This just times it out to free up an executor.

Typical build time of this step is 25 minutes, the longest I've seen in the last 10 builds (on our slowest machine) was 36 minutes.