### PR TITLE
Revert "Symbolic implementation of ==K for Haskell backend"

### DIFF
--- a/k-distribution/include/builtin/domains.k
+++ b/k-distribution/include/builtin/domains.k
@@ -946,20 +946,11 @@ module K-EQUAL-KAST [kast]
 
 endmodule
 
-module K-EQUAL-SYMBOLIC [symbolic, kore]
-  import K-EQUAL-SYNTAX
-
-  rule K1:K ==K K2:K => true requires true #And { K1 #Equals K2 }
-  rule K1:K ==K K2:K => false [owise]
-
-endmodule
-
 module K-EQUAL
   import BOOL
   import K-EQUAL-SYNTAX
   import K-EQUAL-KAST
   import K-EQUAL-KORE
-  import K-EQUAL-SYMBOLIC
 
   rule K1:K =/=K K2:K => notBool (K1 ==K K2)
 


### PR DESCRIPTION
Reverts kframework/k#1196

The Haskell backend will implement these rules internally.