### PR TITLE
Jenkinsfile/Dockerfile formatting

### DIFF
--- a/Dockerfile.arch
+++ b/Dockerfile.arch
@@ -28,35 +28,35 @@ RUN    pacman -Syyu --noconfirm \
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN groupadd -g $GROUP_ID user && \
-    useradd -m -u $USER_ID -s /bin/sh -g user user
+RUN    groupadd -g $GROUP_ID user                     \
+    && useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER $USER_ID:$GROUP_ID
 
 ENV PATH="${PATH}:/usr/bin/core_perl"
 
 ADD k-distribution/src/main/scripts/bin/k-configure-opam-dev k-distribution/src/main/scripts/bin/k-configure-opam-common /home/user/.tmp-opam/bin/
-ADD k-distribution/src/main/scripts/lib/opam  /home/user/.tmp-opam/lib/opam/
-RUN    cd /home/user \
+ADD k-distribution/src/main/scripts/lib/opam                                                                             /home/user/.tmp-opam/lib/opam/
+RUN    cd /home/user                        \
     && ./.tmp-opam/bin/k-configure-opam-dev
 
 ENV LC_ALL=C.UTF-8
-ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
+ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/stack.yaml        /home/user/.tmp-haskell/
 ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
 RUN    cd /home/user/.tmp-haskell \
     && stack build --only-snapshot
 
-ADD pom.xml /home/user/.tmp-maven/
-ADD ktree/pom.xml /home/user/.tmp-maven/ktree/
-ADD llvm-backend/pom.xml /home/user/.tmp-maven/llvm-backend/
+ADD pom.xml                                                    /home/user/.tmp-maven/
+ADD ktree/pom.xml                                              /home/user/.tmp-maven/ktree/
+ADD llvm-backend/pom.xml                                       /home/user/.tmp-maven/llvm-backend/
 ADD llvm-backend/src/main/native/llvm-backend/matching/pom.xml /home/user/.tmp-maven/llvm-backend/src/main/native/llvm-backend/matching/
-ADD haskell-backend/pom.xml /home/user/.tmp-maven/haskell-backend/
-ADD ocaml-backend/pom.xml /home/user/.tmp-maven/ocaml-backend/
-ADD kernel/pom.xml /home/user/.tmp-maven/kernel/
-ADD java-backend/pom.xml /home/user/.tmp-maven/java-backend/
-ADD k-distribution/pom.xml /home/user/.tmp-maven/k-distribution/
-ADD kore/pom.xml /home/user/.tmp-maven/kore/
-RUN    cd /home/user/.tmp-maven \
+ADD haskell-backend/pom.xml                                    /home/user/.tmp-maven/haskell-backend/
+ADD ocaml-backend/pom.xml                                      /home/user/.tmp-maven/ocaml-backend/
+ADD kernel/pom.xml                                             /home/user/.tmp-maven/kernel/
+ADD java-backend/pom.xml                                       /home/user/.tmp-maven/java-backend/
+ADD k-distribution/pom.xml                                     /home/user/.tmp-maven/k-distribution/
+ADD kore/pom.xml                                               /home/user/.tmp-maven/kore/
+RUN    cd /home/user/.tmp-maven               \
     && mvn --batch-mode dependency:go-offline
 
 RUN pip3 install --user graphviz

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -35,31 +35,31 @@ RUN curl -sSL https://get.haskellstack.org/ | sh
 
 ARG USER_ID=1000
 ARG GROUP_ID=1000
-RUN groupadd -g $GROUP_ID user && \
-    useradd -m -u $USER_ID -s /bin/sh -g user user
+RUN    groupadd -g $GROUP_ID user                     \
+    && useradd -m -u $USER_ID -s /bin/sh -g user user
 
 USER $USER_ID:$GROUP_ID
 
 ADD k-distribution/src/main/scripts/bin/k-configure-opam-dev k-distribution/src/main/scripts/bin/k-configure-opam-common /home/user/.tmp-opam/bin/
-ADD k-distribution/src/main/scripts/lib/opam  /home/user/.tmp-opam/lib/opam/
-RUN    cd /home/user \
+ADD k-distribution/src/main/scripts/lib/opam                                                                             /home/user/.tmp-opam/lib/opam/
+RUN    cd /home/user                        \
     && ./.tmp-opam/bin/k-configure-opam-dev
 
 ENV LC_ALL=C.UTF-8
-ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/stack.yaml /home/user/.tmp-haskell/
+ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/stack.yaml        /home/user/.tmp-haskell/
 ADD --chown=user:user haskell-backend/src/main/native/haskell-backend/kore/package.yaml /home/user/.tmp-haskell/kore/
-RUN    cd /home/user/.tmp-haskell \
+RUN    cd /home/user/.tmp-haskell  \
     && stack build --only-snapshot
 
-ADD pom.xml /home/user/.tmp-maven/
-ADD ktree/pom.xml /home/user/.tmp-maven/ktree/
-ADD llvm-backend/pom.xml /home/user/.tmp-maven/llvm-backend/
+ADD pom.xml                                                    /home/user/.tmp-maven/
+ADD ktree/pom.xml                                              /home/user/.tmp-maven/ktree/
+ADD llvm-backend/pom.xml                                       /home/user/.tmp-maven/llvm-backend/
 ADD llvm-backend/src/main/native/llvm-backend/matching/pom.xml /home/user/.tmp-maven/llvm-backend/src/main/native/llvm-backend/matching/
-ADD haskell-backend/pom.xml /home/user/.tmp-maven/haskell-backend/
-ADD ocaml-backend/pom.xml /home/user/.tmp-maven/ocaml-backend/
-ADD kernel/pom.xml /home/user/.tmp-maven/kernel/
-ADD java-backend/pom.xml /home/user/.tmp-maven/java-backend/
-ADD k-distribution/pom.xml /home/user/.tmp-maven/k-distribution/
-ADD kore/pom.xml /home/user/.tmp-maven/kore/
-RUN    cd /home/user/.tmp-maven \
+ADD haskell-backend/pom.xml                                    /home/user/.tmp-maven/haskell-backend/
+ADD ocaml-backend/pom.xml                                      /home/user/.tmp-maven/ocaml-backend/
+ADD kernel/pom.xml                                             /home/user/.tmp-maven/kernel/
+ADD java-backend/pom.xml                                       /home/user/.tmp-maven/java-backend/
+ADD k-distribution/pom.xml                                     /home/user/.tmp-maven/k-distribution/
+ADD kore/pom.xml                                               /home/user/.tmp-maven/kore/
+RUN    cd /home/user/.tmp-maven               \
     && mvn --batch-mode dependency:go-offline

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,10 +1,6 @@
 pipeline {
-  agent {
-    label 'docker'
-  }
-  options {
-    ansiColor('xterm')
-  }
+  agent { label 'docker' }
+  options { ansiColor('xterm') }
   environment {
     PACKAGE  = 'kframework'
     VERSION  = '5.0.0'
@@ -12,13 +8,9 @@ pipeline {
     MAKE_EXTRA_ARGS = '' // Example: 'DEBUG=--debug' to see stack traces
   }
   stages {
-    stage("Init title") {
+    stage('Init title') {
       when { changeRequest() }
-      steps {
-        script {
-          currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}"
-        }
-      }
+      steps { script { currentBuild.displayName = "PR ${env.CHANGE_ID}: ${env.CHANGE_TITLE}" } }
     }
     stage("Create source tarball") {
       agent {
@@ -92,12 +84,7 @@ pipeline {
                     }
                   }
                   stages {
-                    stage('Checkout code') {
-                      steps {
-                        dir('k-exercises') {
-                          git url: 'git@github.com:kframework/k-exercises.git'
-                        }
-                      }
+                    stage('Checkout code') { steps { dir('k-exercises') { git url: 'git@github.com:kframework/k-exercises.git' } }
                     }
                     stage('Build and Test K') {
                       options { timeout(time: 45, unit: 'MINUTES') }
@@ -194,9 +181,7 @@ pipeline {
                   options { skipDefaultCheckout() }
                   steps {
                     unstash "buster"
-                    sh '''
-                      src/main/scripts/test-in-container-debian
-                    '''
+                    sh 'src/main/scripts/test-in-container-debian'
                   }
                   post {
                     always {
@@ -229,9 +214,7 @@ pipeline {
                     stage('Build Pacman Package') {
                       steps {
                         checkout scm
-                        sh '''
-                          makepkg
-                        '''
+                        sh 'makepkg'
                         stash name: "arch", includes: "kframework-git-${env.VERSION}-1-x86_64.pkg.tar.xz"
                       }
                     }
@@ -247,7 +230,7 @@ pipeline {
                   }
                   options { skipDefaultCheckout() }
                   steps {
-                    unstash "arch"
+                    unstash 'arch'
                     sh '''
                       pacman -Syyu --noconfirm
                       pacman -U --noconfirm kframework-git-${VERSION}-1-x86_64.pkg.tar.xz
@@ -304,11 +287,9 @@ pipeline {
             stage('Build on Mac OS') {
               stages {
                 stage('Build Homebrew Bottle') {
-                  agent {
-                    label 'anka'
-                  }
+                  agent { label 'anka' }
                   steps {
-                    unstash "src"
+                    unstash 'src'
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
                       sh '''
@@ -321,16 +302,12 @@ pipeline {
                   }
                 }
                 stage("Test Homebrew Bottle") {
-                  agent {
-                    label 'anka'
-                  }
+                  agent { label 'anka' }
                   steps {
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git', branch: 'brew-release-kframework'
                       unstash "mojave"
-                      sh '''
-                        ${WORKSPACE}/src/main/scripts/brew-install-bottle
-                      '''
+                      sh '${WORKSPACE}/src/main/scripts/brew-install-bottle'
                     }
                     sh '''
                       cp -R /usr/local/lib/kframework/tutorial ~
@@ -346,11 +323,7 @@ pipeline {
                       kompile test.k --backend llvm
                       kompile test.k --backend haskell
                     '''
-                    dir('homebrew-k') {
-                      sh '''
-                        ${WORKSPACE}/src/main/scripts/brew-update-to-final
-                      '''
-                    }
+                    dir('homebrew-k') { sh '${WORKSPACE}/src/main/scripts/brew-update-to-final' }
                   }
                   post {
                     always {
@@ -360,11 +333,7 @@ pipeline {
                   }
                 }
               }
-              post {
-                always {
-                  archiveArtifacts artifacts: 'kserver.log,k-distribution/target/kserver.log', allowEmptyArchive: true
-                }
-              }
+              post { always { archiveArtifacts artifacts: 'kserver.log,k-distribution/target/kserver.log', allowEmptyArchive: true } }
             }
           }
           post {
@@ -399,18 +368,10 @@ pipeline {
       steps {
         unstash "src"
         unstash "binary"
-        dir("bionic") {
-          unstash "bionic"
-        }
-        dir("buster") {
-          unstash "buster"
-        }
-        dir("arch") {
-          unstash "arch"
-        }
-        dir("mojave") {
-          unstash "mojave"
-        }
+        dir('bionic') { unstash 'bionic' }
+        dir('buster') { unstash 'buster' }
+        dir('arch')   { unstash 'arch'   }
+        dir('mojave') { unstash 'mojave' }
         sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
           sh '''
             release_tag="v${VERSION}-$(git rev-parse --short=7 HEAD)"


### PR DESCRIPTION
New formatting guidelines:

-   Any node in Jenkinsfile that just has single-children all the way down gets a single line.
-   Line up (horizontally) as much that makes sense.

This makes scanning the Jenkinsfile much smoother. It doesn't have a huge affect on this one, because it's such a large complicated Jenkinsfile, but I figured it should be brought into line anyway.