### PR TITLE
Brew staging commit [brew-staging: update-test-release]

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,6 +296,11 @@ pipeline {
                         git config --global user.email "admin@runtimeverification.com"
                         git config --global user.name  "RV Jenkins"
                         ${WORKSPACE}/src/main/scripts/brew-build-bottle $(git rev-parse --short=7 HEAD)
+                        REV=$(git rev-parse --short=7 HEAD)
+                        git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 2"
+                        git push -d origin brew-release-$PACKAGE || true
+                        git checkout -b brew-release-$PACKAGE
+                        git push origin brew-release-$PACKAGE
                       '''
                       stash name: "mojave", includes: "kframework--${env.VERSION}.mojave.bottle*.tar.gz"
                     }
@@ -323,7 +328,14 @@ pipeline {
                       kompile test.k --backend llvm
                       kompile test.k --backend haskell
                     '''
-                    dir('homebrew-k') { sh '${WORKSPACE}/src/main/scripts/brew-update-to-final $(git rev-parse --short=7 HEAD)' }
+                    dir('homebrew-k') {
+                      sh '''
+                        ${WORKSPACE}/src/main/scripts/brew-update-to-final $(git rev-parse --short=7 HEAD)
+                        REV=$(git rev-parse --short=7 HEAD)
+                        git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 3"
+                        git push origin brew-release-$PACKAGE
+                      '''
+                    }
                   }
                   post {
                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,7 +293,7 @@ pipeline {
                     unstash 'src'
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
-                      sh '''
+                      sh """
                         git config --global user.email "admin@runtimeverification.com"
                         git config --global user.name  "RV Jenkins"
                         git remote add k-repo 'https://github.com/kframework/k.git'
@@ -308,7 +308,7 @@ pipeline {
                         ${WORKSPACE}/src/main/scripts/brew-build-and-update-to-local-bottle ${SHORT_REV}
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"
                         git push origin brew-release-$PACKAGE
-                      '''
+                      """
                       stash name: "mojave", includes: "kframework--${env.VERSION}.mojave.bottle*.tar.gz"
                     }
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,7 +298,7 @@ pipeline {
                         git config --global user.name  "RV Jenkins"
                         git remote add k-repo 'https://github.com/kframework/k.git'
                         git fetch --all
-                        brew_base_branch=$(git log -n1 --format=%s k-repo/master | sed -n 's/.*\[brew-staging: \(.*\)\].*/\1/p')
+                        brew_base_branch=$(git log -n1 --format=%s k-repo/master | sed -n 's!.*\[brew-staging: \(.*\)\].*!\1!p')
                         [ "$brew_base_branch" != '' ] || brew_base_branch=master
                         git show-ref --verify refs/remotes/origin/$brew_base_branch
                         git push -d origin brew-release-$PACKAGE || true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -293,12 +293,13 @@ pipeline {
                     unstash 'src'
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
-                      sh """
+                      sh '''
                         git config --global user.email "admin@runtimeverification.com"
                         git config --global user.name  "RV Jenkins"
                         git remote add k-repo 'https://github.com/kframework/k.git'
                         git fetch --all
-                        brew_base_branch=$(git log -n1 --format=%s k-repo/master | sed -n 's!.*\[brew-staging: \(.*\)\].*!\1!p')
+                        # Note: double-backslash in sed-command is for Jenkins benefit.
+                        brew_base_branch=$(git log -n1 --format=%s k-repo/master | sed -n 's!.*\\[brew-staging: \\(.*\\)\\].*!\\1!p')
                         [ "$brew_base_branch" != '' ] || brew_base_branch=master
                         git show-ref --verify refs/remotes/origin/$brew_base_branch
                         git push -d origin brew-release-$PACKAGE || true
@@ -308,7 +309,7 @@ pipeline {
                         ${WORKSPACE}/src/main/scripts/brew-build-and-update-to-local-bottle ${SHORT_REV}
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"
                         git push origin brew-release-$PACKAGE
-                      """
+                      '''
                       stash name: "mojave", includes: "kframework--${env.VERSION}.mojave.bottle*.tar.gz"
                     }
                   }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -295,7 +295,7 @@ pipeline {
                       sh '''
                         git config --global user.email "admin@runtimeverification.com"
                         git config --global user.name  "RV Jenkins"
-                        ${WORKSPACE}/src/main/scripts/brew-build-bottle
+                        ${WORKSPACE}/src/main/scripts/brew-build-bottle $(git rev-parse --short=7 HEAD)
                       '''
                       stash name: "mojave", includes: "kframework--${env.VERSION}.mojave.bottle*.tar.gz"
                     }
@@ -323,7 +323,7 @@ pipeline {
                       kompile test.k --backend llvm
                       kompile test.k --backend haskell
                     '''
-                    dir('homebrew-k') { sh '${WORKSPACE}/src/main/scripts/brew-update-to-final' }
+                    dir('homebrew-k') { sh '${WORKSPACE}/src/main/scripts/brew-update-to-final $(git rev-parse --short=7 HEAD)' }
                   }
                   post {
                     always {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,6 +296,8 @@ pipeline {
                       sh '''
                         git config --global user.email "admin@runtimeverification.com"
                         git config --global user.name  "RV Jenkins"
+                        ${WORKSPACE}/src/main/scripts/brew-update-to-local ${SHORT_REV}
+                        git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 1"
                         ${WORKSPACE}/src/main/scripts/brew-build-bottle ${SHORT_REV}
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"
                         git push -d origin brew-release-$PACKAGE || true

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,7 +296,7 @@ pipeline {
                       sh '''
                         git config --global user.email "admin@runtimeverification.com"
                         git config --global user.name  "RV Jenkins"
-                        ${WORKSPACE}/src/main/scripts/brew-update-to-local ${SHORT_REV}
+                        ${WORKSPACE}/src/main/scripts/brew-update-to-local
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 1"
                         ${WORKSPACE}/src/main/scripts/brew-build-bottle ${SHORT_REV}
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,8 +298,7 @@ pipeline {
                         git config --global user.name  "RV Jenkins"
                         ${WORKSPACE}/src/main/scripts/brew-update-to-local
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 1"
-                        ${WORKSPACE}/src/main/scripts/brew-build-bottle
-                        ${WORKSPACE}/src/main/scripts/brew-update-to-local-bottle ${SHORT_REV}
+                        ${WORKSPACE}/src/main/scripts/brew-build-and-update-to-local-bottle ${SHORT_REV}
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"
                         git push -d origin brew-release-$PACKAGE || true
                         git checkout -b brew-release-$PACKAGE

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,7 +298,8 @@ pipeline {
                         git config --global user.name  "RV Jenkins"
                         ${WORKSPACE}/src/main/scripts/brew-update-to-local
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 1"
-                        ${WORKSPACE}/src/main/scripts/brew-build-bottle ${SHORT_REV}
+                        ${WORKSPACE}/src/main/scripts/brew-build-bottle
+                        ${WORKSPACE}/src/main/scripts/brew-update-to-local-bottle ${SHORT_REV}
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"
                         git push -d origin brew-release-$PACKAGE || true
                         git checkout -b brew-release-$PACKAGE

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,10 +2,10 @@ pipeline {
   agent { label 'docker' }
   options { ansiColor('xterm') }
   environment {
-    PACKAGE   = 'kframework'
-    VERSION   = '5.0.0'
-    ROOT_URL  = 'https://github.com/kframework/k/releases/download'
-    SHORT_REV = """${sh(returnStdout: true, script: 'git rev-parse --short=7 HEAD')}"""
+    PACKAGE         = 'kframework'
+    VERSION         = '5.0.0'
+    ROOT_URL        = 'https://github.com/kframework/k/releases/download'
+    SHORT_REV       = """${sh(returnStdout: true, script: 'git rev-parse --short=7 HEAD')}"""
     MAKE_EXTRA_ARGS = '' // Example: 'DEBUG=--debug' to see stack traces
   }
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,7 +5,7 @@ pipeline {
     PACKAGE         = 'kframework'
     VERSION         = '5.0.0'
     ROOT_URL        = 'https://github.com/kframework/k/releases/download'
-    SHORT_REV       = """${sh(returnStdout: true, script: 'git rev-parse --short=7 HEAD')}"""
+    SHORT_REV       = """${sh(returnStdout: true, script: 'git rev-parse --short=7 HEAD').trim()}"""
     MAKE_EXTRA_ARGS = '' // Example: 'DEBUG=--debug' to see stack traces
   }
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -296,12 +296,12 @@ pipeline {
                       sh '''
                         git config --global user.email "admin@runtimeverification.com"
                         git config --global user.name  "RV Jenkins"
+                        git push -d origin brew-release-$PACKAGE || true
+                        git checkout -b brew-release-$PACKAGE
                         ${WORKSPACE}/src/main/scripts/brew-update-to-local
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 1"
                         ${WORKSPACE}/src/main/scripts/brew-build-and-update-to-local-bottle ${SHORT_REV}
                         git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"
-                        git push -d origin brew-release-$PACKAGE || true
-                        git checkout -b brew-release-$PACKAGE
                         git push origin brew-release-$PACKAGE
                       '''
                       stash name: "mojave", includes: "kframework--${env.VERSION}.mojave.bottle*.tar.gz"

--- a/src/main/scripts/brew-build-and-update-to-local-bottle
+++ b/src/main/scripts/brew-build-and-update-to-local-bottle
@@ -1,5 +1,7 @@
 #!/bin/sh -exu
 REV=$1
+brew tap kframework/k "file://$(pwd)"
+brew install $PACKAGE --build-bottle -v
 brew bottle --json $PACKAGE --root-url="$ROOT_URL/v$VERSION-$REV/"
 cat *.bottle.json
 brew bottle --merge --write --no-commit *.bottle.json

--- a/src/main/scripts/brew-build-bottle
+++ b/src/main/scripts/brew-build-bottle
@@ -1,7 +1,5 @@
 #!/bin/sh -exu
 REV=$1
-"$(dirname "$0")"/brew-update-to-local $REV
-git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 1"
 brew tap kframework/k "file://$(pwd)"
 brew install $PACKAGE --build-bottle -v
 "$(dirname "$0")"/brew-update-to-local-bottle $REV

--- a/src/main/scripts/brew-build-bottle
+++ b/src/main/scripts/brew-build-bottle
@@ -1,8 +1,9 @@
 #!/bin/sh -exu
-"$(dirname "$0")"/brew-update-to-local
+REV=$1
+"$(dirname "$0")"/brew-update-to-local $REV
 brew tap kframework/k "file://$(pwd)"
 brew install $PACKAGE --build-bottle -v
-"$(dirname "$0")"/brew-update-to-local-bottle
+"$(dirname "$0")"/brew-update-to-local-bottle $REV
 git push -d origin brew-release-$PACKAGE || true
 git checkout -b brew-release-$PACKAGE
 git push origin brew-release-$PACKAGE

--- a/src/main/scripts/brew-build-bottle
+++ b/src/main/scripts/brew-build-bottle
@@ -4,6 +4,7 @@ REV=$1
 brew tap kframework/k "file://$(pwd)"
 brew install $PACKAGE --build-bottle -v
 "$(dirname "$0")"/brew-update-to-local-bottle $REV
+git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 2"
 git push -d origin brew-release-$PACKAGE || true
 git checkout -b brew-release-$PACKAGE
 git push origin brew-release-$PACKAGE

--- a/src/main/scripts/brew-build-bottle
+++ b/src/main/scripts/brew-build-bottle
@@ -1,6 +1,7 @@
 #!/bin/sh -exu
 REV=$1
 "$(dirname "$0")"/brew-update-to-local $REV
+git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 1"
 brew tap kframework/k "file://$(pwd)"
 brew install $PACKAGE --build-bottle -v
 "$(dirname "$0")"/brew-update-to-local-bottle $REV

--- a/src/main/scripts/brew-build-bottle
+++ b/src/main/scripts/brew-build-bottle
@@ -1,3 +1,0 @@
-#!/bin/sh -exu
-brew tap kframework/k "file://$(pwd)"
-brew install $PACKAGE --build-bottle -v

--- a/src/main/scripts/brew-build-bottle
+++ b/src/main/scripts/brew-build-bottle
@@ -4,7 +4,3 @@ REV=$1
 brew tap kframework/k "file://$(pwd)"
 brew install $PACKAGE --build-bottle -v
 "$(dirname "$0")"/brew-update-to-local-bottle $REV
-git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 2"
-git push -d origin brew-release-$PACKAGE || true
-git checkout -b brew-release-$PACKAGE
-git push origin brew-release-$PACKAGE

--- a/src/main/scripts/brew-build-bottle
+++ b/src/main/scripts/brew-build-bottle
@@ -1,5 +1,3 @@
 #!/bin/sh -exu
-REV=$1
 brew tap kframework/k "file://$(pwd)"
 brew install $PACKAGE --build-bottle -v
-"$(dirname "$0")"/brew-update-to-local-bottle $REV

--- a/src/main/scripts/brew-update-to-final
+++ b/src/main/scripts/brew-update-to-final
@@ -2,6 +2,4 @@
 REV=$1
 sed -i "" -e 's!^  url ".*"$!  url "'$ROOT_URL/v$VERSION-$REV/$PACKAGE-$VERSION-src'.tar.gz"!' \
     Formula/$PACKAGE.rb
-git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 3"
 cat Formula/$PACKAGE.rb
-git push origin brew-release-$PACKAGE

--- a/src/main/scripts/brew-update-to-final
+++ b/src/main/scripts/brew-update-to-final
@@ -1,5 +1,5 @@
 #!/bin/sh -exu
-REV=$(cd .. && git rev-parse --short=7 HEAD)
+REV=$1
 sed -i "" -e 's!^  url ".*"$!  url "'$ROOT_URL/v$VERSION-$REV/$PACKAGE-$VERSION-src'.tar.gz"!' \
     Formula/$PACKAGE.rb
 git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 3"

--- a/src/main/scripts/brew-update-to-local
+++ b/src/main/scripts/brew-update-to-local
@@ -1,5 +1,4 @@
 #!/bin/sh -exu
-REV=$1
 sed -i "" -e '/install-rust/d' -e 's!^  url ".*"$!  url "file:///'$(pwd)/../$PACKAGE-$VERSION'-src.tar.gz"!' \
        -e 's!^  sha256 ".*"$!  sha256 "'$(shasum -a 256 ../$PACKAGE-$VERSION-src.tar.gz | awk '{print $1}')'"!' \
     Formula/$PACKAGE.rb

--- a/src/main/scripts/brew-update-to-local
+++ b/src/main/scripts/brew-update-to-local
@@ -3,4 +3,3 @@ REV=$1
 sed -i "" -e '/install-rust/d' -e 's!^  url ".*"$!  url "file:///'$(pwd)/../$PACKAGE-$VERSION'-src.tar.gz"!' \
        -e 's!^  sha256 ".*"$!  sha256 "'$(shasum -a 256 ../$PACKAGE-$VERSION-src.tar.gz | awk '{print $1}')'"!' \
     Formula/$PACKAGE.rb
-git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 1"

--- a/src/main/scripts/brew-update-to-local
+++ b/src/main/scripts/brew-update-to-local
@@ -1,5 +1,5 @@
 #!/bin/sh -exu
-REV=$(cd .. && git rev-parse HEAD)
+REV=$1
 sed -i "" -e '/install-rust/d' -e 's!^  url ".*"$!  url "file:///'$(pwd)/../$PACKAGE-$VERSION'-src.tar.gz"!' \
        -e 's!^  sha256 ".*"$!  sha256 "'$(shasum -a 256 ../$PACKAGE-$VERSION-src.tar.gz | awk '{print $1}')'"!' \
     Formula/$PACKAGE.rb

--- a/src/main/scripts/brew-update-to-local-bottle
+++ b/src/main/scripts/brew-update-to-local-bottle
@@ -1,5 +1,5 @@
 #!/bin/sh -exu
-REV=$(cd .. && git rev-parse --short=7 HEAD)
+REV=$1
 brew bottle --json $PACKAGE --root-url="$ROOT_URL/v$VERSION-$REV/"
 cat *.bottle.json
 brew bottle --merge --write --no-commit *.bottle.json

--- a/src/main/scripts/brew-update-to-local-bottle
+++ b/src/main/scripts/brew-update-to-local-bottle
@@ -4,4 +4,3 @@ brew bottle --json $PACKAGE --root-url="$ROOT_URL/v$VERSION-$REV/"
 cat *.bottle.json
 brew bottle --merge --write --no-commit *.bottle.json
 cp $(brew formula $PACKAGE) Formula/$PACKAGE.rb
-git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to $REV: part 2"


### PR DESCRIPTION
This PR accomplishes several things:

-   Removes all `git` logic from the `brew-*` scripts, so it's easier to see the sequence of git actions taken directly in the `Jenkinsfile`.
-   Removes all calls to `brew-*` scripts from inside the `brew-*` scripts, so it's easier to see the control flow between those scripts.
-   Combines two of the scripts which were then called one-after-the-other.
-   Makes the brew update step examine the top message in the git log for `[brew-staging: BRANCH_NAME]`, to change which branch it bases the next homebrew release on.

This one, for example, will base it on this branch: https://github.com/kframework/homebrew-k/pull/4

This does make it important that _this_ build make it through the MacOS steps, otherwise it needs to be re-done, or a manual push needs to happen to the homebrew repo or something.