### PR TITLE
Jenkinsfile: use RELEASE_TAG job instead of RELEASE_URL

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -394,6 +394,10 @@ pipeline {
         dir('mojave') { unstash 'mojave' }
         sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
           sh '''
+            git remote add release 'ssh://github.com/kframework/k.git'
+            git tag "${K_RELEASE_TAG}" "${SHORT_REV}"
+            git push release "${K_RELEASE_TAG}"
+
             mv bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
             mv buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
             LOCAL_BOTTLE_NAME=$(echo mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     VERSION         = '5.0.0'
     ROOT_URL        = 'https://github.com/kframework/k/releases/download'
     SHORT_REV       = """${sh(returnStdout: true, script: 'git rev-parse --short=7 HEAD').trim()}"""
-    K_RELEASE_TAG   = "v${VERSION}-${SHORT_REV}"
+    K_RELEASE_TAG   = "v${env.VERSION}-${env.SHORT_REV}"
     MAKE_EXTRA_ARGS = '' // Example: 'DEBUG=--debug' to see stack traces
   }
   stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ pipeline {
     VERSION         = '5.0.0'
     ROOT_URL        = 'https://github.com/kframework/k/releases/download'
     SHORT_REV       = """${sh(returnStdout: true, script: 'git rev-parse --short=7 HEAD').trim()}"""
-    K_RELEASE_TAGE  = "v${VERSION}-${SHORT_REV}"
+    K_RELEASE_TAG   = "v${VERSION}-${SHORT_REV}"
     MAKE_EXTRA_ARGS = '' // Example: 'DEBUG=--debug' to see stack traces
   }
   stages {
@@ -403,9 +403,9 @@ pipeline {
             LOCAL_BOTTLE_NAME=$(echo mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)
             BOTTLE_NAME=`cd mojave && echo kframework--${VERSION}.mojave.bottle*.tar.gz | sed 's!kframework--!kframework-!'`
             mv $LOCAL_BOTTLE_NAME mojave/$BOTTLE_NAME
-            echo "K Framework Release $K_RELEASE_TAG"  > release.md
-            echo ""                                   >> release.md
-            cat k-distribution/INSTALL.md             >> release.md
+            echo "K Framework Release ${K_RELEASE_TAG}"  > release.md
+            echo ""                                     >> release.md
+            cat k-distribution/INSTALL.md               >> release.md
             hub release create                                                                         \
                 --attach kframework-${VERSION}-src.tar.gz"#Source tar.gz"                              \
                 --attach bionic/kframework_${VERSION}_amd64_bionic.deb"#Ubuntu Bionic (18.04) Package" \


### PR DESCRIPTION
This changes from the RELEASE_URL dependency updater for Kore to the RELEASE_TAG dependency updater, which is much simpler and more flexible.

Instead of committing the entire URL to the file `deps/k_release`, it will _only_ commit the tag (the end of the URL). This allows the same job to be used for repos that are not kframework/k.

When it makes the next commit to the `_update-deps_deps_k_release` job on the Haskell backend repo, it needs the logic adjusted, which I have done here: https://github.com/kframework/kore/pull/1764.