### PR TITLE
fix smtlib-forall tests to use smt-hook

### DIFF
--- a/k-distribution/tests/regression-new/smtlib-forall/test1/a.k
+++ b/k-distribution/tests/regression-new/smtlib-forall/test1/a.k
@@ -6,7 +6,7 @@ imports INT
 imports SUBSTITUTION
 
 syntax Int ::= KVar
-syntax Bool ::= forall(KVar, IntList, Bool) [binder, function, smtlib((forall ((#1 Int)) (=> (inI #1 #2) #3)))]
+syntax Bool ::= forall(KVar, IntList, Bool) [binder, function, smt-hook((forall ((#1 Int)) (=> (inI #1 #2) #3)))]
 rule forall(X, V Vs, E) => E[V / X] andBool forall(X, Vs, E)
 rule forall(_, .IntList, _) => true
 

--- a/k-distribution/tests/regression-new/smtlib-forall/test2/a.k
+++ b/k-distribution/tests/regression-new/smtlib-forall/test2/a.k
@@ -10,7 +10,7 @@ syntax Int  ::= IMap "[" Int "]"          [function, klabel(selectI), smtlib(sel
 rule ( M:IMap [ K1 <- V ] ) [ K2 ] => V        requires K1  ==Int K2
 rule ( M:IMap [ K1 <- V ] ) [ K2 ] => M [ K2 ] requires K1 =/=Int K2
 
-syntax Bool ::= forall(KVar, Int, Int, Bool) [binder, function, smtlib((forall ((#1 Int)) (=> (and (>= #1 #2) (< #1 #3)) #4)))]
+syntax Bool ::= forall(KVar, Int, Int, Bool) [binder, function, smt-hook((forall ((#1 Int)) (=> (and (>= #1 #2) (< #1 #3)) #4)))]
 rule forall(X, LB, UB, E) => E[LB / X] andBool forall(X, LB +Int 1, UB, E) requires LB  <Int UB
 rule forall(_, LB, UB, _) => true                                          requires LB >=Int UB
 


### PR DESCRIPTION
`smt-hook` is appropriate for the builtin `forall` symbol, but `smtlib` happens to work for the java backend for the legacy reason --- common builtin symbols are treated differently by the java backend. (Indeed, `smt-hook` was introduced to avoid implementing the ad-hoc process in other backends.)