### PR TITLE
Fixes to published docker images to make useful for CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -191,7 +191,10 @@ pipeline {
               }
             }
             stage('Build and Package on Debian Buster') {
-              when { branch 'master' }
+              when {
+                branch 'master'
+                beforeAgent true
+              }
               stages {
                 stage('Build on Debian Buster') {
                   agent {
@@ -247,7 +250,10 @@ pipeline {
               }
             }
             stage('Build and Package on Arch Linux') {
-              when { branch 'master' }
+              when {
+                branch 'master'
+                beforeAgent true
+              }
               stages {
                 stage('Build on Arch Linux') {
                   agent {
@@ -306,7 +312,10 @@ pipeline {
               }
             }
             stage('Build Platform Independent K Binary') {
-              when { branch 'master' }
+              when {
+                branch 'master'
+                beforeAgent true
+              }
               agent {
                 dockerfile {
                   additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -333,7 +342,10 @@ pipeline {
           }
         }
         stage('Build and Package on Mac OS') {
-          when { branch 'master' }
+          when {
+            branch 'master'
+            beforeAgent true
+          }
           stages {
             stage('Build on Mac OS') {
               stages {

--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -20,16 +20,9 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.6 \
     && cd ../..                                                     \
     && rm -rf z3
 
-ARG USER_ID=1000
-ARG GROUP_ID=1000
-RUN    echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers    \
-    && groupadd -g $GROUP_ID user                             \
-    && useradd -m -u $USER_ID -s /bin/sh -g user -G sudo user
+COPY kframework_amd64_bionic.deb /kframework_amd64_bionic.deb
+RUN    apt-get update                                     \
+    && apt-get upgrade --yes                              \
+    && apt-get install --yes /kframework_amd64_bionic.deb
 
-USER user:user
-WORKDIR /home/user
-
-COPY --chown=user:user kframework_amd64_bionic.deb kframework_amd64_bionic.deb
-RUN    sudo apt-get update                                      \
-    && sudo apt-get upgrade --yes                               \
-    && sudo apt-get install --yes ./kframework_amd64_bionic.deb
+RUN rm -rf /kframework_amd64_bionic.deb

--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -8,8 +8,7 @@ RUN    apt-get update                   \
     && apt-get install --yes            \
                         build-essential \
                         git             \
-                        python          \
-                        sudo
+                        python
 
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.6 \
     && cd z3                                                        \


### PR DESCRIPTION
Currently the Jenkins CI jobs which use the Docker images get confused by how this images is setup.

Instead of adding the user `user:user` here, we let each individual job do that, so that they can create it with the correct uid and gid. This one now just installs K package and that's it.