### PR TITLE
domains.k: #Ceil rules for padLeftBytes, padRightBytes

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -830,9 +830,6 @@ module BYTES-IN-K
   rule padLeftBytes(BS, LEN, VAL) => BS requires lengthBytes(BS) >=Int LEN andBool 0 <=Int LEN
   rule padLeftBytes(BS, LEN, VAL) => padLeftBytes(VAL : BS, LEN, VAL) requires lengthBytes(BS) <Int LEN andBool 0 <=Int LEN
 
-  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-
   syntax Bytes ::= reverseBytes(Bytes) [function, functional]
   syntax Bytes ::= reverseBytes(Bytes, Bytes) [function, klabel(reverseBytesAux)]
   rule reverseBytes(BS) => reverseBytes(BS, nilBytes)
@@ -860,6 +857,10 @@ endmodule
 
 module BYTES-SYMBOLIC [symbolic, kast]
   imports BYTES-IN-K
+
+  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+
 endmodule
 
 module BYTES

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -864,8 +864,8 @@ module BYTES-SYMBOLIC-CEIL [symbolic, kore]
   imports BYTES-HOOKED
   imports INT
 
-  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [simplification]
-  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [simplification]
+  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
 endmodule
 
 module BYTES

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -827,11 +827,11 @@ module BYTES-IN-K
   syntax Bytes ::= padRightBytes(Bytes, Int, Int) [function]
                  | padLeftBytes(Bytes, Int, Int) [function]
   rule padRightBytes(BS, LEN, VAL) => reverseBytes(padLeftBytes(reverseBytes(BS), LEN, VAL))
-  rule padLeftBytes(BS, LEN, VAL) => BS requires lengthBytes(BS) >=Int LEN
-  rule padLeftBytes(BS, LEN, VAL) => padLeftBytes(VAL : BS, LEN, VAL) requires lengthBytes(BS) <Int LEN
+  rule padLeftBytes(BS, LEN, VAL) => BS requires lengthBytes(BS) >=Int LEN andBool 0 <= LEN
+  rule padLeftBytes(BS, LEN, VAL) => padLeftBytes(VAL : BS, LEN, VAL) requires lengthBytes(BS) <Int LEN andBool 0 <= LEN
 
-  rule #Ceil(padRightBytes(_,_, VAL)) => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-  rule #Ceil(padLeftBytes(_,_, VAL))  => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <= LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <= LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
 
   syntax Bytes ::= reverseBytes(Bytes) [function, functional]
   syntax Bytes ::= reverseBytes(Bytes, Bytes) [function, klabel(reverseBytesAux)]

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -853,18 +853,18 @@ endmodule
 
 module BYTES-KORE [kore]
   imports BYTES-HOOKED
+  imports BYTES-SYMBOLIC-CEIL
 endmodule
 
 module BYTES-SYMBOLIC [symbolic, kast]
   imports BYTES-IN-K
-  imports BYTES-SYMBOLIC-CEIL
 endmodule
 
 module BYTES-SYMBOLIC-CEIL [symbolic, kore]
-  imports BYTES-IN-K
+  imports BYTES-HOOKED
 
-  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [simplification]
+  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [simplification]
 endmodule
 
 module BYTES

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -827,11 +827,11 @@ module BYTES-IN-K
   syntax Bytes ::= padRightBytes(Bytes, Int, Int) [function]
                  | padLeftBytes(Bytes, Int, Int) [function]
   rule padRightBytes(BS, LEN, VAL) => reverseBytes(padLeftBytes(reverseBytes(BS), LEN, VAL))
-  rule padLeftBytes(BS, LEN, VAL) => BS requires lengthBytes(BS) >=Int LEN andBool 0 <= LEN
-  rule padLeftBytes(BS, LEN, VAL) => padLeftBytes(VAL : BS, LEN, VAL) requires lengthBytes(BS) <Int LEN andBool 0 <= LEN
+  rule padLeftBytes(BS, LEN, VAL) => BS requires lengthBytes(BS) >=Int LEN andBool 0 <=Int LEN
+  rule padLeftBytes(BS, LEN, VAL) => padLeftBytes(VAL : BS, LEN, VAL) requires lengthBytes(BS) <Int LEN andBool 0 <=Int LEN
 
-  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <= LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <= LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
 
   syntax Bytes ::= reverseBytes(Bytes) [function, functional]
   syntax Bytes ::= reverseBytes(Bytes, Bytes) [function, klabel(reverseBytesAux)]

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -862,6 +862,7 @@ endmodule
 
 module BYTES-SYMBOLIC-CEIL [symbolic, kore]
   imports BYTES-HOOKED
+  imports INT
 
   rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [simplification]
   rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [simplification]

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -853,14 +853,18 @@ endmodule
 
 module BYTES-KORE [kore]
   imports BYTES-HOOKED
-  imports INT
-
-  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
 endmodule
 
 module BYTES-SYMBOLIC [symbolic, kast]
   imports BYTES-IN-K
+  imports BYTES-SYMBOLIC-CEIL
+endmodule
+
+module BYTES-SYMBOLIC-CEIL [symbolic, kore]
+  imports BYTES-IN-K
+
+  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
 endmodule
 
 module BYTES

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -830,8 +830,8 @@ module BYTES-IN-K
   rule padLeftBytes(BS, LEN, VAL) => BS requires lengthBytes(BS) >=Int LEN
   rule padLeftBytes(BS, LEN, VAL) => padLeftBytes(VAL : BS, LEN, VAL) requires lengthBytes(BS) <Int LEN
 
-  rule #Ceil(padRightBytes(_,_, VAL)) => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere]
-  rule #Ceil(padLeftBytes(_,_, VAL))  => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere]
+  rule #Ceil(padRightBytes(_,_, VAL)) => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padLeftBytes(_,_, VAL))  => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
 
   syntax Bytes ::= reverseBytes(Bytes) [function, functional]
   syntax Bytes ::= reverseBytes(Bytes, Bytes) [function, klabel(reverseBytesAux)]

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -830,6 +830,9 @@ module BYTES-IN-K
   rule padLeftBytes(BS, LEN, VAL) => BS requires lengthBytes(BS) >=Int LEN
   rule padLeftBytes(BS, LEN, VAL) => padLeftBytes(VAL : BS, LEN, VAL) requires lengthBytes(BS) <Int LEN
 
+  rule #Ceil(padRightBytes(_,_, VAL)) => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere]
+  rule #Ceil(padLeftBytes(_,_, VAL))  => {(0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere]
+
   syntax Bytes ::= reverseBytes(Bytes) [function, functional]
   syntax Bytes ::= reverseBytes(Bytes, Bytes) [function, klabel(reverseBytesAux)]
   rule reverseBytes(BS) => reverseBytes(BS, nilBytes)

--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -853,14 +853,14 @@ endmodule
 
 module BYTES-KORE [kore]
   imports BYTES-HOOKED
+  imports INT
+
+  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
+  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
 endmodule
 
 module BYTES-SYMBOLIC [symbolic, kast]
   imports BYTES-IN-K
-
-  rule #Ceil(padRightBytes(_, LEN, VAL)) => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-  rule #Ceil(padLeftBytes(_, LEN, VAL))  => {(0 <=Int LEN andBool 0 <=Int VAL andBool VAL <Int 256) #Equals true} [anywhere, simplification]
-
 endmodule
 
 module BYTES


### PR DESCRIPTION
#Ceil rules are based on K implementation for `padLeftBytes`, `padRightBytes`. Hooked rules must have same definedness requirements, e.g. should accept negative Length (2nd argument).

Required for ERC20 verifier.
