### PR TITLE
Bundle opam 2.0 with docker image

### DIFF
--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -3,17 +3,16 @@ FROM ubuntu:bionic
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN    apt-get update                                   \
-    && apt-get upgrade --yes                            \
-    && apt-get install --yes software-properties-common \
-    && add-apt-repository ppa:avsm/ppa
-
-RUN    apt-get update                   \
-    && apt-get upgrade --yes            \
-    && apt-get install --yes            \
-                        build-essential \
-                        git             \
-                        python
+RUN    apt-get update                              \
+    && apt-get upgrade --yes                       \
+    && apt-get install --yes                       \
+                        build-essential            \
+                        git                        \
+                        python                     \
+                        software-properties-common \
+    && add-apt-repository ppa:avsm/ppa             \
+    && apt-get update                              \
+    && apt-get upgrade --yes
 
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.6 \
     && cd z3                                                        \

--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -3,6 +3,11 @@ FROM ubuntu:bionic
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
+RUN    apt-get update                                   \
+    && apt-get upgrade --yes                            \
+    && apt-get install --yes software-properties-common \
+    && add-apt-repository ppa:avsm/ppa
+
 RUN    apt-get update                   \
     && apt-get upgrade --yes            \
     && apt-get install --yes            \


### PR DESCRIPTION
Currently we're installing the default version of opam with Ubuntu docker image, but it's 1.2 version. We should be using 2.0 because more projects rely on it (in this example, Tezos), and we don't have any projects relying on v1.2.