### PR TITLE
scala version bump

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <base>master</base>
     <skipCheckstyleOnWindows>true</skipCheckstyleOnWindows>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <scala.version>2.12.4</scala.version>
+    <scala.version>2.12.11</scala.version>
     <project.build.type>FastBuild</project.build.type>
   </properties>
 


### PR DESCRIPTION
I have been wanting to update to a more recent version of scala for a while now, but whenever I try scala 2.13, I get a bunch of compiler errors. I did not realize that scala 2.12 was still being updated with bugfix releases, however, and this is just as good of a solution. Thus, we update to the latest release of scala 2.12.