### PR TITLE
Issue report: Using incorrect --def-module in kprove results in exception

### DIFF
--- a/k-distribution/tests/regression-new/kprove-wrong-def-module/Makefile
+++ b/k-distribution/tests/regression-new/kprove-wrong-def-module/Makefile
@@ -1,0 +1,10 @@
+DEF=extended
+EXT=test
+TESTDIR=.
+KOMPILE_BACKEND=haskell
+KPROVE_FLAGS=--def-module VERIFICATION-DEMO
+
+export KOMPILE_BACKEND
+export KPROVE_FLAGS
+
+include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/kprove-wrong-def-module/demo.k
+++ b/k-distribution/tests/regression-new/kprove-wrong-def-module/demo.k
@@ -1,0 +1,4 @@
+module DEMO
+  imports DOMAINS
+  configuration <k> .K </k>
+endmodule

--- a/k-distribution/tests/regression-new/kprove-wrong-def-module/extended-bad-module-spec.k
+++ b/k-distribution/tests/regression-new/kprove-wrong-def-module/extended-bad-module-spec.k
@@ -1,0 +1,16 @@
+requires "extended.k"
+
+module VERIFICATION-DEMO
+    imports DEMO
+endmodule
+
+module VERIFICATION-EXTENDED
+    imports EXTENDED
+    imports VERIFICATION-DEMO
+endmodule
+
+module EXTENDED-BAD-MODULE-SPEC
+    imports VERIFICATION-EXTENDED
+
+    rule <k> .K => ?_ </k>
+endmodule

--- a/k-distribution/tests/regression-new/kprove-wrong-def-module/extended.k
+++ b/k-distribution/tests/regression-new/kprove-wrong-def-module/extended.k
@@ -1,0 +1,6 @@
+requires "demo.k"
+
+module EXTENDED
+  imports DEMO
+  configuration <extended> <k/> </extended>
+endmodule


### PR DESCRIPTION
when it uses incompatible configuration