### PR TITLE
don't create scanner for STDIN-STREAM and STDOUT-STREAM if they are not

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -180,9 +180,14 @@ public class DefinitionParsing {
             modules = Stream.concat(modules, Stream.of(syntaxModule.get()));
             modules = Stream.concat(modules, stream(syntaxModule.get().importedModules()));
         }
-        modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("K-REFLECTION").get()));
-        modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("STDIN-STREAM").get()));
-        modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("STDOUT-STREAM").get()));
+        boolean hasStream = stream(parsedDefinition.entryModules()).anyMatch(m -> m.att().contains("stream"));
+        if (!kore || hasStream) {
+            modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("K-REFLECTION").get()));
+        }
+        if (hasStream) {
+            modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("STDIN-STREAM").get()));
+            modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("STDOUT-STREAM").get()));
+        }
         modules = Stream.concat(modules,
                 stream(parsedDefinition.entryModules()).filter(m -> !stream(m.sentences()).anyMatch(s -> s instanceof Bubble)));
         Definition trimmed = Definition(parsedDefinition.mainModule(), modules.collect(Collections.toSet()),

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -631,7 +631,13 @@ void AttributesBodyEOF(ASTNode node) : {} {
   { SwitchTo(ATTR_STATE); } AttributesBody(node) <EOF> { SwitchTo(DEFAULT); } }
 
 /** Parses a set of attributes and adds them to 'node' */
-void AttributesBody(ASTNode node) : {} { Tag(node) ("," Tag(node))* }
+void AttributesBody(ASTNode node) : {} { Tag(node) ("," Tag(node))* 
+  {
+    if (node.getAttributes().contains("cell") && node.getAttributes().contains("stream")) {
+      module.addAttribute("stream", "");
+    }
+  }
+}
 void Attributes(ASTNode node) : {}
 {
   "[" { SwitchTo(ATTR_STATE); }


### PR DESCRIPTION
needed

This ought to significantly decrease incremental parsing time on semantics that do not use these modules.