### PR TITLE
Fix crash when importing BYTES with kompile --coverage

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.k
+++ b/k-distribution/include/kframework/builtin/domains.k
@@ -765,7 +765,7 @@ module BYTES-HOOKED
   rule .Bytes => String2Bytes("")
 endmodule
 
-module BYTES-IN-K
+module BYTES-IN-K [symbolic, kast]
   imports INT
   imports K-EQUAL
   imports STRING
@@ -855,10 +855,6 @@ module BYTES-KORE [kore]
   imports BYTES-SYMBOLIC-CEIL
 endmodule
 
-module BYTES-SYMBOLIC [symbolic, kast]
-  imports BYTES-IN-K
-endmodule
-
 module BYTES-SYMBOLIC-CEIL [symbolic, kore]
   imports BYTES-HOOKED
   imports INT
@@ -870,7 +866,7 @@ endmodule
 module BYTES
   imports BYTES-CONCRETE
   imports BYTES-KORE
-  imports BYTES-SYMBOLIC
+  imports BYTES-IN-K
   imports INT
 
   rule Int2Bytes(I::Int, E::Endianness, Unsigned) => Int2Bytes((log2Int(I) +Int 8) /Int 8, I, E)

--- a/k-distribution/tests/regression-new/bytes-coverage/Makefile
+++ b/k-distribution/tests/regression-new/bytes-coverage/Makefile
@@ -1,0 +1,7 @@
+DEF=test
+EXT=test
+TESTDIR=.
+KOMPILE_BACKEND=llvm
+KOMPILE_FLAGS=--coverage
+
+include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/bytes-coverage/test.k
+++ b/k-distribution/tests/regression-new/bytes-coverage/test.k
@@ -1,0 +1,3 @@
+module TEST
+  imports BYTES
+endmodule


### PR DESCRIPTION
I'm not rightly sure why this happens, but this workaround seems to fix it, so I'm not sure it's worth investigating further at this time.

Fixes #1389 