### PR TITLE
Don't report suppressed warnings as errors

### DIFF
--- a/k-distribution/tests/regression-new/werrorCategory/Makefile
+++ b/k-distribution/tests/regression-new/werrorCategory/Makefile
@@ -1,0 +1,6 @@
+DEF=test
+EXT=test
+TESTDIR=.
+KOMPILE_FLAGS=-w2e -Wno missing-syntax-module
+
+include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/werrorCategory/test.k
+++ b/k-distribution/tests/regression-new/werrorCategory/test.k
@@ -1,0 +1,6 @@
+module TEST
+  imports BOOL
+
+  syntax Foo ::= foo()
+
+endmodule

--- a/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
+++ b/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
@@ -104,6 +104,8 @@ public class KExceptionManager {
 
     private void register(Set<KEMException> errors, ExceptionType type, KExceptionGroup group, String message,
                           Throwable e, Location location, Source source) {
+        if (!options.includesExceptionType(type))
+            return;
         KException exception = new KException(type, group, message, source, location, e);
         if (exception.type == ExceptionType.ERROR || options.warnings2errors) {
             errors.add(new KEMException(exception, ExceptionType.ERROR));


### PR DESCRIPTION
Fixes a bug where -w2e enabled unused symbol errors when it ought not to have.