### PR TITLE
Jenkinsfile: timeout on mac build step

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -366,7 +366,7 @@ pipeline {
             branch 'master'
             beforeAgent true
           }
-          options { timeout(time: 120, unit: 'MINUTES') }
+          options { timeout(time: 150, unit: 'MINUTES') }
           stages {
             stage('Build on Mac OS') {
               stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -366,6 +366,7 @@ pipeline {
             branch 'master'
             beforeAgent true
           }
+          options { timeout(time: 120, unit: 'MINUTES') }
           stages {
             stage('Build on Mac OS') {
               stages {


### PR DESCRIPTION
To keep the K master build from absorbing an executor forever if Anka goes down.