### PR TITLE
Fix deploy process

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -499,8 +499,8 @@ pipeline {
             git tag "${K_RELEASE_TAG}" "${LONG_REV}"
             git push origin "${K_RELEASE_TAG}"
 
-            LOCAL_BOTTLE_NAME=$(find ../mojave -name kframework--${VERSION}.mojave.bottle*.tar.gz)
-            BOTTLE_NAME=$(echo ${LOCAL_BOTTLE_NAME#../mojave} | sed 's!kframework--!kframework-!')
+            LOCAL_BOTTLE_NAME=$(find ../mojave -name "kframework--${VERSION}.mojave.bottle*.tar.gz")
+            BOTTLE_NAME=$(echo ${LOCAL_BOTTLE_NAME#../mojave/} | sed 's!kframework--!kframework-!')
 
             mv ../bionic/kframework_${VERSION}_amd64.deb             kframework_${VERSION}_amd64_bionic.deb
             mv ../focal/kframework_${VERSION}_amd64.deb              kframework_${VERSION}_amd64_focal.deb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,6 +6,7 @@ pipeline {
     VERSION         = '5.0.0'
     ROOT_URL        = 'https://github.com/kframework/k/releases/download'
     SHORT_REV       = """${sh(returnStdout: true, script: 'git rev-parse --short=7 HEAD').trim()}"""
+    LONG_REV        = """${sh(returnStdout: true, script: 'git rev-parse HEAD').trim()}"""
     K_RELEASE_TAG   = "v${env.VERSION}-${env.SHORT_REV}"
     MAKE_EXTRA_ARGS = '' // Example: 'DEBUG=--debug' to see stack traces
   }
@@ -495,7 +496,7 @@ pipeline {
             git push -d origin "${K_RELEASE_TAG}" || true
             hub release delete "${K_RELEASE_TAG}" || true
 
-            git tag "${K_RELEASE_TAG}" "${SHORT_REV}"
+            git tag "${K_RELEASE_TAG}" "${LONG_REV}"
             git push release "${K_RELEASE_TAG}"
 
             mv ../bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -502,11 +502,13 @@ pipeline {
             LOCAL_BOTTLE_NAME=$(find ../mojave -name "kframework--${VERSION}.mojave.bottle*.tar.gz")
             BOTTLE_NAME=$(echo ${LOCAL_BOTTLE_NAME#../mojave/} | sed 's!kframework--!kframework-!')
 
-            mv ../bionic/kframework_${VERSION}_amd64.deb             kframework_${VERSION}_amd64_bionic.deb
-            mv ../focal/kframework_${VERSION}_amd64.deb              kframework_${VERSION}_amd64_focal.deb
-            mv ../buster/kframework_${VERSION}_amd64.deb             kframework_${VERSION}_amd64_buster.deb
-            mv ../arch/kframework-git-${VERSION}-1-x86_64.pkg.tar.xz kframework-git-${VERSION}-1-x86_64.pkg.tar.xz
-            mv $LOCAL_BOTTLE_NAME                                    $BOTTLE_NAME
+            mv ../kframework-${VERSION}-src.tar.gz                      kframework-${VERSION}-src.tar.gz
+            mv ../bionic/kframework_${VERSION}_amd64.deb                kframework_${VERSION}_amd64_bionic.deb
+            mv ../focal/kframework_${VERSION}_amd64.deb                 kframework_${VERSION}_amd64_focal.deb
+            mv ../buster/kframework_${VERSION}_amd64.deb                kframework_${VERSION}_amd64_buster.deb
+            mv ../arch/kframework-git-${VERSION}-1-x86_64.pkg.tar.xz    kframework-git-${VERSION}-1-x86_64.pkg.tar.xz
+            mv $LOCAL_BOTTLE_NAME                                       $BOTTLE_NAME
+            mv ../k-nightly.tar.gz                                      k-nightly.tar.gz
 
             echo "K Framework Release ${K_RELEASE_TAG}"  > release.md
             echo ''                                     >> release.md

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -487,16 +487,23 @@ pipeline {
         dir('mojave') { unstash 'mojave' }
         sshagent(['2b3d8d6b-0855-4b59-864a-6b3ddf9c9d1a']) {
           sh '''
-            git remote add release 'ssh://github.com/kframework/k.git'
+            git clone 'ssh://github.com/kframework/k.git' k-release
+            cd k-release
+            git fetch --all
+
+            git tag -d "${K_RELEASE_TAG}"         || true
+            git push -d origin "${K_RELEASE_TAG}" || true
+            hub release delete "${K_RELEASE_TAG}" || true
+
             git tag "${K_RELEASE_TAG}" "${SHORT_REV}"
             git push release "${K_RELEASE_TAG}"
 
-            mv bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
-            mv focal/kframework_${VERSION}_amd64.deb focal/kframework_${VERSION}_amd64_focal.deb
-            mv buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
-            LOCAL_BOTTLE_NAME=$(echo mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)
-            BOTTLE_NAME=`cd mojave && echo kframework--${VERSION}.mojave.bottle*.tar.gz | sed 's!kframework--!kframework-!'`
-            mv $LOCAL_BOTTLE_NAME mojave/$BOTTLE_NAME
+            mv ../bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
+            mv ../focal/kframework_${VERSION}_amd64.deb focal/kframework_${VERSION}_amd64_focal.deb
+            mv ../buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
+            LOCAL_BOTTLE_NAME=$(echo ../mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)
+            BOTTLE_NAME=$(cd ../mojave && echo kframework--${VERSION}.mojave.bottle*.tar.gz | sed 's!kframework--!kframework-!')
+            mv $LOCAL_BOTTLE_NAME ../mojave/$BOTTLE_NAME
             echo "K Framework Release ${K_RELEASE_TAG}"  > release.md
             echo ''                                     >> release.md
             cat k-distribution/INSTALL.md               >> release.md

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -497,7 +497,7 @@ pipeline {
             hub release delete "${K_RELEASE_TAG}" || true
 
             git tag "${K_RELEASE_TAG}" "${LONG_REV}"
-            git push release "${K_RELEASE_TAG}"
+            git push origin "${K_RELEASE_TAG}"
 
             mv ../bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
             mv ../focal/kframework_${VERSION}_amd64.deb focal/kframework_${VERSION}_amd64_focal.deb

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,10 +170,10 @@ pipeline {
               }
             }
             stage('Build and Package on Debian Buster') {
-              //when {
-              //  branch 'master'
-              //  beforeAgent true
-              //}
+              when {
+                branch 'master'
+                beforeAgent true
+              }
               stages {
                 stage('Build on Debian Buster') {
                   agent {
@@ -229,10 +229,10 @@ pipeline {
               }
             }
             stage('Build and Package on Arch Linux') {
-              //when {
-              //  branch 'master'
-              //  beforeAgent true
-              //}
+              when {
+                branch 'master'
+                beforeAgent true
+              }
               stages {
                 stage('Build on Arch Linux') {
                   agent {
@@ -291,10 +291,10 @@ pipeline {
               }
             }
             stage('Build Platform Independent K Binary') {
-              //when {
-              //  branch 'master'
-              //  beforeAgent true
-              //}
+              when {
+                branch 'master'
+                beforeAgent true
+              }
               agent {
                 dockerfile {
                   additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -321,10 +321,10 @@ pipeline {
           }
         }
         stage('Build and Package on Mac OS') {
-          //when {
-          //  branch 'master'
-          //  beforeAgent true
-          //}
+          when {
+            branch 'master'
+            beforeAgent true
+          }
           options { timeout(time: 150, unit: 'MINUTES') }
           stages {
             stage('Build on Mac OS') {
@@ -408,10 +408,10 @@ pipeline {
       }
     }
     stage('DockerHub') {
-      //when {
-      //  branch 'master'
-      //  beforeAgent true
-      //}
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       environment {
         DOCKERHUB_TOKEN   = credentials('rvdockerhub')
         BIONIC_COMMIT_TAG = "ubuntu-bionic-${env.SHORT_REV}"
@@ -454,10 +454,10 @@ pipeline {
       }
     }
     stage('Deploy') {
-      //when {
-      //  branch 'master'
-      //  beforeAgent true
-      //}
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -552,7 +552,10 @@ pipeline {
       }
     }
     stage('Update Submodules (release)') {
-      when { branch 'master' }
+      when {
+        branch 'master'
+        beforeAgent true
+      }
       steps {
         build job: 'rv-devops/master', propagate: false, wait: false                                   \
             , parameters: [ booleanParam(name: 'UPDATE_DEPS_SUBMODULE', value: true)                   \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -170,10 +170,10 @@ pipeline {
               }
             }
             stage('Build and Package on Debian Buster') {
-              when {
-                branch 'master'
-                beforeAgent true
-              }
+              //when {
+              //  branch 'master'
+              //  beforeAgent true
+              //}
               stages {
                 stage('Build on Debian Buster') {
                   agent {
@@ -229,10 +229,10 @@ pipeline {
               }
             }
             stage('Build and Package on Arch Linux') {
-              when {
-                branch 'master'
-                beforeAgent true
-              }
+              //when {
+              //  branch 'master'
+              //  beforeAgent true
+              //}
               stages {
                 stage('Build on Arch Linux') {
                   agent {
@@ -291,10 +291,10 @@ pipeline {
               }
             }
             stage('Build Platform Independent K Binary') {
-              when {
-                branch 'master'
-                beforeAgent true
-              }
+              //when {
+              //  branch 'master'
+              //  beforeAgent true
+              //}
               agent {
                 dockerfile {
                   additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'
@@ -321,10 +321,10 @@ pipeline {
           }
         }
         stage('Build and Package on Mac OS') {
-          when {
-            branch 'master'
-            beforeAgent true
-          }
+          //when {
+          //  branch 'master'
+          //  beforeAgent true
+          //}
           options { timeout(time: 150, unit: 'MINUTES') }
           stages {
             stage('Build on Mac OS') {
@@ -408,10 +408,10 @@ pipeline {
       }
     }
     stage('DockerHub') {
-      when {
-        branch 'master'
-        beforeAgent true
-      }
+      //when {
+      //  branch 'master'
+      //  beforeAgent true
+      //}
       environment {
         DOCKERHUB_TOKEN   = credentials('rvdockerhub')
         BIONIC_COMMIT_TAG = "ubuntu-bionic-${env.SHORT_REV}"
@@ -454,10 +454,10 @@ pipeline {
       }
     }
     stage('Deploy') {
-      when {
-        branch 'master'
-        beforeAgent true
-      }
+      //when {
+      //  branch 'master'
+      //  beforeAgent true
+      //}
       agent {
         dockerfile {
           additionalBuildArgs '--build-arg USER_ID=$(id -u) --build-arg GROUP_ID=$(id -g)'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -499,23 +499,26 @@ pipeline {
             git tag "${K_RELEASE_TAG}" "${LONG_REV}"
             git push origin "${K_RELEASE_TAG}"
 
-            mv ../bionic/kframework_${VERSION}_amd64.deb bionic/kframework_${VERSION}_amd64_bionic.deb
-            mv ../focal/kframework_${VERSION}_amd64.deb focal/kframework_${VERSION}_amd64_focal.deb
-            mv ../buster/kframework_${VERSION}_amd64.deb buster/kframework_${VERSION}_amd64_buster.deb
-            LOCAL_BOTTLE_NAME=$(echo ../mojave/kframework--${VERSION}.mojave.bottle*.tar.gz)
-            BOTTLE_NAME=$(cd ../mojave && echo kframework--${VERSION}.mojave.bottle*.tar.gz | sed 's!kframework--!kframework-!')
-            mv $LOCAL_BOTTLE_NAME ../mojave/$BOTTLE_NAME
+            LOCAL_BOTTLE_NAME=$(find ../mojave -name kframework--${VERSION}.mojave.bottle*.tar.gz)
+            BOTTLE_NAME=$(echo ${LOCAL_BOTTLE_NAME#../mojave} | sed 's!kframework--!kframework-!')
+
+            mv ../bionic/kframework_${VERSION}_amd64.deb             kframework_${VERSION}_amd64_bionic.deb
+            mv ../focal/kframework_${VERSION}_amd64.deb              kframework_${VERSION}_amd64_focal.deb
+            mv ../buster/kframework_${VERSION}_amd64.deb             kframework_${VERSION}_amd64_buster.deb
+            mv ../arch/kframework-git-${VERSION}-1-x86_64.pkg.tar.xz kframework-git-${VERSION}-1-x86_64.pkg.tar.xz
+            mv $LOCAL_BOTTLE_NAME                                    $BOTTLE_NAME
+
             echo "K Framework Release ${K_RELEASE_TAG}"  > release.md
             echo ''                                     >> release.md
             cat k-distribution/INSTALL.md               >> release.md
-            hub release create                                                                         \
-                --attach kframework-${VERSION}-src.tar.gz'#Source tar.gz'                              \
-                --attach bionic/kframework_${VERSION}_amd64_bionic.deb'#Ubuntu Bionic (18.04) Package' \
-                --attach focal/kframework_${VERSION}_amd64_focal.deb'#Ubuntu Focal (20.04) Package'    \
-                --attach buster/kframework_${VERSION}_amd64_buster.deb'#Debian Buster (10) Package'    \
-                --attach arch/kframework-git-${VERSION}-1-x86_64.pkg.tar.xz'#Arch Package'             \
-                --attach mojave/$BOTTLE_NAME'#Mac OS X Homebrew Bottle'                                \
-                --attach k-nightly.tar.gz'#Platform Indepdendent K Binary'                             \
+            hub release create                                                                  \
+                --attach kframework-${VERSION}-src.tar.gz'#Source tar.gz'                       \
+                --attach kframework_${VERSION}_amd64_bionic.deb'#Ubuntu Bionic (18.04) Package' \
+                --attach kframework_${VERSION}_amd64_focal.deb'#Ubuntu Focal (20.04) Package'   \
+                --attach kframework_${VERSION}_amd64_buster.deb'#Debian Buster (10) Package'    \
+                --attach kframework-git-${VERSION}-1-x86_64.pkg.tar.xz'#Arch Package'           \
+                --attach $BOTTLE_NAME'#Mac OS X Homebrew Bottle'                                \
+                --attach k-nightly.tar.gz'#Platform Indepdendent K Binary'                      \
                 --file release.md "${K_RELEASE_TAG}"
           '''
         }


### PR DESCRIPTION
Deploy process is currently failing for some silly reason, AFAICT it's because we're using a reference repository for the original clone and then the git objects dir doesn't exist for it to make tags based on.

This updates it using improvements I've learned from the Firefly web deploy process too.