### PR TITLE
Update simple-untyped.md with scrapable headers

### DIFF
--- a/k-distribution/tutorial/2_languages/1_simple/1_untyped/simple-untyped.md
+++ b/k-distribution/tutorial/2_languages/1_simple/1_untyped/simple-untyped.md
@@ -1,5 +1,15 @@
 ---
 copyright: Copyright (c) 2014-2020 K Team. All Rights Reserved.
+title: SIMPLE - Untyped
+author:
+  - given: Grigore
+    family: Roșu
+    email: grosu@illinois.edu
+    organization: University of Illinois at Urbana-Champaign
+  - given: Traian Florin
+    family: Șerbănuță
+    email: traian.serbanuta@unibuc.ro
+    organization: University of Bucharest
 ---
 
 SIMPLE — Untyped


### PR DESCRIPTION
Fixes: #1496
Don't really like how GitHub renders them though.
- the table is very long horizontally.
- the copyright column is too narrow.
- to follow the bib and pandoc style for specifying authors I have to split first name of last name

@ehildenb @dwightguth Thoughts on this? Should I continue and do all of them like this, or do we find another format?
I think the GitHub rendering is the most important since this is where most people look at the definitions so we should make them look as good as possible.

I also found a list of supported languages on GitHub for which they offer syntax highlighting: https://github.com/github/linguist/blob/master/vendor/README.md
If we could do something similar it could improve K code readability in the browser.