### PR TITLE
package/docker/Dockerfile.ubuntu-bionic: update to z3 4.8.7

### DIFF
--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -10,7 +10,7 @@ RUN    apt-get update                   \
                         git             \
                         python
 
-RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.6 \
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.7 \
     && cd z3                                                        \
     && python scripts/mk_make.py                                    \
     && cd build                                                     \


### PR DESCRIPTION
4.8.8 has been out for 3 months, 4.8.7 has been out longer. There is a proof on KEVM that takes absurdly long on 4.8.6 vs 4.8.7, so I don't see any reason not to upgrade.

4.8.8 does not have a NixOS version, so that's why I'm keeping it on 4.8.7.