### PR TITLE
Update installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,18 @@ copyright: Copyright (c) 2010-2020 K Team. All Rights Reserved.
 
 [Join the chat at Riot](https://riot.im/app/#/room/#k:matrix.org)
 
-This is a readme file for the developers.
+# Introduction
+
+This is a readme file for _K developers_.
+
+_K-based tool users_ should:
+
+1.  Consult their tool documentation for build/installation instructions.
+2.  If needed, download a [packaged release](https://github.com/kframework/k/releases/)
+    of the K Framework as part of their tool setup process.
+
+The rest of this file assumes you intend to build and install the K Framework
+from source.
 
 # Prerequisite Install Guide
 

--- a/README.md
+++ b/README.md
@@ -215,8 +215,11 @@ Common build-time error messages:
      hLock: invalid argument (Invalid argument)`
     + If you are using a [WSL version 1 environment](https://docs.microsoft.com/en-us/windows/wsl/compare-versions),
       then you have encountered a known issue with the latest versions of GHC. In this
-      case, please either build the K Framework in a different environment
-      or else install a [packaged release for your WSL version 1 distribution](https://github.com/kframework/k/releases/).
+      case, please either: (a) upgrade to [WSL version 2](https://docs.microsoft.com/en-us/windows/wsl/install-win10),
+      (b) install a [packaged release for your WSL version 1 distribution](https://github.com/kframework/k/releases/),
+      (c) switch to a supported system configuration (e.g. Linux on a virtual machine), or
+      (d) if you do not need the symbolic execution capabilities of the K Framework, disable them
+      at build time (and remove the GHC dependency) by doing: `mvn package -Dhaskell.backend.skip`
 
 If something unexpected happens and the project fails to build, try `mvn clean` and
 rebuild the entire project. Generally speaking, however, the project should build incrementally

--- a/README.md
+++ b/README.md
@@ -204,6 +204,20 @@ Common build-time error messages:
      (default-compile) on project k-core: Fatal error compiling: invalid target release: 1.8 -> [Help 1]`
     + You either do not have Java 8 installed, or `$JAVA_HOME` does not point to a Java 8 JDK.
 
+-   `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run
+     (build-haskell) on project haskell-backend: An Ant BuildException has occured: exec returned: 1`
+
+    and scrolling up, you see an error message similar to:
+
+    `[exec] Installing GHC ...
+     [exec] ghc-pkg: Couldn't open database $HOME/.stack/programs/x86_64-linux/ghc-tinfo6-8.10.1/lib/ghc-8.10.1/package.conf.d for modification:
+     {handle: $HOME/.stack/programs/x86_64-linux/ghc-tinfo6-8.10.1/lib/ghc-8.10.1/package.conf.d/package.cache.lock}:
+     hLock: invalid argument (Invalid argument)`
+    + If you are using a [WSL version 1 environment](https://docs.microsoft.com/en-us/windows/wsl/compare-versions),
+      then you have encountered a known issue with the latest versions of GHC. In this
+      case, please either build the K Framework in a different environment
+      or else install a [packaged release for your WSL version 1 distribution](https://github.com/kframework/k/releases/).
+
 If something unexpected happens and the project fails to build, try `mvn clean` and
 rebuild the entire project. Generally speaking, however, the project should build incrementally
 without needing to be cleaned first.

--- a/README.md
+++ b/README.md
@@ -24,9 +24,6 @@ On Arch (from source):
 ```
 git submodule update --init --recursive
 sudo pacman -S git maven jdk-openjdk cmake boost libyaml jemalloc clang llvm lld zlib gmp mpfr z3 opam curl stack base-devel base python
-export PATH=$PATH:/usr/bin/core_perl
-makepkg
-sudo pacman -U kframework-5.0.0-1-x86_64.pkg.tar.zst
 ```
 
 If you install this list of dependencies, continue directly to the Install section.

--- a/README.md
+++ b/README.md
@@ -215,11 +215,12 @@ Common build-time error messages:
      hLock: invalid argument (Invalid argument)`
     + If you are using a [WSL version 1 environment](https://docs.microsoft.com/en-us/windows/wsl/compare-versions),
       then you have encountered a known issue with the latest versions of GHC. In this
-      case, please either: (a) upgrade to [WSL version 2](https://docs.microsoft.com/en-us/windows/wsl/install-win10),
-      (b) install a [packaged release for your WSL version 1 distribution](https://github.com/kframework/k/releases/),
-      (c) switch to a supported system configuration (e.g. Linux on a virtual machine), or
-      (d) if you do not need the symbolic execution capabilities of the K Framework, disable them
-      at build time (and remove the GHC dependency) by doing: `mvn package -Dhaskell.backend.skip`
+      case, please either:
+      -   upgrade to [WSL version 2](https://docs.microsoft.com/en-us/windows/wsl/install-win10),
+      -   install a [packaged release for your WSL version 1 distribution](https://github.com/kframework/k/releases/),
+      -   switch to a supported system configuration (e.g. Linux on a virtual machine), or
+      -   if you do not need the symbolic execution capabilities of the K Framework, disable them
+          at build time (and remove the GHC dependency) by doing: `mvn package -Dhaskell.backend.skip`.
 
 If something unexpected happens and the project fails to build, try `mvn clean` and
 rebuild the entire project. Generally speaking, however, the project should build incrementally

--- a/README.md
+++ b/README.md
@@ -7,9 +7,12 @@ copyright: Copyright (c) 2010-2020 K Team. All Rights Reserved.
 
 This is a readme file for the developers.
 
-# Prerequisites
+# Prerequisite Install Guide
 
-In short:
+Before building and installing the K Framework, the following prerequisites
+must first be installed.
+
+## The Short Version
 
 On Ubuntu:
 
@@ -26,9 +29,11 @@ git submodule update --init --recursive
 sudo pacman -S git maven jdk-openjdk cmake boost libyaml jemalloc clang llvm lld zlib gmp mpfr z3 opam curl stack base-devel base python
 ```
 
-If you install this list of dependencies, continue directly to the Install section.
+If you install this list of dependencies, continue directly to the [Build and Install Guide](#build-and-install-guide).
 
-## Java Development Kit (required JDK8 version 8u45 or higher)
+## The Long Version
+
+### Java Development Kit (required JDK8 version 8u45 or higher)
 
 Linux:
 *   Download from package manager (e.g. `sudo apt-get install openjdk-8-jdk`)
@@ -36,7 +41,7 @@ Linux:
 To make sure that everything works you should be able to call `java -version` and
 `javac -version` from a Terminal.
 
-## Apache Maven
+### Apache Maven
 
 Linux:
 *   Download from package manager (e.g. `sudo apt-get install maven`)
@@ -52,12 +57,12 @@ You can test if it works by calling `mvn -version` in a Terminal.
 This will provide the information about the JDK Maven is using, in case
 it is the wrong one.
 
-## Haskell Stack
+### Haskell Stack
 
 To install, go to <https://docs.haskellstack.org/en/stable/README/> and follow the instructions.
 You may need to do `stack upgrade` to ensure the latest version of Haskell Stack.
 
-## Miscellaneous
+### Miscellaneous
 
 Also required:
 
@@ -73,8 +78,9 @@ Also required:
 
 These can all be installed from your package manager.
 
-# Install
-Checkout the directory of this README in your desired location and call `mvn package` from the main
+# Build and Install Guide
+
+Checkout the project source at your desired location and call `mvn package` from the main
 directory to build the distribution. For convenient usage, you can update
 your $PATH with <checkout-dir>k-distribution/target/release/k/bin (strongly recommended, but optional).
 
@@ -140,22 +146,23 @@ eclipse does not support hierarchical projects.
 IntelliJ IDEA comes with built-in maven integration. For more information, refer to
 the [IntelliJ IDEA wiki](http://wiki.jetbrains.net/intellij/Creating_and_importing_Maven_projects)
 
-# Run test suite
+# Running the Test Suite
+
 To completely test the current version of the K framework, run `mvn verify`.
 This normally takes roughly 30 minutes on a fast machine. If you are interested only
 in running the unit tests and checkstyle goals, run `mvn verify -DskipKTest` to
 skip the lengthy `ktest` execution.
 
-# Changing the KORE data structures
+# Changing the KORE Data Structures
 If you need to change the KORE data structures (unless you are a K core developer, you probably do not), see [Guide-for-changing-the-KORE-data-structures](https://github.com/kframework/k/wiki/Guide-for-changing-the-KORE-data-structures).
 
-# Build the final release directory/archives
+# Building the Final Release Directory/Archives
 Call `mvn install` in the base directory. This will attach an artifact to the local
 maven repository containing a zip and tar.gz of the distribution.
 
 The functionality to create a tagged release is currently incomplete.
 
-# Compiling definitions and running programs
+# Compiling Definitions and Running Programs
 Assuming k-distribution/target/release/k/bin is in your path, you can compile definitions using
 the `kompile` command.  To execute a program you can use `krun`.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ must first be installed.
 
 ## The Short Version
 
-On Ubuntu:
+On Ubuntu Linux:
 
 ```
 git submodule update --init --recursive
@@ -33,7 +33,7 @@ sudo apt-get install build-essential m4 openjdk-8-jdk libgmp-dev libmpfr-dev pkg
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 
-On Arch (from source):
+On Arch Linux:
 
 ```
 git submodule update --init --recursive

--- a/README.md
+++ b/README.md
@@ -180,29 +180,29 @@ the `kompile` command.  To execute a program you can use `krun`.
 For running either program in the debugger, use the main class `org.kframework.main.Main` with an additional argument `-kompile` or `-krun` added before other command line arguments, and use the classpath from the `k-distribution` module.
 
 # Troubleshooting
-Common error messages:
+Common build-time error messages:
 
--  `Error: JAVA_HOME not found in your environment.
-    Please set the JAVA_HOME variable in your environment to match the
-    location of your Java installation.`
+-   `Error: JAVA_HOME not found in your environment.
+     Please set the JAVA_HOME variable in your environment to match the
+     location of your Java installation.`
     + Make sure `JAVA_HOME` points to the JDK and not the JRE directory.
 
-- `[WARNING] Cannot get the branch information from the git repository:
-   Detecting the current branch failed: 'git' is not recognized as an internal or external command,
-   operable program or batch file.`
-   +  `git` might not be installed on your system. Make sure that you can execute
+-   `[WARNING] Cannot get the branch information from the git repository:
+     Detecting the current branch failed: 'git' is not recognized as an internal or external command,
+     operable program or batch file.`
+    + `git` might not be installed on your system. Make sure that you can execute
       `git` from the command line.
 
-- `1) Error injecting constructor, java.lang.Error: Unresolved compilation problems:
-        The import org.kframework.parser.outer.Outer cannot be resolved
-        Outer cannot be resolved`
-   + You may run into this issue if target/generated-sources/javacc is not added to the
-     build path of your IDE. Generally this is solved by regenerating your project /
-     re-syncing it with the pom.xml.
+-   `1) Error injecting constructor, java.lang.Error: Unresolved compilation problems:
+          The import org.kframework.parser.outer.Outer cannot be resolved
+          Outer cannot be resolved`
+    + You may run into this issue if target/generated-sources/javacc is not added to the
+      build path of your IDE. Generally this is solved by regenerating your project /
+      re-syncing it with the pom.xml.
 
-- `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
-   (default-compile) on project k-core: Fatal error compiling: invalid target release: 1.8 -> [Help 1]`
-   + You either do not have Java 8 installed, or `$JAVA_HOME` does not point to a Java 8 JDK.
+-   `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
+     (default-compile) on project k-core: Fatal error compiling: invalid target release: 1.8 -> [Help 1]`
+    + You either do not have Java 8 installed, or `$JAVA_HOME` does not point to a Java 8 JDK.
 
 If something unexpected happens and the project fails to build, try `mvn clean` and
 rebuild the entire project. Generally speaking, however, the project should build incrementally

--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -1,12 +1,12 @@
-Installing K Framework Package
-==============================
+Installing the K Framework Package
+==================================
 
 We currently strive to provide packages for the following platforms:
 
 -   Ubuntu Bionic (18.04)
 -   Debian Buster
 -   Arch Linux
--   MacOS X Mojave
+-   MacOS X Mojave/Homewbrew
 -   Docker Images
 -   Platform Independent K Binary
 
@@ -40,14 +40,22 @@ sudo apt install ./kframework_X.Y.Z_amd64_DISTRO.deb
 pacman -U ./kframework-git-X.Y.Z-1-x86_64.pkg.tar.zst
 ```
 
-### MacOS X Mojave
+### MacOS X Mojave/Homebrew
 
-Tap the `kframework/k` bottle then install (with build number `BN`):
+[Homebrew](https://brew.sh/) (or just brew) is a third-party package manager
+for MacOS.
+If you have not installed brew, you must do so before installing the K
+Framework brew package.
+
+With brew installed, do the following to install the K Framework brew package
+(with build number `BN`):
 
 ```sh
-brew tap kframework/k "file:///$(pwd)"
 brew install kframework--X.Y.Z.ID.bottle.BN.tar.gz -v
 ```
+
+Note: the brew package should install on MacOS X Catalina systems even though
+the package was built for Mojave.
 
 ### Docker Images
 

--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -57,6 +57,24 @@ brew install kframework--X.Y.Z.ID.bottle.BN.tar.gz -v
 Note: the brew package should install on MacOS X Catalina systems even though
 the package was built for Mojave.
 
+#### Homebrew Alternate Installation
+
+To directly install the latest K Framework brew package without needing to
+download it separately, do the following:
+
+```sh
+brew install kframework/k/kframework
+```
+
+Or, to streamline future K Framework upgrades, you can `tap` the K Framework
+package repository. This lets future installations/upgrades/etc... use the
+unprefixed package name.
+
+```sh
+brew tap kframework/k
+brew install kframework
+```
+
 ### Docker Images
 
 Docker images with K pre-installed are available at the


### PR DESCRIPTION
I have updated the installation documentation to fix errors and improve clarity.

I'd like to be able to refer to README.md and k-distribution/INSTALL.md for up-to-date building and installation instructions inside of individual tools (if needed) instead of repeating the same information in different places.

I believe all of the changes to instructions are correct. I made two such changes:

- I deleted the line `brew tap ...` in k-distribution/INSTALL.md because that line did not work on my OSX system and a client's OSX system --- and added a section about using `brew tap` based on the documentation and tested on my system
- I deleted the lines about `makepkg` in README.md for Arch Linux because the `PKGBUILD` file is not in the project root and so that command will always fail