### PR TITLE
Warn if user imports module with not-lr1 attribute when doing LR(1) parsing

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -463,7 +463,7 @@ patterns for doing so, refer to K's
 [user documentation](pending-documentation.md).
 
 ```k
-module SET
+module SET [not-lr1]
   imports INT-SYNTAX
   imports BASIC-K
 
@@ -588,7 +588,7 @@ patterns for doing so, refer to K's
 [user documentation](pending-documentation).
 
 ```k
-module LIST
+module LIST [not-lr1]
   imports INT-SYNTAX
   imports BASIC-K
 
@@ -752,7 +752,7 @@ module BOOL-SYNTAX
   syntax Bool ::= "false" [token]
 endmodule
 
-module BOOL
+module BOOL [not-lr1]
   imports BASIC-K
   imports BOOL-SYNTAX
 ```

--- a/k-distribution/tests/regression-new/issue-1572/Makefile
+++ b/k-distribution/tests/regression-new/issue-1572/Makefile
@@ -1,0 +1,3 @@
+KOMPILE_FLAGS=-w2e -w all --gen-bison-parser
+
+include ../../../include/kframework/ktest-fail.mak

--- a/k-distribution/tests/regression-new/issue-1572/test.k
+++ b/k-distribution/tests/regression-new/issue-1572/test.k
@@ -1,0 +1,9 @@
+module TEST-SYNTAX
+  imports BOOL
+
+endmodule
+
+module TEST
+  imports TEST-SYNTAX
+
+endmodule

--- a/k-distribution/tests/regression-new/issue-1572/test.k.out
+++ b/k-distribution/tests/regression-new/issue-1572/test.k.out
@@ -1,0 +1,2 @@
+[Error] Inner Parser: Importing a module that is tagged as not being LR(1) when
+using Bison's LR(1) parser generator: [BOOL]

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -71,7 +71,7 @@ public class KRead {
                 File scanHdr = files.resolveTemp("scanner.h");
                 File parserFile = files.resolveTemp("parser.y");
                 scanner.writeStandaloneScanner(scannerFile);
-                KSyntax2Bison.writeParser(parseInModule.getParsingModule(), scanner, sort, parserFile, glr);
+                KSyntax2Bison.writeParser(parseInModule.getParsingModule(), scanner, sort, parserFile, glr, kem);
                 int exit = files.getProcessBuilder()
                   .directory(files.resolveTemp("."))
                   .command("flex", "--header-file=" + scanHdr.getAbsolutePath(), "-w", scannerFile.getAbsolutePath())

--- a/kernel/src/main/java/org/kframework/parser/inner/generator/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/generator/RuleGrammarGenerator.java
@@ -9,6 +9,7 @@ import org.kframework.compile.ConfigurationInfoFromModule;
 import org.kframework.compile.GenerateSortPredicateSyntax;
 import org.kframework.compile.GenerateSortProjections;
 import org.kframework.definition.Definition;
+import org.kframework.definition.Import;
 import org.kframework.definition.Module;
 import org.kframework.definition.ModuleTransformer;
 import org.kframework.definition.NonTerminal;
@@ -435,9 +436,14 @@ public class RuleGrammarGenerator {
             parseProds.addAll(res);
             disambProds.addAll(res);
         }
-        Module extensionM = new Module(mod.name() + "-EXTENSION", Set(mod), immutable(extensionProds), mod.att());
-        Module disambM = new Module(mod.name() + "-DISAMB", Set(), immutable(disambProds), mod.att());
-        Module parseM = new Module(mod.name() + "-PARSER", Set(), immutable(parseProds), mod.att());
+        Att att = mod.att();
+        List<String> notLrModules = stream(mod.importedModules()).filter(m -> m.att().contains("not-lr1") && !m.name().endsWith(Import.syntaxString())).map(m -> m.name()).collect(Collectors.toList());
+        if (!notLrModules.isEmpty()) {
+          att = att.add("not-lr1", notLrModules.toString());
+        }
+        Module extensionM = new Module(mod.name() + "-EXTENSION", Set(mod), immutable(extensionProds), att);
+        Module disambM = new Module(mod.name() + "-DISAMB", Set(), immutable(disambProds), att);
+        Module parseM = new Module(mod.name() + "-PARSER", Set(), immutable(parseProds), att);
         parseM.subsorts();
         return Tuple3.apply(extensionM, disambM, parseM);
     }

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
@@ -21,6 +21,7 @@ import org.kframework.kore.Sort;
 import org.kframework.parser.inner.generator.RuleGrammarGenerator;
 import org.kframework.utils.StringUtil;
 import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.errorsystem.KException.ExceptionType;
 import org.kframework.utils.errorsystem.KExceptionManager;
 
 import java.io.File;
@@ -116,6 +117,11 @@ public class KSyntax2Bison {
   }
 
   public static void writeParser(Module module, Scanner scanner, Sort start, File path, boolean glr, KExceptionManager kem) {
+    if (!glr && module.att().contains("not-lr1")) {
+        kem.registerInnerParserWarning(ExceptionType.NON_LR_GRAMMAR, "Importing a module that is tagged as not being LR(1) when using Bison's LR(1) parser generator: " + module.att().get("not-lr1"));
+        // print so it appears before we call bison which may not terminate
+        kem.print();
+    }
     module = transformByPriorityAndAssociativity(module);
     StringBuilder bison = new StringBuilder();
     bison.append("%{\n" +

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
@@ -21,6 +21,7 @@ import org.kframework.kore.Sort;
 import org.kframework.parser.inner.generator.RuleGrammarGenerator;
 import org.kframework.utils.StringUtil;
 import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.errorsystem.KExceptionManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -114,7 +115,7 @@ public class KSyntax2Bison {
     return Module(module.name(), module.imports(), immutable(sentences), module.att());
   }
 
-  public static void writeParser(Module module, Scanner scanner, Sort start, File path, boolean glr) {
+  public static void writeParser(Module module, Scanner scanner, Sort start, File path, boolean glr, KExceptionManager kem) {
     module = transformByPriorityAndAssociativity(module);
     StringBuilder bison = new StringBuilder();
     bison.append("%{\n" +

--- a/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
+++ b/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
@@ -148,6 +148,7 @@ public class KExceptionManager {
                 System.err.println(msg);
                 last = e;
             }
+            exceptions.clear();
         }
     }
 

--- a/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
+++ b/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
@@ -97,6 +97,10 @@ public class KExceptionManager {
         register(type, KExceptionGroup.OUTER_PARSER, message, e, location, source);
     }
 
+    public void registerInnerParserWarning(ExceptionType type, String message) {
+        register(type, KExceptionGroup.INNER_PARSER, message, null, null, null);
+    }
+
     private void register(ExceptionType type, KExceptionGroup group, String message,
                           Throwable e, Location location, Source source) {
         registerInternal(new KException(type, group, message, source, location, e), true);

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -105,6 +105,7 @@ public class KException implements Serializable, HasLocation {
         FUTURE_ERROR,
         UNUSED_VAR,
         PROOF_LINT,
+        NON_LR_GRAMMAR,
         FIRST_HIDDEN, // warnings below here are hidden by default
         MISSING_HOOK_JAVA,
         USELESS_RULE,

--- a/pending-documentation.md
+++ b/pending-documentation.md
@@ -2163,6 +2163,9 @@ some important limitations:
   generated will have shift/reduce or reduce/reduce conflicts and the parser
   may behave differently than `kast` would (`kast` is a GLL parser, ie, it
   is based on LL parsers and parses all unambiguous context-free grammars).
+  K provides an attribute, `not-lr1`, which can be applied to modules known to
+  not be LR(1), and will trigger a warning if the user attempts to generate an
+  LR(1) parser which recursively imports that module.
 * If you are using LR(1) based parsing, the `prefer` and `avoid` attributes are
   ignored. It is only possible to implement these attributes by means of
   generalized LL or LR parsing and a postprocessing on the AST to remove the


### PR DESCRIPTION
Fixes #1572