### PR TITLE
Priority filter fix.

### DIFF
--- a/k-distribution/tests/regression-new/checks/ambError.k
+++ b/k-distribution/tests/regression-new/checks/ambError.k
@@ -1,4 +1,4 @@
-// issue #1593
+// Issue #1593
 // testing that priority between left guarded and
 // right guarded operators are properly disambiguated
 

--- a/k-distribution/tests/regression-new/checks/ambError.k
+++ b/k-distribution/tests/regression-new/checks/ambError.k
@@ -1,0 +1,21 @@
+// issue #1593
+// testing that priority between left guarded and
+// right guarded operators are properly disambiguated
+
+module AMBERROR-SYNTAX
+
+endmodule
+
+module AMBERROR
+  imports AMBERROR-SYNTAX
+    imports INT
+
+    syntax Exp ::= Int
+
+    syntax Exp ::= Exp "+" Exp [klabel(plus), symbol]
+                 > "l" Exp     [klabel(lguard), symbol]
+                 | Exp "r"     [klabel(rguard), symbol]
+    rule . => 1 + l 2 // non ambiguous, should parse
+    rule . => 1 r + 2 // non ambiguous, should parse
+    rule . => l 1 r   // ambiguous - error
+endmodule

--- a/k-distribution/tests/regression-new/checks/ambError.k.out
+++ b/k-distribution/tests/regression-new/checks/ambError.k.out
@@ -1,0 +1,8 @@
+[Error] Inner Parser: Parsing ambiguity.
+1: syntax Exp ::= Exp "r" [klabel(rguard), symbol]
+    rguard(lguard(#token("1","Int")))
+2: syntax Exp ::= "l" Exp [klabel(lguard), symbol]
+    lguard(rguard(#token("1","Int")))
+	Source(ambError.k)
+	Location(20,15,20,20)
+[Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tutorial/2_languages/3_fun/1_untyped/1_environment/fun-untyped.md
+++ b/k-distribution/tutorial/2_languages/3_fun/1_untyped/1_environment/fun-untyped.md
@@ -264,7 +264,7 @@ on incorrect bindings and that the type system will reject those programs.
 // The "prefer" attribute for letrec currently needed due to tool bug,
 // to make sure that "letrec" is not parsed as "let rec".
   syntax Binding  ::= Exp "=" Exp
-  syntax Bindings ::= List{Binding,"and"}
+  syntax Bindings ::= NeList{Binding,"and"}
 ```
 References are first class values in FUN.  The construct `ref`
 takes an expression, evaluates it, and then it stores the resulting value
@@ -352,7 +352,7 @@ a constructor for function types:
 
   syntax TypeCase ::= ConstructorName
                     | ConstructorName "(" Types ")"
-  syntax TypeCases ::= List{TypeCase,"|"}     [klabel(_|TypeCase_)]
+  syntax TypeCases ::= NeList{TypeCase,"|"}     [klabel(_|TypeCase_)]
 ```
 
 ## Additional Priorities

--- a/k-distribution/tutorial/2_languages/3_fun/1_untyped/2_substitution/fun-untyped.md
+++ b/k-distribution/tutorial/2_languages/3_fun/1_untyped/2_substitution/fun-untyped.md
@@ -83,7 +83,7 @@ module FUN-UNTYPED-COMMON
   syntax Exp ::= "let" Bindings "in" Exp
                | "letrec" Bindings "in" Exp                 [prefer]
   syntax Binding  ::= Exp "=" Exp
-  syntax Bindings ::= List{Binding,"and"}
+  syntax Bindings ::= NeList{Binding,"and"}
 
   syntax Exp ::= "ref"
                | "&" Name
@@ -113,7 +113,7 @@ module FUN-UNTYPED-COMMON
 
   syntax TypeCase ::= ConstructorName
                     | ConstructorName "(" Types ")"
-  syntax TypeCases ::= List{TypeCase,"|"}     [klabel(_|TypeCase_)]
+  syntax TypeCases ::= NeList{TypeCase,"|"}     [klabel(_|TypeCase_)]
 ```
 
 ## Additional Priorities

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/PriorityVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/PriorityVisitor.java
@@ -78,8 +78,8 @@ public class PriorityVisitor extends SetsTransformerWithErrors<KEMException> {
 
         public Either<java.util.Set<KEMException>, Term> apply(TermCons tc) {
             if (tc.production().att().contains(Att.BRACKET())) return Right.apply(tc);
-            //if (Side.RIGHT  == side && !(tc.production().items().apply(0) instanceof NonTerminal)) return Right.apply(tc);
-            //if (Side.LEFT == side && !(tc.production().items().apply(tc.production().items().size() - 1) instanceof NonTerminal)) return Right.apply(tc);
+            if (Side.RIGHT  == side && !(tc.production().items().apply(0) instanceof NonTerminal)) return Right.apply(tc);
+            if (Side.LEFT == side && !(tc.production().items().apply(tc.production().items().size() - 1) instanceof NonTerminal)) return Right.apply(tc);
             Tag parentLabel = new Tag(parent.production().klabel().get().name());
             Tag localLabel = new Tag(tc.production().klabel().get().name());
             if (priorities.lessThan(parentLabel, localLabel)) {


### PR DESCRIPTION
Fixes: #1593
Allow for left guarded and right guarded operators under binary operators