### PR TITLE
Add option --emit-json to kprove as well

### DIFF
--- a/k-distribution/src/main/scripts/lib/pyk/kast.py
+++ b/k-distribution/src/main/scripts/lib/pyk/kast.py
@@ -414,7 +414,7 @@ def prettyPrintKast(kast, symbolTable):
              + '\n    '.join(contents.split('\n')) + '\n' \
              + 'endmodule'
     if isKRequire(kast):
-        return 'requires "' + kast['require'] + '.k"'
+        return 'requires "' + kast['require'] + '"'
     if isKDefinition(kast):
         requires = '' if kast['requires'] is None else '\n'.join([prettyPrintKast(require, symbolTable) for require in kast['requires']])
         modules  = '\n\n'.join([prettyPrintKast(module, symbolTable) for module in kast['modules']])

--- a/k-distribution/tests/pyk/defn-tests/build-config.py
+++ b/k-distribution/tests/pyk/defn-tests/build-config.py
@@ -21,12 +21,12 @@ if isKRule(kast_term):
     kast_term = minimizeRule(kast_term)
     defn_name = sys.argv[2][:-5].split("/")[2]
     mod = KFlatModule(defn_name.upper(), ["IMP"], [kast_term])
-    kast_term = KDefinition(defn_name, [mod], requires = [KRequire("imp")])
+    kast_term = KDefinition(defn_name, [mod], requires = [KRequire("imp.k")])
 elif isKClaim(kast_term):
     kast_term = minimizeRule(kast_term)
     defn_name = sys.argv[2][:-5].split("/")[2]
     mod = KFlatModule(defn_name.upper(), ["IMP"], [kast_term])
-    kast_term = KDefinition(defn_name, [mod], requires = [KRequire("imp")])
+    kast_term = KDefinition(defn_name, [mod], requires = [KRequire("imp.k")])
 elif isKApply(kast_term):
     kast_term = simplifyBool(kast_term)
 

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -2,7 +2,6 @@
 package org.kframework.kprove;
 
 import com.google.inject.Inject;
-import org.kframework.RewriterResult;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
@@ -10,8 +9,10 @@ import org.kframework.definition.Rule;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.krun.KRun;
+import org.kframework.RewriterResult;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.unparser.KPrint;
+import org.kframework.unparser.ToJson;
 import org.kframework.utils.BinaryLoader;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -19,6 +20,7 @@ import org.kframework.utils.file.FileUtil;
 import scala.Tuple2;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -71,6 +73,14 @@ public class KProve {
         Rewriter rewriter = rewriterGenerator.apply(compiled._1());
         Module specModule = compiled._2();
         Rule boundaryPattern = buildBoundaryPattern(compiledDefinition);
+
+        if (kproveOptions.emitJson) {
+            try {
+                files.saveToKompiled("def-module.json", new String(ToJson.apply(compiled._1()), "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                throw KEMException.criticalError("Unsupported encoding `UTF-8` when saving JSON definition.");
+            }
+        }
 
         RewriterResult results = rewriter.prove(specModule, boundaryPattern);
         kprint.prettyPrint(compiled._1(), compiled._1().getModule("LANGUAGE-PARSING").get(), kprint::outputFile,

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -76,7 +76,7 @@ public class KProve {
 
         if (kproveOptions.emitJson) {
             try {
-                files.saveToKompiled("def-module.json", new String(ToJson.apply(compiled._1()), "UTF-8"));
+                files.saveToKompiled("prove-definition.json", new String(ToJson.apply(compiled._1()), "UTF-8"));
             } catch (UnsupportedEncodingException e) {
                 throw KEMException.criticalError("Unsupported encoding `UTF-8` when saving JSON definition.");
             }

--- a/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
@@ -82,4 +82,7 @@ public class KProveOptions {
 
     @Parameter(names="--debug-script", description="Run script passed in specified file when the debugger starts. Used with --debugger.")
     public String debugScript;
+
+    @Parameter(names="--emit-json", description="Emit JSON serialized def module and spec module.")
+    public boolean emitJson = false;
 }

--- a/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
@@ -83,6 +83,6 @@ public class KProveOptions {
     @Parameter(names="--debug-script", description="Run script passed in specified file when the debugger starts. Used with --debugger.")
     public String debugScript;
 
-    @Parameter(names="--emit-json", description="Emit JSON serialized def module and spec module.")
+    @Parameter(names="--emit-json", description="Emit JSON serialized main definition for proving.")
     public boolean emitJson = false;
 }


### PR DESCRIPTION
This enables automatically generating (in `pyk`) the proof obligations needed to show that lemmas used for verification are sound.