### PR TITLE
Fix Nix job on pull requests from forks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,10 +10,6 @@ jobs:
         uses: actions/checkout@v2.3.4
         with:
           submodules: recursive
-          # Avoid cloning a detached-HEAD repository on pull_request events.
-          # git-auto-commit-action (below) needs this to find the original
-          # branch where it should push the changes.
-          ref: ${{ github.head_ref }}
 
       - name: 'Install Nix'
         uses: cachix/install-nix-action@v12
@@ -23,15 +19,6 @@ jobs:
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
-
-      - name: 'Update Maven dependencies'
-        run: ./nix/update-maven.sh
-
-      - name: 'Commit changes'
-        uses: stefanzweifel/git-auto-commit-action@v4.7.2
-        with:
-          commit_message: 'Update Maven dependencies'
-          file_pattern: 'nix/'
 
       - name: 'Build K Framework'
         run: nix-build -A k -A llvm-backend -A haskell-backend

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,8 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v2.3.4
         with:
+          # Check out pull request HEAD instead of merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
           submodules: recursive
 
       - name: 'Install Nix'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,40 @@ name: "Test"
 on:
   pull_request:
 jobs:
+  # Check that the pinned Maven dependencies are up-to-date.
+  # We cannot update them here (in the pull request job).
+  check-nix-maven:
+    name: 'Nix: Maven'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v2.3.4
+        with:
+          # Check out pull request HEAD instead of merge commit.
+          ref: ${{ github.event.pull_request.head.sha }}
+          submodules: recursive
+
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v12
+
+      - name: 'Install Cachix'
+        uses: cachix/cachix-action@v8
+        with:
+          name: runtimeverification
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          skipPush: true
+
+      - name: 'Update Maven dependencies'
+        run: ./nix/update-maven.sh
+
+      - name: 'Check for changes'
+        run: |
+          if [ ! $(git status --porcelain | wc -l) -eq 0 ]; then
+            echo "Found dirty files:"
+            git status --porcelain
+            exit 1
+          fi
+
   test-nix:
     name: 'Nix'
     runs-on: ubuntu-latest

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -1,0 +1,36 @@
+name: 'Update'
+on:
+  push:
+    branches-ignore:
+      - 'master'
+jobs:
+  # Update the pinned Maven dependencies for Nix.
+  # This job only runs on push events because we cannot push changes back to a
+  # pull request branch from a fork.
+  nix-maven:
+    name: 'Nix: Maven'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: recursive
+
+      - name: 'Install Nix'
+        uses: cachix/install-nix-action@v12
+
+      - name: 'Install Cachix'
+        uses: cachix/cachix-action@v8
+        with:
+          name: runtimeverification
+          signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'
+          skipPush: true
+
+      - name: 'Update Maven dependencies'
+        run: ./nix/update-maven.sh
+
+      - name: 'Commit changes'
+        uses: stefanzweifel/git-auto-commit-action@v4.7.2
+        with:
+          commit_message: 'Update Maven dependencies'
+          file_pattern: 'nix/'


### PR DESCRIPTION
The Maven update job will only run on push events, so to have that job run automatically, developers should make pull requests from branches on the main repository.