### PR TITLE
Expand macros in kx script

### DIFF
--- a/k-distribution/src/main/scripts/bin/kx
+++ b/k-distribution/src/main/scripts/bin/kx
@@ -36,8 +36,10 @@ tempFiles=("$tempDir")
 trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT
 
 input_file="$(mktemp tmp.in.XXXXXXXXXX)"
+expanded_input_file="$(mktemp tmp.in.XXXXXXXXXX)"
 kore_output="$tempDir/result.kore"
 tempFiles+=("$input_file")
+tempFiles+=("$expanded_input_file")
 tempFiles+=("$kore_output")
 
 execute () {
@@ -198,7 +200,7 @@ do
 
       --dry-run)
       cmdprefix="echo "
-      tempFiles=(${tempFiles[@]/$input_file})
+      tempFiles=(${tempFiles[@]/$expanded_input_file})
       dryRun=true
       ;;
 
@@ -446,6 +448,8 @@ else
   execute llvm-krun $configVars -d "$kompiledDir" $flags --dry-run -o "$input_file"
 fi
 
+# Expand macros
+execute kore-expand-macros "$kompiledDir" "$input_file" > "$expanded_input_file"
 
 # Invoke backend
 if [ -f "$kompiledDir/interpreter" ]; then
@@ -456,7 +460,7 @@ if [ -f "$kompiledDir/interpreter" ]; then
   fi
 
   set +e
-  execute $cmdprefix "$kompiledDir/interpreter" "$input_file" "${depth:--1}" "$kore_output" $interpreter_flags
+  execute $cmdprefix "$kompiledDir/interpreter" "$expanded_input_file" "${depth:--1}" "$kore_output" $interpreter_flags
   result=$?
   set -e
 else
@@ -482,11 +486,11 @@ else
       final_input="$(mktemp tmp.in.XXXXXXXXXX)"
       tempFiles+=("$final_input")
       set +e
-      execute $cmdprefix "$haskellCmd" "$kompiledDir/definition.kore" --module "$mainModuleName" --pattern "$input_file" --output "$final_input" $koreExecFlags
+      execute $cmdprefix "$haskellCmd" "$kompiledDir/definition.kore" --module "$mainModuleName" --pattern "$expanded_input_file" --output "$final_input" $koreExecFlags
       set -e
       depthFlags="--depth 0"
     else
-      final_input="$input_file"
+      final_input="$expanded_input_file"
     fi
 
     if [ -n "$bound" ]; then
@@ -498,7 +502,7 @@ else
     set -e
   else
     set +e
-    execute $cmdprefix "$haskellCmd" "$kompiledDir/definition.kore" --module "$mainModuleName" --pattern "$input_file" --output "$kore_output" $koreExecFlags $depthFlags
+    execute $cmdprefix "$haskellCmd" "$kompiledDir/definition.kore" --module "$mainModuleName" --pattern "$expanded_input_file" --output "$kore_output" $koreExecFlags $depthFlags
     result=$?
     set -e
   fi

--- a/k-distribution/src/main/scripts/bin/kx
+++ b/k-distribution/src/main/scripts/bin/kx
@@ -5,6 +5,7 @@ set -u
 
 export PATH="$(dirname "$0"):$PATH"
 
+# initialize flags
 ARGV=()
 bound=
 depth=
@@ -29,6 +30,7 @@ configVars=
 dryRun=false
 result=1
 
+# setup temp files
 tempDir="$(mktemp -d tmp.krun.XXXXXXXXXX)"
 tempFiles=("$tempDir")
 trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT
@@ -134,6 +136,7 @@ future.
 HERE
 }
 
+# parse options
 while [[ $# -gt 0 ]]
 do
   arg="$1"
@@ -359,6 +362,7 @@ if [[ "${#ARGV[@]}" -gt 1 ]]; then
   error 'Cannot pass more than one configuration variable as a positional argument.'
 fi
 
+# Compute kompiled directory
 kompiledDir=
 hasKompiledDir=false
 for file in "$dir"/*-kompiled; do
@@ -374,6 +378,7 @@ if ! $hasKompiledDir; then
   error 'Could not find a compiled definition. Use --directory to specify one.'
 fi
 
+# Process configuration variables
 hasArgv=false
 if [[ "${#ARGV[@]}" -gt 0 ]]; then
   config_var_PGM="${ARGV[0]}"
@@ -442,6 +447,7 @@ else
 fi
 
 
+# Invoke backend
 if [ -f "$kompiledDir/interpreter" ]; then
   if $statistics; then
     interpreter_flags=--statistics
@@ -498,6 +504,7 @@ else
   fi
 fi
 
+# Unparsing
 if ! $dryRun; then
   if [ -f "$kore_output" ]; then
     if $statistics; then

--- a/k-distribution/src/main/scripts/bin/kx
+++ b/k-distribution/src/main/scripts/bin/kx
@@ -28,6 +28,7 @@ smtPrelude=
 flags=
 configVars=
 dryRun=false
+expandMacros=true
 result=1
 
 # setup temp files
@@ -103,6 +104,10 @@ future.
                            execution, and disabled when --search is passed.
       --no-substitution-filtering  Don't filter conjuncts with anonymous
                                    variables from substitution output
+      --no-expand-macros   Don't expand macros in initial configuration.
+                           This assumes that the initial configuration contains
+                           no macro terms. Behavior is undefined if this is not
+                           true.
   -o, --output MODE        Select output mode to use when unparsing. Valid
                            values are pretty, program, kast, binary, json,
                            latex, kore, and none.
@@ -233,6 +238,10 @@ do
 
       --no-substitution-filtering)
       filterSubst=false
+      ;;
+
+      --no-expand-macros)
+      expandMacros = false
       ;;
 
       -o|--output)
@@ -449,7 +458,11 @@ else
 fi
 
 # Expand macros
-execute kore-expand-macros "$kompiledDir" "$input_file" > "$expanded_input_file"
+if $expandMacros; then
+  execute kore-expand-macros "$kompiledDir" "$input_file" > "$expanded_input_file"
+else
+  execute cp "$input_file" "$expanded_input_file"
+fi
 
 # Invoke backend
 if [ -f "$kompiledDir/interpreter" ]; then

--- a/k-distribution/tests/regression-new/pattern-macro/test.k
+++ b/k-distribution/tests/regression-new/pattern-macro/test.k
@@ -22,7 +22,7 @@ syntax KItem ::= RValue
 syntax KItem ::= RHold
 syntax KItem ::= Type
 
-syntax Expression ::= arithOp(K, K) | stuff(K)
+syntax Expression ::= arithOp(K, K) | stuff(K) | Int
 rule arithOp(L:K, R:K) => stuff(L) [macro]
 rule arithOp(L:RValue, R::RValue) => .K
 rule arithOp(te(t(0, 0, int), t(0, 0, int)), R::RValue) => .K

--- a/k-distribution/tutorial/2_languages/1_simple/1_untyped/simple-untyped.md
+++ b/k-distribution/tutorial/2_languages/1_simple/1_untyped/simple-untyped.md
@@ -106,7 +106,7 @@ keyword to take a list of expressions.  The non-terminals used in the two
 productions below are defined shortly.
 
 ```k
-  syntax Decl ::= "var" Exps ";"
+  syntax Stmt ::= "var" Exps ";"
                 | "function" Id "(" Ids ")" Block
 ```
 ## Expressions
@@ -206,14 +206,14 @@ arguments.
 
 ```k
   syntax Block ::= "{" "}"
-                | "{" Stmts "}"
+                | "{" Stmt "}"
 
-  syntax Stmt ::= Decl | Block
+  syntax Stmt ::= Block
                 | Exp ";"                               [strict]
                 | "if" "(" Exp ")" Block "else" Block   [avoid, strict(1)]
                 | "if" "(" Exp ")" Block
                 | "while" "(" Exp ")" Block
-                | "for" "(" Stmts Exp ";" Exp ")" Block
+                | "for" "(" Stmt Exp ";" Exp ")" Block
                 | "return" Exp ";"                      [strict]
                 | "return" ";"
                 | "print" "(" Exps ")" ";"              [strict]
@@ -240,8 +240,7 @@ also shown below, in which case the latter would not apply anymore because
 of syntactic mismatch.
 
 ```k
-  syntax Stmts ::= Stmt
-                 | Stmts Stmts                          [right]
+  syntax Stmt ::= Stmt Stmt                          [right]
 
 // I wish I were able to write the following instead, but confuses the parser.
 //
@@ -373,7 +372,7 @@ to the **K** tool, as indicated by the `$PGM` variable, followed by the
   configuration <T color="red">
                   <threads color="orange">
                     <thread multiplicity="*" color="yellow">
-                      <k color="green"> $PGM:Stmts ~> execute </k>
+                      <k color="green"> $PGM:Stmt ~> execute </k>
                     //<br/> // TODO(KORE): support latex annotations #1799
                       <control color="cyan">
                         <fstack color="blue"> .List </fstack>
@@ -817,7 +816,7 @@ to something).  This means that once `S₁` completes in the rule below, `S₂`
 becomes automatically the next computation item without any additional
 (explicit or implicit) rules.
 ```k
-  rule S1:Stmts S2:Stmts => S1 ~> S2  [structural]
+  rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
 ```
 
 A subtle aspect of the rule above is that `S₁` is declared to have sort
@@ -908,7 +907,7 @@ is thrown to correctly recover the execution context.  This can be easily
 achieved by pushing/popping the entire current control context onto the
 exception stack.  The three rules below modularly do precisely the above.
 ```k
-  syntax KItem ::= (Id,Stmts,K,Map,ControlCellFragment)
+  syntax KItem ::= (Id,Stmt,K,Map,ControlCellFragment)
 
   syntax KItem ::= "popx"
 
@@ -1067,7 +1066,7 @@ The `mkDecls` auxiliary construct turns a list of identifiers
 and a list of values in a sequence of corresponding variable
 declarations.
 ```k
-  syntax Stmts ::= mkDecls(Ids,Vals)  [function]
+  syntax Stmt ::= mkDecls(Ids,Vals)  [function]
   rule mkDecls((X:Id, Xs:Ids), (V:Val, Vs:Vals)) => var X=V; mkDecls(Xs,Vs)
   rule mkDecls(.Ids,.Vals) => {}
 ```

--- a/k-distribution/tutorial/2_languages/1_simple/2_typed/1_static/simple-typed-static.md
+++ b/k-distribution/tutorial/2_languages/1_simple/2_typed/1_static/simple-typed-static.md
@@ -149,7 +149,7 @@ type, we also introduce a new syntactic category for typed variables,
   syntax Param ::= Type Id
   syntax Params ::= List{Param,","}
 
-  syntax Decl ::= Type Exps ";"
+  syntax Stmt ::= Type Exps ";"
                 | Type Id "(" Params ")" Block
 ```
 
@@ -216,14 +216,14 @@ typing perspective, they are all strict: first type their arguments and then
 type the actual construct.
 ```k
   syntax Block ::= "{" "}"
-                | "{" Stmts "}"
+                | "{" Stmt "}"
 
-  syntax Stmt ::= Decl | Block
+  syntax Stmt ::= Block
                 | Exp ";"                                  [strict]
                 | "if" "(" Exp ")" Block "else" Block      [avoid, strict]
                 | "if" "(" Exp ")" Block
                 | "while" "(" Exp ")" Block                [strict]
-                | "for" "(" Stmts Exp ";" Exp ")" Block
+                | "for" "(" Stmt Exp ";" Exp ")" Block
                 | "return" Exp ";"                         [strict]
                 | "return" ";"
                 | "print" "(" Exps ")" ";"                 [strict]
@@ -238,8 +238,7 @@ Note that the sequential composition is now sequentially strict,
 because, unlike in the dynamic semantics where statements dissolved,
 they now reduce to the `stmt` type, which is a result.
 ```k
-  syntax Stmts ::= Stmt
-                |  Stmts Stmts                             [seqstrict, right]
+  syntax Stmt ::= Stmt Stmt                             [seqstrict, right]
 ```
 ## Desugaring macros
 
@@ -247,7 +246,7 @@ We use the same desugaring macros like in untyped SIMPLE, but, of
 course, including the types of the involved variables.
 ```k
   rule if (E) S => if (E) S else {}                                     [macro]
-  rule for(Start Cond; Step) {S:Stmts} => {Start while(Cond){S Step;}}  [macro]
+  rule for(Start Cond; Step) {S:Stmt} => {Start while(Cond){S Step;}}  [macro]
   rule for(Start Cond; Step) {} => {Start while(Cond){Step;}}           [macro]
   rule T:Type E1:Exp, E2:Exp, Es:Exps; => T E1; T E2, Es;               [macro-rec]
   rule T:Type X:Id = E; => T X; X = E;                                  [macro]
@@ -337,7 +336,7 @@ subcells.
   configuration <T color="yellow">
                   <tasks color="orange">
                     <task multiplicity="*" color="yellow">
-                      <k color="green"> $PGM:Stmts </k>
+                      <k color="green"> $PGM:Stmt </k>
                       <tenv multiplicity="?" color="cyan"> .Map </tenv>
                       <returnType multiplicity="?" color="black"> void </returnType>
                     </task>
@@ -628,7 +627,7 @@ exceptions which are not caught.
 The function `mkDecls` turns a list of parameters into a
 list of variable declarations.
 ```k
-  syntax Stmts ::= mkDecls(Params)  [function]
+  syntax Stmt ::= mkDecls(Params)  [function]
   rule mkDecls(T:Type X:Id, Ps:Params) => T X; mkDecls(Ps)
   rule mkDecls(.Params) => {}
 ```

--- a/k-distribution/tutorial/2_languages/2_kool/1_untyped/kool-untyped.md
+++ b/k-distribution/tutorial/2_languages/2_kool/1_untyped/kool-untyped.md
@@ -167,7 +167,7 @@ syntax includes:
 ```k
   syntax Id ::= "Object" [token] | "Main" [token]
 
-  syntax Decl ::= "var" Exps ";"
+  syntax Stmt ::= "var" Exps ";"
                 | "method" Id "(" Ids ")" Block  // called "function" in SIMPLE
                 | "class" Id Block               // KOOL
                 | "class" Id "extends" Id Block  // KOOL
@@ -214,14 +214,14 @@ syntax includes:
   syntax Vals ::= List{Val,","}          [klabel(exps)]
 
   syntax Block ::= "{" "}"
-                | "{" Stmts "}"
+                | "{" Stmt "}"
 
-  syntax Stmt ::= Decl | Block
+  syntax Stmt ::= Block
                 | Exp ";"                               [strict]
                 | "if" "(" Exp ")" Block "else" Block   [avoid, strict(1)]
                 | "if" "(" Exp ")" Block
                 | "while" "(" Exp ")" Block
-            | "for" "(" Stmts Exp ";" Exp ")" Block
+            | "for" "(" Stmt Exp ";" Exp ")" Block
                 | "return" Exp ";"                      [strict]
                 | "return" ";"
                 | "print" "(" Exps ")" ";"              [strict]
@@ -232,8 +232,7 @@ syntax includes:
                 | "release" Exp ";"                     [strict]
                 | "rendezvous" Exp ";"                  [strict]
 
-  syntax Stmts ::= Stmt
-                 | Stmts Stmts                          [right]
+  syntax Stmt ::= Stmt Stmt                          [right]
 ```
 
 
@@ -307,7 +306,7 @@ discuss the new cells that are added to the configuration of SIMPLE.
   configuration <T color="red">
                   <threads color="orange">
                     <thread multiplicity="*" type="Set" color="yellow">
-                      <k color="green"> $PGM:Stmts ~> execute </k>
+                      <k color="green"> $PGM:Stmt ~> execute </k>
                     //<br/> // TODO(KORE): support latex annotations #1799
                       <control color="cyan">
                         <fstack color="blue"> .List </fstack>
@@ -483,7 +482,7 @@ interestingly, the semantics of return stays unchanged.
   rule <k> { S } => S ~> setEnv(Env) ...</k>  <env> Env </env>  [structural]
 
 
-  rule S1::Stmts S2::Stmts => S1 ~> S2  [structural]
+  rule S1::Stmt S2::Stmt => S1 ~> S2  [structural]
 
   rule _:Val; => .
 
@@ -559,7 +558,7 @@ from SIMPLE unchanged.
 ## Unchanged auxiliary operations from untyped SIMPLE
 
 ```k
-  syntax Stmts ::= mkDecls(Ids,Vals)  [function]
+  syntax Stmt ::= mkDecls(Ids,Vals)  [function]
   rule mkDecls((X:Id, Xs:Ids), (V:Val, Vs:Vals)) => var X=V; mkDecls(Xs,Vs)
   rule mkDecls(.Ids,.Vals) => {}
 

--- a/k-distribution/tutorial/2_languages/2_kool/2_typed/1_dynamic/kool-typed-dynamic.md
+++ b/k-distribution/tutorial/2_languages/2_kool/2_typed/1_dynamic/kool-typed-dynamic.md
@@ -68,7 +68,7 @@ untyped KOOL.
   syntax Param ::= Type Id
   syntax Params ::= List{Param,","}
 
-  syntax Decl ::= Type Exps ";" [avoid]
+  syntax Stmt ::= Type Exps ";" [avoid]
                 | Type Id "(" Params ")" Block    // stays like in typed SIMPLE
                 | "class" Id Block                // KOOL
                 | "class" Id "extends" Id Block   // KOOL
@@ -121,14 +121,14 @@ untyped KOOL.
 
 ```k
   syntax Block ::= "{" "}"
-                | "{" Stmts "}"
+                | "{" Stmt "}"
 
-  syntax Stmt ::= Decl | Block
+  syntax Stmt ::= Block
                 | Exp ";"                               [strict]
                 | "if" "(" Exp ")" Block "else" Block   [avoid, strict(1)]
                 | "if" "(" Exp ")" Block
                 | "while" "(" Exp ")" Block
-                | "for" "(" Stmts Exp ";" Exp ")" Block
+                | "for" "(" Stmt Exp ";" Exp ")" Block
                 | "print" "(" Exps ")" ";"              [strict]
                 | "return" Exp ";"                      [strict]
                 | "return" ";"
@@ -139,15 +139,14 @@ untyped KOOL.
                 | "release" Exp ";"                     [strict]
                 | "rendezvous" Exp ";"                  [strict]
 
-  syntax Stmts ::= Stmt
-                 | Stmts Stmts                          [right]
+  syntax Stmt ::= Stmt Stmt                          [right]
 ```
 
 ## Desugaring macros
 
 ```k
   rule if (E) S => if (E) S else {}                                     [macro]
-  rule for(Start Cond; Step) {S::Stmts} => {Start while(Cond){S Step;}} [macro]
+  rule for(Start Cond; Step) {S::Stmt} => {Start while(Cond){S Step;}} [macro]
   rule T::Type E1::Exp, E2::Exp, Es::Exps; => T E1; T E2, Es;           [macro-rec]
   rule T::Type X::Id = E; => T X; X = E;                                [macro]
 
@@ -190,7 +189,7 @@ the expected type.
   configuration <T color="red">
                   <threads color="orange">
                     <thread multiplicity="*" type="Set" color="yellow">
-                      <k color="green"> ($PGM:Stmts ~> execute) </k>
+                      <k color="green"> ($PGM:Stmt ~> execute) </k>
                     //<br/> // TODO(KORE): support latex annotations #1799
                       <control color="cyan">
                         <fstack color="blue"> .List </fstack>
@@ -333,7 +332,7 @@ KOOL).
   rule <k> { S } => S ~> setEnv(Env) ...</k>  <env> Env </env>  [structural]
 
 
-  rule S1:Stmts S2:Stmts => S1 ~> S2  [structural]
+  rule S1:Stmt S2:Stmt => S1 ~> S2  [structural]
 
 
   rule _:Val; => .
@@ -380,7 +379,7 @@ KOOL).
 ## Unchanged auxiliary operations from dynamically typed SIMPLE
 
 ```k
-  syntax Stmts ::= mkDecls(Params,Vals)  [function]
+  syntax Stmt ::= mkDecls(Params,Vals)  [function]
   rule mkDecls((T:Type X:Id, Ps:Params), (V:Val, Vs:Vals))
     => T X=V; mkDecls(Ps,Vs)
   rule mkDecls(.Params,.Vals) => {}

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -217,6 +217,12 @@ public class ModuleToKORE {
             }
         }
 
+        for (Production lesser : iterable(module.overloads().elements())) {
+            for (Production greater : iterable(module.overloads().relations().get(lesser).getOrElse(() -> Collections.<Production>Set()))) {
+                genOverloadedAxiom(lesser, greater, sb);
+            }
+        }
+
         sb.append("endmodule []\n");
         files.saveToKompiled("syntaxDefinition.kore", sb.toString());
         sb.setLength(length);

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -10,6 +10,7 @@ import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
 import org.kframework.builtin.BooleanUtils;
 import org.kframework.builtin.Sorts;
+import org.kframework.compile.ExpandMacros;
 import org.kframework.compile.GenerateSentencesFromConfigDecl;
 import org.kframework.definition.Bubble;
 import org.kframework.definition.Claim;
@@ -530,7 +531,7 @@ public class DefinitionParsing {
             Att att = parse.getParse().att().addAll(b.att().remove("contentStartLine").remove("contentStartColumn").remove(Source.class).remove(Location.class));
             return Stream.of(new AddAtt(a -> att).apply(parse.getParse()));
         }
-        result = parser.parseString(b.contents(), START_SYMBOL, scanner, source, startLine, startColumn, true, b.att().contains("anywhere"));
+        result = parser.parseString(b.contents(), START_SYMBOL, scanner, source, startLine, startColumn, true, b.att().contains("anywhere") || ExpandMacros.isMacro(b));
         parsedBubbles.getAndIncrement();
         if (kem.options.warnings2errors && !result._2().isEmpty()) {
           for (KEMException err : result._2()) {


### PR DESCRIPTION
This ought to be the last change needed in order to be able to change kx -> krun and krun -> krun-legacy. I will do that in a separate PR after this is merged, though.

Fixes #1648 