### PR TITLE
remove milliseconds since it is not portable

### DIFF
--- a/k-distribution/src/main/scripts/bin/kx
+++ b/k-distribution/src/main/scripts/bin/kx
@@ -32,7 +32,7 @@ expandMacros=true
 result=1
 
 # setup temp files
-now=`date +"%Y-%m-%d-%H-%M-%S-"$((10#$(date +%N)/1000000))`
+now=`date +"%Y-%m-%d-%H-%M-%S"`
 tempDir="$(mktemp -d .krun-${now}-XXXXXXXXXX)"
 tempFiles=("$tempDir")
 trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT


### PR DESCRIPTION
Fix for #1756, hopefully.