### PR TITLE
Changes to `kompile` and `kprove` to allow standalone installations

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -108,7 +108,7 @@ public class DefinitionParsing {
         this.profileRules = options.profileRules;
     }
 
-    public java.util.Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, java.util.Set<String> excludeModules) {
+    public java.util.Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, java.util.Set<String> excludeModules, boolean updateCaches) {
         Definition def = parser.loadDefinition(
                 mainModule,
                 mutable(definition.getParsedDefinition().modules()),
@@ -151,7 +151,9 @@ public class DefinitionParsing {
         }
 
         def = resolveNonConfigBubbles(def, def.getModule(entryPointModule).get(), gen);
-        saveCachesAndReportParsingErrors();
+        if (updateCaches) {
+            saveCachesAndReportParsingErrors();
+        }
         return mutable(def.entryModules());
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -108,7 +108,7 @@ public class DefinitionParsing {
         this.profileRules = options.profileRules;
     }
 
-    public java.util.Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, java.util.Set<String> excludeModules, boolean updateCaches) {
+    public java.util.Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, java.util.Set<String> excludeModules, boolean readOnlyCache) {
         Definition def = parser.loadDefinition(
                 mainModule,
                 mutable(definition.getParsedDefinition().modules()),
@@ -151,7 +151,7 @@ public class DefinitionParsing {
         }
 
         def = resolveNonConfigBubbles(def, def.getModule(entryPointModule).get(), gen);
-        if (updateCaches) {
+        if (! readOnlyCache) {
             saveCachesAndReportParsingErrors();
         }
         return mutable(def.entryModules());

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -453,8 +453,8 @@ public class Kompile {
         return parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, true);
     }
 
-    public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules, boolean updateCaches) {
-        Set<Module> modules = definitionParsing.parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, updateCaches);
+    public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules, boolean readOnlyCache) {
+        Set<Module> modules = definitionParsing.parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, readOnlyCache);
         int totalBubbles = definitionParsing.parsedBubbles.get() + definitionParsing.cachedBubbles.get();
         sw.printIntermediate("Parse spec modules [" + definitionParsing.parsedBubbles.get() + "/" + totalBubbles + " rules]");
         return modules;

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -450,7 +450,11 @@ public class Kompile {
     }
 
     public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules) {
-        Set<Module> modules = definitionParsing.parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules);
+        return parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, true);
+    }
+
+    public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules, boolean updateCaches) {
+        Set<Module> modules = definitionParsing.parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, updateCaches);
         int totalBubbles = definitionParsing.parsedBubbles.get() + definitionParsing.cachedBubbles.get();
         sw.printIntermediate("Parse spec modules [" + definitionParsing.parsedBubbles.get() + "/" + totalBubbles + " rules]");
         return modules;

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -95,11 +95,8 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--bison-lists", description="Make List and NeList left associative. This is useful for creating Bison parsers that use bounded stack space.")
     public boolean bisonLists;
 
-    @Parameter(names="--read-only-parse-cache", description="Treat the parse cache as read-only (for global installs of semantics).")
-    private boolean noUpdateParseCache = false;
-    public boolean updateParseCache() {
-        return ! noUpdateParseCache;
-    }
+    @Parameter(names="--read-only-kompiled-directory", description="Files in the generated kompiled directory should be read-only to other frontend tools.")
+    public boolean readOnlyKompiledDirectory = false;
 
     @ParametersDelegate
     public Experimental experimental = new Experimental();

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -91,8 +91,15 @@ public class KompileOptions implements Serializable {
 
     @Parameter(names="-E", description="Perform outer parsing and then stop and pretty print the definition to standard output. Useful for converting a K definition into a completely self-contained file when reporting a bug.")
     public boolean preprocess;
+
     @Parameter(names="--bison-lists", description="Make List and NeList left associative. This is useful for creating Bison parsers that use bounded stack space.")
     public boolean bisonLists;
+
+    @Parameter(names="--read-only-parse-cache", description="Treat the parse cache as read-only (for global installs of semantics).")
+    private boolean noUpdateParseCache = false;
+    public boolean updateParseCache() {
+        return ! noUpdateParseCache;
+    }
 
     @ParametersDelegate
     public Experimental experimental = new Experimental();

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -64,7 +64,7 @@ public class KProve {
         }
 
         Tuple2<Definition, Module> compiled = proofDefinitionBuilder
-                .build(kproveOptions.specFile(files), kproveOptions.defModule, kproveOptions.specModule, compiledDefinition.kompileOptions.updateParseCache());
+                .build(kproveOptions.specFile(files), kproveOptions.defModule, kproveOptions.specModule, compiledDefinition.kompileOptions.readOnlyKompiledDirectory);
 
         if (kproveOptions.saveProofDefinitionTo != null) {
             saveFullDefinition(compiled._1());

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -64,7 +64,7 @@ public class KProve {
         }
 
         Tuple2<Definition, Module> compiled = proofDefinitionBuilder
-                .build(kproveOptions.specFile(files), kproveOptions.defModule, kproveOptions.specModule);
+                .build(kproveOptions.specFile(files), kproveOptions.defModule, kproveOptions.specModule, compiledDefinition.kompileOptions.updateParseCache());
 
         if (kproveOptions.saveProofDefinitionTo != null) {
             saveFullDefinition(compiled._1());

--- a/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
+++ b/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
@@ -56,7 +56,7 @@ public class ProofDefinitionBuilder {
      * @param specModuleName Module containing specifications to prove
      */
     public Tuple2<Definition, Module> build(File specFile, String defModuleName, String specModuleName) {
-        return build(specFile, defModuleName, specModuleName, true);
+        return build(specFile, defModuleName, specModuleName, false);
     }
 
     public Tuple2<Definition, Module> build(File specFile, String defModuleName, String specModuleName, boolean readOnlyCache) {

--- a/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
+++ b/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
@@ -56,6 +56,10 @@ public class ProofDefinitionBuilder {
      * @param specModuleName Module containing specifications to prove
      */
     public Tuple2<Definition, Module> build(File specFile, String defModuleName, String specModuleName) {
+        return build(specFile, defModuleName, specModuleName, true);
+    }
+
+    public Tuple2<Definition, Module> build(File specFile, String defModuleName, String specModuleName, boolean updateCaches) {
         String defModuleNameUpdated =
                 defModuleName == null ? compiledDefinition.kompiledDefinition.mainModule().name() : defModuleName;
         String specModuleNameUpdated =
@@ -63,7 +67,7 @@ public class ProofDefinitionBuilder {
         File absSpecFile = files.resolveWorkingDirectory(specFile).getAbsoluteFile();
 
         Set<Module> modules = kompile.parseModules(compiledDefinition, defModuleNameUpdated, specModuleNameUpdated, absSpecFile,
-                backend.excludedModuleTags());
+                backend.excludedModuleTags(), updateCaches);
         Map<String, Module> modulesMap = modules.stream().collect(Collectors.toMap(Module::name, m -> m));
         Definition parsedDefinition = compiledDefinition.getParsedDefinition();
         Module specModule = getModule(specModuleNameUpdated, modulesMap, parsedDefinition);

--- a/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
+++ b/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
@@ -59,7 +59,7 @@ public class ProofDefinitionBuilder {
         return build(specFile, defModuleName, specModuleName, true);
     }
 
-    public Tuple2<Definition, Module> build(File specFile, String defModuleName, String specModuleName, boolean updateCaches) {
+    public Tuple2<Definition, Module> build(File specFile, String defModuleName, String specModuleName, boolean readOnlyCache) {
         String defModuleNameUpdated =
                 defModuleName == null ? compiledDefinition.kompiledDefinition.mainModule().name() : defModuleName;
         String specModuleNameUpdated =
@@ -67,7 +67,7 @@ public class ProofDefinitionBuilder {
         File absSpecFile = files.resolveWorkingDirectory(specFile).getAbsoluteFile();
 
         Set<Module> modules = kompile.parseModules(compiledDefinition, defModuleNameUpdated, specModuleNameUpdated, absSpecFile,
-                backend.excludedModuleTags(), updateCaches);
+                backend.excludedModuleTags(), readOnlyCache);
         Map<String, Module> modulesMap = modules.stream().collect(Collectors.toMap(Module::name, m -> m));
         Definition parsedDefinition = compiledDefinition.getParsedDefinition();
         Module specModule = getModule(specModuleNameUpdated, modulesMap, parsedDefinition);


### PR DESCRIPTION
Fixes #1754 

The goal is to be able to have a standalone semantics installation which bundles the correct version of K with it. This is already possible for concrete backends, but it's important that the frontend that is bundled not attempt to write to the `*-kompiled` directories (because it will be in an unwriteable location).

Changes needed are:

-   Parse cache is not writeable (`cache.bin`)