### PR TITLE
fix bison generation bug when nonterminal has no productions

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
@@ -206,15 +206,18 @@ public class KSyntax2Bison {
     encode(start, bison);
     bison.append(" { result = $1.nterm; } ;\n");
     for (Sort sort : reachableSorts) {
-      encode(sort, bison);
-      bison.append(":\n");
-      String conn = "";
-      for (Production prod : Optional.ofNullable(prods.get(sort)).orElse(java.util.Collections.emptyList())) {
-        bison.append("  " + conn);
-        processProduction(prod, module, disambModule, scanner, bison, glr);
-        conn = "|";
+      List<Production> prodsForSort = Optional.ofNullable(prods.get(sort)).orElse(java.util.Collections.emptyList());
+      if (!prodsForSort.isEmpty()) {
+        encode(sort, bison);
+        bison.append(":\n");
+        String conn = "";
+        for (Production prod : prodsForSort) {
+          bison.append("  " + conn);
+          processProduction(prod, module, disambModule, scanner, bison, glr);
+          conn = "|";
+        }
+        bison.append(";\n");
       }
-      bison.append(";\n");
     }
     bison.append("\n%%\n");
     bison.append("\n" +


### PR DESCRIPTION
Basically, we were accidentally inserting a production from epsilon to every sort that didn't have any productions. This comes about because I misunderstood the syntax of Bison. The PR should fix this and thus no longer emit these spurious bison rules. I have tested that this fixes the memory exhuastion bug in Algorand and substantially reduces the number of conflicts in definitions with nonterminals that have no productions.