### PR TITLE
Use a global Stack cache

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,9 +339,7 @@ pipeline {
               stages {
                 stage('Build Homebrew Bottle') {
                   agent { label 'anka' }
-                  environment {
-                    STACK_ROOT = '/opt/stack'
-                  }
+                  environment { STACK_ROOT = '/opt/stack' }
                   steps {
                     unstash 'src'
                     dir('kframework') { checkout scm }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,6 +339,9 @@ pipeline {
               stages {
                 stage('Build Homebrew Bottle') {
                   agent { label 'anka' }
+                  environment {
+                    STACK_ROOT = '/opt/stack'
+                  }
                   steps {
                     unstash 'src'
                     dir('kframework') { checkout scm }

--- a/Jenkinsfile.anka
+++ b/Jenkinsfile.anka
@@ -13,6 +13,9 @@ pipeline {
     stage('Build Anka VM') {
       options { timeout(time: 150, unit: 'MINUTES') }
       agent { label 'anka-k-master' }
+      environment {
+        STACK_ROOT = '/opt/stack'
+      }
       steps {
         sh '''
           package/macos/brew-install-deps

--- a/Jenkinsfile.anka
+++ b/Jenkinsfile.anka
@@ -13,9 +13,7 @@ pipeline {
     stage('Build Anka VM') {
       options { timeout(time: 150, unit: 'MINUTES') }
       agent { label 'anka-k-master' }
-      environment {
-        STACK_ROOT = '/opt/stack'
-      }
+      environment { STACK_ROOT = '/opt/stack' }
       steps {
         sh '''
           package/macos/brew-install-deps


### PR DESCRIPTION
This pull request would use a global Stack cache for macOS builds. I'm not quite sure how to test it before merging; I think it would have to be merged to rebuild the Anka template. And, this is all a moot point if Homebrew clears the environment.