### PR TITLE
Allowing calling ModuleToKORE in file-IO pure way

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackend.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackend.java
@@ -7,6 +7,7 @@ import org.kframework.backend.kore.KoreBackend;
 import org.kframework.compile.Backend;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.KompileOptions;
+import org.kframework.main.Tool;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.file.FileUtil;
@@ -27,8 +28,9 @@ public class HaskellBackend extends KoreBackend {
     public HaskellBackend(
             KompileOptions kompileOptions,
             FileUtil files,
-            KExceptionManager kem) {
-        super(kompileOptions, files, kem, EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION), false);
+            KExceptionManager kem,
+            Tool tool) {
+        super(kompileOptions, files, kem, EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION), false, tool);
     }
 
 

--- a/k-distribution/src/test/scala/org/kframework/backend/kore/KoreTest.scala
+++ b/k-distribution/src/test/scala/org/kframework/backend/kore/KoreTest.scala
@@ -5,6 +5,7 @@ import org.kframework.compile.Backend;
 import org.kframework.kompile.Kompile
 import org.kframework.kompile.KompileOptions
 import org.kframework.main.GlobalOptions
+import org.kframework.main.Tool
 import org.kframework.utils.errorsystem.KExceptionManager
 import org.kframework.utils.file.FileUtil
 import org.kframework.utils.options.OuterParsingOptions
@@ -38,7 +39,7 @@ class KoreTest {
 
   def kompile(k: String): Definition = {
     val compiler = new Kompile(options, files, kem, false)
-    val backend = new KoreBackend(options, files, kem)
+    val backend = new KoreBackend(options, files, kem, Tool.KOMPILE)
     files.saveToDefinitionDirectory("test.k", k)
     val defn = compiler.run(files.resolveDefinitionDirectory("test.k"), "TEST", "TEST", backend.steps, backend.excludedModuleTags)
     backend.accept(new Backend.Holder(defn))

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -38,6 +38,7 @@ import org.kframework.definition.ModuleTransformer;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.Kompile;
 import org.kframework.kompile.KompileOptions;
+import org.kframework.main.Tool;
 import org.kframework.Strategy;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
@@ -60,21 +61,24 @@ public class KoreBackend extends AbstractBackend {
     private final KExceptionManager kem;
     private final EnumSet<ResolveHeatCoolAttribute.Mode> heatCoolConditions;
     private final boolean heatCoolEquations;
+    private final Tool tool;
 
     @Inject
     public KoreBackend(
             KompileOptions kompileOptions,
             FileUtil files,
-            KExceptionManager kem) {
-        this(kompileOptions, files, kem, kompileOptions.optimize2 || kompileOptions.optimize3 ? EnumSet.of(HEAT_RESULT) : EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION), false);
+            KExceptionManager kem,
+            Tool tool) {
+        this(kompileOptions, files, kem, kompileOptions.optimize2 || kompileOptions.optimize3 ? EnumSet.of(HEAT_RESULT) : EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION), false, tool);
     }
 
-    public KoreBackend(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem, EnumSet<ResolveHeatCoolAttribute.Mode> heatCoolConditions, boolean heatCoolEquations) {
+    public KoreBackend(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem, EnumSet<ResolveHeatCoolAttribute.Mode> heatCoolConditions, boolean heatCoolEquations, Tool tool) {
         this.kompileOptions = kompileOptions;
         this.files = files;
         this.kem = kem;
         this.heatCoolConditions = heatCoolConditions;
         this.heatCoolEquations = heatCoolEquations;
+        this.tool = tool;
     }
 
     @Override
@@ -90,23 +94,25 @@ public class KoreBackend extends AbstractBackend {
     protected String getKompiledString(CompiledDefinition def) {
         Module mainModule = getKompiledModule(def.kompiledDefinition.mainModule());
         ModuleToKORE converter = new ModuleToKORE(mainModule, def.topCellInitializer, def.kompileOptions);
-        return getKompiledString(converter, files, heatCoolEquations);
+        return getKompiledString(converter, files, heatCoolEquations, tool);
     }
 
-    public static String getKompiledString(ModuleToKORE converter, FileUtil files, boolean heatCoolEquations) {
+    public static String getKompiledString(ModuleToKORE converter, FileUtil files, boolean heatCoolEquations, Tool t) {
         StringBuilder sb = new StringBuilder();
-        String kompiledString = getKompiledStringAndWriteSyntaxMacros(converter, files, heatCoolEquations, sb);
+        String kompiledString = getKompiledStringAndWriteSyntaxMacros(converter, files, heatCoolEquations, sb, t);
         return kompiledString;
     }
 
-    public static String getKompiledStringAndWriteSyntaxMacros(ModuleToKORE converter, FileUtil files, boolean heatCoolEq, StringBuilder sb) {
+    public static String getKompiledStringAndWriteSyntaxMacros(ModuleToKORE converter, FileUtil files, boolean heatCoolEq, StringBuilder sb, Tool t) {
         StringBuilder semantics = new StringBuilder();
         StringBuilder syntax    = new StringBuilder();
         StringBuilder macros    = new StringBuilder();
         String prelude = files.loadFromKIncludeDir("kore/prelude.kore");
         converter.convert(heatCoolEq, prelude, semantics, syntax, macros);
-        files.saveToKompiled("syntaxDefinition.kore", syntax.toString());
-        files.saveToKompiled("macros.kore", macros.toString());
+        if (t == Tool.KOMPILE) {
+            files.saveToKompiled("syntaxDefinition.kore", syntax.toString());
+            files.saveToKompiled("macros.kore", macros.toString());
+        }
         return semantics.toString();
     }
 

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -126,11 +126,13 @@ public class ModuleToKORE {
         StringBuilder macros    = new StringBuilder();
         String prelude = files.loadFromKIncludeDir("kore/prelude.kore");
         convert(heatCoolEq, prelude, common, semantics, syntax, macros);
-        int length = common.length();
-        common.append(syntax);
-        files.saveToKompiled("syntaxDefinition.kore", common.toString());
-        files.saveToKompiled("macros.kore", macros.toString());
-        common.setLength(length);
+        if (! options.readOnlyKompiledDirectory) {
+            int length = common.length();
+            common.append(syntax);
+            files.saveToKompiled("syntaxDefinition.kore", common.toString());
+            files.saveToKompiled("macros.kore", macros.toString());
+            common.setLength(length);
+        }
         common.append(semantics);
         return common.toString();
     }

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -124,7 +124,8 @@ public class ModuleToKORE {
         StringBuilder semantics = new StringBuilder();
         StringBuilder syntax    = new StringBuilder();
         StringBuilder macros    = new StringBuilder();
-        convert(heatCoolEq, common, semantics, syntax, macros);
+        String prelude = files.loadFromKIncludeDir("kore/prelude.kore");
+        convert(heatCoolEq, prelude, common, semantics, syntax, macros);
         int length = common.length();
         common.append(syntax);
         files.saveToKompiled("syntaxDefinition.kore", common.toString());
@@ -134,11 +135,10 @@ public class ModuleToKORE {
         return common.toString();
     }
 
-    public void convert(boolean heatCoolEq, StringBuilder common, StringBuilder semantics, StringBuilder syntax, StringBuilder macros) {
+    public void convert(boolean heatCoolEq, String prelude, StringBuilder common, StringBuilder semantics, StringBuilder syntax, StringBuilder macros) {
         ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(module);
         Sort topCellSort = configInfo.getRootCell();
         String topCellSortStr = getSortStr(topCellSort);
-        String prelude = files.loadFromKIncludeDir("kore/prelude.kore");
         common.append("[topCellInitializer{}(");
         convert(topCellInitializer, common);
         common.append("())]\n\n");

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -46,7 +46,6 @@ import org.kframework.kore.VisitK;
 import org.kframework.unparser.Formatter;
 import org.kframework.utils.StringUtil;
 import org.kframework.utils.errorsystem.KEMException;
-import org.kframework.utils.file.FileUtil;
 import scala.Int;
 import scala.Option;
 import scala.Tuple2;
@@ -105,30 +104,17 @@ public class ModuleToKORE {
     public static final String ALL_PATH_OP = KLabels.RL_wAF.name();
     public static final String HAS_DOMAIN_VALUES = "hasDomainValues";
     private final Module module;
-    private final FileUtil files;
     private final Set<String> impureFunctions = new HashSet<>();
     private final KLabel topCellInitializer;
     private final Set<String> mlBinders = new HashSet<>();
     private final KompileOptions options;
 
-    public ModuleToKORE(Module module, FileUtil files, KLabel topCellInitializer, KompileOptions options) {
+    public ModuleToKORE(Module module, KLabel topCellInitializer, KompileOptions options) {
         this.module = module;
-        this.files = files;
         this.topCellInitializer = topCellInitializer;
         this.options = options;
     }
     private static final boolean METAVAR = false;
-
-    public String convert(boolean heatCoolEq, StringBuilder sb) {
-        StringBuilder semantics = new StringBuilder();
-        StringBuilder syntax    = new StringBuilder();
-        StringBuilder macros    = new StringBuilder();
-        String prelude = files.loadFromKIncludeDir("kore/prelude.kore");
-        convert(heatCoolEq, prelude, semantics, syntax, macros);
-        files.saveToKompiled("syntaxDefinition.kore", syntax.toString());
-        files.saveToKompiled("macros.kore", macros.toString());
-        return semantics.toString();
-    }
 
     public void convert(boolean heatCoolEq, String prelude, StringBuilder semantics, StringBuilder syntax, StringBuilder macros) {
         ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(module);

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -125,10 +125,8 @@ public class ModuleToKORE {
         StringBuilder macros    = new StringBuilder();
         String prelude = files.loadFromKIncludeDir("kore/prelude.kore");
         convert(heatCoolEq, prelude, semantics, syntax, macros);
-        if (! options.readOnlyKompiledDirectory) {
-            files.saveToKompiled("syntaxDefinition.kore", syntax.toString());
-            files.saveToKompiled("macros.kore", macros.toString());
-        }
+        files.saveToKompiled("syntaxDefinition.kore", syntax.toString());
+        files.saveToKompiled("macros.kore", macros.toString());
         return semantics.toString();
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -450,7 +450,7 @@ public class Kompile {
     }
 
     public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules) {
-        return parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, true);
+        return parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, false);
     }
 
     public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules, boolean readOnlyCache) {

--- a/kernel/src/main/java/org/kframework/ksearchpattern/KSearchPatternFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/ksearchpattern/KSearchPatternFrontEnd.java
@@ -95,7 +95,7 @@ public class KSearchPatternFrontEnd extends FrontEnd {
           K patternTerm = RewriteToTop.toLeft(pattern.body());
           K patternCondition = pattern.requires();
           org.kframework.definition.Module mod = compiledDef.executionModule();
-          ModuleToKORE converter = new ModuleToKORE(mod, files, compiledDef.topCellInitializer, kompileOptions);
+          ModuleToKORE converter = new ModuleToKORE(mod, compiledDef.topCellInitializer, kompileOptions);
           StringBuilder sb = new StringBuilder();
           ExpandMacros macroExpander = ExpandMacros.forNonSentences(mod, files, kompileOptions, false);
           K withMacros = macroExpander.expand(patternTerm);

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -177,7 +177,7 @@ public class KPrint {
                 if (compiledDefinition == null) {
                     throw KEMException.criticalError("KORE output requires a compiled definition.");
                 }
-                ModuleToKORE converter = new ModuleToKORE(module, files, compiledDefinition.topCellInitializer, kompileOptions);
+                ModuleToKORE converter = new ModuleToKORE(module, compiledDefinition.topCellInitializer, kompileOptions);
                 result = ExpandMacros.forNonSentences(compiledDefinition.executionModule(), files, kompileOptions, false).expand(result);
                 result = new AddSortInjections(compiledDefinition.executionModule()).addSortInjections(result, s);
                 StringBuilder sb = new StringBuilder();

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -9,6 +9,7 @@ import org.kframework.backend.kore.KoreBackend;
 import org.kframework.compile.Backend;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.KompileOptions;
+import org.kframework.main.Tool;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KException.ExceptionType;
@@ -27,17 +28,20 @@ public class LLVMBackend extends KoreBackend {
     private final LLVMKompileOptions options;
     private final KExceptionManager kem;
     private final KompileOptions kompileOptions;
+    private final Tool tool;
 
     @Inject
     public LLVMBackend(
             KompileOptions kompileOptions,
             FileUtil files,
             KExceptionManager kem,
-            LLVMKompileOptions options) {
-        super(kompileOptions, files, kem);
+            LLVMKompileOptions options,
+            Tool tool) {
+        super(kompileOptions, files, kem, tool);
         this.options = options;
         this.kompileOptions = kompileOptions;
         this.kem = kem;
+        this.tool = tool;
     }
 
 

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMRewriter.java
@@ -79,7 +79,7 @@ public class LLVMRewriter implements Function<Definition, Rewriter> {
             public RewriterResult execute(K k, Optional<Integer> depth) {
                 Module mod = def.executionModule();
                 ExpandMacros macroExpander = ExpandMacros.forNonSentences(mod, files, kompileOptions, false);
-                ModuleToKORE converter = new ModuleToKORE(mod, files, def.topCellInitializer, kompileOptions);
+                ModuleToKORE converter = new ModuleToKORE(mod, def.topCellInitializer, kompileOptions);
                 K withMacros = macroExpander.expand(k);
                 K kWithInjections = new AddSortInjections(mod).addInjections(withMacros);
                 StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
-   Removes all calls to file-IO out of ModuleToKORE by hoisting `convert` function out of `ModuleToKORE` into `KoreBackend`.
-   Provides a function with the same signature as the previous `convert` function which does the reads and writes.
-   Makes the file writes in KoreBackend only happen if the tool calling it is `KOMPILE`, so that other tools are not updating `syntaxDefinition.kore` or `macros.kore` erroneously.

This is needed for two things:

-   Having standalone installations of semantics. It's important that `kprove` does not try to write back to the `*-kompiled` directory when executing, so this is needed.
-   Fixing the KEVM K update to use the latest kx script, because the KEVM test-suite first builds (`kompile`), then proves, (`kprove`), then searches (`krun --search`). The issue here is hard to explain, but I'll try:
    -   Calling `kompile` leads to the generation of `syntaxDefinition.kore`.
    -   Subsequent calls to `krun` use `kore-expand-macros`, which uses `syntaxDefinition.kore` in the new `kx` codepath (used to use the serialized definition in `compiled.bin` directly instead).
    -   Calling `kprove` then _overwrites_ `syntaxDefinition.kore`, with contents relevant for the proof being done, because it calls `ModuleToKORE` via `KoreBackend`.
    -   Then a subsequent call to `krun` causes a crash, because the `syntaxDefinition.kore` is not the correct one from the original `kompile` call.