### PR TITLE
Fix krun --dry-run warnings

### DIFF
--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -215,7 +215,9 @@ do
       # slash removes prefixes so build a new array with the files to keep
       newArray=()
       for value in "${tempFiles[@]}"; do
-          $value != $tempDir && newArray+=($value)
+          if [ $value != $tempDir ]; then 
+            newArray+=($value)
+          fi
       done
       tempFiles="${newArray[@]}"
       unset newArray


### PR DESCRIPTION
`$value != $tempDir && newArray+=($value)`
This would try to execute as a command line and gave an error message because it couldn't.
So wrap it inside an if.