### PR TITLE
slight optimization to bison parser generator

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
@@ -158,7 +158,7 @@ public class TypeInferencer implements AutoCloseable {
     Map<SortHead, Integer> ordinals = new HashMap<>();
     int i = 0;
 
-    for (Sort s : iterable(TopologicalSort.tsort(relations.directRelations()))) {
+    for (Sort s : iterable(relations.sortedElements())) {
       if (!isRealSort(s.head())) {
         continue;
       }

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
@@ -266,7 +266,7 @@ public class KSyntax2Bison {
   }
 
   private static void appendOverloadChecks(StringBuilder bison, Module module, Module disambModule, Production greater, List<Integer> nts, boolean hasLocation) {
-    for (Production lesser : iterable(TopologicalSort.tsort(disambModule.overloads().directRelations()))) {
+    for (Production lesser : iterable(disambModule.overloads().sortedElements())) {
       if (disambModule.overloads().lessThan(lesser, greater)) {
         bison.append("  if (");
         appendOverloadCondition(bison, module, greater, lesser, nts);

--- a/kore/src/main/scala/org/kframework/POSet.scala
+++ b/kore/src/main/scala/org/kframework/POSet.scala
@@ -17,6 +17,8 @@ class POSet[T](val directRelations: Set[(T, T)]) extends Serializable {
 
   lazy val elements: Set[T] = directRelations.flatMap(a => Set(a._1, a._2))
 
+  lazy val sortedElements: scala.collection.immutable.List[T] = TopologicalSort.tsort(directRelations).toList
+
   /**
    * Internal private method. Computes the transitive closer of the initial relations.
    * It also checks for cycles during construction and throws an exception if it finds any.


### PR DESCRIPTION
Topologically sorting a partially ordered set is expensive, so we cache the result.