### PR TITLE
Use a global Stack cache on macOS

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -336,6 +336,7 @@ pipeline {
                 stage('Build Homebrew Bottle') {
                   agent { label 'anka' }
                   environment {
+                    // TODO (ttuegel): Use brew --env=std instead.
                     HOMEBREW_NO_ENV_FILTERING = '1'
                     STACK_ROOT = '/opt/stack'
                   }
@@ -345,7 +346,9 @@ pipeline {
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
                       sh '''
-                        stat /var/cache
+                        mkdir -p /opt/stack
+                        stat /opt/stack
+
                         git config --global user.email 'admin@runtimeverification.com'
                         git config --global user.name  'RV Jenkins'
                         # Note: double-backslash in sed-command is for Jenkins benefit.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -345,6 +345,7 @@ pipeline {
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
                       sh '''
+                        stat /var/cache
                         git config --global user.email 'admin@runtimeverification.com'
                         git config --global user.name  'RV Jenkins'
                         # Note: double-backslash in sed-command is for Jenkins benefit.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,7 +338,7 @@ pipeline {
                   environment {
                     // TODO (ttuegel): Use brew --env=std instead.
                     HOMEBREW_NO_ENV_FILTERING = '1'
-                    STACK_ROOT = "${env.WORKSPACE}/.stack"
+                    STACK_ROOT = "${env.HOME}/.stack"
                   }
                   steps {
                     unstash 'src'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -329,10 +329,6 @@ pipeline {
           }
         }
         stage('Build and Package on Mac OS') {
-          when {
-            branch 'master'
-            beforeAgent true
-          }
           options { timeout(time: 150, unit: 'MINUTES') }
           stages {
             stage('Build on Mac OS') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -342,7 +342,13 @@ pipeline {
                   }
                   steps {
                     unstash 'src'
-                    dir('kframework') { checkout scm }
+                    dir('kframework') {
+                      checkout scm
+                      sh '''
+                        cd haskell-backend/src/main/native/haskell-backend/
+                        stack build --only-snapshot
+                      '''
+                    }
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
                       sh '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -347,6 +347,8 @@ pipeline {
                       sh '''
                         cd haskell-backend/src/main/native/haskell-backend/
                         stack build --only-snapshot
+                        chmod go+rwx "$STACK_ROOT"
+                        chmod -R go+rw "$STACK_ROOT"
                       '''
                     }
                     dir('homebrew-k') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -346,8 +346,6 @@ pipeline {
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
                       sh '''
-                        env
-                        exit 1
                         git config --global user.email 'admin@runtimeverification.com'
                         git config --global user.name  'RV Jenkins'
                         # Note: double-backslash in sed-command is for Jenkins benefit.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -339,7 +339,10 @@ pipeline {
               stages {
                 stage('Build Homebrew Bottle') {
                   agent { label 'anka' }
-                  environment { STACK_ROOT = '/opt/stack' }
+                  environment {
+                    HOMEBREW_NO_ENV_FILTERING = '1'
+                    STACK_ROOT = '/opt/stack'
+                  }
                   steps {
                     unstash 'src'
                     dir('kframework') { checkout scm }
@@ -456,7 +459,7 @@ pipeline {
                 docker tag "${DOCKERHUB_REPO}:${FOCAL_COMMIT_TAG}" "${DOCKERHUB_REPO}:${FOCAL_BRANCH_TAG}"
                 docker push "${DOCKERHUB_REPO}:${FOCAL_BRANCH_TAG}"
             '''
- 
+
           }
         }
         stage('Test Bionic Image') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -346,6 +346,8 @@ pipeline {
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
                       sh '''
+                        env
+                        exit 1
                         git config --global user.email 'admin@runtimeverification.com'
                         git config --global user.name  'RV Jenkins'
                         # Note: double-backslash in sed-command is for Jenkins benefit.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -338,7 +338,7 @@ pipeline {
                   environment {
                     // TODO (ttuegel): Use brew --env=std instead.
                     HOMEBREW_NO_ENV_FILTERING = '1'
-                    STACK_ROOT = '/opt/stack'
+                    STACK_ROOT = "${env.WORKSPACE}/.stack"
                   }
                   steps {
                     unstash 'src'
@@ -346,9 +346,6 @@ pipeline {
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git'
                       sh '''
-                        mkdir -p /opt/stack
-                        stat /opt/stack
-
                         git config --global user.email 'admin@runtimeverification.com'
                         git config --global user.name  'RV Jenkins'
                         # Note: double-backslash in sed-command is for Jenkins benefit.


### PR DESCRIPTION
Set HOMEBREW_NO_ENV_FILTERING=1 so that we can point Stack at the global cache
in the Anka template. Otherwise, Stack-inside-Homebrew will download and compile
all dependencies on every CI job.

See also: #1813 