### PR TITLE
Improve kprove performance by reusing caches

### DIFF
--- a/kernel/src/main/java/org/kframework/kbmc/KBMC.java
+++ b/kernel/src/main/java/org/kframework/kbmc/KBMC.java
@@ -4,6 +4,7 @@ package org.kframework.kbmc;
 import org.kframework.RewriterResult;
 import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
+import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kprove.ProofDefinitionBuilder;
 import org.kframework.rewriter.Rewriter;
 import org.kframework.unparser.KPrint;
@@ -37,13 +38,13 @@ public class KBMC {
                     options.specFile(files).getAbsolutePath());
         }
 
-        Tuple2<Definition, Module> compiled = proofDefinitionBuilder
+        Tuple2<CompiledDefinition, Module> compiled = proofDefinitionBuilder
                 .build(options.specFile(files), options.defModule, options.specModule);
-        Rewriter rewriter = rewriterGenerator.apply(compiled._1());
+        Rewriter rewriter = rewriterGenerator.apply(compiled._1().kompiledDefinition);
         Module specModule = compiled._2();
 
         RewriterResult results = rewriter.bmc(specModule);
-        kprint.prettyPrint(compiled._1(), compiled._1().getModule("LANGUAGE-PARSING").get(), kprint::outputFile,
+        kprint.prettyPrint(compiled._1().kompiledDefinition, compiled._1().kompiledDefinition.getModule("LANGUAGE-PARSING").get(), kprint::outputFile,
                 results.k());
         return results.exitCode().orElse(KEMException.TERMINATED_WITH_ERRORS_EXIT_CODE);
     }

--- a/kernel/src/main/java/org/kframework/keq/KEq.java
+++ b/kernel/src/main/java/org/kframework/keq/KEq.java
@@ -28,14 +28,14 @@ public class KEq {
                    FileUtil files) {
         Rewriter commonRewriter = commonGen.apply(commonDef.kompiledDefinition);
 
-        Tuple2<Definition, Module> compiled1 = pdb1.build(
+        Tuple2<CompiledDefinition, Module> compiled1 = pdb1.build(
                 files.resolveWorkingDirectory(keqOptions.spec1), keqOptions.defModule1, keqOptions.specModule1);
-        Rewriter rewriter1 = gen1.apply(compiled1._1());
+        Rewriter rewriter1 = gen1.apply(compiled1._1().kompiledDefinition);
         Module spec1 = compiled1._2();
 
-        Tuple2<Definition, Module> compiled2 = pdb2.build(
+        Tuple2<CompiledDefinition, Module> compiled2 = pdb2.build(
                 files.resolveWorkingDirectory(keqOptions.spec2), keqOptions.defModule2, keqOptions.specModule2);
-        Rewriter rewriter2 = gen2.apply(compiled2._1());
+        Rewriter rewriter2 = gen2.apply(compiled2._1().kompiledDefinition);
         Module spec2 = compiled2._2();
 
         boolean isEquivalent = commonRewriter.equivalence(rewriter1, rewriter2, spec1, spec2);

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -269,7 +269,7 @@ public class DefinitionParsing {
         return result;
     }
 
-    Map<String, ParseCache> caches;
+    public Map<String, ParseCache> caches;
     private java.util.Set<KEMException> errors;
     RuleGrammarGenerator gen;
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -79,7 +79,7 @@ public class Kompile {
     private final KExceptionManager kem;
     private final ParserUtils parser;
     private final Stopwatch sw;
-    private final DefinitionParsing definitionParsing;
+    public final DefinitionParsing definitionParsing;
     java.util.Set<KEMException> errors;
 
     public Kompile(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem, boolean cacheParses) {


### PR DESCRIPTION
Fixes: #1333
Work in progress, but can be tested:
```
kompile normally
kprove common-spec.k --save-proof-definition-to ./save
kprove toprove-spec.k -d ./save
```
The second step will create a new directory where it will store `compiled.bin` and `cache.bin` with updated modules.
There are a few other issues I need to figure out:
 - the configuration seems to be parsed a second time in the first kprove call. Not sure why, but it wastes time.
 - I ran the normal kprove on the evm semantics and it takes 10 seconds to parse [0/1588] rules, while kompile takes 6 sec to parse [1458/1458]. Clearly, something is wrong somewhere.