### PR TITLE
Include Haskell backend with Nix packages

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -31,7 +31,7 @@ let
   inherit (llvm-backend-project) clang llvm-backend;
 
   k = callPackage ./nix/k.nix {
-    inherit llvm-backend mavenix;
+    inherit haskell-backend llvm-backend mavenix;
   };
 
   haskell-backend-project = import ./haskell-backend/src/main/native/haskell-backend {

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -1,5 +1,6 @@
 { lib, mavenix, nix-gitignore, runCommand, makeWrapper
-, flex, gcc, git, gmp, jdk, llvm-backend, mpfr, pkgconfig, python3, z3
+, flex, gcc, git, gmp, jdk, mpfr, pkgconfig, python3, z3
+, haskell-backend, llvm-backend
 }:
 
 let inherit (nix-gitignore) gitignoreSourcePure; in
@@ -85,7 +86,10 @@ let
 in
 
 let
-  hostInputs = [ flex gcc gmp jdk llvm-backend mpfr pkgconfig python3 z3 ];
+  hostInputs = [
+    flex gcc gmp jdk mpfr pkgconfig python3 z3
+    haskell-backend llvm-backend
+  ];
   # PATH used at runtime
   hostPATH = lib.makeBinPath hostInputs;
 in
@@ -111,4 +115,3 @@ runCommand unwrapped.name
       ln -s $unwrapped/$each $out/$each
     done
   ''
-  


### PR DESCRIPTION
This bundles the Haskell backend with the frontend by default, as users expect. At one time, both backends were optional in the Nix package and users could choose, but the LLVM backend later became required for `krun`. At this point, it's just confusing to have one backend be privileged over the other.