### PR TITLE
Add a Nix lock file to releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: "Release"
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  nix-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2.3.4
+        with:
+          submodules: recursive
+
+      - name: Install Nix
+        uses: cachix/install-nix-action@v12
+
+      - name: Upload release.nix
+        uses: ttuegel/upload-release.nix@v1.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This is necessary to automatically update repositories which depend on kframework/k but do not include it as a submodule.