### PR TITLE
Forbid macro att on function rules

### DIFF
--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
@@ -5,7 +5,4 @@ module CHECKFUNCRULEATT
     syntax FOO ::= "foo" [function]
                  | "boo"
     rule foo => boo [macro]
-    rule foo => boo [macro-rec]
-    rule foo => boo [alias]
-    rule foo => boo [alias-rec]
 endmodule

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
@@ -2,18 +2,19 @@ module CHECKFUNCRULEATT-SYNTAX
 endmodule
 module CHECKFUNCRULEATT
     imports CHECKFUNCRULEATT-SYNTAX
+    imports INT
     syntax FOO ::= "foo" [function]
-                 | "boo"
+                 | Int
     configuration <k> foo </k>
-                  <notk> boo </notk>
-    rule foo => boo [macro]
-    rule foo => boo [macro-rec]
-    rule foo => boo [alias]
-    rule foo => boo [alias-rec]
-    rule foo => boo
-    rule <k> boo => foo </k>
-    rule [[ foo => boo ]]
-         <notk> boo </notk> [macro]
-    rule [[ foo => boo ]]
-         <notk> boo </notk>
+                  <notk> 0 </notk>
+    rule foo => 0 [macro]
+    rule foo => 1 [macro-rec]
+    rule foo => 2 [alias]
+    rule foo => 3 [alias-rec]
+    rule foo => 4
+    rule <k> 5 => foo </k>
+    rule [[ foo => 6 ]]
+         <notk> 7 </notk> [macro]
+    rule [[ foo => 8 ]]
+         <notk> 9 </notk>
 endmodule

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
@@ -1,0 +1,11 @@
+module CHECKFUNCRULEATT-SYNTAX
+endmodule
+module CHECKFUNCRULEATT
+    imports CHECKFUNCRULEATT-SYNTAX
+    syntax FOO ::= "foo" [function]
+                 | "boo"
+    rule foo => boo [macro]
+    rule foo => boo [macro-rec]
+    rule foo => boo [alias]
+    rule foo => boo [alias-rec]
+endmodule

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k
@@ -4,5 +4,16 @@ module CHECKFUNCRULEATT
     imports CHECKFUNCRULEATT-SYNTAX
     syntax FOO ::= "foo" [function]
                  | "boo"
+    configuration <k> foo </k>
+                  <notk> boo </notk>
     rule foo => boo [macro]
+    rule foo => boo [macro-rec]
+    rule foo => boo [alias]
+    rule foo => boo [alias-rec]
+    rule foo => boo
+    rule <k> boo => foo </k>
+    rule [[ foo => boo ]]
+         <notk> boo </notk> [macro]
+    rule [[ foo => boo ]]
+         <notk> boo </notk>
 endmodule

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
@@ -2,16 +2,4 @@
 function rules.
 	Source(checkFuncRuleAtt.k)
 	Location(7,10,7,20)
-[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
-function rules.
-	Source(checkFuncRuleAtt.k)
-	Location(8,10,8,20)
-[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
-function rules.
-	Source(checkFuncRuleAtt.k)
-	Location(9,10,9,20)
-[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
-function rules.
-	Source(checkFuncRuleAtt.k)
-	Location(10,10,10,20)
-[Error] Compiler: Had 4 structural errors.
+[Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
@@ -1,0 +1,17 @@
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(7,10,7,20)
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(8,10,8,20)
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(9,10,9,20)
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(10,10,10,20)
+[Error] Compiler: Had 4 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
@@ -1,21 +1,21 @@
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
 function rules.
 	Source(checkFuncRuleAtt.k)
-	Location(9,10,9,20)
+	Location(10,10,10,18)
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
 function rules.
 	Source(checkFuncRuleAtt.k)
-	Location(10,10,10,20)
+	Location(11,10,11,18)
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
 function rules.
 	Source(checkFuncRuleAtt.k)
-	Location(11,10,11,20)
+	Location(12,10,12,18)
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
 function rules.
 	Source(checkFuncRuleAtt.k)
-	Location(12,10,12,20)
+	Location(13,10,13,18)
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
 function rules.
 	Source(checkFuncRuleAtt.k)
-	Location(15,10,16,28)
+	Location(16,10,17,26)
 [Error] Compiler: Had 5 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
@@ -1,5 +1,21 @@
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
 function rules.
 	Source(checkFuncRuleAtt.k)
-	Location(7,10,7,20)
-[Error] Compiler: Had 1 structural errors.
+	Location(9,10,9,20)
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(10,10,10,20)
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(11,10,11,20)
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(12,10,12,20)
+[Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on
+function rules.
+	Source(checkFuncRuleAtt.k)
+	Location(15,10,16,28)
+[Error] Compiler: Had 5 structural errors.

--- a/k-distribution/tests/regression-new/proof-tests/deposit/spec/deposit-symbolic.k
+++ b/k-distribution/tests/regression-new/proof-tests/deposit/spec/deposit-symbolic.k
@@ -5,7 +5,7 @@ module DEPOSIT-SYMBOLIC
 imports DEPOSIT
 
 syntax Bool ::= isNat(Int) [function]
-rule isNat(I) => I >=Int 0 [macro]
+rule isNat(I) => I >=Int 0
 
 syntax Int ::= tn(Int, Int, Int) /* tn(m,l,i) := T_m(l,i)  */ [function, smtlib(tn)]
              | up(Int, Int)      /* up(k,x)   := \up^k x   */ [function, smtlib(up)]

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
@@ -90,7 +90,7 @@ public class CheckFunctions {
         new RewriteAwareVisitor(true, errors) {
             @Override
             public void apply(KApply k) {
-                if (isRHS() || k.klabel() instanceof KVariable || CheckKLabels.isInternalKLabel(k.klabel().name(), m) || !m.attributesFor().contains(k.klabel())) {
+                if (isRHS() || k.klabel() instanceof KVariable || !m.attributesFor().contains(k.klabel())) {
                     return;
                 }
                 if (k.klabel().name().equals("#withConfig")) {

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
@@ -40,12 +40,19 @@ public class CheckFunctions {
                 check(rl.body());
         } else if (sentence instanceof Claim) {
             // functions are allowed on LHS of claims
+            Claim c = (Claim) sentence;
+            if (c.att().contains("macro") || c.att().contains("macro-rec") || c.att().contains("alias") || c.att().contains("alias-rec"))
+                errors.add(KEMException.compilerError("Attributes macro|macro-rec|alias|alias-rec are not allowed on claims.", c));
         } else if (sentence instanceof Context) {
             Context ctx = (Context) sentence;
             check(ctx.body());
+            if (ctx.att().contains("macro") || ctx.att().contains("macro-rec") || ctx.att().contains("alias") || ctx.att().contains("alias-rec"))
+                errors.add(KEMException.compilerError("Attributes macro|macro-rec|alias|alias-rec are not allowed on contexts.", ctx));
         } else if (sentence instanceof ContextAlias) {
             ContextAlias ctx = (ContextAlias) sentence;
             check(ctx.body());
+            if (ctx.att().contains("macro") || ctx.att().contains("macro-rec") || ctx.att().contains("alias") || ctx.att().contains("alias-rec"))
+                errors.add(KEMException.compilerError("Attributes macro|macro-rec|alias|alias-rec are not allowed on contexts.", ctx));
         }
     }
 
@@ -86,15 +93,15 @@ public class CheckFunctions {
         }.apply(body);
     }
 
-    public void checkFuncAtt(RuleOrClaim r) {
+    public void checkFuncAtt(Rule r) {
         new RewriteAwareVisitor(true, errors) {
             @Override
             public void apply(KApply k) {
-                if (isRHS() || k.klabel() instanceof KVariable || !m.attributesFor().contains(k.klabel())) {
-                    return;
-                }
                 if (k.klabel().name().equals("#withConfig")) {
                     super.apply(k);
+                    return;
+                }
+                if ((isRHS() && !isLHS()) || k.klabel() instanceof KVariable || !m.attributesFor().contains(k.klabel())) {
                     return;
                 }
                 Att attributes = m.attributesFor().apply(k.klabel());


### PR DESCRIPTION
Fixes: #1852

I'm assuming all of these attributes are not allowed on function rules: macro|macro-rec|alias|alias-rec
How about claims. What attributes are not allowed?