### PR TITLE
nix: Add ncurses to runtime dependencies for tput

### DIFF
--- a/nix/k.nix
+++ b/nix/k.nix
@@ -1,5 +1,5 @@
 { lib, mavenix, nix-gitignore, runCommand, makeWrapper
-, flex, gcc, git, gmp, jdk, mpfr, pkgconfig, python3, z3
+, flex, gcc, git, gmp, jdk, mpfr, ncurses, pkgconfig, python3, z3
 , haskell-backend, llvm-backend
 }:
 
@@ -87,7 +87,7 @@ in
 
 let
   hostInputs = [
-    flex gcc gmp jdk mpfr pkgconfig python3 z3
+    flex gcc gmp jdk mpfr ncurses pkgconfig python3 z3
     haskell-backend llvm-backend
   ];
   # PATH used at runtime


### PR DESCRIPTION
The K frontend needs package `ncurses` at runtime for the `tput` executable.