### PR TITLE
Pyk updates

### DIFF
--- a/k-distribution/src/main/scripts/lib/pyk/__init__.py
+++ b/k-distribution/src/main/scripts/lib/pyk/__init__.py
@@ -48,24 +48,15 @@ def kastJSON(definition, inputJSON, kastArgs = [], teeOutput = True, kRelease = 
         tempf.flush()
         return kast(definition, tempf.name, kastArgs = kastArgs, teeOutput = teeOutput, kRelease = kRelease)
 
-def krunJSON(definition, inputJSON, krunArgs = [], teeOutput = True, kRelease = None, keepTemp = False):
+def krunJSON(definition, inputJSON, kastArgs = [], krunArgs = [], teeOutput = True, kRelease = None, keepTemp = False):
     with tempfile.NamedTemporaryFile(mode = 'w', delete = not keepTemp) as tempJSON:
         tempJSON.write(json.dumps(inputJSON))
         tempJSON.flush()
-        (rC, kore, err) = kast(definition, tempJSON.name, kastArgs = ['--output', 'kore', '--input', 'json'], teeOutput = teeOutput, kRelease = kRelease)
-        print(rC)
-        print(kore)
-        print(err)
-        sys.stdout.flush()
+        (rC, kore, err) = kast(definition, tempJSON.name, kastArgs = ['--output', 'kore', '--input', 'json'] + kastArgs, teeOutput = teeOutput, kRelease = kRelease)
         with tempfile.NamedTemporaryFile(mode = 'w', delete = not keepTemp) as tempKore:
             tempKore.write(kore)
             tempKore.flush()
             (rC, out, err) = krun(definition, tempKore.name, krunArgs = krunArgs + ['--output', 'json', '--parser', 'cat'], teeOutput = teeOutput, kRelease = kRelease)
-            print(rC)
-            print(out)
-            print(err)
-            sys.stdout.flush()
-            # sys.exit(1)
             out = None if out == '' else json.loads(out)['term']
             return (rC, out, err)
 

--- a/k-distribution/src/main/scripts/lib/pyk/__init__.py
+++ b/k-distribution/src/main/scripts/lib/pyk/__init__.py
@@ -60,6 +60,14 @@ def krunJSON(definition, inputJSON, kastArgs = [], krunArgs = [], teeOutput = Tr
             out = None if out == '' else json.loads(out)['term']
             return (rC, out, err)
 
+def krunJSONLegacy(definition, inputJSON, krunArgs = [], teeOutput = True, kRelease = None, keepTemp = False):
+    with tempfile.NamedTemporaryFile(mode = 'w', delete = not keepTemp) as tempf:
+        tempf.write(json.dumps(inputJSON))
+        tempf.flush()
+        (rC, out, err) = krunLegacy(definition, tempf.name, krunArgs = krunArgs + ['--output', 'json', '--parser', 'cat'], teeOutput = teeOutput, kRelease = kRelease)
+        out = None if out == '' else json.loads(out)['term']
+        return (rC, out, err)
+
 def kproveJSON(definition, inputJSON, symbolTable, kproveArgs = [], teeOutput = True, kRelease = None, keepTemp = False):
     if not isKDefinition(inputJSON):
         sys.stderr.write(inputJSON)

--- a/k-distribution/src/main/scripts/lib/pyk/__init__.py
+++ b/k-distribution/src/main/scripts/lib/pyk/__init__.py
@@ -49,12 +49,25 @@ def kastJSON(definition, inputJSON, kastArgs = [], teeOutput = True, kRelease = 
         return kast(definition, tempf.name, kastArgs = kastArgs, teeOutput = teeOutput, kRelease = kRelease)
 
 def krunJSON(definition, inputJSON, krunArgs = [], teeOutput = True, kRelease = None, keepTemp = False):
-    with tempfile.NamedTemporaryFile(mode = 'w', delete = not keepTemp) as tempf:
-        tempf.write(json.dumps(inputJSON))
-        tempf.flush()
-        (rC, out, err) = krunLegacy(definition, tempf.name, krunArgs = krunArgs + ['--output', 'json', '--parser', 'cat'], teeOutput = teeOutput, kRelease = kRelease)
-        out = None if out == '' else json.loads(out)['term']
-        return (rC, out, err)
+    with tempfile.NamedTemporaryFile(mode = 'w', delete = not keepTemp) as tempJSON:
+        tempJSON.write(json.dumps(inputJSON))
+        tempJSON.flush()
+        (rC, kore, err) = kast(definition, tempJSON.name, kastArgs = ['--output', 'kore', '--input', 'json'], teeOutput = teeOutput, kRelease = kRelease)
+        print(rC)
+        print(kore)
+        print(err)
+        sys.stdout.flush()
+        with tempfile.NamedTemporaryFile(mode = 'w', delete = not keepTemp) as tempKore:
+            tempKore.write(kore)
+            tempKore.flush()
+            (rC, out, err) = krun(definition, tempKore.name, krunArgs = krunArgs + ['--output', 'json', '--parser', 'cat'], teeOutput = teeOutput, kRelease = kRelease)
+            print(rC)
+            print(out)
+            print(err)
+            sys.stdout.flush()
+            # sys.exit(1)
+            out = None if out == '' else json.loads(out)['term']
+            return (rC, out, err)
 
 def kproveJSON(definition, inputJSON, symbolTable, kproveArgs = [], teeOutput = True, kRelease = None, keepTemp = False):
     if not isKDefinition(inputJSON):

--- a/k-distribution/src/main/scripts/lib/pyk/coverage.py
+++ b/k-distribution/src/main/scripts/lib/pyk/coverage.py
@@ -94,9 +94,7 @@ def translateCoverage(src_all_rules, dst_all_rules, dst_definition, src_rules_li
             _fatal('COULD NOT FIND RULE LOCATION IN dst_rule_map: ' + src_rule_loc)
         dst_rule = dst_rule_map[src_rule_loc]
 
-        if dst_rule not in dst_non_function_rules:
-            _notif('Skipping non-semantic rule: ' + dst_rule)
-        else:
+        if dst_rule in dst_non_function_rules:
             dst_rule_list.append(dst_rule)
 
     return dst_rule_list


### PR DESCRIPTION
Updates `krunJSON` to use the newer `krun` instead of `krunLegacy`. Renames the existing `krunJSON` as `krunJSONLegacy`, so that people can continue using it as needed.
Also quiet down the rule coverage converter (used for rule merging).

This requires an explicit call to `kast`.

If you are passing in an entire configuration to `krunJSON`, make sure to add `krunFlags = ['--term']`, and `kastFlags = ['--sort', 'GeneratedTopCell']`. If you are just parsing some initial statement, this isn't needed.