### PR TITLE
Nix: Purify source inputs

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -6,20 +6,10 @@ in
 { pkgs ? pinned }:
 
 let
-  ttuegel =
-    let
-      src = builtins.fetchGit {
-        url = "https://github.com/ttuegel/nix-lib";
-        rev = "66bb0ab890ff4d828a2dcfc7d5968465d0c7084f";
-        ref = "main";
-      };
-    in import src { inherit pkgs; };
-in
-
-let
   inherit (pkgs) callPackage;
 
   mavenix = import sources."mavenix" { inherit pkgs; };
+  ttuegel = import sources."ttuegel" { inherit pkgs; };
 
   llvm-backend-project = import ./llvm-backend/src/main/native/llvm-backend {
     inherit pkgs;
@@ -33,6 +23,7 @@ let
 
   k = callPackage ./nix/k.nix {
     inherit haskell-backend llvm-backend mavenix;
+    inherit (ttuegel) cleanGit cleanSourceWith;
   };
 
   haskell-backend-project = import ./haskell-backend/src/main/native/haskell-backend {

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -1,25 +1,26 @@
-{ lib, mavenix, nix-gitignore, runCommand, makeWrapper
+{ lib, mavenix, cleanGit, cleanSourceWith, runCommand, makeWrapper
 , flex, gcc, git, gmp, jdk, mpfr, ncurses, pkgconfig, python3, z3
 , haskell-backend, llvm-backend
 }:
-
-let inherit (nix-gitignore) gitignoreSourcePure; in
 
 let
   unwrapped = mavenix.buildMaven {
     name = "k-5.0.0";
     infoFile = ./mavenix.lock;
     src =
-      gitignoreSourcePure
-        [
-          ".git/" "result*" "nix/" "*.nix"
-          "haskell-backend/src/main/native/haskell-backend/*"
-          "!haskell-backend/src/main/native/haskell-backend/src"  # need prelude.kore
-          "llvm-backend/src/main/native/llvm-backend/*"
-          "!llvm-backend/src/main/native/llvm-backend/matching"  # need pom.xml
-          "k-distribution/tests/regression-new"
-        ]
-        ./..;
+      cleanSourceWith {
+        name = "k";
+        src = cleanGit { src = ./..; name = "k"; };
+        ignore =
+          [
+            "result*" "nix/" "*.nix"
+            "haskell-backend/src/main/native/haskell-backend/*"
+            "!haskell-backend/src/main/native/haskell-backend/src"  # need prelude.kore
+            "llvm-backend/src/main/native/llvm-backend/*"
+            "!llvm-backend/src/main/native/llvm-backend/matching"  # need pom.xml
+            "k-distribution/tests/regression-new"
+          ];
+      };
 
     # Cannot enable unit tests until a bug is fixed upstream (in Mavenix).
     doCheck = false;

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -34,5 +34,17 @@
         "type": "tarball",
         "url": "https://github.com/nixos/nixpkgs/archive/16b3b1eef03e6fb8211b095079aba5059f26081e.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "ttuegel": {
+        "branch": "main",
+        "description": "A library of useful Nix functions",
+        "homepage": null,
+        "owner": "ttuegel",
+        "repo": "nix-lib",
+        "rev": "66bb0ab890ff4d828a2dcfc7d5968465d0c7084f",
+        "sha256": "03828qxfxc1xv44jj6y2ar5h58lcppg0admn0smqzm3s1gk6rbnc",
+        "type": "tarball",
+        "url": "https://github.com/ttuegel/nix-lib/archive/66bb0ab890ff4d828a2dcfc7d5968465d0c7084f.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/test.nix
+++ b/test.nix
@@ -15,11 +15,18 @@ let
   inherit (default) k haskell-backend llvm-backend;
   inherit (default) clang;
 
+  ttuegel = import sources."ttuegel" { inherit pkgs ; };
+  inherit (ttuegel) cleanGitSubtree;
+
 in
 
 stdenv.mkDerivation {
   name = "k-test";
-  src = ./k-distribution;
+  src = cleanGitSubtree {
+    name = "k-distribution";
+    src = ./.;
+    subDir = "k-distribution";
+  };
   preferLocalBuild = true;
   buildInputs = [
     diffutils ncurses bison clang gmp mpfr libffi jemalloc


### PR DESCRIPTION
The source inputs to packages are cleaned (using gitignore) to make the builds reproducible, even in an un-clean repository.