### PR TITLE
Brew updates for semantic versioning

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -371,7 +371,7 @@ pipeline {
                         git merge origin/master
                         ${WORKSPACE}/package/macos/brew-update-to-local ${PACKAGE} ${VERSION}
                         git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${SHORT_REV}: part 1"
-                        ${WORKSPACE}/package/macos/brew-build-and-update-to-local-bottle ${PACKAGE} ${VERSION} ${ROOT_URL} ${SHORT_REV}
+                        ${WORKSPACE}/package/macos/brew-build-and-update-to-local-bottle ${PACKAGE} ${VERSION} ${ROOT_URL}
                         git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${SHORT_REV}: part 2"
                         git push origin brew-release-$PACKAGE
                       '''
@@ -407,7 +407,7 @@ pipeline {
                     '''
                     dir('homebrew-k') {
                       sh '''
-                        ${WORKSPACE}/package/macos/brew-update-to-final ${PACKAGE} ${VERSION} ${ROOT_URL} ${SHORT_REV}
+                        ${WORKSPACE}/package/macos/brew-update-to-final ${PACKAGE} ${VERSION} ${ROOT_URL}
                         git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${SHORT_REV}: part 3"
                         git push origin brew-release-$PACKAGE
                       '''

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -369,10 +369,10 @@ pipeline {
                         git push -d origin brew-release-$PACKAGE || true
                         git checkout -b brew-release-$PACKAGE "origin/$brew_base_branch"
                         git merge origin/master
-                        ${WORKSPACE}/package/macos/brew-update-to-local
-                        git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 1"
-                        ${WORKSPACE}/package/macos/brew-build-and-update-to-local-bottle ${SHORT_REV}
-                        git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 2"
+                        ${WORKSPACE}/package/macos/brew-update-to-local ${PACKAGE} ${VERSION}
+                        git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${SHORT_REV}: part 1"
+                        ${WORKSPACE}/package/macos/brew-build-and-update-to-local-bottle ${PACKAGE} ${VERSION} ${ROOT_URL} ${SHORT_REV}
+                        git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${SHORT_REV}: part 2"
                         git push origin brew-release-$PACKAGE
                       '''
                       stash name: 'mojave', includes: "kframework--${env.VERSION}.mojave.bottle*.tar.gz"
@@ -385,7 +385,7 @@ pipeline {
                     dir('homebrew-k') {
                       git url: 'git@github.com:kframework/homebrew-k.git', branch: 'brew-release-kframework'
                       unstash 'mojave'
-                      sh '${WORKSPACE}/package/macos/brew-install-bottle'
+                      sh '${WORKSPACE}/package/macos/brew-install-bottle ${PACKAGE} ${VERSION}'
                     }
                     sh '''
                       brew install opam
@@ -407,8 +407,8 @@ pipeline {
                     '''
                     dir('homebrew-k') {
                       sh '''
-                        ${WORKSPACE}/package/macos/brew-update-to-final ${SHORT_REV}
-                        git commit Formula/$PACKAGE.rb -m "Update $PACKAGE to ${SHORT_REV}: part 3"
+                        ${WORKSPACE}/package/macos/brew-update-to-final ${PACKAGE} ${VERSION} ${ROOT_URL} ${SHORT_REV}
+                        git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${SHORT_REV}: part 3"
                         git push origin brew-release-$PACKAGE
                       '''
                     }

--- a/package/macos/brew-build-and-update-to-local-bottle
+++ b/package/macos/brew-build-and-update-to-local-bottle
@@ -2,10 +2,9 @@
 package="$1"  ; shift
 version="$1"  ; shift
 root_url="$1" ; shift
-rev="$1"      ; shift
 brew tap kframework/k "file://$(pwd)"
 brew install $package --build-bottle -v
-brew bottle --json $package --root-url="$root_url/v$version-$rev/"
+brew bottle --json $package --root-url="$root_url/v$version/"
 cat *.bottle.json
 brew bottle --merge --write --no-commit *.bottle.json
 cp $(brew formula $package) Formula/$package.rb

--- a/package/macos/brew-build-and-update-to-local-bottle
+++ b/package/macos/brew-build-and-update-to-local-bottle
@@ -1,8 +1,11 @@
 #!/bin/sh -exu
-REV=$1
+package="$1"  ; shift
+version="$1"  ; shift
+root_url="$1" ; shift
+rev="$1"      ; shift
 brew tap kframework/k "file://$(pwd)"
-brew install $PACKAGE --build-bottle -v
-brew bottle --json $PACKAGE --root-url="$ROOT_URL/v$VERSION-$REV/"
+brew install $package --build-bottle -v
+brew bottle --json $package --root-url="$root_url/v$version-$rev/"
 cat *.bottle.json
 brew bottle --merge --write --no-commit *.bottle.json
-cp $(brew formula $PACKAGE) Formula/$PACKAGE.rb
+cp $(brew formula $package) Formula/$package.rb

--- a/package/macos/brew-install-bottle
+++ b/package/macos/brew-install-bottle
@@ -1,3 +1,5 @@
 #!/bin/sh -ex
+package="$1" ; shift
+version="$1" ; shift
 brew tap kframework/k "file:///$(pwd)"
-brew install $PACKAGE--$VERSION.*.bottle*.tar.gz -v
+brew install $package--$version.*.bottle*.tar.gz -v

--- a/package/macos/brew-update-to-final
+++ b/package/macos/brew-update-to-final
@@ -1,5 +1,7 @@
 #!/bin/sh -exu
-REV=$1
-sed -i "" -e 's!^  url ".*"$!  url "'$ROOT_URL/v$VERSION-$REV/$PACKAGE-$VERSION-src'.tar.gz"!' \
-    Formula/$PACKAGE.rb
-cat Formula/$PACKAGE.rb
+package="$1"  ; shift
+version="$1"  ; shift
+root_url="$1" ; shift
+rev="$1"      ; shift
+sed -i "" -e 's!^  url ".*"$!  url "'$root_url/v$version-$rev/$package-$version-src'.tar.gz"!' Formula/$package.rb
+cat Formula/$package.rb

--- a/package/macos/brew-update-to-final
+++ b/package/macos/brew-update-to-final
@@ -2,6 +2,5 @@
 package="$1"  ; shift
 version="$1"  ; shift
 root_url="$1" ; shift
-rev="$1"      ; shift
-sed -i "" -e 's!^  url ".*"$!  url "'$root_url/v$version-$rev/$package-$version-src'.tar.gz"!' Formula/$package.rb
+sed -i "" -e 's!^  url ".*"$!  url "'$root_url/v$version/$package-$version-src'.tar.gz"!' Formula/$package.rb
 cat Formula/$package.rb

--- a/package/macos/brew-update-to-local
+++ b/package/macos/brew-update-to-local
@@ -1,4 +1,6 @@
 #!/bin/sh -exu
-sed -i "" -e '/install-rust/d' -e 's!^  url ".*"$!  url "file:///'$(pwd)/../$PACKAGE-$VERSION'-src.tar.gz"!' \
-       -e 's!^  sha256 ".*"$!  sha256 "'$(shasum -a 256 ../$PACKAGE-$VERSION-src.tar.gz | awk '{print $1}')'"!' \
-    Formula/$PACKAGE.rb
+package="$1" ; shift
+version="$1" ; shift
+sed -i "" -e '/install-rust/d' -e 's!^  url ".*"$!  url "file:///'$(pwd)/../$package-$version'-src.tar.gz"!' \
+       -e 's!^  sha256 ".*"$!  sha256 "'$(shasum -a 256 ../$package-$version-src.tar.gz | awk '{print $1}')'"!' \
+    Formula/$package.rb


### PR DESCRIPTION
Two changes here (maybe review each commit separately):

-   The scripts `package/macos/brew-*` now take their arguments as command-line variables, and not environment variables.
-   The scripts `package/macos/brew-*` now no longer place the revision in the `url` or `root_url` used to make the brew Formula, as that's not used anymore for our release process.