### PR TITLE
package/version.sh: correct hardcoded substitution version

### DIFF
--- a/package/version.sh
+++ b/package/version.sh
@@ -62,11 +62,11 @@ version_bump() {
 version_sub() {
     local version
     version="$(cat $version_file)"
-    sed --in-place 's/K_VERSION=5.0.0/K_VERSION='${version}'/'                                                         install-k
-    sed --in-place 's/name = "k-5.0.0";/name = "k-'${version}'";/'                                                     nix/k.nix
-    sed --in-place 's/pkgver=5.0.0/pkgver='${version}'/'                                                               package/arch/PKGBUILD
-    sed --in-place 's/kframework (5.0.0) unstable; urgency=medium/kframework ('${version}') unstable; urgency=medium/' package/debian/changelog
-    sed --in-place 's/K_VERSION=5.0.0/K_VERSION='${version}'/'                                                         src/main/scripts/test-in-container-debian
+    sed --in-place 's/^K_VERSION=.*$/K_VERSION='${version}'/'                                                         install-k
+    sed --in-place 's/^    name = "k-.*";$/    name = "k-'${version}'";/'                                             nix/k.nix
+    sed --in-place 's/^pkgver=.*$/pkgver='${version}'/'                                                               package/arch/PKGBUILD
+    sed --in-place 's/^kframework (.*) unstable; urgency=medium$/kframework ('${version}') unstable; urgency=medium/' package/debian/changelog
+    sed --in-place 's/^K_VERSION=.*$/K_VERSION='${version}'/'                                                         src/main/scripts/test-in-container-debian
 }
 
 version_command="$1"


### PR DESCRIPTION
This script is used to bump the version number throughout the repo. It worked on the first run because it looked for the hardcoded `5.0.0`, but then after that it hasn't worked because it doesn't do the substitution correctly.