### PR TITLE
Insert location information in kore files

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -3,7 +3,6 @@ package org.kframework.backend.haskell;
 
 import com.google.inject.Inject;
 import org.kframework.attributes.Att;
-import org.kframework.attributes.Source;
 import org.kframework.backend.kore.KoreBackend;
 import org.kframework.backend.kore.ModuleToKORE;
 import org.kframework.builtin.KLabels;
@@ -286,8 +285,9 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
             }
 
             private String saveKoreSpecToTemp(ModuleToKORE converter, Module rules) {
+                StringBuilder sb = new StringBuilder();
                 String koreOutput = converter.convertSpecificationModule(module, rules,
-                        haskellKRunOptions.defaultClaimType, Source.apply(kProveOptions.specFile(files).getAbsolutePath()));
+                        haskellKRunOptions.defaultClaimType, sb);
                 files.saveToTemp("spec.kore", koreOutput);
                 String specPath = files.resolveTemp("spec.kore").getAbsolutePath();
                 return specPath;

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -3,6 +3,7 @@ package org.kframework.backend.haskell;
 
 import com.google.inject.Inject;
 import org.kframework.attributes.Att;
+import org.kframework.attributes.Source;
 import org.kframework.backend.kore.KoreBackend;
 import org.kframework.backend.kore.ModuleToKORE;
 import org.kframework.builtin.KLabels;
@@ -285,9 +286,8 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
             }
 
             private String saveKoreSpecToTemp(ModuleToKORE converter, Module rules) {
-                StringBuilder sb = new StringBuilder();
                 String koreOutput = converter.convertSpecificationModule(module, rules,
-                        haskellKRunOptions.defaultClaimType, sb);
+                        haskellKRunOptions.defaultClaimType, Source.apply(kProveOptions.specFile(files).getAbsolutePath()));
                 files.saveToTemp("spec.kore", koreOutput);
                 String specPath = files.resolveTemp("spec.kore").getAbsolutePath();
                 return specPath;

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -841,15 +841,15 @@ public class ModuleToKORE {
         return prod.klabel().nonEmpty() && ConstructorChecks.isBuiltinLabel(prod.klabel().get());
     }
 
-    public String convertSpecificationModule(Module definition, Module spec, SentenceType defaultSentenceType, Source mainFile) {
+    public String convertSpecificationModule(Module definition, Module spec, SentenceType defaultSentenceType, StringBuilder sb) {
         SentenceType sentenceType = getSentenceType(spec.att()).orElse(defaultSentenceType);
-        StringBuilder sb = new StringBuilder();
+        sb.setLength(0); // reset string writer
         ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(definition);
         Sort topCellSort = configInfo.getRootCell();
         String topCellSortStr = getSortStr(topCellSort);
         HashMap<String, Boolean> considerSource = new HashMap<>();
         considerSource.put(Att.SOURCE(), true);
-        convert(considerSource, Att.empty().add(Source.class, mainFile), sb, null, null);
+        convert(considerSource, Att.empty().add(Source.class, spec.att().get(Source.class)), sb, null, null);
         sb.append("\n");
         sb.append("module ");
         convert(spec.name(), sb);


### PR DESCRIPTION
To identify the entry point of kompile or kprove
For `definition.kore` it looks like:
```
[topCellInitializer{}(LblinitGeneratedTopCell{}()), org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/radu/work/test/kprove/./verif.k)")]
module BASIC-K
...
```
for `spec.kore` it looks like:
```
[org'Stop'kframework'Stop'attributes'Stop'Source{}("Source(/home/radu/work/test/kprove/./sum-spec.k)")]
module SUM-SPEC
...
```
I would prefer that kore-exec returns the location information from the spec file when running kprove.
I'm not sure if I can add location info for krun since the file contains only a term.

This should be merged before: https://github.com/kframework/kore/pull/2529