### PR TITLE
Front end cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -81,7 +81,7 @@ pipeline {
                           echo 'Starting kserver...'
                           k-distribution/target/release/k/bin/spawn-kserver kserver.log
                           cd k-exercises/tutorial
-                          make -j`nproc` ${MAKE_EXTRA_ARGS}
+                          make -j`nproc` --output-sync ${MAKE_EXTRA_ARGS}
                         '''
                       }
                       post {
@@ -398,7 +398,7 @@ pipeline {
                       spawn-kserver $WD/kserver.log
                       cd pl-tutorial
                       echo 'Testing tutorial in user environment...'
-                      make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+                      make -j`sysctl -n hw.ncpu` --output-sync ${MAKE_EXTRA_ARGS}
                       cd ~
                       echo 'module TEST imports BOOL endmodule' > test.k
                       kompile test.k --backend ocaml

--- a/k-distribution/pom.xml
+++ b/k-distribution/pom.xml
@@ -122,6 +122,7 @@
               <target>
                 <exec dir="${ktestDir}" executable="make" failonerror="true">
                   <arg value="-j12" />
+                  <arg value="--output-sync" />
                 </exec>
               </target>
               <skip>${skipKTest}</skip>

--- a/k-distribution/tests/regression-new/bison-glr-bug/Makefile
+++ b/k-distribution/tests/regression-new/bison-glr-bug/Makefile
@@ -11,7 +11,7 @@ test.kore: forwarder.iele kompile
 include ../../../include/kframework/ktest.mak
 
 clean:
-	rm -rf test.kore test-kompiled .depend-tmp .depend .krun-*
+	rm -rf test.kore $(KOMPILED_DIR) .depend-tmp .depend .kompile-* .krun-* .kprove-* kore-exec.tar.gz
 
 
 KRUN_OR_KX=./parse

--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -92,7 +92,6 @@ case class FlatModule(name: String, imports: Set[Import], localSentences: Set[Se
   extends OuterKORE with Sorting with Serializable {
 
   def toModule(allModules: Set[FlatModule], koreModules: scala.collection.mutable.Map[String, Module], visitedModules: Seq[FlatModule]): Module = {
-    var mainModName = this.name
     var items = this.localSentences
     var importedModuleNames = this.imports
     var importedSyntax = importedModuleNames.map(m => Import.asSyntax(m))
@@ -104,8 +103,8 @@ case class FlatModule(name: String, imports: Set[Import], localSentences: Set[Se
       throw KEMException.compilerError(msg)
     }
 
-    if (koreModules.contains(mainModName))
-      return koreModules(mainModName)
+    if (koreModules.contains(this.name))
+      return koreModules(this.name)
 
     def resolveImport(_import: Import): Module = {
       var baseName = Import.noSyntax(_import.name)

--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -104,6 +104,9 @@ case class FlatModule(name: String, imports: Set[Import], localSentences: Set[Se
       throw KEMException.compilerError(msg)
     }
 
+    if (koreModules.contains(mainModName))
+      return koreModules(mainModName)
+
     def resolveImport(_import: Import): Module = {
       var baseName = Import.noSyntax(_import.name)
       var modOption = allModules.find(m => m.name.equals(baseName))


### PR DESCRIPTION
Splitting the rule refactoring into more pieces.
This is solving:
- interleaving in Jenkins output. This should make it easier to identify the output of each file.
- one test was not cleaning the temp files correctly
- quadratic behavior in FlatModule creation