### PR TITLE
Correctly report new scanner creation

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -281,8 +281,8 @@ public class DefinitionParsing {
         Module ruleParserModule = gen.getRuleGrammar(mainModule);
         ParseCache cache = loadCache(ruleParserModule);
         try (ParseInModule parser = RuleGrammarGenerator.getCombinedGrammar(cache.getModule(), isStrict, profileRules, files)) {
-            parser.getScanner();
-            Map<String, Module> parsed = defWithConfig.parMap(m -> this.resolveNonConfigBubbles(m, parser.getScanner(), gen));
+            parser.getScanner(options.global);
+            Map<String, Module> parsed = defWithConfig.parMap(m -> this.resolveNonConfigBubbles(m, parser.getScanner(options.global), gen));
             return DefinitionTransformer.from(m -> Module(m.name(), m.imports(), parsed.get(m.name()).localSentences(), m.att()), "parsing rules").apply(defWithConfig);
         }
     }
@@ -310,13 +310,13 @@ public class DefinitionParsing {
         Set<Sentence> configDeclProductions;
         ParseCache cache = loadCache(gen.getConfigGrammar(module));
         try (ParseInModule parser = RuleGrammarGenerator.getCombinedGrammar(cache.getModule(), isStrict, profileRules, files)) {
-             parser.getScanner();
+             parser.getScanner(options.global);
              configDeclProductions = stream(module.localSentences())
                     .parallel()
                     .filter(s -> s instanceof Bubble)
                     .map(b -> (Bubble) b)
                     .filter(b -> b.sentenceType().equals(configuration))
-                    .flatMap(b -> performParse(cache.getCache(), parser, parser.getScanner(), b))
+                    .flatMap(b -> performParse(cache.getCache(), parser, parser.getScanner(options.global), b))
                     .map(contents -> {
                         KApply configContents = (KApply) contents;
                         List<K> items = configContents.klist().items();
@@ -378,10 +378,7 @@ public class DefinitionParsing {
 
             // this scanner is not good for this module, so we must generate a new scanner.
             boolean needNewScanner = !scanner.getModule().importedModuleNames().contains(module.name());
-            if (needNewScanner && kem.options.verbose) {
-              System.out.println("New scanner: " + module.name());
-            }
-            final Scanner realScanner = needNewScanner ? parser.getScanner() : scanner;
+            final Scanner realScanner = needNewScanner ? parser.getScanner(options.global) : scanner;
 
             Set<Sentence> claimSet = stream(module.localSentences())
                     .parallel()
@@ -433,7 +430,7 @@ public class DefinitionParsing {
         gen = new RuleGrammarGenerator(compiledDef.kompiledDefinition);
         try (ParseInModule parser = RuleGrammarGenerator
                 .getCombinedGrammar(gen.getRuleGrammar(compiledDef.executionModule()), isStrict, profileRules, files)) {
-            java.util.Set<K> res = performParse(new HashMap<>(), parser, parser.getScanner(),
+            java.util.Set<K> res = performParse(new HashMap<>(), parser, parser.getScanner(options.global),
                     new Bubble(rule, contents, Att().add("contentStartLine", Integer.class, 1)
                             .add("contentStartColumn", Integer.class, 1).add(Source.class, source)))
                     .collect(Collectors.toSet());

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -66,7 +66,7 @@ public class KRead {
 
     public void createBisonParser(Module mod, Sort sort, File outputFile, boolean glr, String bisonFile, long stackDepth) {
         try (ParseInModule parseInModule = RuleGrammarGenerator.getCombinedGrammar(mod, true)) {
-            try (Scanner scanner = parseInModule.getScanner()) {
+            try (Scanner scanner = parseInModule.getScanner(kem.options)) {
                 File scannerFile = files.resolveTemp("scanner.l");
                 File scanHdr = files.resolveTemp("scanner.h");
                 File parserFile = files.resolveTemp("parser.y");

--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -7,6 +7,7 @@ import org.kframework.builtin.Sorts;
 import org.kframework.definition.Module;
 import org.kframework.kore.K;
 import org.kframework.kore.Sort;
+import org.kframework.main.GlobalOptions;
 import org.kframework.parser.Term;
 import org.kframework.parser.TreeNodesToKORE;
 import org.kframework.parser.inner.disambiguation.*;
@@ -172,6 +173,12 @@ public class ParseInModule implements Serializable, AutoCloseable {
     private ThreadLocal<TypeInferencer> inferencer = new ThreadLocal<>();
     private Queue<TypeInferencer> inferencers = new ConcurrentLinkedQueue<>();
 
+    public Scanner getScanner(GlobalOptions go) {
+        if (scanner == null) {
+            scanner = new Scanner(this, go);
+        }
+        return scanner;
+    }
     public Scanner getScanner() {
         if (scanner == null) {
             scanner = new Scanner(this);

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
@@ -13,8 +13,10 @@ import org.kframework.definition.RegexTerminal;
 import org.kframework.definition.SyntaxLexical;
 import org.kframework.definition.Terminal;
 import org.kframework.definition.TerminalLike;
+import org.kframework.main.GlobalOptions;
 import org.kframework.parser.inner.ParseInModule;
 import org.kframework.utils.OS;
+import org.kframework.utils.Stopwatch;
 import org.kframework.utils.StringUtil;
 import org.kframework.utils.errorsystem.KEMException;
 import scala.Tuple2;
@@ -43,8 +45,16 @@ public class Scanner implements AutoCloseable {
     private final Map<TerminalLike, Tuple2<Integer, Integer>> tokens;
     private final File scanner;
     private final Module module;
+    private GlobalOptions go = new GlobalOptions();
 
     private static final String EXE_EXTENSION = OS.current().equals(OS.WINDOWS) ? ".exe" : "";
+
+    public Scanner(ParseInModule module, GlobalOptions go) {
+        this.go = go;
+        this.tokens  = KSyntax2GrammarStatesFilter.getTokens(module.getParsingModule());
+        this.module  = module.seedModule();
+        this.scanner = getScanner();
+    }
 
     public Scanner(ParseInModule module) {
         this.tokens  = KSyntax2GrammarStatesFilter.getTokens(module.getParsingModule());
@@ -124,6 +134,7 @@ public class Scanner implements AutoCloseable {
     }
 
     public File getScanner() {
+        Stopwatch sw = new Stopwatch(go);
         File scanner;
         // tokenization
         try {
@@ -216,6 +227,7 @@ public class Scanner implements AutoCloseable {
         } catch (IOException | InterruptedException e) {
             throw KEMException.internalError("Failed to write file for scanner", e);
         }
+        sw.printIntermediate("New scanner: " + module.name());
         return scanner;
     }
 

--- a/kernel/src/main/java/org/kframework/utils/Stopwatch.java
+++ b/kernel/src/main/java/org/kframework/utils/Stopwatch.java
@@ -19,7 +19,7 @@ public class Stopwatch {
 
     @Inject
     public Stopwatch(GlobalOptions options) {
-        this.options = options;
+        this.options = options != null ? options : new GlobalOptions();
         start = System.currentTimeMillis();
         lastIntermediate = start;
     }


### PR DESCRIPTION
This is another cleanup in the front end.
Before, some of the new scanners were not properly reported when using the verbose option.
Now I moved the print message inside the scanner creation directly.
Before:
```
Outer parsing [133 modules]                                  =  1.171s
Parse configurations [0/6 declarations]                      =  1.546s
New scanner: STRING-COMMON
New scanner: STRING-KORE
New scanner: K-IO
New scanner: STDOUT-STREAM
New scanner: STDIN-STREAM
Parse rules [0/101 rules]                                    =  0.586s
```
After:
```
Outer parsing [133 modules]                                  =  1.145s
New scanner: TEST$SYNTAX-CONFIG-CELLS                        =  0.130s
New scanner: TEST-CONFIG-CELLS                               =  0.156s
New scanner: STDOUT-STREAM$SYNTAX-CONFIG-CELLS               =  0.206s
New scanner: STDOUT-STREAM-CONFIG-CELLS                      =  0.225s
New scanner: STDIN-STREAM$SYNTAX-CONFIG-CELLS                =  0.226s
New scanner: STDIN-STREAM-CONFIG-CELLS                       =  0.243s
Parse configurations [0/6 declarations]                      =  1.520s
New scanner: TEST-RULE-CELLS                                 =  0.151s
New scanner: STRING-KORE-RULE-CELLS                          =  0.152s
New scanner: STRING-COMMON-RULE-CELLS                        =  0.162s
New scanner: K-IO-RULE-CELLS                                 =  0.231s
New scanner: STDOUT-STREAM-RULE-CELLS                        =  0.223s
New scanner: STDIN-STREAM-RULE-CELLS                         =  0.239s
Parse rules [0/101 rules]                                    =  0.573s
```
The fix for the extra scanners will be added after this is merged.