### PR TITLE
Refactor rule parsing

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -411,19 +411,19 @@ public class DefinitionParsing {
         // scanners can be reused so find the top modules which include all other modules
         java.util.Set<Module> topMods = getTopModules(defWithCaches.modules()).stream().filter(m -> m.sentences().filter(s -> s instanceof Bubble).size() != 0).collect(Collectors.toSet());
         // prefer modules that import the main module. This way we avoid using the main syntax module which could contain problematic syntax for rule parsing
-        java.util.Set<Module> orderedBotMods = new java.util.LinkedHashSet<>();
+        java.util.Set<Module> orderedTopMods = new java.util.LinkedHashSet<>();
         for (Module m : topMods) {
             if (m.name().equals(defWithCaches.mainModule().name()) || m.importedModuleNames().contains(defWithCaches.mainModule().name()))
-                orderedBotMods.add(m);
+                orderedTopMods.add(m);
         }
-        orderedBotMods.addAll(topMods);
+        orderedTopMods.addAll(topMods);
 
         // map the module name to the scanner that it should use when parsing
         java.util.Map<String, Module> donorModule = new HashMap<>();
         for (Module m : mutable(defWithCaches.modules())) {
             if (stream(m.localSentences()).anyMatch(s -> s instanceof Bubble)) {
-                Module scannerModule = orderedBotMods.stream().filter(bm -> m.equals(bm) || bm.importedModuleNames().contains(m.name())).findFirst()
-                        .orElseThrow(() -> new AssertionError("Expected at least one bottom module to have a suitable scanner: " + m.name()));
+                Module scannerModule = orderedTopMods.stream().filter(bm -> m.equals(bm) || bm.importedModuleNames().contains(m.name())).findFirst()
+                        .orElseThrow(() -> new AssertionError("Expected at least one top module to have a suitable scanner: " + m.name()));
                 donorModule.put(m.name(), scannerModule);
             }
         }
@@ -508,12 +508,12 @@ public class DefinitionParsing {
         }
     }
 
-    private Sentence upSentence(K contens, String sentenceType) {
+    private Sentence upSentence(K contents, String sentenceType) {
         switch (sentenceType) {
-        case claim:         return upClaim(contens);
-        case rule:          return upRule(contens);
-        case context:       return upContext(contens);
-        case alias:         return upAlias(contens);
+        case claim:         return upClaim(contents);
+        case rule:          return upRule(contents);
+        case context:       return upContext(contents);
+        case alias:         return upAlias(contents);
         }
         throw new AssertionError("Unexpected sentence type: " + sentenceType);
     }

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -154,7 +154,7 @@ public class DefinitionParsing {
             throw new AssertionError("should not reach this statement");
         }
 
-        def = resolveNonConfigBubbles(def, def.getModule(entryPointModule).get());
+        def = resolveNonConfigBubbles(def);
         if (! readOnlyCache) {
             saveCachesAndReportParsingErrors();
         }
@@ -205,7 +205,7 @@ public class DefinitionParsing {
         parsedBubbles.set(0);
         cachedBubbles.set(0);
         RuleGrammarGenerator gen = new RuleGrammarGenerator(afterResolvingConfigBubbles);
-        Definition afterResolvingAllOtherBubbles = resolveNonConfigBubbles(afterResolvingConfigBubbles, afterResolvingConfigBubbles.mainModule());
+        Definition afterResolvingAllOtherBubbles = resolveNonConfigBubbles(afterResolvingConfigBubbles);
         saveCachesAndReportParsingErrors();
         return afterResolvingAllOtherBubbles;
     }
@@ -364,7 +364,7 @@ public class DefinitionParsing {
         return rez;
     }
 
-    public Definition resolveNonConfigBubbles(Definition defWithConfig, Module mainModule) {
+    public Definition resolveNonConfigBubbles(Definition defWithConfig) {
         RuleGrammarGenerator gen = new RuleGrammarGenerator(defWithConfig);
         // load cached bubbles
         Definition defWithCaches = DefinitionTransformer.from(m -> {

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -411,18 +411,18 @@ public class DefinitionParsing {
         // scanners can be reused so find the top modules which include all other modules
         java.util.Set<Module> topMods = getTopModules(defWithCaches.modules()).stream().filter(m -> m.sentences().filter(s -> s instanceof Bubble).size() != 0).collect(Collectors.toSet());
         // prefer modules that import the main module. This way we avoid using the main syntax module which could contain problematic syntax for rule parsing
-        java.util.Set<Module> orderedTopMods = new java.util.LinkedHashSet<>();
+        java.util.Set<Module> orderedBotMods = new java.util.LinkedHashSet<>();
         for (Module m : topMods) {
             if (m.name().equals(defWithCaches.mainModule().name()) || m.importedModuleNames().contains(defWithCaches.mainModule().name()))
-                orderedTopMods.add(m);
+                orderedBotMods.add(m);
         }
-        orderedTopMods.addAll(topMods);
+        orderedBotMods.addAll(topMods);
 
         // map the module name to the scanner that it should use when parsing
         java.util.Map<String, Module> donorModule = new HashMap<>();
         for (Module m : mutable(defWithCaches.modules())) {
             if (stream(m.localSentences()).anyMatch(s -> s instanceof Bubble)) {
-                Module scannerModule = orderedTopMods.stream().filter(bm -> m.equals(bm) || bm.importedModuleNames().contains(m.name())).findFirst()
+                Module scannerModule = orderedBotMods.stream().filter(bm -> m.equals(bm) || bm.importedModuleNames().contains(m.name())).findFirst()
                         .orElseThrow(() -> new AssertionError("Expected at least one bottom module to have a suitable scanner: " + m.name()));
                 donorModule.put(m.name(), scannerModule);
             }

--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -179,11 +179,16 @@ public class ParseInModule implements Serializable, AutoCloseable {
         }
         return scanner;
     }
+
     public Scanner getScanner() {
         if (scanner == null) {
             scanner = new Scanner(this);
         }
         return scanner;
+    }
+
+    public void setScanner(Scanner scanner) {
+        this.scanner = scanner;
     }
 
     public Tuple2<Either<Set<KEMException>, K>, Set<KEMException>>


### PR DESCRIPTION
Part 1 in fixing: #1867
It is slightly faster:
```
          this branch (master)
test.k:          4.0s (4.0s)
time make -j 32 -O
regression-new: 8m24s (8m46s)
    kserver:    2m45s (2m52s)
pl-tutorial:    8m19s (8m13s)
    kserver:    1m33s (1m40s)
```
Here is the output of kompile on a test file with one rule and a configuration:
```
Outer parsing [133 modules]                                  =  0.884s
New scanner: TEST$SYNTAX-CONFIG-CELLS                        =  0.139s
New scanner: TEST-CONFIG-CELLS                               =  0.163s
New scanner: STDOUT-STREAM$SYNTAX-CONFIG-CELLS               =  0.227s
New scanner: STDOUT-STREAM-CONFIG-CELLS                      =  0.232s
New scanner: STDIN-STREAM$SYNTAX-CONFIG-CELLS                =  0.211s
New scanner: STDIN-STREAM-CONFIG-CELLS                       =  0.236s
Parse configurations [6/6 declarations]                      =  1.695s
New scanner: TEST-RULE-CELLS                                 =  0.151s
New scanner: STDIN-STREAM-RULE-CELLS                         =  0.234s
New scanner: STDOUT-STREAM-RULE-CELLS                        =  0.226s
Parse rules [101/101 rules]                                  =  0.672s
```
second time:
```
Outer parsing [133 modules]                                  =  0.858s
New scanner: TEST$SYNTAX-CONFIG-CELLS                        =  0.130s
New scanner: TEST-CONFIG-CELLS                               =  0.161s
New scanner: STDOUT-STREAM$SYNTAX-CONFIG-CELLS               =  0.211s
New scanner: STDOUT-STREAM-CONFIG-CELLS                      =  0.227s
New scanner: STDIN-STREAM$SYNTAX-CONFIG-CELLS                =  0.237s
New scanner: STDIN-STREAM-CONFIG-CELLS                       =  0.234s
Parse configurations [0/6 declarations]                      =  1.528s
Parse rules [0/101 rules]                                    =  0.081s
```
The diff was getting pretty big so I'm limiting the changes to rules only.
I'm going to start working on the configuration after this gets merged. I will deal with code duplication at the same time.

Just as a comparison. Here is the output of -v on master:
```
Outer parsing [133 modules]                                  =  0.836s
New scanner: TEST$SYNTAX-CONFIG-CELLS                        =  0.148s
New scanner: TEST-CONFIG-CELLS                               =  0.166s
New scanner: STDOUT-STREAM$SYNTAX-CONFIG-CELLS               =  0.218s
New scanner: STDOUT-STREAM-CONFIG-CELLS                      =  0.227s
New scanner: STDIN-STREAM$SYNTAX-CONFIG-CELLS                =  0.209s
New scanner: STDIN-STREAM-CONFIG-CELLS                       =  0.242s
Parse configurations [6/6 declarations]                      =  1.650s
New scanner: TEST-RULE-CELLS                                 =  0.146s
New scanner: STRING-KORE-RULE-CELLS                          =  0.177s
New scanner: STRING-COMMON-RULE-CELLS                        =  0.179s
New scanner: K-IO-RULE-CELLS                                 =  0.279s
New scanner: STDOUT-STREAM-RULE-CELLS                        =  0.287s
New scanner: STDIN-STREAM-RULE-CELLS                         =  0.287s
Parse rules [101/101 rules]                                  =  0.710s
```
second time:
```
Outer parsing [133 modules]                                  =  0.829s
New scanner: TEST$SYNTAX-CONFIG-CELLS                        =  0.139s
New scanner: TEST-CONFIG-CELLS                               =  0.152s
New scanner: STDOUT-STREAM$SYNTAX-CONFIG-CELLS               =  0.215s
New scanner: STDOUT-STREAM-CONFIG-CELLS                      =  0.226s
New scanner: STDIN-STREAM$SYNTAX-CONFIG-CELLS                =  0.221s
New scanner: STDIN-STREAM-CONFIG-CELLS                       =  0.245s
Parse configurations [0/6 declarations]                      =  1.544s
New scanner: TEST-RULE-CELLS                                 =  0.153s
New scanner: STRING-COMMON-RULE-CELLS                        =  0.157s
New scanner: STRING-KORE-RULE-CELLS                          =  0.166s
New scanner: K-IO-RULE-CELLS                                 =  0.239s
New scanner: STDOUT-STREAM-RULE-CELLS                        =  0.249s
New scanner: STDIN-STREAM-RULE-CELLS                         =  0.256s
Parse rules [0/101 rules]                                    =  0.587s
```