### PR TITLE
Fix and simplify release trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -661,8 +661,14 @@ pipeline {
             cd k-release
             git fetch --all
             git checkout -B release origin/release
-            git merge origin/master
-            ./package/version.sh bump
+            old_master="$(git merge-base origin/master origin/release)"
+            new_master="$(git rev-parse origin/master)"
+            if git diff --exit-code ${old_master} ${new_master} -- package/version; then
+                git merge origin/master
+                ./package/version.sh bump
+            else
+                git merge origin/master --strategy=theirs
+            fi
             ./package/version.sh sub
             git add -u
             git commit -m "Set Version: $(cat package/version)"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -667,7 +667,7 @@ pipeline {
                 git merge origin/master
                 ./package/version.sh bump
             else
-                git merge origin/master --strategy=theirs
+                git merge origin/master --strategy-option=theirs
             fi
             ./package/version.sh sub
             git add -u

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -664,14 +664,14 @@ pipeline {
             old_master="$(git merge-base origin/master origin/release)"
             new_master="$(git rev-parse origin/master)"
             if git diff --exit-code ${old_master} ${new_master} -- package/version; then
-                git merge origin/master
+                git merge --no-edit origin/master
                 ./package/version.sh bump
             else
-                git merge origin/master --strategy-option=theirs
+                git merge --no-edit --strategy-option=theirs origin/master
             fi
             ./package/version.sh sub
-            git add -u
-            git commit -m "Set Version: $(cat package/version)"
+            git add --update
+            git commit --no-edit --allow-empty --message "Set Version: $(cat package/version)"
             git push origin release
           '''
         }

--- a/package/version.sh
+++ b/package/version.sh
@@ -2,61 +2,20 @@
 
 set -xeuo pipefail
 
-UPSTREAM="${UPSTREAM:-origin}"
-MASTER="${MASTER:-master}"
-RELEASE="${RELEASE:-release}"
-
 notif() { echo "== $@" >&2 ; }
 fatal() { echo "[FATAL] $@" ; exit 1 ; }
 
 version_file="package/version"
 
-version_set_major_minor_patch() {
-    local version_commit
-
-    version_commit="$1" ; shift
-
-    version_major="$(git show $version_commit:$version_file | cut --delimiter '.' --field 1)"
-    version_minor="$(git show $version_commit:$version_file | cut --delimiter '.' --field 2)"
-    version_patch="$(git show $version_commit:$version_file | cut --delimiter '.' --field 3)"
-}
-
 version_bump() {
-    local master_commit master_major master_minor master_patch
-    local release_commit release_patch release_minor release_major
+    local release_commit version_major version_minor version_patch new_version
 
-    master_commit="$(git rev-parse --short=7 ${UPSTREAM}/${MASTER})"
-    release_commit="$(git rev-parse --short=7 ${UPSTREAM}/${RELEASE})"
-
-    version_set_major_minor_patch "$master_commit"
-    master_major="$version_major"
-    master_minor="$version_minor"
-    master_patch="$version_patch"
-
-    version_set_major_minor_patch "$release_commit"
-    release_major="$version_major"
-    release_minor="$version_minor"
-    release_patch="$version_patch"
-
-    major="$release_major"
-    minor="$release_minor"
-    patch="$release_patch"
-    if [[ "$master_major" -gt "$release_major" ]]; then
-        major="$master_major"
-        minor='0'
-        patch='0'
-    elif [[ "$master_minor" -gt "$release_minor" ]]; then
-        major="$master_major"
-        minor="$master_minor"
-        patch='0'
-    else
-        patch=$(($patch + 1))
-    fi
-
-    version="${major}.${minor}.${patch}"
-    echo "$version" > $version_file
-
-    notif "Version: ${version}"
+    version_major="$(cat $version_file | cut --delimiter '.' --field 1)"
+    version_minor="$(cat $version_file | cut --delimiter '.' --field 2)"
+    version_patch="$(cat $version_file | cut --delimiter '.' --field 3)"
+    new_version="${version_major}.${version_minor}.$((version_patch + 1))"
+    echo "${new_version}" > "${version_file}"
+    notif "Version: ${new_version}"
 }
 
 version_sub() {


### PR DESCRIPTION
-   Hoists logic out of `package/version.sh` into the Jenkinsfile.
-   Correctly takes the version on `master` if the user has changed it, only bumps the version if it's unchanged on master (reasoning being that changes to `version` file on `master` mean "this is the version I want to set to").