### PR TITLE
Add MAP import to all modules containing configs

### DIFF
--- a/k-distribution/tests/regression-new/checks/mapImportInConfigModules.k
+++ b/k-distribution/tests/regression-new/checks/mapImportInConfigModules.k
@@ -1,0 +1,19 @@
+module MAPIMPORTINCONFIGMODULES-SYNTAX
+  imports INT-SYNTAX
+endmodule
+
+module CONFIG
+  imports INT
+  syntax E ::= "balance"
+  configuration <k> $PGM:Int </k> <balance> .Map </balance>
+
+endmodule
+
+module MAPIMPORTINCONFIGMODULES
+  imports MAPIMPORTINCONFIGMODULES-SYNTAX
+  imports INT
+  imports CONFIG
+
+  rule <balance> .Map => .Map </balance>
+  rule <k> 0 => 1 </k>
+endmodule

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -321,13 +321,7 @@ public class DefinitionParsing {
                     .collect(Collections.toSet());
         }
 
-        Module mapModule;
-        if (def.getModule("MAP").isDefined()) {
-            mapModule = def.getModule("MAP").get();
-        } else {
-            throw KEMException.compilerError("Module Map must be visible at the configuration declaration, in module " + module.name());
-        }
-        return Module(module.name(), (Set<Module>) module.imports().$bar(Set(mapModule)),
+        return Module(module.name(), module.imports(),
                 (Set<Sentence>) module.localSentences().$bar(configDeclProductions)
                         .filter(s -> !(s instanceof Bubble && ((Bubble) s).sentenceType().equals(configuration))),
                 module.att());

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -192,13 +192,14 @@ public class DefinitionParsing {
         modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("K-REFLECTION").get()));
         modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("STDIN-STREAM").get()));
         modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("STDOUT-STREAM").get()));
+        modules = Stream.concat(modules, Stream.of(parsedDefinition.getModule("MAP").get()));
         modules = Stream.concat(modules,
                 stream(parsedDefinition.entryModules()).filter(m -> stream(m.sentences()).noneMatch(s -> s instanceof Bubble)));
         Definition trimmed = Definition(parsedDefinition.mainModule(), modules.collect(Collections.toSet()),
                 parsedDefinition.att());
         trimmed = Kompile.excludeModulesByTag(excludedModuleTags).apply(trimmed);
         sw.printIntermediate("Outer parsing [" + trimmed.entryModules().size() + " modules]");
-        Definition afterResolvingConfigBubbles = resolveConfigBubbles(trimmed, parsedDefinition.getModule("DEFAULT-CONFIGURATION").get(), parsedDefinition.getModule("MAP").get());
+        Definition afterResolvingConfigBubbles = resolveConfigBubbles(trimmed, parsedDefinition.getModule("DEFAULT-CONFIGURATION").get());
         sw.printIntermediate("Parse configurations [" + parsedBubbles.get() + "/" + (parsedBubbles.get() + cachedBubbles.get()) + " declarations]");
         parsedBubbles.set(0);
         cachedBubbles.set(0);
@@ -230,28 +231,35 @@ public class DefinitionParsing {
         return options.coverage ? DefinitionTransformer.from(mod -> mod.equals(m) ? Module(m.name(), (Set<Module>)m.imports().$bar(Set(definition.getModule("K-IO").get())), m.localSentences(), m.att()) : mod, "add implicit modules").apply(definition) : definition;
     }
 
-    protected Definition resolveConfigBubbles(Definition definition, Module defaultConfiguration, Module mapModule) {
-        boolean hasConfigDecl = stream(definition.mainModule().sentences())
-                .anyMatch(s -> s instanceof Bubble && ((Bubble) s).sentenceType().equals(configuration));
-
+    protected Definition resolveConfigBubbles(Definition definition, Module defaultConfiguration) {
         Definition definitionWithConfigBubble = DefinitionTransformer.from(mod -> {
-            if (mod.equals(definition.mainModule())) {
-                java.util.Set<Module> imports = mutable(mod.imports());
+            if (mod.name().equals(definition.mainModule().name())) {
+                boolean hasConfigDecl = stream(mod.sentences())
+                        .anyMatch(s -> s instanceof Bubble && ((Bubble) s).sentenceType().equals(configuration));
                 if (!hasConfigDecl) {
-                    imports.add(defaultConfiguration);
+                    return Module(mod.name(), mod.imports().$bar(Set(defaultConfiguration)).seq(), mod.localSentences(), mod.att());
                 }
-                imports.add(mapModule);
-                return Module(mod.name(), (Set<Module>) immutable(imports), mod.localSentences(), mod.att());
             }
             return mod;
         }, "adding default configuration").apply(definition);
+
+        Module mapModule = definitionWithConfigBubble.getModule("MAP")
+                .getOrElse(() -> { throw KEMException.compilerError("Module MAP must be visible at the configuration declaration"); });
+        Definition definitionWithMapForConfig = DefinitionTransformer.from(mod -> {
+            boolean hasConfigDecl = stream(mod.localSentences())
+                    .anyMatch(s -> s instanceof Bubble && ((Bubble) s).sentenceType().equals(configuration));
+            if (hasConfigDecl) {
+                return Module(mod.name(), mod.imports().$bar(Set(mapModule)).seq(), mod.localSentences(), mod.att());
+            }
+            return mod;
+        }, "adding MAP to modules with configs").apply(definitionWithConfigBubble);
 
         errors = java.util.Collections.synchronizedSet(Sets.newHashSet());
         caches = loadCaches();
 
         Definition result;
         try {
-            result = resolveConfigBubbles(definitionWithConfigBubble);
+            result = resolveConfigBubbles(definitionWithMapForConfig);
         } catch (KEMException e) {
             errors.add(e);
             throwExceptionIfThereAreErrors();

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -349,7 +349,7 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
   override lazy val hashCode: Int = name.hashCode
 
   override def equals(that: Any) = that match {
-    case m: Module => m.name == name && m.sentences == sentences
+    case m: Module => m.name == name && m.sentences == sentences && m.imports.map(x => x.name) == imports.map(x => x.name)
   }
 
   def flattened()   : FlatModule                = new FlatModule(name, imports.map(m => Import(m.name, Att.empty)), localSentences, att)

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -348,10 +348,6 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
 
   override lazy val hashCode: Int = name.hashCode
 
-  override def equals(that: Any) = that match {
-    case m: Module => m.name == name && m.sentences == sentences && m.imports.map(x => x.name) == imports.map(x => x.name)
-  }
-
   def flattened()   : FlatModule                = new FlatModule(name, imports.map(m => Import(m.name, Att.empty)), localSentences, att)
   def flatModules() : (String, Set[FlatModule]) = (name, Set(flattened) ++ imports.map(m => m.flatModules._2).flatten)
 }


### PR DESCRIPTION
This simple test fails on master.
The `MAP` module should be added to every module where a configuration is present.
