### PR TITLE
Keep indentation for long lines

### DIFF
--- a/k-distribution/tests/regression-new/checks/paramAmb.k.out
+++ b/k-distribution/tests/regression-new/checks/paramAmb.k.out
@@ -1,13 +1,10 @@
 [Error] Inner Parser: Parsing ambiguity.
 1: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
-   
-#KRewrite(#SemanticCastToB(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToB(#token("X","#KVariable")),`wrap__PARAMAMB_T_M`(#SemanticCastToB(#token("X","#KVariable")))))
+    #KRewrite(#SemanticCastToB(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToB(#token("X","#KVariable")),`wrap__PARAMAMB_T_M`(#SemanticCastToB(#token("X","#KVariable")))))
 2: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
-   
-#KRewrite(#SemanticCastToX(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToX(#token("X","#KVariable")),`wrap__PARAMAMB_T_X`(#SemanticCastToX(#token("X","#KVariable")))))
+    #KRewrite(#SemanticCastToX(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToX(#token("X","#KVariable")),`wrap__PARAMAMB_T_X`(#SemanticCastToX(#token("X","#KVariable")))))
 3: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
-   
-#KRewrite(#SemanticCastToA(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToA(#token("X","#KVariable")),`wrap__PARAMAMB_T_M`(#SemanticCastToA(#token("X","#KVariable")))))
+    #KRewrite(#SemanticCastToA(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToA(#token("X","#KVariable")),`wrap__PARAMAMB_T_M`(#SemanticCastToA(#token("X","#KVariable")))))
 	Source(paramAmb.k)
 	Location(11,8,11,29)
 [Error] Compiler: Had 1 parsing errors.

--- a/kore/src/main/java/org/kframework/utils/StringUtil.java
+++ b/kore/src/main/java/org/kframework/utils/StringUtil.java
@@ -411,14 +411,18 @@ public class StringUtil {
             return str;
         }
 
+        // keep indentation of long lines (like term ambiguities)
+        int firstChar = 0;
+        while (str.charAt(firstChar) == ' ')
+            firstChar++;
         // scan from `col` to left
-        for (int i = col - 1; i > 0; i--) {
+        for (int i = col - 1; i > firstChar; i--) {
             if (str.charAt(i) == ' ') {
                 return str.substring(0, i) + "\n" + splitLine(str.substring(i + 1), col);
             }
         }
 
-        // we reached to beginning of the string and it contains no whitespaces before the `col`
+        // we reached the beginning of the string and it contains no whitespaces before the `col`
         // but it's longer than `col` so we should replace first space after rightmost column
         // with a newline to make it shorter
         for (int i = col; i < str.length(); i++) {


### PR DESCRIPTION
Fixes: #1968
Note that the current behavior matches that of `org.apache.commons.text.WordUtils.wrap()`
This is a non standard change. Looks better though.

Output looks like this:
```
[Error] Inner Parser: Parsing ambiguity.
1: syntax Exp ::= Exp "+" Exp
    `_+__TEST-SYNTAX_Exp_Exp_Exp`(`_+__TEST-SYNTAX_Exp_Exp_Exp`(#token("1","Int"),#token("2","Int")),#token("3","Int"))
2: syntax Exp ::= Exp "+" Exp
    `_+__TEST-SYNTAX_Exp_Exp_Exp`(#token("1","Int"),`_+__TEST-SYNTAX_Exp_Exp_Exp`(#token("2","Int"),#token("3","Int")))
	Source(/home/radu/work/test/./1.test)
	Location(1,1,1,10)
```
And if your term contains strings with spaces, then something like this:
```
[Error] Inner Parser: Parsing ambiguity.
1: syntax Exp ::= Exp "+" Exp
    `_+__TEST-SYNTAX_Exp_Exp_Exp`(#token("1","Int"),`_+__TEST-SYNTAX_Exp_Exp_Exp`(#token("2","Int"),#token("\"
abc \"","String")))
2: syntax Exp ::= Exp "+" Exp
    `_+__TEST-SYNTAX_Exp_Exp_Exp`(`_+__TEST-SYNTAX_Exp_Exp_Exp`(#token("1","Int"),#token("2","Int")),#token("\"
abc \"","String"))
	Source(/home/radu/work/test/./1.test)
	Location(1,1,1,16)
```
Thoughts?