### PR TITLE
Force mvn to use en_US locale for tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,13 @@
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-	  <version>2.17</version>
+          <version>2.17</version>
+          <configuration>
+            <environmentVariables>
+              <!-- forcing en_US locale because of decimal separator in tests -->
+              <LC_NUMERIC>en_US.UTF-8</LC_NUMERIC>
+            </environmentVariables>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>


### PR DESCRIPTION
This would make some float tests fail because of the decimal separator
Fixes: #1969