### PR TITLE
Exclude simplification rules in concrete backend

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -10,7 +10,6 @@ import org.kframework.builtin.Sorts;
 import org.kframework.compile.*;
 import org.kframework.definition.*;
 import org.kframework.definition.Module;
-import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.Kompile;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.ADT;
@@ -95,7 +94,7 @@ public class JavaBackend extends AbstractBackend {
                 .andThen(DefinitionTransformer.from(new GenerateSortProjections(kompileOptions.coverage)::gen, "adding sort projections"))
                 .andThen(d2 -> {
                   ResolveFunctionWithConfig transformer = new ResolveFunctionWithConfig(d2, false);
-                  return DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(transformer, m, files, kem, kompileOptions, false, true).expand(s), "expand macros").apply(d2);
+                  return DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(transformer, m, files, kem, kompileOptions, false).expand(s), "expand macros").apply(d2);
                 })
                 .andThen(DefinitionTransformer.fromSentenceTransformer(new NormalizeAssoc(KORE.c()), "normalize assoc"))
                 .andThen(convertDataStructureToLookup)
@@ -107,7 +106,7 @@ public class JavaBackend extends AbstractBackend {
                 .andThen(DefinitionTransformer.fromSentenceTransformer(JavaBackend::markSingleVariables, "mark single variables"))
                 .andThen(DefinitionTransformer.from(new AssocCommToAssoc(), "convert AC matching to A matching"))
                 .andThen(DefinitionTransformer.from(new MergeRules(MAIN_AUTOMATON, Att.TOP_RULE()), "merge regular rules into one rule with or clauses"))
-                .apply(Kompile.defaultSteps(kompileOptions, kem, files, true).apply(d));
+                .apply(Kompile.defaultSteps(kompileOptions, kem, files).apply(d));
              // .andThen(KoreToMiniToKore::apply) // for serialization/deserialization test
     }
 
@@ -126,7 +125,7 @@ public class JavaBackend extends AbstractBackend {
                 .andThen(ModuleTransformer.from(new GenerateSortProjections(false)::gen, "adding sort projections"))
                 .andThen(m2 -> {
                   ResolveFunctionWithConfig transformer = new ResolveFunctionWithConfig(m2, false);
-                  return ModuleTransformer.fromSentenceTransformer((mod, s) -> new ExpandMacros(transformer, mod, files, kem, kompileOptions, false, true).expand(s), "expand macros").apply(m2);
+                  return ModuleTransformer.fromSentenceTransformer((mod, s) -> new ExpandMacros(transformer, mod, files, kem, kompileOptions, false).expand(s), "expand macros").apply(m2);
                 })
                 .andThen(AddImplicitComputationCell::transformModule)
                 .andThen(ConcretizeCells::transformModule)

--- a/k-distribution/tests/regression-new/checks/checkExcludeSimplification.k
+++ b/k-distribution/tests/regression-new/checks/checkExcludeSimplification.k
@@ -1,0 +1,13 @@
+module CHECKEXCLUDESIMPLIFICATION-SYNTAX
+endmodule
+
+module CHECKEXCLUDESIMPLIFICATION
+  imports CHECKEXCLUDESIMPLIFICATION-SYNTAX
+  imports INT
+
+syntax Int ::= f(Int)  [function, functional]
+syntax Int ::= g(Int)  [function, functional]
+
+rule g(f(X)) => X [simplification]
+
+endmodule

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -3,7 +3,6 @@ package org.kframework.backend.kore;
 
 import com.google.inject.Inject;
 import org.apache.commons.io.FilenameUtils;
-import org.kframework.attributes.Att;
 import org.kframework.compile.AbstractBackend;
 import org.kframework.compile.AddCoolLikeAtt;
 import org.kframework.compile.AddImplicitComputationCell;
@@ -140,7 +139,7 @@ public class KoreBackend extends AbstractBackend {
         Function1<Definition, Definition> addCoolLikeAtt = d -> DefinitionTransformer.fromSentenceTransformer(new AddCoolLikeAtt(d.mainModule())::add, "add cool-like attribute").apply(d);
         Function1<Definition, Definition> expandMacros = d -> {
           ResolveFunctionWithConfig transformer = new ResolveFunctionWithConfig(d, true);
-          return DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(transformer, m, files, kem, kompileOptions, false, excludedModuleTags().contains(Att.CONCRETE())).expand(s), "expand macros").apply(d);
+          return DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(transformer, m, files, kem, kompileOptions, false).expand(s), "expand macros").apply(d);
         };
         DefinitionTransformer constantFolding = DefinitionTransformer.fromSentenceTransformer(new ConstantFolding()::fold, "constant expression folding");
         Function1<Definition, Definition> resolveFreshConstants = d -> DefinitionTransformer.from(m -> GeneratedTopFormat.resolve(new ResolveFreshConstants(d, true).resolve(m)), "resolving !Var variables").apply(d);
@@ -194,7 +193,7 @@ public class KoreBackend extends AbstractBackend {
                 "resolving semantic casts");
         Function1<Module, Module> expandMacros = m -> {
           ResolveFunctionWithConfig transformer = new ResolveFunctionWithConfig(m, true);
-          return ModuleTransformer.fromSentenceTransformer((m2, s) -> new ExpandMacros(transformer, m2, files, kem, kompileOptions, false, true).expand(s), "expand macros").apply(m);
+          return ModuleTransformer.fromSentenceTransformer((m2, s) -> new ExpandMacros(transformer, m2, files, kem, kompileOptions, false).expand(s), "expand macros").apply(m);
         };
         ModuleTransformer subsortKItem = ModuleTransformer.from(Kompile::subsortKItem, "subsort all sorts to KItem");
         ModuleTransformer addImplicitComputationCell = ModuleTransformer.fromSentenceTransformer(

--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -66,29 +66,27 @@ public class ExpandMacros {
     private final PrintWriter coverage;
     private final FileChannel channel;
     private final boolean reverse;
-    private final boolean isSymbolic;
     private final ResolveFunctionWithConfig transformer;
     private final KompileOptions kompileOptions;
     private final KExceptionManager kem;
 
-    public static ExpandMacros fromMainModule(Module mod, FileUtil files, KExceptionManager kem, KompileOptions kompileOptions, boolean reverse, boolean isSymbolic) {
-        return new ExpandMacros(mod, files, kem, kompileOptions, reverse, true, isSymbolic);
+    public static ExpandMacros fromMainModule(Module mod, FileUtil files, KExceptionManager kem, KompileOptions kompileOptions, boolean reverse) {
+        return new ExpandMacros(mod, files, kem, kompileOptions, reverse, true);
     }
 
     public static ExpandMacros forNonSentences(Module mod, FileUtil files, KompileOptions kompileOptions, boolean reverse) {
-        return new ExpandMacros(mod, files, null, kompileOptions, reverse, false, true);
+        return new ExpandMacros(mod, files, null, kompileOptions, reverse, false);
     }
 
-    private ExpandMacros(Module mod, FileUtil files, KExceptionManager kem, KompileOptions kompileOptions, boolean reverse, boolean sentences, boolean isSymbolic) {
-        this(sentences ? new ResolveFunctionWithConfig(mod, kompileOptions.isKore()) : null, mod, files, kem, kompileOptions, reverse, isSymbolic);
+    private ExpandMacros(Module mod, FileUtil files, KExceptionManager kem, KompileOptions kompileOptions, boolean reverse, boolean sentences) {
+        this(sentences ? new ResolveFunctionWithConfig(mod, kompileOptions.isKore()) : null, mod, files, kem, kompileOptions, reverse);
     }
 
-    public ExpandMacros(ResolveFunctionWithConfig transformer, Module mod, FileUtil files, KExceptionManager kem, KompileOptions kompileOptions, boolean reverse, boolean isSymbolic) {
+    public ExpandMacros(ResolveFunctionWithConfig transformer, Module mod, FileUtil files, KExceptionManager kem, KompileOptions kompileOptions, boolean reverse) {
         this.mod = mod;
         this.reverse = reverse;
         this.cover = kompileOptions.coverage;
         this.kompileOptions = kompileOptions;
-        this.isSymbolic = isSymbolic;
         this.kem = kem;
         files.resolveKompiled(".").mkdirs();
         List<Rule> allMacros = stream(mod.rules()).filter(r -> isMacro(r.att(), reverse)).sorted(Comparator.comparingInt(r -> ModuleToKORE.getPriority(r.att()))).collect(Collectors.toList());
@@ -178,7 +176,7 @@ public class ExpandMacros {
 
     private Sentence check(Sentence s) {
         Set<KEMException> errors = new HashSet<>();
-        new CheckFunctions(errors, mod, isSymbolic).check(s);
+        new CheckFunctions(errors, mod).check(s);
         if (!errors.isEmpty()) {
           kem.addAllKException(errors.stream().map(e -> e.exception).collect(Collectors.toList()));
           throw KEMException.compilerError("Had " + errors.size() + " structural errors after macro expansion.");

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
@@ -35,8 +35,8 @@ public class CheckFunctions {
         if (sentence instanceof Rule) {
             Rule rl = (Rule) sentence;
             checkFuncAtt(rl);
-            if (!(isSymbolic && rl.att().contains(Att.SIMPLIFICATION())))
-                // functions are allowed on the LHS of simplification rules on the symbolic engines
+            if (!rl.att().contains(Att.SIMPLIFICATION()))
+                // functions are allowed on the LHS of simplification rules
                 check(rl.body());
         } else if (sentence instanceof Claim) {
             // functions are allowed on LHS of claims

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
@@ -8,7 +8,6 @@ import org.kframework.definition.Context;
 import org.kframework.definition.ContextAlias;
 import org.kframework.definition.Module;
 import org.kframework.definition.Rule;
-import org.kframework.definition.RuleOrClaim;
 import org.kframework.definition.Sentence;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
@@ -23,12 +22,10 @@ import java.util.Set;
 public class CheckFunctions {
     private final Set<KEMException> errors;
     private final Module m;
-    private final boolean isSymbolic;
 
-    public CheckFunctions(Set<KEMException> errors, Module m, boolean isSymbolic) {
+    public CheckFunctions(Set<KEMException> errors, Module m) {
         this.errors = errors;
         this.m = m;
-        this.isSymbolic = isSymbolic;
     }
 
     public void check(Sentence sentence) {

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -198,6 +198,7 @@ public class DefinitionParsing {
         Definition trimmed = Definition(parsedDefinition.mainModule(), modules.collect(Collections.toSet()),
                 parsedDefinition.att());
         trimmed = Kompile.excludeModulesByTag(excludedModuleTags).apply(trimmed);
+        trimmed = Kompile.excludeSentencesByBackend(excludedModuleTags.contains(Att.CONCRETE())).apply(trimmed);
         sw.printIntermediate("Outer parsing [" + trimmed.entryModules().size() + " modules]");
         Definition afterResolvingConfigBubbles = resolveConfigBubbles(trimmed, parsedDefinition.getModule("DEFAULT-CONFIGURATION").get());
         sw.printIntermediate("Parse configurations [" + parsedBubbles.get() + "/" + (parsedBubbles.get() + cachedBubbles.get()) + " declarations]");

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -198,7 +198,6 @@ public class DefinitionParsing {
         Definition trimmed = Definition(parsedDefinition.mainModule(), modules.collect(Collections.toSet()),
                 parsedDefinition.att());
         trimmed = Kompile.excludeModulesByTag(excludedModuleTags).apply(trimmed);
-        trimmed = Kompile.excludeSentencesByBackend(excludedModuleTags.contains(Att.CONCRETE())).apply(trimmed);
         sw.printIntermediate("Outer parsing [" + trimmed.entryModules().size() + " modules]");
         Definition afterResolvingConfigBubbles = resolveConfigBubbles(trimmed, parsedDefinition.getModule("DEFAULT-CONFIGURATION").get());
         sw.printIntermediate("Parse configurations [" + parsedBubbles.get() + "/" + (parsedBubbles.get() + cachedBubbles.get()) + " declarations]");

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -236,7 +236,7 @@ public class Kompile {
         return dt.andThen(d -> Definition(d.mainModule(), immutable(stream(d.entryModules()).filter(mod -> excludedModuleTags.stream().noneMatch(tag -> mod.att().contains(tag))).collect(Collectors.toSet())), d.att()));
     }
 
-    public static Function<Definition, Definition> defaultSteps(KompileOptions kompileOptions, KExceptionManager kem, FileUtil files, boolean isSymbolic) {
+    public static Function<Definition, Definition> defaultSteps(KompileOptions kompileOptions, KExceptionManager kem, FileUtil files) {
         Function1<Definition, Definition> resolveStrict = d -> DefinitionTransformer.from(new ResolveStrict(kompileOptions, d)::resolve, "resolving strict and seqstrict attributes").apply(d);
         DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.experimental.transition), EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION))::resolve, "resolving heat and cool attributes");
         DefinitionTransformer resolveAnonVars = DefinitionTransformer.fromSentenceTransformer(new ResolveAnonVar()::resolve, "resolving \"_\" vars");
@@ -250,7 +250,7 @@ public class Kompile {
         DefinitionTransformer subsortKItem = DefinitionTransformer.from(Kompile::subsortKItem, "subsort all sorts to KItem");
         Function1<Definition, Definition> expandMacros = d -> {
           ResolveFunctionWithConfig transformer = new ResolveFunctionWithConfig(d, false);
-          return DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(transformer, m, files, kem, kompileOptions, false, isSymbolic).expand(s), "expand macros").apply(d);
+          return DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(transformer, m, files, kem, kompileOptions, false).expand(s), "expand macros").apply(d);
         };
         GenerateCoverage cov = new GenerateCoverage(kompileOptions.coverage, files);
         Function1<Definition, Definition> genCoverage = d -> DefinitionTransformer.fromRuleBodyTransformerWithRule((r, body) -> cov.gen(r, body, d.mainModule()), "generate coverage instrumentation").apply(d);
@@ -386,7 +386,7 @@ public class Kompile {
         stream(modules).forEach(m -> stream(m.localSentences()).forEach(new CheckK(errors)::check));
 
         stream(modules).forEach(m -> stream(m.localSentences()).forEach(
-              new CheckFunctions(errors, m, isSymbolic)::check));
+              new CheckFunctions(errors, m)::check));
 
         stream(modules).forEach(m -> stream(m.localSentences()).forEach(new CheckAnonymous(errors, m, kem)::check));
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -236,16 +236,6 @@ public class Kompile {
         return dt.andThen(d -> Definition(d.mainModule(), immutable(stream(d.entryModules()).filter(mod -> excludedModuleTags.stream().noneMatch(tag -> mod.att().contains(tag))).collect(Collectors.toSet())), d.att()));
     }
 
-    public static Function1<Definition, Definition> excludeSentencesByBackend(boolean isSymbolic) {
-        DefinitionTransformer dt = DefinitionTransformer.from(m -> {
-            scala.collection.Set<Sentence> snt = m.localSentences().filter(s -> !(!isSymbolic && s.att().contains(Att.SIMPLIFICATION()))).toSet();
-            if (snt.size() != m.localSentences().size())
-                return Module(m.name(), m.imports(), snt, m.att());
-            return m;
-        }, "exclude backend specific rules");
-        return dt.andThen(dt);
-    }
-
     public static Function<Definition, Definition> defaultSteps(KompileOptions kompileOptions, KExceptionManager kem, FileUtil files, boolean isSymbolic) {
         Function1<Definition, Definition> resolveStrict = d -> DefinitionTransformer.from(new ResolveStrict(kompileOptions, d)::resolve, "resolving strict and seqstrict attributes").apply(d);
         DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.experimental.transition), EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION))::resolve, "resolving heat and cool attributes");

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -236,6 +236,16 @@ public class Kompile {
         return dt.andThen(d -> Definition(d.mainModule(), immutable(stream(d.entryModules()).filter(mod -> excludedModuleTags.stream().noneMatch(tag -> mod.att().contains(tag))).collect(Collectors.toSet())), d.att()));
     }
 
+    public static Function1<Definition, Definition> excludeSentencesByBackend(boolean isSymbolic) {
+        DefinitionTransformer dt = DefinitionTransformer.from(m -> {
+            scala.collection.Set<Sentence> snt = m.localSentences().filter(s -> !(!isSymbolic && s.att().contains(Att.SIMPLIFICATION()))).toSet();
+            if (snt.size() != m.localSentences().size())
+                return Module(m.name(), m.imports(), snt, m.att());
+            return m;
+        }, "exclude backend specific rules");
+        return dt.andThen(dt);
+    }
+
     public static Function<Definition, Definition> defaultSteps(KompileOptions kompileOptions, KExceptionManager kem, FileUtil files, boolean isSymbolic) {
         Function1<Definition, Definition> resolveStrict = d -> DefinitionTransformer.from(new ResolveStrict(kompileOptions, d)::resolve, "resolving strict and seqstrict attributes").apply(d);
         DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.experimental.transition), EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION))::resolve, "resolving heat and cool attributes");

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
@@ -219,7 +219,7 @@ public class DefinitionToOcaml implements Serializable {
         constants = serialized.constants;
         realStepFunctions = serialized.realStepFunctions;
         if (serialized.expandMacros == null) {
-            serialized.expandMacros = ExpandMacros.fromMainModule(def.executionModule(), files, kem, kompileOptions, false, false);
+            serialized.expandMacros = ExpandMacros.fromMainModule(def.executionModule(), files, kem, kompileOptions, false);
         }
         if (serialized.convertDataStructure == null) {
             serialized.convertDataStructure = new ConvertDataStructureToLookup(def.executionModule(), true);
@@ -244,7 +244,7 @@ public class DefinitionToOcaml implements Serializable {
         this.convertDataStructure = new ConvertDataStructureToLookup(def.executionModule(), true);
         ModuleTransformer convertLookups = ModuleTransformer.fromSentenceTransformer(convertDataStructure::convert, "convert data structures to lookups");
         ModuleTransformer liftToKSequence = ModuleTransformer.fromSentenceTransformer(new LiftToKSequence()::lift, "lift K into KSequence");
-        this.expandMacros = ExpandMacros.fromMainModule(def.executionModule(), files, kem, kompileOptions, false, false);
+        this.expandMacros = ExpandMacros.fromMainModule(def.executionModule(), files, kem, kompileOptions, false);
         ModuleTransformer expandMacros = ModuleTransformer.fromSentenceTransformer(this.expandMacros::expand, "expand macro rules");
         ModuleTransformer deconstructInts = ModuleTransformer.fromSentenceTransformer(new DeconstructIntegerAndFloatLiterals()::convert, "remove matches on integer literals in left hand side");
         this.threadCellExists = containsThreadCell(def);

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlBackend.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/OcamlBackend.java
@@ -165,7 +165,7 @@ public class OcamlBackend extends AbstractBackend {
 
     @Override
     public Function<Definition, Definition> steps() {
-        return Kompile.defaultSteps(kompileOptions, kem, files, false);
+        return Kompile.defaultSteps(kompileOptions, kem, files);
     }
 
     @Override


### PR DESCRIPTION
Fixes: #1940
Exclude sentences depending on backend type before parsing starts

I'm not sure if there was a step to exclude simplification rules for concrete backends. If I missed it please point it out.
The best place is before parsing anyway.