### PR TITLE
Parse configs in parallel

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -283,6 +283,10 @@ public class DefinitionParsing {
         RuleGrammarGenerator gen = new RuleGrammarGenerator(def);
 
         // parse config bubbles in parallel
+        // step 1 - use scala parallel streams to generate parsers
+        // step 2 - use java parallel streams to parse sentences
+        // this avoids creation of extra (costly) threads at the cost
+        // of a small thread contention between the two thread pools
         Map<String, Module> parsed = defWithCaches.parMap(m -> {
             if (stream(m.localSentences()).noneMatch(s -> s instanceof Bubble && ((Bubble) s).sentenceType().equals(configuration)))
                 return m;


### PR DESCRIPTION
Fixes: #1867
The most efficient way is with nested parallel streams

There is a slight speed improvement. I'm including the config parsing time reported by kompile -v
EVM: 1.0s, down from 1.6s (3 configs)
Algorand: 6.1s, down from 8.6s

I've tried creating FutureTasks directly with the exact dependencies to send to the ThreadPool, but that made the code look a lot uglier and no speed improvement.

This doesn't entirely fix the problem with extra scanners being generated, but I'm fine with that. The extra scanners are not that expensive anyway. Here is the output for a simple test file:
First time
```
Outer parsing [58 modules]                                   =  0.728s
New scanner: TEST-CONFIG-CELLS                               =  0.138s
New scanner: STDIN-STREAM-CONFIG-CELLS                       =  0.211s
New scanner: STDOUT-STREAM-CONFIG-CELLS                      =  0.206s
Parse configurations [3/3 declarations]                      =  0.452s
New scanner: TEST-RULE-CELLS                                 =  0.121s
New scanner: STRING-KORE-RULE-CELLS                          =  0.197s
New scanner: STRING-COMMON-RULE-CELLS                        =  0.195s
New scanner: K-IO-RULE-CELLS                                 =  0.281s
New scanner: STDOUT-STREAM-RULE-CELLS                        =  0.285s
New scanner: STDIN-STREAM-RULE-CELLS                         =  0.311s
Parse rules [101/101 rules]                                  =  0.575s
```
second time:
```
Outer parsing [58 modules]                                   =  0.750s
Parse configurations [0/3 declarations]                      =  0.263s
New scanner: TEST-RULE-CELLS                                 =  0.121s
Parse rules [0/101 rules]                                    =  0.251s
```
