### PR TITLE
Attributes have restricted value type

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -951,7 +951,8 @@ public class ModuleToKORE {
         if (ruleInfo.isEquation) {
             assertNoExistentials(rule, existentials);
             sb.append("  axiom{R");
-            Option<Set> sortParams = rule.att().getOption("sortParams", Set.class);
+            Option<Sort> sortParamsWrapper = rule.att().getOption("sortParams", Sort.class);
+            Option<Set<String>> sortParams = sortParamsWrapper.map(s -> stream(s.params()).map(sort -> sort.name()).collect(Collectors.toSet()));
             if (sortParams.nonEmpty()) {
                 for (Object sortParamName : sortParams.get())
                     sb.append("," + sortParamName);
@@ -1191,7 +1192,8 @@ public class ModuleToKORE {
         } else {
             assertNoExistentials(rule, existentials);
             sb.append("  axiom{R");
-            Option<Set> sortParams = rule.att().getOption("sortParams", Set.class);
+            Option<Sort> sortParamsWrapper = rule.att().getOption("sortParams", Sort.class);
+            Option<Set<String>> sortParams = sortParamsWrapper.map(s -> stream(s.params()).map(sort -> sort.name()).collect(Collectors.toSet()));
             if (sortParams.nonEmpty()) {
                 for (Object sortParamName : sortParams.get())
                     sb.append("," + sortParamName);

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -1,6 +1,7 @@
 // Copyright (c) 2018-2019 K Team. All Rights Reserved.
 package org.kframework.compile;
 
+import org.kframework.Collections;
 import org.kframework.attributes.Att;
 import org.kframework.attributes.HasLocation;
 import org.kframework.builtin.Sorts;
@@ -71,7 +72,7 @@ public class AddSortInjections {
         K ensures = internalAddSortInjections(roc.ensures(), Sorts.Bool());
         Att att = roc.att();
         if (!sortParams.isEmpty()) {
-            att = att.add("sortParams", Set.class, new HashSet<>(sortParams));
+            att = att.add("sortParams", Sort.class, Sort("", sortParams.stream().map(s -> Sort(s)).collect(Collections.toList())));
         }
         return roc.newInstance(body, requires, ensures, att);
     }

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -476,8 +476,8 @@ public class DefinitionParsing {
         try (ParseInModule parser = RuleGrammarGenerator
                 .getCombinedGrammar(gen.getRuleGrammar(compiledDef.executionModule()), isStrict, profileRules, files)) {
             java.util.Set<K> res = parseBubble(parser, new HashMap<>(),
-                    new Bubble(rule, contents, Att().add("contentStartLine", Integer.class, 1)
-                            .add("contentStartColumn", Integer.class, 1).add(Source.class, source)))
+                    new Bubble(rule, contents, Att().add("contentStartLine", 1)
+                            .add("contentStartColumn", 1).add(Source.class, source)))
                     .collect(Collectors.toSet());
             if (!errors.isEmpty()) {
                 throw errors.iterator().next();

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -115,8 +115,8 @@ public class KILtoKORE extends KILTransformation<Object> {
     public org.kframework.definition.Bubble apply(StringSentence sentence) {
         org.kframework.attributes.Att attrs =
             convertAttributes(sentence)
-            .add("contentStartLine", Integer.class, sentence.getContentStartLine())
-            .add("contentStartColumn", Integer.class, sentence.getContentStartColumn());
+            .add("contentStartLine", sentence.getContentStartLine())
+            .add("contentStartColumn", sentence.getContentStartColumn());
 
         String label = sentence.getLabel();
         if (!label.isEmpty()) {

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -5,6 +5,14 @@ import java.util.Optional
 import org.kframework.Collections._
 import scala.collection.Set
 
+/**
+ * Marker class for objects that can be stored as the value of an attribute.
+ *
+ * So far this trait implements no methods, but in the future it may
+ * include some methods relating to serialization/deserialization that
+ * all inheritors must implement. It may depend on what serialization library
+ * we choose to use going forward.
+ */
 trait AttValue
 
 /**

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -3,6 +3,7 @@ package org.kframework.attributes
 import java.util.Optional
 
 import org.kframework.Collections._
+import scala.collection.Set
 
 trait AttValue
 
@@ -117,6 +118,13 @@ object Att {
 
   def from(thatAtt: java.util.Map[String, String]): Att =
     Att(immutable(thatAtt).map { case (k, v) => ((k, Att.stringClassName), v) }.toMap)
+
+  def mergeAttributes(p: Set[Att]) = {
+    val union = p.flatMap(_.att)
+    val attMap = union.groupBy({ case ((name, _), _) => name})
+    Att(union.filter { key => attMap(key._1._1).size == 1 }.toMap)
+  }
+
 }
 
 trait AttributesToString {

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -9,7 +9,7 @@ trait AttValue
 /**
  * 2nd value in key is always a class name. For a key of type (s1, s2), value must be of type class.forName(s2).
  */
-case class Att(att: Map[(String, String), Any]) extends AttributesToString {
+case class Att private (att: Map[(String, String), Any]) extends AttributesToString {
 
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Att.this)
 
@@ -33,9 +33,11 @@ case class Att(att: Map[(String, String), Any]) extends AttributesToString {
   def add(key: String): Att = add(key, "")
   def add(key: String, value: String): Att = add(key, Att.stringClassName, value)
   def add(key: String, value: Int): Att = add(key, Att.intClassName, value)
-  def add[T](key: Class[T], value: T): Att = add(key.getName, key.getName, value)
-  def add[T](key: String, cls: Class[T], value: T): Att = add(key, cls.getName, value)
-  private def add[T](key: String, clsStr: String, value: T): Att = Att(att + ((key, clsStr) -> value))
+  def add[T <: AttValue](key: Class[T], value: T): Att = add(key.getName, key.getName, value)
+  def add[T <: AttValue](key: String, cls: Class[T], value: T): Att = add(key, cls.getName, value)
+  private def add[T <: AttValue](key: String, clsStr: String, value: T): Att = Att(att + ((key, clsStr) -> value))
+  private def add(key: String, clsStr: String, value: String): Att = Att(att + ((key, clsStr) -> value))
+  private def add(key: String, clsStr: String, value: Int): Att = Att(att + ((key, clsStr) -> value))
   def addAll(thatAtt: Att) = Att(att ++ thatAtt.att)
 
   def remove(key: String): Att = remove(key, Att.stringClassName)

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -30,6 +30,7 @@ case class Att(att: Map[(String, String), Any]) extends AttributesToString {
 
   def add(key: String): Att = add(key, "")
   def add(key: String, value: String): Att = add(key, Att.stringClassName, value)
+  def add(key: String, value: Int): Att = add(key, Att.intClassName, value)
   def add[T](key: Class[T], value: T): Att = add(key.getName, key.getName, value)
   def add[T](key: String, cls: Class[T], value: T): Att = add(key, cls.getName, value)
   private def add[T](key: String, clsStr: String, value: T): Att = Att(att + ((key, clsStr) -> value))
@@ -108,6 +109,7 @@ object Att {
   val UNIQUE_ID = "UNIQUE_ID"
 
   private val stringClassName = classOf[String].getName
+  private val intClassName = classOf[java.lang.Integer].getName
 
   def from(thatAtt: java.util.Map[String, String]): Att =
     Att(immutable(thatAtt).map { case (k, v) => ((k, Att.stringClassName), v) }.toMap)

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -4,6 +4,8 @@ import java.util.Optional
 
 import org.kframework.Collections._
 
+trait AttValue
+
 /**
  * 2nd value in key is always a class name. For a key of type (s1, s2), value must be of type class.forName(s2).
  */

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -10,9 +10,13 @@ trait AttValue
 /**
  * 2nd value in key is always a class name. For a key of type (s1, s2), value must be of type class.forName(s2).
  */
-case class Att private (att: Map[(String, String), Any]) extends AttributesToString {
+class Att private (val att: Map[(String, String), Any]) extends AttributesToString with Serializable {
 
-  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Att.this)
+  override lazy val hashCode: Int = att.hashCode()
+  override def equals(that: Any) = that match {
+    case a: Att => a.att == att
+    case _ => false
+  }
 
   def contains(cls: Class[_]): Boolean = att.contains((cls.getName, cls.getName))
   def contains(key: String): Boolean = att.contains((key, Att.stringClassName))
@@ -118,6 +122,10 @@ object Att {
 
   def from(thatAtt: java.util.Map[String, String]): Att =
     Att(immutable(thatAtt).map { case (k, v) => ((k, Att.stringClassName), v) }.toMap)
+
+  private def apply(thatAtt: Map[(String, String), Any]) = {
+    new Att(thatAtt)
+  }
 
   def mergeAttributes(p: Set[Att]) = {
     val union = p.flatMap(_.att)

--- a/kore/src/main/scala/org/kframework/attributes/Location.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Location.scala
@@ -1,10 +1,10 @@
 package org.kframework.attributes
 
-case class Location(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int) extends Comparable[Location] {
+case class Location(startLine: Int, startColumn: Int, endLine: Int, endColumn: Int) extends Comparable[Location] with AttValue {
   import scala.math.Ordered.orderingToOrdered
   def compareTo(that: Location): Int = (startLine, startColumn, endLine, endColumn) compare (that.startLine, that.startColumn, that.endLine, that.endColumn)
 }
 
-case class Source(source: String) extends Comparable[Source] {
+case class Source(source: String) extends Comparable[Source] with AttValue {
   def compareTo(that: Source): Int = this.source.compareTo(that.source)
 }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -7,7 +7,7 @@ import javax.annotation.Nonnull
 
 import dk.brics.automaton.{BasicAutomata, RegExp, RunAutomaton, SpecialOperations}
 import org.kframework.POSet
-import org.kframework.attributes.{Att, HasLocation, Location, Source}
+import org.kframework.attributes.{Att, AttValue, HasLocation, Location, Source}
 import org.kframework.definition.Constructors._
 import org.kframework.kore.Unapply.{KApply, KLabel}
 import org.kframework.kore
@@ -39,7 +39,7 @@ case class Definition(
                        mainModule: Module,
                        entryModules: Set[Module],
                        att: Att)
-  extends DefinitionToString with OuterKORE {
+  extends DefinitionToString with OuterKORE with AttValue {
 
   private def allModules(m: Module): Set[Module] = m.importedModules + m
 
@@ -91,7 +91,7 @@ object Module {
 }
 
 case class Module(val name: String, val imports: Set[Module], localSentences: Set[Sentence], @(Nonnull@param) val att: Att = Att.empty)
-  extends ModuleToString with OuterKORE with Sorting with Serializable {
+  extends ModuleToString with OuterKORE with Sorting with Serializable with AttValue {
 
   assert(att != null)
 
@@ -356,7 +356,7 @@ trait HasAtt {
   val att: Att
 }
 
-trait Sentence extends HasLocation with HasAtt {
+trait Sentence extends HasLocation with HasAtt with AttValue {
   // marker
   val isSyntax: Boolean
   val isNonSyntax: Boolean

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -269,9 +269,7 @@ case class Module(val name: String, val imports: Set[Module], localSentences: Se
   @transient lazy val sortAttributesFor: Map[SortHead, Att] = sortDeclarationsFor mapValues {mergeAttributes(_)}
 
   private def mergeAttributes[T <: Sentence](p: Set[T]) = {
-    val union = p.flatMap(_.att.att)
-    val attMap = union.groupBy({ case ((name, _), _) => name})
-    Att(union.filter { key => attMap(key._1._1).size == 1 }.toMap)
+    Att.mergeAttributes(p.map(_.att))
   }
 
   lazy val definedSorts: Set[SortHead] = (productions filter {p => !p.isSortVariable(p.sort)} map {_.sort.head}) ++ (sortDeclarations filter { s => s.params.isEmpty } map {_.sort.head}) ++ definedInstantiations.values.flatten.flatMap(_.params).filter(_.isNat).map(_.head)

--- a/kore/src/main/scala/org/kframework/kore/Rich.scala
+++ b/kore/src/main/scala/org/kframework/kore/Rich.scala
@@ -9,13 +9,10 @@ case class Rich(theModule: Module) {
   private val module = theModule
 
   implicit class RichKApply(k: KApply) {
-    def att = k.klabel.att
   }
 
   implicit class RichKLabel(klabel: KLabel) {
     def productions = module.productionsFor(klabel)
-
-    def att: Att = Att(productions.flatMap(_.att.att).toMap)
   }
 
 }

--- a/kore/src/main/scala/org/kframework/kore/interface.scala
+++ b/kore/src/main/scala/org/kframework/kore/interface.scala
@@ -14,7 +14,7 @@ import scala.collection.JavaConverters._
  * https://github.com/kframework/k/wiki/KORE-data-structures-guide
  */
 
-trait K extends Serializable with HasLocation {
+trait K extends Serializable with HasLocation with AttValue {
   def att: Att
   override def toString = ToKast.apply(this)
 
@@ -62,7 +62,7 @@ object K {
 
 trait KItem extends K
 
-trait KLabel {
+trait KLabel extends AttValue {
   def name: String
   def params: Seq[Sort]
   override def equals(other: Any) = other match {
@@ -93,7 +93,7 @@ trait KToken extends KItem {
   def computeHashCode = sort.hashCode() * 13 + s.hashCode
 }
 
-trait Sort extends Ordered[Sort] {
+trait Sort extends Ordered[Sort] with AttValue {
   def name: String
   def params: Seq[Sort]
   override def equals(other: Any) = other match {
@@ -159,7 +159,7 @@ trait KCollection {
   def computeHashCode = items.hashCode
 }
 
-trait KList extends KCollection {
+trait KList extends KCollection with AttValue {
 }
 
 trait KApply extends KItem with KCollection {


### PR DESCRIPTION
Here we drastically restrict what can be stored in an `Att`. This should make it massively easier later on for us to switch serialization libraries.

Here's what we allow in the value of an attribute now:

* String
* int
* Source
* Location
* Definition
* Module
* Sentence
* K
* KLabel
* Sort
* KList

Here are (most of) the classes that are implicitly exposed as serialized because of the above list:
* scala.collection.Set
* Context
* ContextAlias
* Configuration
* Bubble
* Rule
* Claim
* scala.collection.Seq
* Tag
* Associativity
* Option
* Production
* ProductionItem
* NonTerminal
* RegexTerminal
* Terminal
* KToken
* SortHead
* KApply
* KSequence
* KVariable
* KAs
* KRewrite
* InjectedKLabel

I don't see any reason why we shouldn't be able to get a serialization library to work with all of these, with a bit of effort.