### PR TITLE
when building brew, update from llvm 8 to llvm 12

### DIFF
--- a/package/macos/brew-update-to-local
+++ b/package/macos/brew-update-to-local
@@ -1,6 +1,6 @@
 #!/bin/sh -exu
 package="$1" ; shift
 version="$1" ; shift
-sed -i "" -e '/install-rust/d' -e 's!^  url ".*"$!  url "file:///'$(pwd)/../$package-$version'-src.tar.gz"!' \
+sed -i "" -e 's/llvm@8/llvm@12/' -e 's!^  url ".*"$!  url "file:///'$(pwd)/../$package-$version'-src.tar.gz"!' \
        -e 's!^  sha256 ".*"$!  sha256 "'$(shasum -a 256 ../$package-$version-src.tar.gz | awk '{print $1}')'"!' \
     Formula/$package.rb


### PR DESCRIPTION
This ought to make it so that the next K release will change the llvm version associated with the homebrew package from llvm 8 to llvm 12. This should (hopefully) fix the issues with Big Sur where the version of clang used by the llvm backend can't find the C standard library.