### PR TITLE
Don't use FST serialization in `kast`

### DIFF
--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -3,12 +3,14 @@ package org.kframework.kast;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
+import org.kframework.attributes.Att;
 import org.kframework.attributes.Source;
 import org.kframework.builtin.Sorts;
-import org.kframework.compile.ExpandMacros;
+import org.kframework.definition.Definition;
 import org.kframework.definition.Module;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kore.K;
+import org.kframework.kore.Sort;
 import org.kframework.main.FrontEnd;
 import org.kframework.parser.KRead;
 import org.kframework.parser.outer.Outer;
@@ -50,7 +52,7 @@ public class KastFrontEnd extends FrontEnd {
     private final Provider<FileUtil> files;
     private final Map<String, String> env;
     private final Provider<File> kompiledDir;
-    private final Provider<CompiledDefinition> compiledDef;
+    private final Provider<Definition> kompiledDefinition;
     private final Provider<KPrint> kprint;
     private final DefinitionScope scope;
 
@@ -64,7 +66,7 @@ public class KastFrontEnd extends FrontEnd {
             @Environment Map<String, String> env,
             Provider<FileUtil> files,
             @KompiledDir Provider<File> kompiledDir,
-            Provider<CompiledDefinition> compiledDef,
+            Provider<Definition> kompiledDefinition,
             Provider<KPrint> kprint,
             DefinitionScope scope) {
         super(kem, options.global, usage, jarInfo, files);
@@ -74,7 +76,7 @@ public class KastFrontEnd extends FrontEnd {
         this.files = files;
         this.env = env;
         this.kompiledDir = kompiledDir;
-        this.compiledDef = compiledDef;
+        this.kompiledDefinition = kompiledDefinition;
         this.kprint = kprint;
         this.scope = scope;
     }
@@ -87,36 +89,35 @@ public class KastFrontEnd extends FrontEnd {
     public int run() {
         scope.enter(kompiledDir.get());
         try {
-            CompiledDefinition def = compiledDef.get();
-
             org.kframework.kore.Sort sort = options.sort;
+            Definition kompiledDefinition = this.kompiledDefinition.get();
             if (sort == null) {
                 if (env.get("KRUN_SORT") != null) {
                     sort = Outer.parseSort(env.get("KRUN_SORT"));
                 } else {
-                    sort = def.programStartSymbol;
+                    sort = Outer.parseSort(kompiledDefinition.att().get("startSymbol"));
                 }
             }
 
             Module unparsingMod;
             if (options.module == null) {
-                options.module = def.mainSyntaxModuleName();
+                options.module = kompiledDefinition.att().get(Att.SYNTAX_MODULE());
                 switch (options.input) {
                     case KORE:
-                        unparsingMod = def.languageParsingModule();
+                        unparsingMod = kompiledDefinition.getModule("LANGUAGE-PARSING").get();
                         break;
                     default:
-                        unparsingMod = def.kompiledDefinition.getModule(def.mainSyntaxModuleName()).get();
+                        unparsingMod = kompiledDefinition.getModule(options.module).get();
                 }
             } else {
-                Option<Module> maybeUnparsingMod = def.kompiledDefinition.getModule(options.module);
+                Option<Module> maybeUnparsingMod = kompiledDefinition.getModule(options.module);
                 if (maybeUnparsingMod.isEmpty()) {
                     throw KEMException.innerParserError("Module " + options.module + " not found.");
                 }
                 unparsingMod = maybeUnparsingMod.get();
             }
 
-            Option<Module> maybeMod = def.programParsingModuleFor(options.module, kem);
+            Option<Module> maybeMod = CompiledDefinition.programParsingModuleFor(kompiledDefinition, options.module, kem);
             if (maybeMod.isEmpty()) {
                 throw KEMException.innerParserError("Module " + options.module + " not found. Specify a module with -m.");
             }
@@ -128,17 +129,13 @@ public class KastFrontEnd extends FrontEnd {
             } else {
                 Reader stringToParse = options.stringToParse();
                 Source source = options.source();
-                K parsed = kread.prettyRead(parsingMod, sort, def, source, FileUtil.read(stringToParse));
-
-                if (options.expandMacros) {
-                    parsed = ExpandMacros.forNonSentences(unparsingMod, files.get(), def.kompileOptions, false).expand(parsed);
-                }
+                K parsed = kread.prettyRead(parsingMod, sort, source, FileUtil.read(stringToParse));
 
                 if (sort.equals(Sorts.K())) {
                     sort = Sorts.KItem();
                 }
 
-                kprint.get().prettyPrint(def.kompiledDefinition, unparsingMod, s -> kprint.get().outputFile(s), parsed, sort);
+                kprint.get().prettyPrint(kompiledDefinition, unparsingMod, s -> kprint.get().outputFile(s), parsed, sort);
             }
 
             sw.printTotal("Total");

--- a/kernel/src/main/java/org/kframework/kast/KastModule.java
+++ b/kernel/src/main/java/org/kframework/kast/KastModule.java
@@ -1,7 +1,9 @@
 // Copyright (c) 2014-2019 K Team. All Rights Reserved.
 package org.kframework.kast;
 
+import org.kframework.definition.Definition;
 import org.kframework.kil.loader.Context;
+import org.kframework.kompile.CompiledDefinition;
 import org.kframework.krun.KRunOptions;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
@@ -17,6 +19,8 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+
+import static org.kframework.definition.Constructors.*;
 
 public class KastModule extends AbstractModule {
 
@@ -46,5 +50,10 @@ public class KastModule extends AbstractModule {
     @Provides
     DefinitionLoadingOptions defLoadingOptions(KastOptions options) {
         return options.definitionLoading;
+    }
+
+    @Provides
+    Definition def(CompiledDefinition d) {
+      return Definition(d.kompiledDefinition.mainModule(), d.kompiledDefinition.modules(), d.kompiledDefinition.att().add("startSymbol", d.programStartSymbol.toString()));
     }
 }

--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -126,9 +126,6 @@ public final class KastOptions {
     @Parameter(names={"--module", "-m"}, description="Parse text in the specified module. Defaults to the syntax module of the definition.")
     public String module;
 
-    @Parameter(names="--expand-macros", description="Also expand macros in the parsed string.")
-    public boolean expandMacros = false;
-
     @Parameter(names={"--input", "-i"}, converter=InputModeConverter.class,
             description="How to read kast input in. <mode> is either [program|binary|kast|json|kore].")
     public InputModes input = InputModes.PROGRAM;

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -150,14 +150,14 @@ public class CompiledDefinition implements Serializable {
      * It automatically generates this module unless the user has already defined a module postfixed with
      * {@link RuleGrammarGenerator#POSTFIX}. In latter case, it uses the user-defined module.
      */
-    public Option<Module> programParsingModuleFor(String moduleName, KExceptionManager kem) {
-        RuleGrammarGenerator gen = new RuleGrammarGenerator(parsedDefinition);
+    public static Option<Module> programParsingModuleFor(Definition kompiledDefinition, String moduleName, KExceptionManager kem) {
+        RuleGrammarGenerator gen = new RuleGrammarGenerator(kompiledDefinition);
 
-        Option<Module> userProgramParsingModule = parsedDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);
+        Option<Module> userProgramParsingModule = kompiledDefinition.getModule(moduleName + RuleGrammarGenerator.POSTFIX);
         if (userProgramParsingModule.isDefined()) {
             return userProgramParsingModule;
         } else {
-            Option<Module> moduleOption = parsedDefinition.getModule(moduleName);
+            Option<Module> moduleOption = kompiledDefinition.getModule(moduleName);
             Option<Module> programParsingModuleOption = moduleOption.isDefined() ?
                     Option.apply(gen.getProgramsGrammar(moduleOption.get())) :
                     Option.empty();
@@ -173,14 +173,14 @@ public class CompiledDefinition implements Serializable {
      * @return the parsed term.
      */
 
-    public K parseSingleTerm(Module module, Sort programStartSymbol, KExceptionManager kem, String s, Source source) {
-        try (ParseInModule parseInModule = RuleGrammarGenerator.getCombinedGrammar(module, kompileOptions.strict())) {
+    public static K parseSingleTerm(Module module, Sort programStartSymbol, KExceptionManager kem, String s, Source source) {
+        try (ParseInModule parseInModule = RuleGrammarGenerator.getCombinedGrammar(module, true)) {
             Tuple2<Either<Set<KEMException>, K>, Set<KEMException>> res = parseInModule.parseString(s, programStartSymbol, source);
             kem.addAllKException(res._2().stream().map(e -> e.getKException()).collect(Collectors.toSet()));
             if (res._1().isLeft()) {
                 throw res._1().left().get().iterator().next();
             }
-            return new TreeNodesToKORE(Outer::parseSort, kompileOptions.strict()).down(res._1().right().get());
+            return new TreeNodesToKORE(Outer::parseSort, true).down(res._1().right().get());
         }
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -163,7 +163,7 @@ public class Kompile {
 
         if (kompileOptions.genBisonParser || kompileOptions.genGlrBisonParser) {
             if (def.configurationVariableDefaultSorts.containsKey("$PGM")) {
-                new KRead(kem, files, InputModes.PROGRAM).createBisonParser(def.programParsingModuleFor(def.mainSyntaxModuleName(), kem).get(), def.programStartSymbol, files.resolveKompiled("parser_PGM"), kompileOptions.genGlrBisonParser, kompileOptions.bisonFile, kompileOptions.bisonStackMaxDepth);
+                new KRead(kem, files, InputModes.PROGRAM).createBisonParser(CompiledDefinition.programParsingModuleFor(def.kompiledDefinition, def.mainSyntaxModuleName(), kem).get(), def.programStartSymbol, files.resolveKompiled("parser_PGM"), kompileOptions.genGlrBisonParser, kompileOptions.bisonFile, kompileOptions.bisonStackMaxDepth);
             }
             for (Production prod : iterable(kompiledDefinition.mainModule().productions())) {
                 if (prod.att().contains("cell") && prod.att().contains("parser")) {
@@ -175,7 +175,7 @@ public class Kompile {
                         }
                         String name = part[0];
                         String module = part[1];
-                        Option<Module> mod = def.programParsingModuleFor(module, kem);
+                        Option<Module> mod = CompiledDefinition.programParsingModuleFor(def.kompiledDefinition, module, kem);
                         if (!mod.isDefined()) {
                             throw KEMException.compilerError("Could not find module referenced by parser attribute: " + module, prod);
                         }

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -45,11 +45,11 @@ public class KRead {
         this.input = input;
     }
 
-    public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse) {
-        return prettyRead(mod, sort, def, source, stringToParse, this.input);
+    public K prettyRead(Module mod, Sort sort, Source source, String stringToParse) {
+        return prettyRead(mod, sort, source, stringToParse, this.input);
     }
 
-    public K prettyRead(Module mod, Sort sort, CompiledDefinition def, Source source, String stringToParse, InputModes inputMode) {
+    public K prettyRead(Module mod, Sort sort, Source source, String stringToParse, InputModes inputMode) {
         switch (inputMode) {
             case BINARY:
             case JSON:
@@ -58,7 +58,7 @@ public class KRead {
             case KORE:
                 return new KoreParser(mod.sortAttributesFor()).parseString(stringToParse);
             case PROGRAM:
-                return def.parseSingleTerm(mod, sort, kem, stringToParse, source);
+                return CompiledDefinition.parseSingleTerm(mod, sort, kem, stringToParse, source);
             default:
                 throw KEMException.criticalError("Unsupported input mode: " + inputMode);
         }


### PR DESCRIPTION
This is purely for testing purposes at this point; don't bother reviewing. I just want to see if it will pass CI.

Right now we're just testing the first step of the refactor, which removes references to instances of CompiledDefinition from `KastFrontEnd`. They still exist in the guice bindings. The next step is going to be to serialize the syntax of the definition, and its relevant attributes, at the end of kompile, and then try to load /that/ definition instead of the full serialized definition, and see if kast still works right in all its permutations. If that also works, then we will measure performance and see if this is a viable way to solve the serialization woes we're having, when combined with #2015 .