### PR TITLE
copy and replace parser

### DIFF
--- a/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kast/KastFrontEnd.java
@@ -32,6 +32,7 @@ import java.io.IOException;
 import java.io.Reader;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -128,7 +129,7 @@ public class KastFrontEnd extends FrontEnd {
             if (options.genParser || options.genGlrParser) {
                 kread.createBisonParser(parsingMod, sort, options.bisonOutputFile(), options.genGlrParser, options.bisonFile, options.bisonStackMaxDepth);
                 try {
-                  Files.copy(options.bisonOutputFile().toPath(), files.get().resolveKompiled("parser_" + sort.name() + "_" + options.module).toPath());
+                  Files.copy(options.bisonOutputFile().toPath(), files.get().resolveKompiled("parser_" + sort.name() + "_" + options.module).toPath(), StandardCopyOption.REPLACE_EXISTING);
                 } catch (IOException e) {}
             } else {
                 Reader stringToParse = options.stringToParse();

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -169,6 +169,7 @@ public class Kompile {
                 File linkFile = files.resolveKompiled("parser_PGM");
                 new KRead(kem, files, InputModes.PROGRAM).createBisonParser(def.programParsingModuleFor(def.mainSyntaxModuleName(), kem).get(), def.programStartSymbol, outputFile, kompileOptions.genGlrBisonParser, kompileOptions.bisonFile, kompileOptions.bisonStackMaxDepth);
                 try {
+                    linkFile.delete();
                     Files.createSymbolicLink(linkFile.toPath(), files.resolveKompiled(".").toPath().relativize(outputFile.toPath()));
                 } catch (IOException e) {
                     throw KEMException.internalError("Cannot write to kompiled directory.", e);
@@ -194,6 +195,7 @@ public class Kompile {
                         File linkFile = files.resolveKompiled("parser_" + name);
                         new KRead(kem, files, InputModes.PROGRAM).createBisonParser(mod.get(), sort, outputFile, kompileOptions.genGlrBisonParser, null, kompileOptions.bisonStackMaxDepth);
                         try {
+                            linkFile.delete();
                             Files.createSymbolicLink(linkFile.toPath(), files.resolveKompiled(".").toPath().relativize(outputFile.toPath()));
                         } catch (IOException e) {
                             throw KEMException.internalError("Cannot write to kompiled directory.", e);


### PR DESCRIPTION
This should (hopefully) fix the issue @sskeirik discovered on Mac OS where there was a regression if you compiled a bison parser that already existed.