### PR TITLE
Outer: remove redundancy in parser error message

### DIFF
--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -227,7 +227,7 @@ public class Outer {
                   sb.deleteCharAt(sb.length() - 1);
                   return sb.toString();
                 }
-              }).collect(Collectors.toList()).toString(), e, source,
+              }).collect(Collectors.toList()).toString(),  source,
             new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn));
     } catch (TokenMgrException e) {
       // TODO: report location


### PR DESCRIPTION
Consider the following files:
primay.k:

  requires "secondary.k"

  module PRIMARY

    syntax Foo ::= "bar"

  endmodule

secondary.k:

  module SECONDARY

    syntax Foo ::= | "baz"

  endmodule

When compiling primary.k, the following error message is generated:

  [Error] Outer Parser: Encountered "|".
  Was expecting one of: ["non-assoc", <STRING>, <STRING_REGEX>, "(", "left",
  "right", "List", "NeList", <UPPER_ID>, <LOWER_ID>, <NAT>, <UPPER_ID>, "List",
  "NeList", <LOWER_ID>] (ParseException: Encountered " "|" "|"" at line 3, column
  18.

  Was expecting one of:

  "non-assoc" ...
      <STRING> ...
      <STRING_REGEX> ...
      "(" ...
      "left" ...
      "right" ...
      "List" ...
      "NeList" ...
      <UPPER_ID> ...
      <LOWER_ID> ...
      <NAT> ...
      <UPPER_ID> ...
      "List" ...
      "NeList" ...
      <LOWER_ID> ...
      )
  	Source(/home/erik/samps-k/secondary.k)
  	Location(3,18,3,18)

This error message's "ParseException: ..." message is redundant. Remove
this redundancy by not passing the ParseException object when
registering the exception so that the error message looks like the
following:

  [Error] Outer Parser: Encountered "|".
  Was expecting one of: ["non-assoc", <STRING>, <STRING_REGEX>, "(", "left",
  "right", "List", "NeList", <UPPER_ID>, <LOWER_ID>, <NAT>, <UPPER_ID>, "List",
  "NeList", <LOWER_ID>]
  	Source(/home/erik/samps-k/secondary.k)
  	Location(3,18,3,18)

Signed-off-by: Erik Kaneda <erik.kaneda@runtimeverification.com>