### PR TITLE
Outer: remove redundancy in parser error message

### DIFF
--- a/k-distribution/tests/regression-new/checks/missingBar.k
+++ b/k-distribution/tests/regression-new/checks/missingBar.k
@@ -1,0 +1,9 @@
+module MISSINGBAR
+
+  syntax Foo ::= foo ()
+                 bar ()
+
+  rule foo () => bar ()
+
+endmodule
+

--- a/k-distribution/tests/regression-new/checks/missingBar.k.out
+++ b/k-distribution/tests/regression-new/checks/missingBar.k.out
@@ -1,0 +1,4 @@
+[Error] Outer Parser: Encountered <LOWER_ID>.
+Was expecting one of: ["rule", "context", "configuration", "claim", "syntax", "endmodule", "[", ">", "|"]
+	Source(missingBar.k)
+	Location(4,18,4,20)

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -228,7 +228,7 @@ public class Outer {
                   return sb.toString();
                 }
               }).collect(Collectors.toList()).toString(), e, source,
-            new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn));
+            new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn), false);
     } catch (TokenMgrException e) {
       // TODO: report location
       throw KEMException.outerParserError(e.getMessage(), e, source, null);

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KEMException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KEMException.java
@@ -116,6 +116,10 @@ public class KEMException extends RuntimeException {
         return create(ExceptionType.ERROR, KExceptionGroup.OUTER_PARSER, message, e, location, source);
     }
 
+    public static KEMException outerParserError(String message, Throwable e, Source source, Location location, boolean printException) {
+        return create(ExceptionType.ERROR, KExceptionGroup.OUTER_PARSER, message, e, location, source, printException);
+    }
+
     public static KEMException asError(KEMException warning) {
         return new KEMException(warning.exception, ExceptionType.ERROR);
     }
@@ -137,6 +141,11 @@ public class KEMException extends RuntimeException {
     private static KEMException create(ExceptionType type, KExceptionGroup group, String message,
                                        Throwable e, Location location, Source source) {
         return new KEMException(new KException(type, group, message, source, location, e));
+    }
+
+    private static KEMException create(ExceptionType type, KExceptionGroup group, String message,
+                                       Throwable e, Location location, Source source, boolean printException) {
+        return new KEMException(new KException(type, group, message, source, location, e, printException));
     }
 
     @Override

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -15,6 +15,7 @@ public class KException implements Serializable, HasLocation {
     private final Location location;
     private final String message;
     private final Throwable exception;
+    private final boolean printException;
     private StringBuilder trace = new StringBuilder();
 
     private static final Map<KExceptionGroup, String> labels;
@@ -42,7 +43,11 @@ public class KException implements Serializable, HasLocation {
     }
 
     public KException(ExceptionType type, KExceptionGroup label, String message, Source source, Location location) {
-        this(type, label, message, source, location, null);
+        this(type, label, message, source, location, null, true);
+    }
+
+    public KException(ExceptionType type, KExceptionGroup label, String message, Source source, Location location, Throwable exception) {
+        this(type, label, message, source, location, exception, true);
     }
 
     public KException(
@@ -51,7 +56,8 @@ public class KException implements Serializable, HasLocation {
             String message,
             Source source,
             Location location,
-            Throwable exception) {
+            Throwable exception,
+            boolean printException) {
         super();
         this.type = type;
         this.exceptionGroup = label;
@@ -59,6 +65,7 @@ public class KException implements Serializable, HasLocation {
         this.source = source;
         this.location = location;
         this.exception = exception;
+        this.printException = printException;
     }
 
     @Override
@@ -122,7 +129,7 @@ public class KException implements Serializable, HasLocation {
 
     public String toString(boolean verbose) {
         return "[" + (type == ExceptionType.ERROR ? "Error" : "Warning") + "] " + labels.get(exceptionGroup) + ": " + message
-                + (exception == null ? "" : " (" + exception.getClass().getSimpleName() + ": " + exception.getMessage() + ")")
+                + (exception != null && printException ? " (" + exception.getClass().getSimpleName() + ": " + exception.getMessage() + ")" : "")
                 + trace.toString() + traceTail()
                 + (source == null ? "" : "\n\t" + source)
                 + (location == null ? "" : "\n\t" + location);


### PR DESCRIPTION
Consider the following files:
primay.k:

```k
requires "secondary.k"

module PRIMARY

  syntax Foo ::= "bar"

endmodule
```

secondary.k:

```k
module SECONDARY

  syntax Foo ::= | "baz"

endmodule
```

When compiling primary.k, the following error message is generated:
```
  [Error] Outer Parser: Encountered "|".
  Was expecting one of: ["non-assoc", <STRING>, <STRING_REGEX>, "(", "left",
  "right", "List", "NeList", <UPPER_ID>, <LOWER_ID>, <NAT>, <UPPER_ID>, "List",
  "NeList", <LOWER_ID>] (ParseException: Encountered " "|" "|"" at line 3, column
  18.

  Was expecting one of:

  "non-assoc" ...
      <STRING> ...
      <STRING_REGEX> ...
      "(" ...
      "left" ...
      "right" ...
      "List" ...
      "NeList" ...
      <UPPER_ID> ...
      <LOWER_ID> ...
      <NAT> ...
      <UPPER_ID> ...
      "List" ...
      "NeList" ...
      <LOWER_ID> ...
      )
  	Source(/home/erik/samps-k/secondary.k)
  	Location(3,18,3,18)
```

This error message's "ParseException: ..." message is redundant. Remove
the redundancy by adding a boolean field to the KException class and
overloading several other methods to create KException objects that do
not print exception messages that are redundant to the actual error
messages. Doing so shortens the previous error message to look like this:
```
  [Error] Outer Parser: Encountered "|".
  Was expecting one of: ["non-assoc", <STRING>, <STRING_REGEX>, "(", "left",
  "right", "List", "NeList", <UPPER_ID>, <LOWER_ID>, <NAT>, <UPPER_ID>, "List",
  "NeList", <LOWER_ID>]
  	Source(/home/erik/samps-k/secondary.k)
  	Location(3,18,3,18)
```

Signed-off-by: Erik Kaneda <erik.kaneda@runtimeverification.com>