### PR TITLE
fix krun script to use module specified by module attribute for kparse

### DIFF
--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -478,7 +478,9 @@ else
       fi
     fi
     indirectName="declaredConfigVar_$name"
+    indirectModuleName="declaredConfigVarModule_$name"
     sortName=${!indirectName}
+    moduleName=${!indirectModuleName:-unset}
     if [ -z "${!parser_name+unset}" ]; then
       if [ "$name" = "PGM" ]; then
         if $hasArgv; then
@@ -486,8 +488,10 @@ else
         else
           parser=(kparse --directory "$dir" --module "$mainModuleName")
         fi
-      else
+      elif [ -z "${!indirectModuleName+unset}" ]; then
         parser=(kparse --sort "$sortName" --directory "$dir" --module "$mainModuleName")
+      else
+        parser=(kparse --sort "$sortName" --directory "$dir" --module "$moduleName")
       fi
     else
       parser=("${!parser_name}")

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -25,6 +25,7 @@ import org.kframework.parser.outer.Outer;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
+import org.kframework.utils.StringUtil;
 import scala.Option;
 import scala.Tuple2;
 import scala.util.Either;
@@ -125,7 +126,23 @@ public class CompiledDefinition implements Serializable {
                     }.apply(r.body());
                 });
         sb.append(arr);
-        sb.append(")");
+        sb.append(")\n");
+
+        for (Production prod : iterable(kompiledDefinition.mainModule().productions())) {
+            if (prod.att().contains("cell") && prod.att().contains("parser")) {
+                String att = prod.att().get("parser");
+                String[][] parts = StringUtil.splitTwoDimensionalAtt(att);
+                for (String[] part : parts) {
+                    if (part.length != 2) {
+                        throw KEMException.compilerError("Invalid value for parser attribute: " + att, prod);
+                    }
+                    String name = part[0];
+                    String module = part[1];
+                    sb.append("declaredConfigVarModule_" + name + "='" + module + "'\n");
+                }
+            }
+        }
+
         files.saveToKompiled("configVars.sh", sb.toString());
     }
 


### PR DESCRIPTION
by default

Currently, if you specify the`parser` attribute for a configuration variable, krun will not actually store that module and use it to perform parsing, which leads to a performance regression because we use the jit parser even though a bison parser exists. The solution is simply to record the module we are supposed to use for parsing and use it by default when we call kparse.