### PR TITLE
don't strip any kllvm libraries

### DIFF
--- a/package/debian/rules
+++ b/package/debian/rules
@@ -24,7 +24,7 @@ override_dh_auto_install:
 	DESTDIR=$(shell pwd)/debian/kframework PREFIX=/usr package/package
 
 override_dh_strip:
-	dh_strip -Xliballoc.a -Xlibarithmetic.a -XlibAST.a -Xlibconfigurationparser.a -XlibParser.a -Xlibstrings.a -Xlibmeta.a -Xlibio.a
+	dh_strip -Xliballoc.a -Xlibarithmetic.a -XlibAST.a -Xlibutil.a -XlibParser.a -Xlibcollect.a -Xlibcollections.a -Xlibjson.a -Xlibstrings.a -Xlibmeta.a -Xlibio.a
 
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )


### PR DESCRIPTION
We had a list of libraries included in the llvm backend that were supposed to be excluded from automated stripping by the debian packaging process, but it became out of date. I believe this is why the ubuntu bionic package does not correctly display configurations when you run gdb.