### PR TITLE
Remove unneeded provider

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/KompileModule.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileModule.java
@@ -3,16 +3,11 @@ package org.kframework.kompile;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
-import com.google.inject.TypeLiteral;
-import com.google.inject.multibindings.MapBinder;
 import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Named;
-import org.kframework.kprove.KProveOptions;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.main.Tool;
-import org.kframework.utils.errorsystem.KEMException;
-import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.inject.Options;
 import org.kframework.utils.inject.OuterParsingModule;
 import org.kframework.utils.inject.RequestScoped;
@@ -20,7 +15,6 @@ import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 import java.util.List;
-import java.util.Map;
 
 public class KompileModule extends AbstractModule {
 
@@ -51,10 +45,4 @@ public class KompileModule extends AbstractModule {
 
     @Provides
     OuterParsingOptions outerParsingOptions(KompileOptions options) { return options.outerParsing; }
-
-    @Provides
-    @Named("extraConcreteRuleLabels")
-    List<String> extraConcreteRuleLabels(KProveOptions options) {
-        return options.extraConcreteRuleLabels;
-    }
 }


### PR DESCRIPTION
Copy-paste error when I added kprovex.
`extraConcreteRuleLabels` is used in kprove to enhance the kompile pipeline. But when this step is applied in kompile is not needed in kprovex. It was also wrong because it was trying to extract the info from KProveOptions instead of KompileOptions.

Discovered this when I was working with @SchmErik. Now when you generate the dependency graph, you should see the KProveOptions instance disappear.