### PR TITLE
Refactor Module class to use Import class

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/GenerateSortPredicateRules.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSortPredicateRules.java
@@ -53,7 +53,7 @@ public class GenerateSortPredicateRules {
     public Module gen(Module mod) {
         this.mod = mod;
         predicateRules = stream(mod.rules()).filter(this::isPredicate).collect(Collectors.toSet());
-        return Module(mod.name(), mod.publicImports(), mod.privateImports(), (Set<Sentence>) mod.localSentences().$bar(stream(mod.allSorts())
+        return Module(mod.name(), mod.imports(), (Set<Sentence>) mod.localSentences().$bar(stream(mod.allSorts())
                 .flatMap(this::gen).collect(Collections.toSet())), mod.att());
     }
 

--- a/kernel/src/main/java/org/kframework/compile/GenerateSortPredicateSyntax.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSortPredicateSyntax.java
@@ -29,7 +29,7 @@ public class GenerateSortPredicateSyntax {
         if (!res.isEmpty()) {
             res.add(SyntaxSort(Seq(), Sorts.K()));
         }
-        return Module(mod.name(), mod.publicImports(), mod.privateImports(), (scala.collection.Set<Sentence>) mod.localSentences().$bar(immutable(res)), mod.att());
+        return Module(mod.name(), mod.imports(), (scala.collection.Set<Sentence>) mod.localSentences().$bar(immutable(res)), mod.att());
     }
 
     public Set<Sentence> gen(Module mod, Sort sort) {

--- a/kernel/src/main/java/org/kframework/compile/GenerateSortProjections.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSortProjections.java
@@ -42,7 +42,7 @@ public class GenerateSortProjections {
 
     public Module gen(Module mod) {
         this.mod = mod;
-        return Module(mod.name(), mod.publicImports(), mod.privateImports(), (Set<Sentence>) mod.localSentences().$bar(
+        return Module(mod.name(), mod.imports(), (Set<Sentence>) mod.localSentences().$bar(
               Stream.concat(stream(mod.allSorts()).flatMap(this::gen),
                 stream(mod.localProductions()).flatMap(this::gen)).collect(Collections.toSet())), mod.att());
     }

--- a/kernel/src/main/java/org/kframework/compile/GeneratedTopFormat.java
+++ b/kernel/src/main/java/org/kframework/compile/GeneratedTopFormat.java
@@ -51,7 +51,7 @@ public class GeneratedTopFormat {
 
     public static Module resolve(Module m) {
         Set<Sentence> newSentences = JavaConverters.asScalaSet(stream(m.localSentences()).map(s -> s instanceof Production ? resolve((Production) s) : s).collect(Collectors.toSet()));
-        return Module(m.name(), m.publicImports(), m.privateImports(), newSentences, m.att());
+        return Module(m.name(), m.imports(), newSentences, m.att());
     }
 
 }

--- a/kernel/src/main/java/org/kframework/compile/ResolveContexts.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveContexts.java
@@ -58,7 +58,7 @@ public class ResolveContexts {
         if (!rulesToAdd.isEmpty()) {
             rulesToAdd.add(SyntaxSort(Seq(), Sorts.K()));
         }
-        return Module(input.name(), input.publicImports(), input.privateImports(), (scala.collection.Set<Sentence>) stream(input.localSentences()).filter(s -> !(s instanceof Context)).collect(Collections.toSet()).$bar(immutable(rulesToAdd)), input.att());
+        return Module(input.name(), input.imports(), (scala.collection.Set<Sentence>) stream(input.localSentences()).filter(s -> !(s instanceof Context)).collect(Collections.toSet()).$bar(immutable(rulesToAdd)), input.att());
     }
 
     private Set<KLabel> klabels;

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
@@ -7,6 +7,7 @@ import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Sorts;
 import org.kframework.definition.Context;
 import org.kframework.definition.Definition;
+import org.kframework.definition.Import;
 import org.kframework.definition.Module;
 import org.kframework.definition.NonTerminal;
 import org.kframework.definition.Production;
@@ -275,7 +276,7 @@ public class ResolveFreshConstants {
         if (sentences.equals(m.localSentences())) {
             return m;
         }
-        return Module(m.name(), kore ? m.publicImports() : add(def.getModule("K-REFLECTION").get(), m.publicImports()), m.privateImports(), sentences, m.att());
+        return Module(m.name(), kore ? m.imports() : (Set<Import>) m.imports().$bar(Set(Import(def.getModule("K-REFLECTION").get(), true))), sentences, m.att());
     }
 }
 

--- a/kernel/src/main/java/org/kframework/compile/ResolveFun.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFun.java
@@ -259,6 +259,6 @@ public class ResolveFun {
         Set<Sentence> newSentences = stream(m.localSentences()).map(this::resolve).collect(Collectors.toSet());
         newSentences.addAll(funProds);
         newSentences.addAll(funRules);
-        return Module(m.name(), m.publicImports(), m.privateImports(), immutable(newSentences), m.att());
+        return Module(m.name(), m.imports(), immutable(newSentences), m.att());
     }
 }

--- a/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
@@ -5,6 +5,7 @@ import org.kframework.attributes.Location;
 import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Sorts;
 import org.kframework.definition.Definition;
+import org.kframework.definition.Import;
 import org.kframework.definition.Module;
 import org.kframework.definition.Production;
 import org.kframework.definition.Rule;
@@ -81,10 +82,10 @@ public class ResolveIOStreams {
                     sentences.addAll(getStreamModuleSentences(p));
                 }
             }
-            return Module(m.name(), (Set<Module>)m.publicImports().
-                            $bar(Set(definition.getModule("K-IO").get())).
-                            $bar(Set(definition.getModule("K-REFLECTION").get())),
-                    m.privateImports(), immutable(sentences), m.att());
+            return Module(m.name(), (Set<Import>)m.imports().
+                            $bar(Set(Import(definition.getModule("K-IO").get(), true))).
+                            $bar(Set(Import(definition.getModule("K-REFLECTION").get(), true))),
+                    immutable(sentences), m.att());
         }
     }
 

--- a/kernel/src/main/java/org/kframework/compile/ResolveStrict.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveStrict.java
@@ -252,6 +252,6 @@ public class ResolveStrict {
                 .filter(s -> s instanceof Production)
                 .map(s -> (Production) s)
                 .filter(p -> p.att().contains("strict") || p.att().contains("seqstrict")).collect(Collectors.toSet()));
-        return Module(input.name(), input.publicImports(), input.privateImports(), (scala.collection.Set<Sentence>) stream(input.localSentences()).filter(s -> !(s instanceof ContextAlias)).collect(Collections.toSet()).$bar(immutable(contextsToAdd)), input.att());
+        return Module(input.name(), input.imports(), (scala.collection.Set<Sentence>) stream(input.localSentences()).filter(s -> !(s instanceof ContextAlias)).collect(Collections.toSet()).$bar(immutable(contextsToAdd)), input.att());
     }
 }

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -243,7 +243,7 @@ public class Kompile {
 
     private static Module filterStreamModules(Module input) {
         if (input.name().equals("STDIN-STREAM") || input.name().equals("STDOUT-STREAM")) {
-            return Module(input.name(), Set(), Set(), Set(), input.att());
+            return Module(input.name(), Set(), Set(), input.att());
         }
         return input;
     }
@@ -255,10 +255,9 @@ public class Kompile {
     }
 
     private static Module excludeModulesByTag(Set<String> excludedModuleTags, Module mod) {
-        Predicate<Module> f = _import -> excludedModuleTags.stream().noneMatch(tag -> _import.att().contains(tag));
-        Set<Module> newPublicImports = stream(mod.publicImports()).filter(f).collect(Collectors.toSet());
-        Set<Module> newPrivateImports = stream(mod.privateImports()).filter(f).collect(Collectors.toSet());
-        return Module(mod.name(), immutable(newPublicImports), immutable(newPrivateImports), mod.localSentences(), mod.att());
+        Predicate<Import> f = _import -> excludedModuleTags.stream().noneMatch(tag -> _import.module().att().contains(tag));
+        Set<Import> newImports = stream(mod.imports()).filter(f).collect(Collectors.toSet());
+        return Module(mod.name(), immutable(newImports), mod.localSentences(), mod.att());
     }
 
     public static Function1<Definition, Definition> excludeModulesByTag(Set<String> excludedModuleTags) {
@@ -343,7 +342,7 @@ public class Kompile {
         if (prods.isEmpty()) {
             return module;
         } else {
-            return Module(module.name(), module.publicImports(), module.privateImports(), Stream.concat(stream(module.localSentences()), prods.stream())
+            return Module(module.name(), module.imports(), Stream.concat(stream(module.localSentences()), prods.stream())
                     .collect(org.kframework.Collections.toSet()), module.att());
         }
     }
@@ -481,10 +480,10 @@ public class Kompile {
         java.util.Set<Module> allModules = mutable(d.modules());
 
         Module languageParsingModule = Constructors.Module("LANGUAGE-PARSING",
-                Set(d.mainModule(),
-                        d.getModule(d.att().get(Att.SYNTAX_MODULE())).get(),
-                        d.getModule("K-TERM").get(),
-                        d.getModule(RuleGrammarGenerator.ID_PROGRAM_PARSING).get()), Set(), Set(), Att());
+                Set(Import(d.mainModule(), true),
+                        Import(d.getModule(d.att().get(Att.SYNTAX_MODULE())).get(), true),
+                        Import(d.getModule("K-TERM").get(), true),
+                        Import(d.getModule(RuleGrammarGenerator.ID_PROGRAM_PARSING).get(), true)), Set(), Att());
         allModules.add(languageParsingModule);
         return Constructors.Definition(d.mainModule(), immutable(allModules), d.att());
     }

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -79,7 +79,7 @@ public class KILtoKORE extends KILTransformation<Object> {
                                 ).collect(Collectors.toSet());
         items.addAll(tempCellSorts);
 
-        Set<org.kframework.definition.Import> importedModuleNames = m.getItems().stream()
+        Set<org.kframework.definition.FlatImport> importedModuleNames = m.getItems().stream()
                 .filter(imp -> imp instanceof Import)
                 .map(imp -> apply((Import)imp))
                 .collect(Collectors.toSet());
@@ -89,8 +89,8 @@ public class KILtoKORE extends KILTransformation<Object> {
         return new FlatModule(moduleName, immutable(importedModuleNames), immutable(items), att);
     }
 
-    public org.kframework.definition.Import apply(Import imp) {
-        return org.kframework.definition.Import.apply(imp.getName(), imp.isPublic(), convertAttributes(imp));
+    public org.kframework.definition.FlatImport apply(Import imp) {
+        return org.kframework.definition.FlatImport.apply(imp.getName(), imp.isPublic(), convertAttributes(imp));
     }
 
     public org.kframework.definition.Definition apply(Definition d) {

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
@@ -97,7 +97,7 @@ public class KSyntax2Bison {
         sentences.add(s);
       }
     }
-    module = Module(module.name(), module.publicImports(), module.privateImports(), immutable(sentences), module.att());
+    module = Module(module.name(), module.imports(), immutable(sentences), module.att());
     Deque<Tuple2<Sort, Set<Tag>>> worklist = new ArrayDeque<>(nts);
     worklist.addAll(nts);
     while (!worklist.isEmpty()) {
@@ -113,7 +113,7 @@ public class KSyntax2Bison {
         }
       }
     }
-    return Module(module.name(), module.publicImports(), module.privateImports(), immutable(sentences), module.att());
+    return Module(module.name(), module.imports(), immutable(sentences), module.att());
   }
 
   public static void writeParser(Module module, Module disambModule, Scanner scanner, Sort start, File path, boolean glr, long stackDepth, KExceptionManager kem) {

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -10,7 +10,7 @@ import org.kframework.definition.Constructors;
 import org.kframework.definition.Context;
 import org.kframework.definition.Definition;
 import org.kframework.definition.FlatModule;
-import org.kframework.definition.Import;
+import org.kframework.definition.FlatImport;
 import org.kframework.definition.Module;
 import org.kframework.definition.NonTerminal;
 import org.kframework.definition.Production;
@@ -146,8 +146,8 @@ public class JsonParser {
         String name = data.getString("name");
 
         JsonArray jsonimports = data.getJsonArray("imports");
-        Set<Import> imports = new HashSet<>();
-        jsonimports.getValuesAs(JsonObject.class).forEach(i -> imports.add(Import.apply(i.getString("name"), i.getBoolean("public"), Att.empty())));
+        Set<FlatImport> imports = new HashSet<>();
+        jsonimports.getValuesAs(JsonObject.class).forEach(i -> imports.add(FlatImport.apply(i.getString("name"), i.getBoolean("public"), Att.empty())));
 
         JsonArray sentences = data.getJsonArray("localSentences");
         Set<Sentence> localSentences = new HashSet<>();

--- a/kernel/src/test/java/org/kframework/kore/compile/GenerateSentencesFromConfigDeclTest.java
+++ b/kernel/src/test/java/org/kframework/kore/compile/GenerateSentencesFromConfigDeclTest.java
@@ -63,7 +63,7 @@ public class GenerateSentencesFromConfigDeclTest {
                         cells(cell("k", Collections.emptyMap(), KApply(KLabel("#SemanticCastToKItem"), KList(KToken("$PGM", Sorts.KConfigVar())), Att.empty().add(Production.class, prod2))),
                                 cell("opt", Collections.singletonMap("multiplicity", "?"),
                                         KApply(KLabel(".Opt"), KList(), Att.empty().add(Production.class, prod))))));
-        Module m1 = Module("CONFIG", Set(def.getModule("KSEQ").get()), Set(), Set(prod), Att());
+        Module m1 = Module("CONFIG", Set(Import(def.getModule("KSEQ").get(), true)), Set(prod), Att());
         RuleGrammarGenerator parserGen = new RuleGrammarGenerator(def);
         Module m = RuleGrammarGenerator.getCombinedGrammar(parserGen.getConfigGrammar(m1), true).getExtensionModule();
         Set<Sentence> gen = GenerateSentencesFromConfigDecl.gen(configuration, BooleanUtils.FALSE, Att(), m, false);

--- a/kore/src/main/scala/org/kframework/Strategy.scala
+++ b/kore/src/main/scala/org/kframework/Strategy.scala
@@ -22,7 +22,7 @@ object Strategy {
         if (module.name != mainModuleName || !module.importedModuleNames.contains("STRATEGY")) {
           module
         } else {
-          Module(module.name, module.publicImports, module.privateImports, module.localSentences + Rule(
+          Module(module.name, module.imports, module.localSentences + Rule(
             KORE.KApply(KLabels.STRATEGY_CELL,
               KORE.KApply(KLabels.NO_DOTS),
               KORE.KRewrite(

--- a/kore/src/main/scala/org/kframework/compile/AddBottomSortForListsWithIdenticalLabels.scala
+++ b/kore/src/main/scala/org/kframework/compile/AddBottomSortForListsWithIdenticalLabels.scala
@@ -33,7 +33,7 @@ object AddBottomSortForListsWithIdenticalLabels extends Function[Module, Module]
     val theAdditionalSubsortingProductions = theAdditionalSubsortingProductionsSets.flatten
 
     if (theAdditionalSubsortingProductions.nonEmpty)
-      Module(m.name, m.publicImports, m.privateImports, m.localSentences ++ theAdditionalSubsortingProductions, m.att)
+      Module(m.name, m.imports, m.localSentences ++ theAdditionalSubsortingProductions, m.att)
     else
       m
   }

--- a/kore/src/main/scala/org/kframework/compile/AssocCommToAssoc.scala
+++ b/kore/src/main/scala/org/kframework/compile/AssocCommToAssoc.scala
@@ -16,7 +16,7 @@ import scala.collection.Set
 class AssocCommToAssoc extends Function[Module, Module] {
 
   override def apply(m: Module) = {
-    Module(m.name, m.publicImports, m.privateImports, m.localSentences flatMap {apply(_)(m)}, m.att)
+    Module(m.name, m.imports, m.localSentences flatMap {apply(_)(m)}, m.att)
   }
 
   private def apply(s: Sentence)(implicit m: Module): List[Sentence] = s match {

--- a/kore/src/main/scala/org/kframework/compile/MergeRules.scala
+++ b/kore/src/main/scala/org/kframework/compile/MergeRules.scala
@@ -35,7 +35,7 @@ class MergeRules(val automatonAttribute: String, filterAttribute: String) extend
     if (rulesToMerge.nonEmpty) {
       val newBody = pushDisjunction(rulesToMerge map { r => (convertKRewriteToKApply(r.body), KApply(isRulePredicate,KToken(r.hashCode.toString, Sorts.K, Att.empty))) })(m)
       val automatonRule = Rule(newBody, TrueToken, TrueToken, Att.empty.add(automatonAttribute))
-      Module(m.name, m.publicImports, m.privateImports, m.localSentences + automatonRule, m.att)
+      Module(m.name, m.imports, m.localSentences + automatonRule, m.att)
     } else {
       m
     }

--- a/kore/src/main/scala/org/kframework/definition/Constructors.scala
+++ b/kore/src/main/scala/org/kframework/definition/Constructors.scala
@@ -21,8 +21,11 @@ object Constructors {
   def Definition(mainModule: Module, modules: Set[Module], att: Att) =
     definition.Definition(mainModule, modules, att)
 
-  def Module(name: String, publicImports: Set[Module], privateImports: Set[Module], sentences: Set[Sentence], att: attributes.Att) =
-    definition.Module(name, publicImports, privateImports, sentences, att)
+  def Import(module: Module, isPublic: Boolean) =
+    definition.Import(module, isPublic)
+
+  def Module(name: String, imports: Set[Import], sentences: Set[Sentence], att: attributes.Att) =
+    definition.Module(name, imports, sentences, att)
 
   def SyntaxSort(params: Seq[Sort], sort: Sort) = definition.SyntaxSort(params, sort)
   def SyntaxSort(params: Seq[Sort], sort: Sort, att: attributes.Att) = definition.SyntaxSort(params, sort, att)

--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -56,14 +56,13 @@ object FlatModule {
       }
       memoization.getOrElseUpdate(m.name, {
         // transform all imports into Module
-        val f = (i: FlatImport) => memoization.getOrElse(i.name
+        val f = (i: FlatImport) => Import(memoization.getOrElse(i.name
           // if can't find the Module in memoization, build a new one
           , toModuleRec(allModules.find(f => f.name.equals(i.name))
               .getOrElse(throw KEMException.compilerError("Could not find module: " + i.name, i))
-            , visitedModules :+ m))
-        val newPublicImports = m.imports.filter(_.isPublic).map(f)
-        val newPrivateImports = m.imports.filter(!_.isPublic).map(f)
-        val newM = new Module(m.name, newPublicImports, newPrivateImports, m.localSentences, m.att)
+            , visitedModules :+ m)), i.isPublic)
+        val newImports = m.imports.map(f)
+        val newM = new Module(m.name, newImports, m.localSentences, m.att)
         newM.checkSorts()
         newM
       })

--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -24,12 +24,12 @@ case class Bubble(sentenceType: String, contents: String, att: Att = Att.empty) 
   override def withAtt(att: Att) = Bubble(sentenceType, contents, att)
 }
 
-case class Import(name: String, isPublic: Boolean, att: Att = Att.empty) extends HasLocation {
+case class FlatImport(name: String, isPublic: Boolean, att: Att = Att.empty) extends HasLocation {
   override def location(): Optional[Location] = att.getOptional(classOf[Location])
   override def source(): Optional[Source] = att.getOptional(classOf[Source])
 }
 
-case class FlatModule(name: String, imports: Set[Import], localSentences: Set[Sentence], @(Nonnull@param) val att: Att = Att.empty)
+case class FlatModule(name: String, imports: Set[FlatImport], localSentences: Set[Sentence], @(Nonnull@param) val att: Att = Att.empty)
   extends OuterKORE with Sorting with Serializable {
 }
 
@@ -56,7 +56,7 @@ object FlatModule {
       }
       memoization.getOrElseUpdate(m.name, {
         // transform all imports into Module
-        val f = (i: Import) => memoization.getOrElse(i.name
+        val f = (i: FlatImport) => memoization.getOrElse(i.name
           // if can't find the Module in memoization, build a new one
           , toModuleRec(allModules.find(f => f.name.equals(i.name))
               .getOrElse(throw KEMException.compilerError("Could not find module: " + i.name, i))

--- a/kore/src/main/scala/org/kframework/definition/outer-to-string.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-to-string.scala
@@ -7,7 +7,7 @@ import collection._
 trait ModuleToString {
   self: Module =>
   override def toString = "module " + name + att.postfixString + "\n" +
-    prettyPrintSet(imports map {"imports " + _.name}) +
+    prettyPrintSet(fullImports map {"imports " + _.name}) +
     prettyPrintSet(localSentences) +
     "endmodule"
 

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -358,7 +358,7 @@ case class Module(val name: String, val publicImports: Set[Module], val privateI
 
   override lazy val hashCode: Int = name.hashCode
 
-  def flattened()   : FlatModule                = new FlatModule(name, imports.map(m => Import(m.name, publicImports.contains(m), Att.empty)), localSentences, att)
+  def flattened()   : FlatModule                = new FlatModule(name, imports.map(m => FlatImport(m.name, publicImports.contains(m), Att.empty)), localSentences, att)
   def flatModules() : (String, Set[FlatModule]) = (name, Set(flattened) ++ imports.map(m => m.flatModules._2).flatten)
 }
 

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -30,7 +30,7 @@ object ModuleTransformer {
       }
       //TODO(compare attributes)
       if (newSentences != m.localSentences)
-        Module(m.name, m.publicImports, m.privateImports, newSentences, m.att)
+        Module(m.name, m.imports, newSentences, m.att)
       else
         m
     }, name)
@@ -72,10 +72,9 @@ class ModuleTransformer(f: Module => Module, name: String) extends (Module => Mo
 
   override def apply(input: Module): Module = {
     memoization.getOrElseUpdate(input, {
-      var newPublicImports = input.publicImports map this
-      var newPrivateImports = input.privateImports map this
-      if (newPublicImports != input.publicImports || newPrivateImports != input.privateImports)
-        f(Module(input.name, newPublicImports, newPrivateImports, input.localSentences, input.att))
+      var newImports = input.imports map (i => Import(this(i.module), i.isPublic))
+      if (newImports != input.imports)
+        f(Module(input.name, newImports, input.localSentences, input.att))
       else
         f(input)
     })

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
@@ -265,7 +265,7 @@ public class DefinitionToOcaml implements Serializable {
         Function1<Module, Module> pipeline = removePolyKLabels
                 .andThen(preprocessKLabelPredicates)
                 .andThen(splitThreadCell)
-                .andThen(mod -> Module(mod.name(), mod.publicImports(), mod.privateImports(),
+                .andThen(mod -> Module(mod.name(), mod.imports(),
                         Stream.concat(stream(mod.localSentences()),
                                 Stream.<Sentence>of(thread, bottom, threadLocal)).collect(org.kframework.Collections.toSet()), mod.att()))
                 .andThen(convertLookups)


### PR DESCRIPTION
This is a preliminary refactoring in preparation for adding partial imports that extracts out metadata about each import in a module into its own class in the AST. This will help us with the task of adding additional metadata about each import indicating which sentences are imported.