### PR TITLE
Mark concrete rules for Haskell backend

### DIFF
--- a/k-distribution/tests/regression-new/issue-2142-markConcrete/Makefile
+++ b/k-distribution/tests/regression-new/issue-2142-markConcrete/Makefile
@@ -1,0 +1,10 @@
+DEF=test
+TESTDIR=.
+KOMPILE_BACKEND=haskell
+KOMPILE_FLAGS=--syntax-module TEST --concrete-rules SERIALIZATION.keccak
+export KORE_EXEC_OPTS=--log-level error
+
+include ../../../include/kframework/ktest.mak
+
+KPROVE_OR_X=$(KPROVEX)
+CONSIDER_PROVER_ERRORS=2>&1

--- a/k-distribution/tests/regression-new/issue-2142-markConcrete/test-spec.k
+++ b/k-distribution/tests/regression-new/issue-2142-markConcrete/test-spec.k
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 K Team. All Rights Reserved.
+
+requires "test.k"
+
+module TEST-SPEC
+    imports TEST
+
+    claim <k> runLemma(keccak(_)) => doneLemma(0) ... </k>
+
+endmodule

--- a/k-distribution/tests/regression-new/issue-2142-markConcrete/test-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-2142-markConcrete/test-spec.k.out
@@ -1,0 +1,9 @@
+  #Not ( {
+    0
+  #Equals
+    keccak ( _0 )
+  } )
+#And
+  <k>
+    doneLemma ( keccak ( _0 ) ) ~> _DotVar1 ~> .
+  </k>

--- a/k-distribution/tests/regression-new/issue-2142-markConcrete/test.k
+++ b/k-distribution/tests/regression-new/issue-2142-markConcrete/test.k
@@ -1,0 +1,21 @@
+module SERIALIZATION
+    imports INT
+    imports BYTES
+
+    syntax Int ::= keccak ( Bytes ) [function, functional, smtlib(smt_keccak)]
+ // --------------------------------------------------------------------------
+    rule [keccak]: keccak(_) => 1
+
+endmodule
+
+module TEST
+    imports SERIALIZATION
+
+    syntax KItem ::= runLemma ( Step ) | doneLemma ( Step )
+ // -------------------------------------------------------
+    rule <k> runLemma(S) => doneLemma(S) ... </k>
+
+    syntax Step ::= Int
+ // -------------------
+
+endmodule


### PR DESCRIPTION
Fixes: #2142 
Apparently, I forgot to add the mark step to the Haskell backend compilation steps.
@ehildenb I've tested the issue. The label appears in the kore file, but kprovex still returns #Top.