### PR TITLE
Verbose tutorial cmds

### DIFF
--- a/k-distribution/k-tutorial/1_basic/11_casts/README.md
+++ b/k-distribution/k-tutorial/1_basic/11_casts/README.md
@@ -64,7 +64,7 @@ module LESSON-11-B
   syntax Term ::= Exp | Stmt
   syntax Bool ::= isExpression(Term) [function]
 
-  rule isExpression(E:Exp) => true
+  rule isExpression(_E:Exp) => true
   rule isExpression(_) => false [owise]
 endmodule
 ```

--- a/k-distribution/k-tutorial/1_basic/commands.sh
+++ b/k-distribution/k-tutorial/1_basic/commands.sh
@@ -1,45 +1,45 @@
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-A -d build/02a
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-B -d build/02b
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-C -d build/02c
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-D -d build/02d
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-A -d build/03a
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-B -d build/03b
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-C -d build/03c
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-D -d build/03d --gen-bison-parser
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-A -d build/04a
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-B -d build/04b
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-C -d build/04c
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-D -d build/04d
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-E -d build/04e
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-F -d build/04f
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-A -d build/05a
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-B -d build/05b
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-C -d build/05c
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-D-2 -d build/05d
-kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-A -d build/06a
-kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-B -d build/06b
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-A --syntax-module LESSON-02-A -d build/02a
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-B --syntax-module LESSON-02-B -d build/02b
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-C --syntax-module LESSON-02-C -d build/02c
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-D --syntax-module LESSON-02-D -d build/02d
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-A --syntax-module LESSON-03-A -d build/03a
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-B --syntax-module LESSON-03-B -d build/03b
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-C --syntax-module LESSON-03-C -d build/03c
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-D --syntax-module LESSON-03-D -d build/03d --gen-bison-parser
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-A --syntax-module LESSON-04-A -d build/04a
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-B --syntax-module LESSON-04-B -d build/04b
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-C --syntax-module LESSON-04-C -d build/04c
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-D --syntax-module LESSON-04-D -d build/04d
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-E --syntax-module LESSON-04-E -d build/04e
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-F --syntax-module LESSON-04-F -d build/04f
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-A --syntax-module LESSON-05-A -d build/05a
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-B --syntax-module LESSON-05-B -d build/05b
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-C --syntax-module LESSON-05-C -d build/05c
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-D-2 --syntax-module LESSON-05-D-2 -d build/05d
+kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-A --syntax-module LESSON-06-A  -d build/06a
+kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-B --syntax-module LESSON-06-B  -d build/06b
 kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-C -d build/06c
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-A -d build/07a
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-B -d build/07b
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-C -d build/07c
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-D -d build/07d
-kompile 08_literate_programming/README.md --md-selector "k & ! exclude" --main-module LESSON-08 -d build/08
-kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-A -d build/09a
-kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-B -d build/09b
-kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-C -d build/09c
-kompile 10_strings/README.md --md-selector "k & ! exclude" --main-module LESSON-10 -d build/10
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-A -d build/11a
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-B -d build/11b
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-C -d build/11c
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-D -d build/11d
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-A --syntax-module LESSON-07-A -d build/07a
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-B --syntax-module LESSON-07-B -d build/07b
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-C --syntax-module LESSON-07-C -d build/07c
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-D --syntax-module LESSON-07-D -d build/07d
+kompile 08_literate_programming/README.md --md-selector "k & ! exclude" --main-module LESSON-08 --syntax-module LESSON-08 -d build/08
+kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-A --syntax-module LESSON-09-A -d build/09a
+kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-B --syntax-module LESSON-09-B -d build/09b
+kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-C --syntax-module LESSON-09-C -d build/09c
+kompile 10_strings/README.md --md-selector "k & ! exclude" --main-module LESSON-10 --syntax-module LESSON-10 -d build/10
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-A --syntax-module LESSON-11-A -d build/11a
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-B --syntax-module LESSON-11-B -d build/11b
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-C --syntax-module LESSON-11-C -d build/11c
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-D --syntax-module LESSON-11-D -d build/11d
 kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-A -d build/12a
 kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-B -d build/12b
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-C -d build/12c
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-D -d build/12d
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-E -d build/12e
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-F -d build/12f
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-G -d build/12g
-kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-A -d build/13a
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-C --syntax-module LESSON-12-C -d build/12c
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-D --syntax-module LESSON-12-D -d build/12d
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-E --syntax-module LESSON-12-E -d build/12e
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-F --syntax-module LESSON-12-F -d build/12f
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-G --syntax-module LESSON-12-G  -d build/12g
+kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-A --syntax-module LESSON-13-A -d build/13a
 kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-B -d build/13b
 kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-C -d build/13c
 kompile 14_evaluation_order/README.md --md-selector "k & ! exclude & ! alias" --main-module LESSON-14-A -d build/14a
@@ -52,10 +52,10 @@ kompile 15_configurations/README.md --md-selector "k & ! exclude" --main-module 
 kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-A -d build/16a
 kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-B -d build/16b
 kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-C -d build/16c
-kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-A -d build/17a
-kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-B -d build/17b
-kompile 18_equality_and_conditionals/README.md --md-selector "k & ! exclude" --main-module LESSON-18 -d build/18
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-A -d build/19a
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-B -d build/19b
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-C -d build/19c
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-D -d build/19d
+kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-A --syntax-module LESSON-17-A -d build/17a
+kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-B --syntax-module LESSON-17-B -d build/17b
+kompile 18_equality_and_conditionals/README.md --md-selector "k & ! exclude" --main-module LESSON-18 --syntax-module LESSON-18 -d build/18
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-A --syntax-module LESSON-19-A -d build/19a
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-B --syntax-module LESSON-19-B -d build/19b
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-C --syntax-module LESSON-19-C -d build/19c
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-D --syntax-module LESSON-19-D -d build/19d

--- a/k-distribution/k-tutorial/1_basic/test_kompile.sh
+++ b/k-distribution/k-tutorial/1_basic/test_kompile.sh
@@ -1,4 +1,4 @@
 #!/usr/bin/env bash
 set -ex
 export PATH="$PATH:`cd "$(dirname "$0")"; pwd`/../../target/release/k/bin"
-parallel < commands.sh
+parallel -v < commands.sh


### PR DESCRIPTION
This hides all the warnings thrown by kompile and prints out the command for each call.
Makes it easier to spot errors.

Also, this cmd takes 44 seconds to generate the bison parser on my machine:
`kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-D --syntax-module LESSON-03-D -d build/03d --gen-bison-parser`
