### PR TITLE
Improve parser error messages

### DIFF
--- a/k-distribution/tests/regression-new/checks/functionContextInRewrite.k.out
+++ b/k-distribution/tests/regression-new/checks/functionContextInRewrite.k.out
@@ -1,4 +1,4 @@
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '('. Expected one of: K, "...".
 	Source(functionContextInRewrite.k)
 	Location(8,12,8,13)
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/nestedFunctionContext.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedFunctionContext.k.out
@@ -1,7 +1,7 @@
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '['. Expected one of: K.
 	Source(nestedFunctionContext.k)
 	Location(14,8,14,9)
-[Error] Inner Parser: Parse error: unexpected token '<baz>'.
+[Error] Inner Parser: Parse error: unexpected token '<baz>' following token '1'. Expected one of: "#And", "#Implies", "#Or", "#as", "%Int", etc.
 	Source(nestedFunctionContext.k)
 	Location(19,6,19,11)
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/nestedFunctionContextInFun.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedFunctionContextInFun.k.out
@@ -1,7 +1,7 @@
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '('. Expected one of: K.
 	Source(nestedFunctionContextInFun.k)
 	Location(8,16,8,17)
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '('. Expected one of: K.
 	Source(nestedFunctionContextInFun.k)
 	Location(10,16,10,17)
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/parseErrorExpected.k
+++ b/k-distribution/tests/regression-new/checks/parseErrorExpected.k
@@ -1,0 +1,8 @@
+module PARSEERROREXPECTED
+  imports INT
+
+rule => false
+rule 0 => true
+rule <k> 0 => true </k>
+
+endmodule

--- a/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
+++ b/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
@@ -1,0 +1,10 @@
+[Error] Inner Parser: Parse error: unexpected token '=>'. Expected one of: #RuleBody.
+	Source(parseErrorExpected.k)
+	Location(4,6,4,8)
+[Error] Inner Parser: Parse error: unexpected end of file following token 'true'. Expected one of: "(", "::KLabel", ":KLabel".
+	Source(parseErrorExpected.k)
+	Location(5,15,5,16)
+[Error] Inner Parser: Parse error: unexpected token '</k>' following token 'true'. Expected one of: "(", "::KLabel", ":KLabel".
+	Source(parseErrorExpected.k)
+	Location(6,20,6,24)
+[Error] Compiler: Had 3 parsing errors.

--- a/k-distribution/tests/regression-new/checks/partialImport.k.out
+++ b/k-distribution/tests/regression-new/checks/partialImport.k.out
@@ -1,7 +1,7 @@
-[Error] Inner Parser: Parse error: unexpected token ')'.
+[Error] Inner Parser: Parse error: unexpected token ')' following token '('. Expected one of: KList.
 	Source(partialImport.k)
 	Location(6,12,6,13)
-[Error] Inner Parser: Parse error: unexpected token ')'.
+[Error] Inner Parser: Parse error: unexpected token ')' following token '('. Expected one of: KList.
 	Source(partialImport.k)
 	Location(8,12,8,13)
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/signature.k.out
+++ b/k-distribution/tests/regression-new/checks/signature.k.out
@@ -1,31 +1,31 @@
-[Error] Inner Parser: Parse error: unexpected token 'foo'.
+[Error] Inner Parser: Parse error: unexpected token 'foo'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(24,8,24,11)
-[Error] Inner Parser: Parse error: unexpected token 'fu'.
+[Error] Inner Parser: Parse error: unexpected token 'fu'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(26,8,26,10)
-[Error] Inner Parser: Parse error: unexpected token 'baz'.
+[Error] Inner Parser: Parse error: unexpected token 'baz'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(28,8,28,11)
-[Error] Inner Parser: Parse error: unexpected token 'foo'.
+[Error] Inner Parser: Parse error: unexpected token 'foo'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(36,8,36,11)
-[Error] Inner Parser: Parse error: unexpected token 'bam'.
+[Error] Inner Parser: Parse error: unexpected token 'bam'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(37,8,37,11)
-[Error] Inner Parser: Parse error: unexpected token 'fu'.
+[Error] Inner Parser: Parse error: unexpected token 'fu'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(38,8,38,10)
-[Error] Inner Parser: Parse error: unexpected token 'bar'.
+[Error] Inner Parser: Parse error: unexpected token 'bar'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(39,8,39,11)
-[Error] Inner Parser: Parse error: unexpected token 'baz'.
+[Error] Inner Parser: Parse error: unexpected token 'baz'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(40,8,40,11)
-[Error] Inner Parser: Parse error: unexpected token 'b'.
+[Error] Inner Parser: Parse error: unexpected token 'b'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(42,8,42,9)
-[Error] Inner Parser: Parse error: unexpected token 'a'.
+[Error] Inner Parser: Parse error: unexpected token 'a'. Expected one of: #RuleBody.
 	Source(signature.k)
 	Location(54,8,54,9)
 [Error] Compiler: Had 10 parsing errors.

--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -243,7 +243,7 @@ public class ParseInModule implements Serializable, AutoCloseable {
 
             Term parsed;
             try {
-                Parser parser = new Parser(input, scanner, source, startLine, startColumn);
+                Parser parser = new Parser(input, scanner, source, startLine, startColumn, getParsingModule().syntacticSubsorts());
                 parsed = parser.parse(startSymbolNT, 0);
             } catch (KEMException e) {
                 return Tuple2.apply(Left.apply(Collections.singleton(e)), Collections.emptySet());

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Grammar.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Grammar.java
@@ -5,6 +5,7 @@ import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
+import org.kframework.kore.Sort;
 import org.kframework.utils.algorithms.SCCTarjan;
 
 import java.io.Serializable;
@@ -58,12 +59,14 @@ public class Grammar implements Serializable {
     /** The set of "root" NonTerminals */
     private BiMap<String, NonTerminal> startNonTerminals = HashBiMap.create();
 
-    public NonTerminal nullNT() {
-      return get("_Null");
-    }
-
-    public Grammar() {
-      add(new NonTerminal("_Null"));
+    public NonTerminal nullNT(Sort sort) {
+      String name = "_Null" + sort.toString();
+      NonTerminal nt = get(name);
+      if (nt == null) {
+        nt = new NonTerminal(name, sort);
+        add(nt);
+      }
+      return nt;
     }
 
     public boolean add(NonTerminal newNT) {
@@ -196,6 +199,7 @@ public class Grammar implements Serializable {
      */
     public class NonTerminal implements Serializable {
         public final String name;
+        public final Sort sort;
         private final int hashCode;
         public final int unique;
         /**
@@ -213,10 +217,11 @@ public class Grammar implements Serializable {
         private boolean[] firstSet;
         private boolean nullable;
 
-        public NonTerminal(String name) {
+        public NonTerminal(String name, Sort sort) {
             unique = ntCounter++;
             assert name != null && !name.equals("") : "NonTerminal name cannot be null or empty.";
             this.name = name;
+            this.sort = sort;
             hashCode = name.hashCode();
             this.entryState = new EntryState(name + "-entry", this);
             this.exitState = new ExitState(name + "-exit", this);

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2GrammarStatesFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2GrammarStatesFilter.java
@@ -45,7 +45,7 @@ public class KSyntax2GrammarStatesFilter {
         Set<Sort> sorts = Stream.concat(stream(module.allSorts()), stream(module.usedCellSorts())).collect(Collectors.toSet());
         // create a NonTerminal for every declared sort
         for (Sort sort : sorts) {
-            grammar.add(grammar.new NonTerminal(sort.toString()));
+            grammar.add(grammar.new NonTerminal(sort.toString(), sort));
         }
 
         stream(module.productions()).filter(p -> p.params().isEmpty()).collect(Collectors.groupingBy(p -> p.sort())).entrySet().stream().sorted(Comparator.comparing(e2 -> e2.getKey().toString())).forEach(e -> processProductions(e.getKey(), e.getValue(), grammar, scanner));
@@ -133,7 +133,7 @@ public class KSyntax2GrammarStatesFilter {
                 if (prdItem instanceof org.kframework.definition.NonTerminal) {
                     org.kframework.definition.NonTerminal srt = (org.kframework.definition.NonTerminal) prdItem;
                     Grammar.NonTerminalState nts = grammar.new NonTerminalState(sort + " ::= " + srt.sort(), nt,
-                            Optional.ofNullable(grammar.get(srt.sort().toString())).orElse(grammar.nullNT()));
+                            Optional.ofNullable(grammar.get(srt.sort().toString())).orElse(grammar.nullNT(srt.sort())));
                     previous.next.add(nts);
                     previous = nts;
                 } else if (prdItem instanceof TerminalLike) {

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -8,6 +8,7 @@ import org.kframework.POSet;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Production;
+import org.kframework.definition.TerminalLike;
 import org.kframework.kore.Sort;
 import org.kframework.parser.Ambiguity;
 import org.kframework.parser.KList;
@@ -392,6 +393,7 @@ public class Parser {
     private static class ParseState {
         // the input string which needs parsing
         final Scanner.Token[] input;
+        private final Scanner scanner;
         final String originalInput;
         // a priority queue containing the return states to be processed
         final StateReturnWorkList stateReturnWorkList = new StateReturnWorkList();
@@ -417,6 +419,7 @@ public class Parser {
              * http://www.unicode.org/reports/tr18/#Line_Boundaries
              */
             this.originalInput = input;
+            this.scanner = scanner;
             this.syntacticSubsorts = syntacticSubsorts;
             this.source = source;
             byte[] utf8 = StringUtils.getBytesUtf8(input);
@@ -458,6 +461,10 @@ public class Parser {
             lines[utf8.length] = l;
             columns[utf8.length] = c;
             this.input = scanner.tokenize(input, source, lines, columns);
+        }
+
+        public TerminalLike resolve(int kind) {
+          return scanner.getTokenByKind(kind);
         }
     }
 

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -698,7 +698,7 @@ public class Parser {
           }
           int actualItems = Integer.min(maxItems, expected.size());
           List<ProductionItem> l = new ArrayList<>(expected);
-          Collections.sort(l, 
+          Collections.sort(l,
               Comparator.comparing(p -> p instanceof TerminalLike)
               .thenComparing(Comparator.comparing(p -> p instanceof RegexTerminal))
               .thenComparing(Comparator.comparing(p -> p.toString())));

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -4,9 +4,11 @@ package org.kframework.parser.inner.kernel;
 import org.apache.commons.codec.binary.StringUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.kframework.POSet;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
 import org.kframework.definition.Production;
+import org.kframework.kore.Sort;
 import org.kframework.parser.Ambiguity;
 import org.kframework.parser.KList;
 import org.kframework.parser.Term;
@@ -403,8 +405,9 @@ public class Parser {
         Map<NonTerminalCall.Key, NonTerminalCall> ntCalls = new HashMap<>();
         Map<StateCall.Key, StateCall> stateCalls = new HashMap<>();
         Map<StateReturn.Key, StateReturn> stateReturns = new HashMap<>();
+        final POSet<Sort> syntacticSubsorts;
 
-        public ParseState(String input, Scanner scanner, Source source, int startLine, int startColumn) {
+        public ParseState(String input, Scanner scanner, Source source, int startLine, int startColumn, POSet<Sort> syntacticSubsorts) {
             /**
              * Create arrays corresponding to the index in the input CharSequence and the line and
              * column in the text. Tab counts as one.
@@ -414,6 +417,7 @@ public class Parser {
              * http://www.unicode.org/reports/tr18/#Line_Boundaries
              */
             this.originalInput = input;
+            this.syntacticSubsorts = syntacticSubsorts;
             this.source = source;
             byte[] utf8 = StringUtils.getBytesUtf8(input);
             lines = new int[utf8.length+1];
@@ -549,12 +553,12 @@ public class Parser {
 
     private final ParseState s;
 
-    public Parser(String input, Scanner scanner) {
-        s = new ParseState(input, scanner, Source.apply("<unknown>"), 1, 1);
+    public Parser(String input, Scanner scanner, POSet<Sort> syntacticSubsorts) {
+        s = new ParseState(input, scanner, Source.apply("<unknown>"), 1, 1, syntacticSubsorts);
     }
 
-    public Parser(String input, Scanner scanner, Source source, int startLine, int startColumn) {
-        s = new ParseState(input, scanner, source, startLine, startColumn);
+    public Parser(String input, Scanner scanner, Source source, int startLine, int startColumn, POSet<Sort> syntacticSubsorts) {
+        s = new ParseState(input, scanner, source, startLine, startColumn, syntacticSubsorts);
     }
 
     /**

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -10,6 +10,7 @@ import org.kframework.attributes.Source;
 import org.kframework.definition.Production;
 import org.kframework.definition.ProductionItem;
 import org.kframework.definition.TerminalLike;
+import org.kframework.definition.RegexTerminal;
 import org.kframework.kore.Sort;
 import org.kframework.parser.Ambiguity;
 import org.kframework.parser.KList;
@@ -26,8 +27,12 @@ import org.kframework.parser.inner.kernel.Grammar.State;
 import org.kframework.utils.errorsystem.KEMException;
 import org.pcollections.ConsPStack;
 
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
@@ -683,6 +688,29 @@ public class Parser {
             this.source = source;
             this.position = position;
             this.expected = expected;
+        }
+
+        public String getExpected(boolean verbose) {
+          int maxItems = 5;
+          if (verbose) {
+            maxItems = Integer.MAX_VALUE;
+          }
+          int actualItems = Integer.min(maxItems, expected.size());
+          List<ProductionItem> l = new ArrayList<>(expected);
+          Collections.sort(l, 
+              Comparator.comparing(p -> p instanceof TerminalLike)
+              .thenComparing(Comparator.comparing(p -> p instanceof RegexTerminal))
+              .thenComparing(Comparator.comparing(p -> p.toString())));
+          StringBuilder sb = new StringBuilder();
+          String conn = "";
+          for (int i = 0; i < actualItems; i++) {
+            sb.append(conn).append(l.get(i).toString());
+            conn = ", ";
+          }
+          if (actualItems < expected.size()) {
+            sb.append(", etc");
+          }
+          return sb.toString();
         }
     }
 

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -598,8 +598,11 @@ public class Parser {
             ParseError perror = getErrors();
 
             String msg = s.input.length == perror.position ?
-                    "Parse error: unexpected end of file." :
-                    "Parse error: unexpected token '" + s.input[perror.position].value + "'.";
+                    "Parse error: unexpected end of file" :
+                    "Parse error: unexpected token '" + s.input[perror.position].value + "'";
+            if (perror.position != 0) {
+                msg = msg + " following token '" + s.input[perror.position - 1].value + "'";
+            }
             Location loc = new Location(perror.startLine, perror.startColumn,
                     perror.endLine, perror.endColumn);
             Source source = perror.source;

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -612,6 +612,7 @@ public class Parser {
             if (perror.position != 0) {
                 msg = msg + " following token '" + s.input[perror.position - 1].value + "'";
             }
+            msg = msg + ". Expected one of: " + perror.getExpected(s.scanner.getGlobalOptions().verbose) + ".";
             Location loc = new Location(perror.startLine, perror.startColumn,
                     perror.endLine, perror.endColumn);
             Source source = perror.source;

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -407,6 +407,7 @@ public class Parser {
         Map<NonTerminalCall.Key, NonTerminalCall> ntCalls = new HashMap<>();
         Map<StateCall.Key, StateCall> stateCalls = new HashMap<>();
         Map<StateReturn.Key, StateReturn> stateReturns = new HashMap<>();
+        private final Set<StateCall.Key> failedStates = new HashSet<>();
         final POSet<Sort> syntacticSubsorts;
 
         public ParseState(String input, Scanner scanner, Source source, int startLine, int startColumn, POSet<Sort> syntacticSubsorts) {
@@ -748,6 +749,8 @@ public class Parser {
                 s.stateReturnWorkList.enqueue(
                     s.stateReturns.computeIfAbsent(
                             new StateReturn.Key(stateCall, stateCall.key.stateBegin + 1), StateReturn.Key::create));
+            } else {
+              s.failedStates.add(stateCall.key);
             }
         // not instanceof SimpleState
         } else if (nextState instanceof NonTerminalState) {
@@ -769,6 +772,7 @@ public class Parser {
                 }
             } else {
                 // we don't create an entry in the map for this statecall, so we need to track its location another way.
+                s.failedStates.add(stateCall.key);
                 s.maxPosition = Math.max(s.maxPosition, stateCall.key.stateBegin);
             }
         } else { throw unknownStateType(); }

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
@@ -133,6 +133,10 @@ public class Scanner implements AutoCloseable {
         }
     }
 
+    public GlobalOptions getGlobalOptions() {
+        return go;
+    }
+
     public File getScanner() {
         Stopwatch sw = new Stopwatch(go);
         File scanner;


### PR DESCRIPTION
This PR adds two major improvements to error messages of the form `unexpected token 'foo'`. The first is that the error message mentions the last token that parsed successfully, which can be useful in understanding why the error occurred in many, but not all, cases. The second is that we report a list of ProductionItems that could have appeared next. We show at most 5 by default, but you can get the complete list by passing --verbose to kompile or kast. The list is sorted first by type of production item and then alphabetically, and we automatically filter out non-maximal sorts.

This is not ready for review yet as I still need to test to ensure it doesn't introduce any meaningful performance regressions to the case when parsing succeeds.