### PR TITLE
Demonstrate test failures with Haskell backend

### DIFF
--- a/k-distribution/tests/regression-new/proof-tests/deposit/spec/Makefile
+++ b/k-distribution/tests/regression-new/proof-tests/deposit/spec/Makefile
@@ -1,7 +1,7 @@
 DEF=deposit-symbolic
 EXT=deposit
 TESTDIR=.
-KOMPILE_BACKEND=java
+KOMPILE_BACKEND=haskell
 KOMPILE_FLAGS=--syntax-module DEPOSIT-SYMBOLIC
 KPROVE_FLAGS=--smt-prelude imap.smt2
 


### PR DESCRIPTION
This PR just changes the `proof-tests/deposit/spec` test case to run with the Haskell backend, as a demo for #2154. Not for merging.