### PR TITLE
Allow LESSON-05-D tutorial file to compile without flags

### DIFF
--- a/k-distribution/k-tutorial/1_basic/05_modules/README.md
+++ b/k-distribution/k-tutorial/1_basic/05_modules/README.md
@@ -71,7 +71,7 @@ module LESSON-05-D-1
   syntax Boolean ::= "not" Boolean [function]
 endmodule
 
-module LESSON-05-D-2
+module LESSON-05-D
   imports LESSON-05-D-1
 
   rule not true => false
@@ -79,21 +79,21 @@ module LESSON-05-D-2
 endmodule
 ```
 
-If we assume that module `LESSON-05-D-2` is the main semantics module of the
-definition, then this K definition is equivalent to the definition expressed
-by the single module `LESSON-05-C`. Essentially, by importing a module, we
-include all of the sentences in the module being imported into the module that
-we import from. There are a few minor differences between importing a module
-and simply including its sentences in another module directly, but we will
-cover these differences later. Essentially, you can think of modules as
-a way of conceptually grouping sentences in a larger K definition.
+This K definition is equivalent to the definition expressed by the single module
+`LESSON-05-C`. Essentially, by importing a module, we include all of the
+sentences in the module being imported into the module that we import from.
+There are a few minor differences between importing a module and simply
+including its sentences in another module directly, but we will cover these
+differences later. Essentially, you can think of modules as a way of
+conceptually grouping sentences in a larger K definition.
 
 ### Exercise
 
 Modify `lesson-05-d.k` to include four modules: one containing the syntax, two
-with one rule each that imports the first module, and one module containing
-no sentences that imports the second and third module. Check to make sure the
-definition still compiles and that you can still evaluate the `not` function.
+with one rule each that imports the first module, and a final module
+`LESSON-05-D` containing no sentences that imports the second and third module.
+Check to make sure the definition still compiles and that you can still evaluate
+the `not` function.
 
 ## Parsing in the presence of multiple modules
 

--- a/k-distribution/k-tutorial/1_basic/commands.sh
+++ b/k-distribution/k-tutorial/1_basic/commands.sh
@@ -15,7 +15,7 @@ kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module 
 kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-A --syntax-module LESSON-05-A -d build/05a
 kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-B --syntax-module LESSON-05-B -d build/05b
 kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-C --syntax-module LESSON-05-C -d build/05c
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-D-2 --syntax-module LESSON-05-D-2 -d build/05d
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-D --syntax-module LESSON-05-D -d build/05d
 kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-A --syntax-module LESSON-06-A  -d build/06a
 kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-B --syntax-module LESSON-06-B  -d build/06b
 kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-C -d build/06c


### PR DESCRIPTION
All previous lessons compile without the use of the --main-module flag.
While this flag does get explained further on in this tutorial, by
changing the wording here it avoids potential confusion on why the
command no longer works.