### PR TITLE
report better error if bison parsing fails

### DIFF
--- a/k-distribution/include/kframework/cparser/main.c
+++ b/k-distribution/include/kframework/cparser/main.c
@@ -146,7 +146,10 @@ int main(int argc, char **argv) {
     exit(1);
   }
   yyset_in(f, scanner);
-  yyparse(scanner);
+  int status = yyparse(scanner);
+  if (status) {
+    exit(status);
+  }
   print(result);
   printf("\n");
   yylex_destroy(scanner);

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
@@ -102,6 +102,10 @@ public class Scanner implements AutoCloseable {
             "    yylloc->first_column = yycolumn; yylloc->last_column = yycolumn + yyleng - 1; \\\n" +
             "   yycolumn += yyleng; \\\n" +
             "   yylloc->filename = filename;\n" +
+            "#define ECHO do {\\\n" +
+            "  fprintf (stderr, \"%d:%d:%d:%d:syntax error: unexpected %s\\n\", yylloc->first_line, yylloc->first_column, yylloc->last_line, yylloc->last_column, yytext);\\\n" +
+            "  exit(1);\\\n" +
+            "} while (0)\n" +
             "void line_marker(char *, void *);\n" +
             "%}\n\n" +
             "%option reentrant bison-bridge\n" +


### PR DESCRIPTION
Previously we had several minor issues that arose if the user passed a program that did not parse correctly to the bison parser. Now we correctly print a helpful error message and then immediately exit in all such cases.