### PR TITLE
Update parser error messages, second draft

### DIFF
--- a/k-distribution/tests/regression-new/checks/functionContextInRewrite.k.out
+++ b/k-distribution/tests/regression-new/checks/functionContextInRewrite.k.out
@@ -1,4 +1,4 @@
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '('.
 	Source(functionContextInRewrite.k)
 	Location(8,12,8,13)
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/nestedFunctionContext.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedFunctionContext.k.out
@@ -1,7 +1,7 @@
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '['.
 	Source(nestedFunctionContext.k)
 	Location(14,8,14,9)
-[Error] Inner Parser: Parse error: unexpected token '<baz>'.
+[Error] Inner Parser: Parse error: unexpected token '<baz>' following token '1'.
 	Source(nestedFunctionContext.k)
 	Location(19,6,19,11)
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/nestedFunctionContextInFun.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedFunctionContextInFun.k.out
@@ -1,7 +1,7 @@
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '('.
 	Source(nestedFunctionContextInFun.k)
 	Location(8,16,8,17)
-[Error] Inner Parser: Parse error: unexpected token '['.
+[Error] Inner Parser: Parse error: unexpected token '[' following token '('.
 	Source(nestedFunctionContextInFun.k)
 	Location(10,16,10,17)
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/parseErrorExpected.k
+++ b/k-distribution/tests/regression-new/checks/parseErrorExpected.k
@@ -1,0 +1,8 @@
+module PARSEERROREXPECTED
+  imports INT
+
+rule => false
+rule 0 => true
+rule <k> 0 => true </k>
+
+endmodule

--- a/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
+++ b/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
@@ -1,0 +1,10 @@
+[Error] Inner Parser: Parse error: unexpected token '=>'. Expected one of: #RuleBody.
+	Source(parseErrorExpected.k)
+	Location(4,6,4,8)
+[Error] Inner Parser: Parse error: unexpected end of file following token 'true'. Expected one of: "(", "::KLabel", ":KLabel".
+	Source(parseErrorExpected.k)
+	Location(5,15,5,16)
+[Error] Inner Parser: Parse error: unexpected token '</k>' following token 'true'. Expected one of: "(", "::KLabel", ":KLabel".
+	Source(parseErrorExpected.k)
+	Location(6,20,6,24)
+[Error] Compiler: Had 3 parsing errors.

--- a/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
+++ b/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
@@ -1,10 +1,10 @@
-[Error] Inner Parser: Parse error: unexpected token '=>'. Expected one of: #RuleBody.
+[Error] Inner Parser: Parse error: unexpected token '=>'.
 	Source(parseErrorExpected.k)
 	Location(4,6,4,8)
-[Error] Inner Parser: Parse error: unexpected end of file following token 'true'. Expected one of: "(", "::KLabel", ":KLabel".
+[Error] Inner Parser: Parse error: unexpected end of file following token 'true'.
 	Source(parseErrorExpected.k)
 	Location(5,15,5,16)
-[Error] Inner Parser: Parse error: unexpected token '</k>' following token 'true'. Expected one of: "(", "::KLabel", ":KLabel".
+[Error] Inner Parser: Parse error: unexpected token '</k>' following token 'true'.
 	Source(parseErrorExpected.k)
 	Location(6,20,6,24)
 [Error] Compiler: Had 3 parsing errors.

--- a/k-distribution/tests/regression-new/checks/partialImport.k.out
+++ b/k-distribution/tests/regression-new/checks/partialImport.k.out
@@ -1,7 +1,7 @@
-[Error] Inner Parser: Parse error: unexpected token ')'.
+[Error] Inner Parser: Parse error: unexpected token ')' following token '('.
 	Source(partialImport.k)
 	Location(6,12,6,13)
-[Error] Inner Parser: Parse error: unexpected token ')'.
+[Error] Inner Parser: Parse error: unexpected token ')' following token '('.
 	Source(partialImport.k)
 	Location(8,12,8,13)
 [Error] Compiler: Had 2 parsing errors.

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Parser.java
@@ -586,8 +586,13 @@ public class Parser {
             ParseError perror = getErrors();
 
             String msg = s.input.length == perror.position ?
-                    "Parse error: unexpected end of file." :
-                    "Parse error: unexpected token '" + s.input[perror.position].value + "'.";
+                    "Parse error: unexpected end of file" :
+                    "Parse error: unexpected token '" + s.input[perror.position].value + "'";
+            if (perror.position != 0) {
+                msg = msg + " following token '" + s.input[perror.position - 1].value + "'.";
+            } else {
+                msg = msg + ".";
+            }
             Location loc = new Location(perror.startLine, perror.startColumn,
                     perror.endLine, perror.endColumn);
             Source source = perror.source;


### PR DESCRIPTION
This is a version of #2157 which has had the "expected" logic stripped out, leaving only the "following token" logic.