### PR TITLE
Make grade D/F percentiles explicit in lesson 07

### DIFF
--- a/k-distribution/k-tutorial/1_basic/07_side_conditions/README.md
+++ b/k-distribution/k-tutorial/1_basic/07_side_conditions/README.md
@@ -108,8 +108,9 @@ followed by all the `owise` rules, in any order.
 
 ### Exercise
 
-Write another implementation of `gradeFromPercentile` which handles only the
-cases for `D` and `F`, and uses the `owise` attribute to avoid redundant
+The grades `D` and `F` correspond to the percentile ranges [60, 70) and [0, 60)
+respectively. Write another implementation of `gradeFromPercentile` which
+handles only these cases, and uses the `owise` attribute to avoid redundant
 Boolean comparisons. Test that various percentiles in the range [0, 70) are
 evaluated correctly.
 


### PR DESCRIPTION
This is a very minor change, but keeps this paragraph of the tutorial in line with the rest of the section.