### PR TITLE
Implement -I, --md-selector, and --no-prelude in kprove, kprovex, keq, and kbmc

### DIFF
--- a/k-distribution/src/test/scala/org/kframework/backend/kore/KoreTest.scala
+++ b/k-distribution/src/test/scala/org/kframework/backend/kore/KoreTest.scala
@@ -38,7 +38,7 @@ class KoreTest {
   }
 
   def kompile(k: String): Definition = {
-    val compiler = new Kompile(options, files, kem, false)
+    val compiler = new Kompile(options, new OuterParsingOptions(), files, kem, false)
     val backend = new KoreBackend(options, files, kem, Tool.KOMPILE)
     files.saveToDefinitionDirectory("test.k", k)
     val defn = compiler.run(files.resolveDefinitionDirectory("test.k"), "TEST", "TEST", backend.steps, backend.excludedModuleTags)

--- a/k-distribution/tests/pyk/Makefile
+++ b/k-distribution/tests/pyk/Makefile
@@ -36,7 +36,7 @@ $(llvm_imp_kompiled): $(llvm_imp) $(KOMPILE)
 	$(KOMPILE) --directory $(llvm_dir) --backend llvm -I $(llvm_dir) $< --emit-json --coverage
 
 $(haskell_imp_kompiled): $(haskell_imp) $(KOMPILE)
-	$(KOMPILE) --directory $(haskell_dir) --backend haskell -I $(haskell_dir) $< --emit-json
+	$(KOMPILE) --directory $(haskell_dir) --backend haskell $< --emit-json
 
 update-results:
 kompile: $(llvm_imp_kompiled) $(haskell_imp_kompiled)
@@ -75,7 +75,7 @@ $(defn_tests)/kast-tests/%.out: $(defn_tests)/kast-tests/%.gen $(llvm_imp_kompil
 	$(KAST) --directory $(llvm_dir) --output pretty --sort $(basename $(basename $*)) -m IMP $< > $@
 
 $(defn_tests)/proof-tests/%-spec.json.prove: $(defn_tests)/proof-tests/%-spec.k $(haskell_imp_kompiled)
-	$(KPROVE) --directory $(haskell_dir) $< -m IMP
+	$(KPROVE) --directory $(haskell_dir) $< -m IMP -I $(haskell_dir)
 
 ## kpyk runner tests
 

--- a/k-distribution/tests/regression-new/kprove-markdown/Makefile
+++ b/k-distribution/tests/regression-new/kprove-markdown/Makefile
@@ -3,6 +3,6 @@ EXT=set-balance
 KOMPILE_BACKEND=haskell
 KOMPILE_FLAGS=--syntax-module SET-BALANCE
 TESTDIR=.
-KPROVE_FLAGS=--def-module VERIFICATION
+KPROVE_FLAGS=--def-module VERIFICATION --md-selector 'keep&!(discard|k)'
 
 include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/kprove-markdown/set-balance-spec.md
+++ b/k-distribution/tests/regression-new/kprove-markdown/set-balance-spec.md
@@ -1,7 +1,7 @@
 Balances Module Specifications
 ==============================
 
-```k
+```keep
 requires "set-balance.md"
 
 module VERIFICATION
@@ -16,9 +16,13 @@ module SET-BALANCE-SPEC
     imports VERIFICATION
 ```
 
+```k
+ignore thie code block!
+```
+
 ### `total_balance` tests
 
-```k
+```keep
     claim <k> totalBalance(AID) => 50 </k>
           <account>
             <accountID> AID </accountID>
@@ -34,7 +38,7 @@ This property shows that `set_balance` will not result in a zero-balance attack.
 **TODO**: Generalize to any EntryAction.
 **TODO**: Assertions about log events.
 
-```
+```discard
     rule <k> set_balance(Root, WHO, FREE_BALANCE', RESERVED_BALANCE') => . ... </k>
          <totalIssuance> TOTAL_ISSUANCE => TOTAL_ISSUANCE +Int ( FREE_BALANCE' -Int FREE_BALANCE ) +Int ( RESERVED_BALANCE' -Int RESERVED_BALANCE ) </totalIssuance>
          <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
@@ -50,7 +54,7 @@ This property shows that `set_balance` will not result in a zero-balance attack.
        andBool EXISTENTIAL_DEPOSIT <=Int RESERVED_BALANCE'
 ```
 
-```k
+```keep
     claim <k> set_balance_reserved ( WHO , RESERVED_BALANCE' ) => . ... </k>
           <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
           <totalIssuance> TOTAL_ISSUANCE +Int ( FREE_BALANCE' -Int FREE_BALANCE ) => TOTAL_ISSUANCE +Int ( FREE_BALANCE' -Int FREE_BALANCE ) +Int ( RESERVED_BALANCE' -Int RESERVED_BALANCE ) </totalIssuance>
@@ -64,6 +68,6 @@ This property shows that `set_balance` will not result in a zero-balance attack.
        andBool EXISTENTIAL_DEPOSIT <=Int RESERVED_BALANCE'
 ```
 
-```k
+```keep
 endmodule
 ```

--- a/kernel/src/main/java/org/kframework/kbmc/KBMCModule.java
+++ b/kernel/src/main/java/org/kframework/kbmc/KBMCModule.java
@@ -15,6 +15,7 @@ import org.kframework.utils.inject.Options;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.BackendOptions;
 import org.kframework.utils.options.DefinitionLoadingOptions;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 public class KBMCModule extends AbstractModule {
@@ -32,6 +33,9 @@ public class KBMCModule extends AbstractModule {
 
     @Provides @RequestScoped
     GlobalOptions globalOptions(KBMCOptions options) { return options.global; }
+
+    @Provides @RequestScoped
+    OuterParsingOptions outerParsingOptions(KBMCOptions options) { return options.outer; }
 
     @Provides @RequestScoped
     PrintOptions printOptions(KBMCOptions options) {

--- a/kernel/src/main/java/org/kframework/kbmc/KBMCOptions.java
+++ b/kernel/src/main/java/org/kframework/kbmc/KBMCOptions.java
@@ -10,6 +10,7 @@ import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.BackendOptions;
 import org.kframework.utils.options.DefinitionLoadingOptions;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 import java.io.File;
@@ -19,6 +20,9 @@ public class KBMCOptions {
 
     @ParametersDelegate
     public transient GlobalOptions global = new GlobalOptions();
+
+    @ParametersDelegate
+    public transient OuterParsingOptions outer = new OuterParsingOptions();
 
     @ParametersDelegate
     public DefinitionLoadingOptions definitionLoading = new DefinitionLoadingOptions();

--- a/kernel/src/main/java/org/kframework/kdep/KDepModule.java
+++ b/kernel/src/main/java/org/kframework/kdep/KDepModule.java
@@ -5,6 +5,7 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import com.google.inject.TypeLiteral;
 import com.google.inject.multibindings.Multibinder;
+import org.kframework.kompile.KompileOptions;
 import org.kframework.main.FrontEnd;
 import org.kframework.main.GlobalOptions;
 import org.kframework.main.Tool;
@@ -12,6 +13,7 @@ import org.kframework.utils.inject.Options;
 import org.kframework.utils.inject.OuterParsingModule;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.OuterParsingOptions;
+import org.kframework.utils.options.OutputDirectoryOptions;
 
 /**
  * Guice module for kdep tool. Binds the information needed to compute the kompiled directory as well as the options
@@ -36,7 +38,8 @@ public class KDepModule extends AbstractModule {
     }
 
     @Provides
-    OuterParsingOptions outerParsingOptions(KDepOptions options) {
-        return options.outerParsing;
-    }
+    OuterParsingOptions outerParsingOptions(KDepOptions options) { return options.outerParsing; }
+
+    @Provides
+    OutputDirectoryOptions outputDirectoryOptions(KompileOptions options) { return options.outputDirectory; }
 }

--- a/kernel/src/main/java/org/kframework/kdep/KDepOptions.java
+++ b/kernel/src/main/java/org/kframework/kdep/KDepOptions.java
@@ -5,6 +5,7 @@ import com.beust.jcommander.ParametersDelegate;
 import org.kframework.main.GlobalOptions;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.OuterParsingOptions;
+import org.kframework.utils.options.OutputDirectoryOptions;
 
 /**
  * JCommander options for kdep. Essentially, this should contain all the kompile options needed in order to decide what
@@ -19,4 +20,7 @@ public class KDepOptions {
 
     @ParametersDelegate
     public OuterParsingOptions outerParsing = new OuterParsingOptions();
+
+    @ParametersDelegate
+    public OutputDirectoryOptions outputDirectory = new OutputDirectoryOptions();
 }

--- a/kernel/src/main/java/org/kframework/keq/KEqModule.java
+++ b/kernel/src/main/java/org/kframework/keq/KEqModule.java
@@ -30,6 +30,7 @@ import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.inject.Spec1;
 import org.kframework.utils.inject.Spec2;
 import org.kframework.utils.options.DefinitionLoadingOptions;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 import java.util.List;
@@ -73,6 +74,9 @@ public class KEqModule extends AbstractModule {
     GlobalOptions globalOptions(KEqOptions options) {
         return options.global;
     }
+
+    @Provides @RequestScoped
+    OuterParsingOptions outerParsingOptions(KEqOptions options) { return options.outer; }
 
     @Provides
     SMTOptions smtOptions(KEqOptions options) { return options.smt; }

--- a/kernel/src/main/java/org/kframework/keq/KEqOptions.java
+++ b/kernel/src/main/java/org/kframework/keq/KEqOptions.java
@@ -7,12 +7,16 @@ import org.kframework.main.GlobalOptions;
 import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.DefinitionLoadingOptions;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 @RequestScoped
 public final class KEqOptions {
     @ParametersDelegate
     public transient GlobalOptions global = new GlobalOptions();
+
+    @ParametersDelegate
+    public transient OuterParsingOptions outer = new OuterParsingOptions();
 
     @ParametersDelegate
     public DefinitionLoadingOptions definitionLoading = new DefinitionLoadingOptions();

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -26,6 +26,7 @@ import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.StringUtil;
+import org.kframework.utils.options.OuterParsingOptions;
 import scala.Option;
 import scala.Tuple2;
 import scala.util.Either;
@@ -48,6 +49,7 @@ import static org.kframework.kore.KORE.*;
 
 public class CompiledDefinition implements Serializable {
     public final KompileOptions kompileOptions;
+    public final OuterParsingOptions outerParsingOptions;
     private final Definition parsedDefinition;
     public final Definition kompiledDefinition;
     public final Sort programStartSymbol;
@@ -59,8 +61,9 @@ public class CompiledDefinition implements Serializable {
     private Map<String, Rule> cachedParsedPatterns = new ConcurrentHashMap<>();
 
 
-    public CompiledDefinition(KompileOptions kompileOptions, Definition parsedDefinition, Definition kompiledDefinition, FileUtil files, KExceptionManager kem, KLabel topCellInitializer) {
+    public CompiledDefinition(KompileOptions kompileOptions, OuterParsingOptions outerParsingOptions, Definition parsedDefinition, Definition kompiledDefinition, FileUtil files, KExceptionManager kem, KLabel topCellInitializer) {
         this.kompileOptions = kompileOptions;
+        this.outerParsingOptions = outerParsingOptions;
         this.parsedDefinition = parsedDefinition;
         this.kompiledDefinition = kompiledDefinition;
         initializeConfigurationVariableDefaultSorts(files);
@@ -76,7 +79,7 @@ public class CompiledDefinition implements Serializable {
         if (exitCodeRule == null) {
             this.exitCodePattern = null;
         } else {
-            this.exitCodePattern = new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).compileRule(kompiledDefinition, exitCodeRule);
+            this.exitCodePattern = new Kompile(kompileOptions, outerParsingOptions, files, kem).compileRule(kompiledDefinition, exitCodeRule);
         }
     }
 
@@ -206,11 +209,11 @@ public class CompiledDefinition implements Serializable {
     }
 
     public Rule compilePatternIfAbsent(FileUtil files, KExceptionManager kem, String pattern, Source source) {
-        return cachedcompiledPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).parseAndCompileRule(this, p, source,
+        return cachedcompiledPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, outerParsingOptions, files, kem).parseAndCompileRule(this, p, source,
                 Optional.of(parsePatternIfAbsent(files, kem, pattern, source))));
     }
 
     public Rule parsePatternIfAbsent(FileUtil files, KExceptionManager kem, String pattern, Source source) {
-        return cachedParsedPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).parseRule(this, p, source));
+        return cachedParsedPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, outerParsingOptions, files, kem).parseRule(this, p, source));
     }
 }

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -76,7 +76,7 @@ public class CompiledDefinition implements Serializable {
         if (exitCodeRule == null) {
             this.exitCodePattern = null;
         } else {
-            this.exitCodePattern = new Kompile(kompileOptions, files, kem).compileRule(kompiledDefinition, exitCodeRule);
+            this.exitCodePattern = new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).compileRule(kompiledDefinition, exitCodeRule);
         }
     }
 
@@ -206,11 +206,11 @@ public class CompiledDefinition implements Serializable {
     }
 
     public Rule compilePatternIfAbsent(FileUtil files, KExceptionManager kem, String pattern, Source source) {
-        return cachedcompiledPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, files, kem).parseAndCompileRule(this, p, source,
+        return cachedcompiledPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).parseAndCompileRule(this, p, source,
                 Optional.of(parsePatternIfAbsent(files, kem, pattern, source))));
     }
 
     public Rule parsePatternIfAbsent(FileUtil files, KExceptionManager kem, String pattern, Source source) {
-        return cachedParsedPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, files, kem).parseRule(this, p, source));
+        return cachedParsedPatterns.computeIfAbsent(pattern, p -> new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).parseRule(this, p, source));
     }
 }

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -43,6 +43,7 @@ import org.kframework.utils.Stopwatch;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
+import org.kframework.utils.options.OuterParsingOptions;
 import scala.Option;
 import scala.Tuple2;
 import scala.collection.Set;
@@ -95,6 +96,7 @@ public class DefinitionParsing {
     public DefinitionParsing(
             List<File> lookupDirectories,
             KompileOptions options,
+            OuterParsingOptions outerParsingOptions,
             KExceptionManager kem,
             FileUtil files,
             ParserUtils parser,
@@ -108,7 +110,7 @@ public class DefinitionParsing {
         this.parser = parser;
         this.cacheParses = cacheParses;
         this.cacheFile = cacheFile;
-        this.autoImportDomains = !options.outerParsing.noPrelude;
+        this.autoImportDomains = !outerParsingOptions.noPrelude;
         this.kore = options.isKore();
         this.loader = new BinaryLoader(this.kem);
         this.isStrict = options.strict();

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -42,6 +42,7 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.JarInfo;
 
+import org.kframework.utils.options.OuterParsingOptions;
 import scala.collection.JavaConverters;
 import scala.Function1;
 import scala.Option;
@@ -86,7 +87,7 @@ public class Kompile {
     java.util.Set<KEMException> errors;
 
     public Kompile(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem, boolean cacheParses) {
-        this(kompileOptions, files, kem, new Stopwatch(kompileOptions.global), cacheParses);
+        this(kompileOptions, null, files, kem, new Stopwatch(kompileOptions.global), cacheParses);
     }
 
     public Kompile(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem) {
@@ -94,12 +95,24 @@ public class Kompile {
     }
 
     @Inject
-    public Kompile(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem, Stopwatch sw) {
-        this(kompileOptions, files, kem, sw, true);
+    public Kompile(KompileOptions kompileOptions, OuterParsingOptions outerParsing, FileUtil files, KExceptionManager kem, Stopwatch sw) {
+        this(kompileOptions, outerParsing, files, kem, sw, true);
     }
 
     public Kompile(KompileOptions kompileOptions, FileUtil files, KExceptionManager kem, Stopwatch sw, boolean cacheParses) {
+        this(kompileOptions, null, files, kem, sw, cacheParses);
+    }
+
+    public Kompile(KompileOptions kompileOptions, OuterParsingOptions outerParsing, FileUtil files, KExceptionManager kem, Stopwatch sw, boolean cacheParses) {
         this.kompileOptions = kompileOptions;
+
+        /**
+         * Invoking the kompile command will inject outerParsing into kompileOptions.outerParsing and leave the outerParsing parameter as null.
+         * Skip this assignment to prevent kompileOptions.outerParsing from being clobbered for the kompile utility.
+         */
+        if (outerParsing != null) {
+            kompileOptions.outerParsing = outerParsing;
+        }
         this.files = files;
         this.kem = kem;
         this.errors = new HashSet<>();

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -171,7 +171,7 @@ public class Kompile {
         } else {
           rootCell = Sorts.GeneratedTopCell();
         }
-        CompiledDefinition def = new CompiledDefinition(kompileOptions, parsedDef, kompiledDefinition, files, kem, configInfo.getDefaultCell(rootCell).klabel());
+        CompiledDefinition def = new CompiledDefinition(kompileOptions, kompileOptions.outerParsing, parsedDef, kompiledDefinition, files, kem, configInfo.getDefaultCell(rootCell).klabel());
 
         if (kompileOptions.genBisonParser || kompileOptions.genGlrBisonParser) {
             if (def.configurationVariableDefaultSorts.containsKey("$PGM")) {

--- a/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
@@ -16,6 +16,7 @@ import org.kframework.utils.inject.CommonModule;
 import org.kframework.utils.inject.JCommanderModule;
 import org.kframework.utils.inject.JCommanderModule.ExperimentalUsage;
 import org.kframework.utils.inject.JCommanderModule.Usage;
+import org.kframework.utils.options.OuterParsingOptions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -32,6 +33,7 @@ public class KompileFrontEnd extends FrontEnd {
 
 
     private final KompileOptions options;
+    private final OuterParsingOptions outerOptions;
     private final Provider<Backend> koreBackend;
     private final Stopwatch sw;
     private final KExceptionManager kem;
@@ -41,6 +43,7 @@ public class KompileFrontEnd extends FrontEnd {
     @Inject
     KompileFrontEnd(
             KompileOptions options,
+            OuterParsingOptions outerOptions,
             @Usage String usage,
             Provider<Backend> koreBackend,
             Stopwatch sw,
@@ -50,6 +53,7 @@ public class KompileFrontEnd extends FrontEnd {
             Provider<FileUtil> files) {
         super(kem, options.global, usage, jarInfo, files);
         this.options = options;
+        this.outerOptions = outerOptions;
         this.koreBackend = koreBackend;
         this.sw = sw;
         this.kem = kem;
@@ -59,14 +63,14 @@ public class KompileFrontEnd extends FrontEnd {
 
     @Override
     public int run() {
-        if (!options.outerParsing.mainDefinitionFile(files.get()).exists()) {
+        if (!outerOptions.mainDefinitionFile(files.get()).exists()) {
             throw KEMException.criticalError("Definition file doesn't exist: " +
-                    options.outerParsing.mainDefinitionFile(files.get()).getAbsolutePath());
+                    outerOptions.mainDefinitionFile(files.get()).getAbsolutePath());
         }
 
-        Kompile kompile = new Kompile(options, options.outerParsing, files.get(), kem, sw, !options.profileRules);
+        Kompile kompile = new Kompile(options, outerOptions, files.get(), kem, sw, !options.profileRules);
         Backend backend = koreBackend.get();
-        CompiledDefinition def = kompile.run(options.outerParsing.mainDefinitionFile(files.get()), options.mainModule(files.get()), options.syntaxModule(files.get()), backend.steps(), backend.excludedModuleTags());
+        CompiledDefinition def = kompile.run(outerOptions.mainDefinitionFile(files.get()), options.mainModule(files.get()), options.syntaxModule(files.get()), backend.steps(), backend.excludedModuleTags());
         kompile = null;
         files.get().saveToKompiled("mainModule.txt", def.executionModule().name());
         files.get().saveToKompiled("mainSyntaxModule.txt", def.mainSyntaxModuleName());

--- a/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileFrontEnd.java
@@ -64,7 +64,7 @@ public class KompileFrontEnd extends FrontEnd {
                     options.outerParsing.mainDefinitionFile(files.get()).getAbsolutePath());
         }
 
-        Kompile kompile = new Kompile(options, files.get(), kem, sw, !options.profileRules);
+        Kompile kompile = new Kompile(options, options.outerParsing, files.get(), kem, sw, !options.profileRules);
         Backend backend = koreBackend.get();
         CompiledDefinition def = kompile.run(options.outerParsing.mainDefinitionFile(files.get()), options.mainModule(files.get()), options.syntaxModule(files.get()), backend.steps(), backend.excludedModuleTags());
         kompile = null;

--- a/kernel/src/main/java/org/kframework/kompile/KompileModule.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileModule.java
@@ -12,6 +12,7 @@ import org.kframework.utils.inject.Options;
 import org.kframework.utils.inject.OuterParsingModule;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.OuterParsingOptions;
+import org.kframework.utils.options.OutputDirectoryOptions;
 import org.kframework.utils.options.SMTOptions;
 
 import java.util.List;
@@ -45,4 +46,7 @@ public class KompileModule extends AbstractModule {
 
     @Provides
     OuterParsingOptions outerParsingOptions(KompileOptions options) { return options.outerParsing; }
+
+    @Provides
+    OutputDirectoryOptions outputDirectoryOptions(KompileOptions options) { return options.outputDirectory; }
 }

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -12,6 +12,7 @@ import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.OuterParsingOptions;
+import org.kframework.utils.options.OutputDirectoryOptions;
 import org.kframework.utils.options.SMTOptions;
 import org.kframework.utils.options.BaseEnumConverter;
 import org.kframework.utils.options.StringListConverter;
@@ -34,6 +35,9 @@ public class KompileOptions implements Serializable {
 
     @ParametersDelegate
     public OuterParsingOptions outerParsing = new OuterParsingOptions();
+
+    @ParametersDelegate
+    public OutputDirectoryOptions outputDirectory = new OutputDirectoryOptions();
 
     // Common options
     @Parameter(names="--backend", description="Choose a backend. <backend> is one of [llvm|haskell|kore|java|ocaml]. Each creates the kompiled K definition.")

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -37,7 +37,7 @@ public class KompileOptions implements Serializable {
     public OuterParsingOptions outerParsing = new OuterParsingOptions();
 
     @ParametersDelegate
-    public OutputDirectoryOptions outputDirectory = new OutputDirectoryOptions();
+    public transient OutputDirectoryOptions outputDirectory = new OutputDirectoryOptions();
 
     // Common options
     @Parameter(names="--backend", description="Choose a backend. <backend> is one of [llvm|haskell|kore|java|ocaml]. Each creates the kompiled K definition.")

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -37,10 +37,10 @@ public class KompileOptions implements Serializable {
     }
 
     @ParametersDelegate
-    public OuterParsingOptions outerParsing = new OuterParsingOptions();
+    public transient OuterParsingOptions outerParsing = new OuterParsingOptions();
 
     @ParametersDelegate
-    public transient OutputDirectoryOptions outputDirectory = new OutputDirectoryOptions();
+    public OutputDirectoryOptions outputDirectory = new OutputDirectoryOptions();
 
     // Common options
     @Parameter(names="--backend", description="Choose a backend. <backend> is one of [llvm|haskell|kore|java|ocaml]. Each creates the kompiled K definition.")

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -91,7 +91,7 @@ public class KProve {
     // Saving combined verification definition to disk to be usable by other tools (e.g., kast)
     private void saveFullDefinition(Definition fullDefinition) {
         CompiledDefinition fullCompiledDefinition = new CompiledDefinition(
-                compiledDefinition.kompileOptions,
+                compiledDefinition.kompileOptions, compiledDefinition.outerParsingOptions,
                 fullDefinition, fullDefinition,
                 files, kem, compiledDefinition.topCellInitializer);
         Path proveKompiledDir = Paths.get(kproveOptions.saveProofDefinitionTo).resolve("prove-spec-kompiled");

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -91,7 +91,7 @@ public class KProve {
     // Saving combined verification definition to disk to be usable by other tools (e.g., kast)
     private void saveFullDefinition(Definition fullDefinition) {
         CompiledDefinition fullCompiledDefinition = new CompiledDefinition(
-                compiledDefinition.kompileOptions, compiledDefinition.outerParsingOptions,
+                compiledDefinition.kompileOptions, kproveOptions.outerParsing,
                 fullDefinition, fullDefinition,
                 files, kem, compiledDefinition.topCellInitializer);
         Path proveKompiledDir = Paths.get(kproveOptions.saveProofDefinitionTo).resolve("prove-spec-kompiled");

--- a/kernel/src/main/java/org/kframework/kprove/KProveModule.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveModule.java
@@ -15,6 +15,7 @@ import org.kframework.utils.inject.Options;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.BackendOptions;
 import org.kframework.utils.options.DefinitionLoadingOptions;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 import java.util.List;
@@ -36,6 +37,9 @@ public class KProveModule extends AbstractModule {
     GlobalOptions globalOptions(KProveOptions options) {
         return options.global;
     }
+
+    @Provides @RequestScoped
+    OuterParsingOptions outerParsingOptions(KProveOptions options) { return options.outerParsing; }
 
     @Provides @RequestScoped
     PrintOptions printOptions(KProveOptions options) {

--- a/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
@@ -11,6 +11,7 @@ import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.BackendOptions;
 import org.kframework.utils.options.DefinitionLoadingOptions;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 import java.io.File;
@@ -26,19 +27,13 @@ public class KProveOptions {
     @ParametersDelegate
     public DefinitionLoadingOptions definitionLoading = new DefinitionLoadingOptions();
 
-    @Parameter(description="<file>")
-    private List<String> parameters;
+    @ParametersDelegate
+    public OuterParsingOptions outerParsing = new OuterParsingOptions();
 
     private File specFile;
 
     public synchronized File specFile(FileUtil files) {
-        if (specFile == null) {
-            if (parameters == null || parameters.size() == 0) {
-                throw KEMException.criticalError("You have to provide exactly one main file in order to do outer parsing.");
-            }
-            specFile = files.resolveWorkingDirectory(parameters.get(0));
-        }
-        return specFile;
+        return outerParsing.mainDefinitionFile(files);
     }
 
     @ParametersDelegate

--- a/kernel/src/main/java/org/kframework/kprovex/KProveModule.java
+++ b/kernel/src/main/java/org/kframework/kprovex/KProveModule.java
@@ -11,9 +11,11 @@ import org.kframework.main.GlobalOptions;
 import org.kframework.main.Tool;
 import org.kframework.unparser.PrintOptions;
 import org.kframework.utils.inject.Options;
+import org.kframework.utils.inject.OuterParsingModule;
 import org.kframework.utils.inject.RequestScoped;
 import org.kframework.utils.options.BackendOptions;
 import org.kframework.utils.options.DefinitionLoadingOptions;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.SMTOptions;
 
 public class KProveModule extends AbstractModule {
@@ -33,6 +35,9 @@ public class KProveModule extends AbstractModule {
     GlobalOptions globalOptions(KProveOptions options) {
         return options.global;
     }
+
+    @Provides @RequestScoped
+    OuterParsingOptions outerParsingOptions(KProveOptions options) { return options.outerParsing; }
 
     @Provides @RequestScoped
     PrintOptions printOptions(KProveOptions options) {

--- a/kernel/src/main/java/org/kframework/utils/inject/OuterParsingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/OuterParsingModule.java
@@ -10,6 +10,7 @@ import org.kframework.utils.file.KompiledDir;
 import org.kframework.utils.file.TempDir;
 import org.kframework.utils.file.WorkingDir;
 import org.kframework.utils.options.OuterParsingOptions;
+import org.kframework.utils.options.OutputDirectoryOptions;
 
 import java.io.File;
 
@@ -27,14 +28,14 @@ public class OuterParsingModule extends AbstractModule {
 
     @Provides
     @DefinitionDir
-    File definitionDir(@WorkingDir File workingDir, OuterParsingOptions options) {
-        if (options.directory == null) {
+    File definitionDir(@WorkingDir File workingDir, OuterParsingOptions options, OutputDirectoryOptions output) {
+        if (output.directory == null) {
             // bootstrap the part of FileUtil we need
             return options.mainDefinitionFile(new FileUtil(null, null, workingDir, null, null, null)).getParentFile();
         }
-        File f = new File(options.directory);
+        File f = new File(output.directory);
         if (f.isAbsolute()) return f;
-        return new File(workingDir, options.directory);
+        return new File(workingDir, output.directory);
     }
 
     @Provides @KompiledDir

--- a/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
@@ -42,8 +42,6 @@ public class OuterParsingOptions implements Serializable {
         return mainDefinitionFile;
     }
 
-    @Parameter(names={"--directory", "-d"}, description="Path to the directory in which the output resides. An output can be either a kompiled K definition or a document which depends on the type of backend. The default is the directory containing the main definition file.")
-    public String directory;
 
     @Parameter(names="-I", description="Add a directory to the search path for requires statements.")
     public List<String> includes = new ArrayList<>();

--- a/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
@@ -1,0 +1,17 @@
+package org.kframework.utils.options;
+
+import com.beust.jcommander.Parameter;
+import com.google.inject.Inject;
+
+import java.io.Serializable;
+
+public class OutputDirectoryOptions implements Serializable {
+
+    public OutputDirectoryOptions() {}
+
+    @Inject
+    public OutputDirectoryOptions(Void v) {}
+
+    @Parameter(names={"--directory", "-d"}, description="Path to the directory in which the output resides. An output can be either a kompiled K definition or a document which depends on the type of backend. The default is the directory containing the main definition file.")
+    public String directory;
+}

--- a/kernel/src/test/java/org/kframework/kompile/KompileFrontEndTest.java
+++ b/kernel/src/test/java/org/kframework/kompile/KompileFrontEndTest.java
@@ -6,6 +6,7 @@ import org.junit.Test;
 import org.kframework.utils.IOTestCase;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.JarInfo;
+import org.kframework.utils.options.OuterParsingOptions;
 import org.mockito.Mock;
 
 import java.io.IOException;
@@ -25,18 +26,19 @@ public class KompileFrontEndTest extends IOTestCase {
     FileUtil files;
 
     KompileOptions options = new KompileOptions();
+    OuterParsingOptions outerOptions = new OuterParsingOptions();
 
     @Test
     public void testHelp() throws IOException {
         options.global.help = true;
-        new KompileFrontEnd(options, "foo", Providers.of(koreBackend), sw, kem, loader, jarInfo, Providers.of(files)).main();
+        new KompileFrontEnd(options, outerOptions, "foo", Providers.of(koreBackend), sw, kem, loader, jarInfo, Providers.of(files)).main();
         assertEquals("foo", stdout.toString());
     }
 
     @Test
     public void testVersion() {
         options.global.version = true;
-        new KompileFrontEnd(options, "", Providers.of(koreBackend), sw, kem, loader, jarInfo, Providers.of(files)).main();
+        new KompileFrontEnd(options, outerOptions, "", Providers.of(koreBackend), sw, kem, loader, jarInfo, Providers.of(files)).main();
         verify(jarInfo).printVersionMessage();
     }
 }

--- a/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
+++ b/ocaml-backend/src/main/java/org/kframework/backend/ocaml/DefinitionToOcaml.java
@@ -286,9 +286,9 @@ public class DefinitionToOcaml implements Serializable {
                 throw KEMException.criticalError("Must have only one klabel with the \"thread\" attribute. Found: " + threadKLabels);
             }
             Rule matchThreadSet = Rule(IncompleteCellUtils.make(threadKLabels.iterator().next(), false, KVariable("Threads"), false), BooleanUtils.TRUE, BooleanUtils.TRUE);
-            this.matchThreadSet = convert(new Kompile(kompileOptions, files, kem).compileRule(def.kompiledDefinition, matchThreadSet));
+            this.matchThreadSet = convert(new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).compileRule(def.kompiledDefinition, matchThreadSet));
             Rule rewriteThreadSet = Rule(IncompleteCellUtils.make(threadKLabels.iterator().next(), false, KRewrite(KVariable("Threads"), KVariable("NewThreads")), false), BooleanUtils.TRUE, BooleanUtils.TRUE);
-            this.rewriteThreadSet = convert(new Kompile(kompileOptions, files, kem).compileRule(def.kompiledDefinition, rewriteThreadSet));
+            this.rewriteThreadSet = convert(new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).compileRule(def.kompiledDefinition, rewriteThreadSet));
             this.rewriteThreadSet = Rule(new TransformK() { public K apply(KVariable var) { return KVariable(var.name(), var.att().remove(Sort.class)); } }.apply(this.rewriteThreadSet.body()),
                     this.rewriteThreadSet.requires(), this.rewriteThreadSet.ensures());
         }
@@ -296,8 +296,8 @@ public class DefinitionToOcaml implements Serializable {
         if (mainModule.definedKLabels().contains(stratCell)) {
             Rule makeStuck = Rule(IncompleteCellUtils.make(stratCell, false, KRewrite(KSequence(), KApply(KLabel("#STUCK"))), true), BooleanUtils.TRUE, BooleanUtils.TRUE);
             Rule makeUnstuck = Rule(IncompleteCellUtils.make(stratCell, false, KRewrite(KApply(KLabel("#STUCK")), KSequence()), true), BooleanUtils.TRUE, BooleanUtils.TRUE);
-            this.makeStuck = convert(new Kompile(kompileOptions, files, kem).compileRule(def.kompiledDefinition, makeStuck));
-            this.makeUnstuck = convert(new Kompile(kompileOptions, files, kem).compileRule(def.kompiledDefinition, makeUnstuck));
+            this.makeStuck = convert(new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).compileRule(def.kompiledDefinition, makeStuck));
+            this.makeUnstuck = convert(new Kompile(kompileOptions, kompileOptions.outerParsing, files, kem).compileRule(def.kompiledDefinition, makeUnstuck));
         } else {
             this.makeStuck = null;
             this.makeUnstuck = null;


### PR DESCRIPTION
This change implements command line options from OuterParsingOptions class for several tools other than kompile. This is broken down into the following changes:

Extract `-d` from `OuterParsingOptions`
----------------------------------------------------
This extraction prepares `OuterParsingOptions` class to be included in the
following tools: kprove, kprovex, keq, and kmbc.

KProve, KEq, KBMC: add OuterParsing options
----------------------------------------------------
Adding this object enables the `-I`, `--md-selector`, and `--no-prelude`
options to these tools. By doing so, each tool can configure their own
OuterParsing options rather than getting this information by de-serializing
the kompile object from the cache left by a previous invocation of the
`kompile` command.

pyk tests: remove -I from kompile add -I to kprove
----------------------------------------------------
This test case utilized -I in the kompile command in order to pass the
parameter of this option to kprove. This was done through serializing
the `kompile` object during the invocation of the `kompile` command and
de-serializing the `kompile` object to access the `outerParsingOption`
during the invocation of the `kprove` command. Since the -I option has
been added to `kprove`, drop this command from the `kompile` command and
move it to the `kprove` command.

kprove-markdown test: use --md-selector for testing
-------------------------------------------------------
Add additional lines in a test file to test the new --md-selector
option for kprove. Before this feature was added, the default behavior was for
kprove to use `k` which is the default md-selector. In order to test that the --md-selector
option is functional, text has been added to the test case so that it will
cause a failure on the default md-selector.



Fixes: #1909
Fixes: #1330 