### PR TITLE
Fix kprovex not throwing exception when claim fails to parse

### DIFF
--- a/k-distribution/tests/regression-new/issue-2174-kprovexParseError/Makefile
+++ b/k-distribution/tests/regression-new/issue-2174-kprovexParseError/Makefile
@@ -1,0 +1,10 @@
+DEF=test
+TESTDIR=.
+KOMPILE_FLAGS=--syntax-module TEST
+KOMPILE_BACKEND=haskell
+export KORE_EXEC_OPTS=--log-level error
+
+include ../../../include/kframework/ktest.mak
+
+KPROVE_OR_X=$(KPROVEX)
+CONSIDER_PROVER_ERRORS=2>&1

--- a/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test-spec.k
+++ b/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test-spec.k
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 K Team. All Rights Reserved.
+
+requires "test.k"
+
+module TEST-SPEC
+    imports TEST
+
+    claim <k> asdf ... </k>
+
+endmodule

--- a/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test-spec.k.out
@@ -1,0 +1,4 @@
+[Error] Inner Parser: Parse error: unexpected token '...' following token 'asdf'.
+	Source(test-spec.k)
+	Location(8,20,8,23)
+[Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test.k
+++ b/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test.k
@@ -1,0 +1,21 @@
+module SERIALIZATION
+    imports INT
+    imports BYTES
+
+    syntax Int ::= keccak ( Bytes ) [function, functional, smtlib(smt_keccak)]
+ // --------------------------------------------------------------------------
+    rule [keccak]: keccak(_) => 1
+
+endmodule
+
+module TEST
+    imports SERIALIZATION
+
+    syntax KItem ::= runLemma ( Step ) | doneLemma ( Step )
+ // -------------------------------------------------------
+    rule <k> runLemma(S) => doneLemma(S) ... </k>
+
+    syntax Step ::= Int
+ // -------------------
+
+endmodule

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -158,8 +158,9 @@ public class DefinitionParsing {
 
         def = resolveNonConfigBubbles(def);
         if (! readOnlyCache) {
-            saveCachesAndReportParsingErrors();
+            saveCaches();
         }
+        throwExceptionIfThereAreErrors();
         return mutable(def.entryModules());
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -501,10 +501,6 @@ public class Kompile {
                 .apply(parsedRule);
     }
 
-    public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules) {
-        return parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, false);
-    }
-
     public Set<Module> parseModules(CompiledDefinition definition, String mainModule, String entryPointModule, File definitionFile, Set<String> excludeModules, boolean readOnlyCache) {
         Set<Module> modules = definitionParsing.parseModules(definition, mainModule, entryPointModule, definitionFile, excludeModules, readOnlyCache);
         int totalBubbles = definitionParsing.parsedBubbles.get() + definitionParsing.cachedBubbles.get();


### PR DESCRIPTION
Fixes: #2174
