### PR TITLE
Remove --transition flag

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/InitializeRewriter.java
@@ -65,7 +65,6 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
     private final KExceptionManager kem;
     private final SMTOptions smtOptions;
     private final Map<String, MethodHandle> hookProvider;
-    private final List<String> transitions;
     private final KRunOptions krunOptions;
     private final KProveOptions kproveOptions;
     private final FileUtil files;
@@ -95,7 +94,6 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
         this.kem = kem;
         this.smtOptions = smtOptions;
         this.hookProvider = HookProvider.get(kem);
-        this.transitions = kompileOptions.transition;
         this.krunOptions = krunOptions;
         this.kproveOptions = kproveOptions;
         this.kompileOptions = kompileOptions;
@@ -169,7 +167,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
             Term backendKil = converter.convert(macroExpander.expand(resolveCasts.resolve(k))).evaluate(termContext);
             rewritingContext.stateLog.log(StateLog.LogEvent.EXECINIT, backendKil, KApply(KLabels.ML_TRUE));
             rewritingContext.setExecutionPhase(true);
-            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, transitions, converter);
+            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, converter);
             if (javaExecutionOptions.skipInvokingBackend) {
                 System.err.println("Skipping invoking the backend!");
                 return new RewriterResult(Optional.empty(), Optional.of(0), KORE.KApply(KLabels.ML_TRUE));
@@ -196,7 +194,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
             Term javaTerm = converter.convert(macroExpander.expand(resolveCasts.resolve(initialConfiguration))).evaluate(termContext);
             rewritingContext.stateLog.log(StateLog.LogEvent.SEARCHINIT, javaTerm, KApply(KLabels.ML_TRUE));
             org.kframework.backend.java.kil.Rule javaPattern = convertToJavaPattern(converter, pattern);
-            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, transitions, converter);
+            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, converter);
             if (javaExecutionOptions.skipInvokingBackend) {
                 System.err.println("Skipping invoking the backend!");
                 return KORE.KApply(KLabels.ML_TRUE);
@@ -228,7 +226,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
                     .map(org.kframework.backend.java.kil.Rule::renameVariables)
                     .collect(Collectors.toList());
 
-            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, transitions, converter);
+            SymbolicRewriter rewriter = new SymbolicRewriter(rewritingContext, converter);
 
             if (javaExecutionOptions.skipInvokingBackend) {
                 System.err.println("Skipping invoking the backend!");
@@ -349,10 +347,6 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
             return ((BuiltinList) ((KList) ((KItem) e.equalities().get(0).leftHandSide()).kList()).getContents().get(0)).children;
         }
 
-        private List<String> getTransitions() {
-            return transitions;
-        }
-
         private class ProcessProofRules {
             private final KOREtoBackendKIL converter;
             private final TermContext termContext;
@@ -437,7 +431,7 @@ public class InitializeRewriter implements Function<org.kframework.definition.De
                     .collect(Collectors.toList());
 
             //// prove spec rules
-            rewriter = new SymbolicRewriter(glue.rewritingContext, glue.getTransitions(), processProofRules.converter);
+            rewriter = new SymbolicRewriter(glue.rewritingContext, processProofRules.converter);
 
             startSyncNodes = new ArrayList<>();
             targetSyncNodes = new ArrayList<>();

--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/SymbolicRewriter.java
@@ -72,11 +72,10 @@ public class SymbolicRewriter {
     private final FastRuleMatcher theFastMatcher;
     private final Definition definition;
 
-    public SymbolicRewriter(GlobalContext global, List<String> transitions,
-                            KOREtoBackendKIL constructor) {
+    public SymbolicRewriter(GlobalContext global, KOREtoBackendKIL constructor) {
         this.constructor = constructor;
         this.definition = global.getDefinition();
-        this.transitions = transitions;
+        this.transitions = Collections.singletonList("transition");
         this.theFastMatcher = new FastRuleMatcher(global);
         this.transition = true;
         this.global = global;

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -50,7 +50,6 @@ import scala.Function1;
 import java.io.File;
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashSet;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -128,7 +127,7 @@ public class KoreBackend extends AbstractBackend {
     @Override
     public Function<Definition, Definition> steps() {
         Function1<Definition, Definition> resolveStrict = d -> DefinitionTransformer.from(new ResolveStrict(kompileOptions, d)::resolve, "resolving strict and seqstrict attributes").apply(d);
-        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.transition), heatCoolConditions)::resolve, "resolving heat and cool attributes");
+        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(heatCoolConditions)::resolve, "resolving heat and cool attributes");
         DefinitionTransformer resolveAnonVars = DefinitionTransformer.fromSentenceTransformer(new ResolveAnonVar()::resolve, "resolving \"_\" vars");
         DefinitionTransformer guardOrs = DefinitionTransformer.fromSentenceTransformer(new GuardOrPatterns(true)::resolve, "resolving or patterns");
         DefinitionTransformer resolveSemanticCasts =

--- a/kernel/src/main/java/org/kframework/compile/ResolveHeatCoolAttribute.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveHeatCoolAttribute.java
@@ -16,6 +16,7 @@ import org.kframework.kore.TransformK;
 import org.kframework.parser.outer.Outer;
 import org.kframework.utils.errorsystem.KEMException;
 
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Set;
 
@@ -32,8 +33,8 @@ public class ResolveHeatCoolAttribute {
         HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION
     }
 
-    public ResolveHeatCoolAttribute(Set<String> transitions, EnumSet<Mode> modes) {
-        this.transitions = transitions;
+    public ResolveHeatCoolAttribute(EnumSet<Mode> modes) {
+        this.transitions = Collections.singleton("transition");
         this.modes = modes;
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -267,7 +267,7 @@ public class Kompile {
 
     public static Function<Definition, Definition> defaultSteps(KompileOptions kompileOptions, KExceptionManager kem, FileUtil files) {
         Function1<Definition, Definition> resolveStrict = d -> DefinitionTransformer.from(new ResolveStrict(kompileOptions, d)::resolve, "resolving strict and seqstrict attributes").apply(d);
-        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(new HashSet<>(kompileOptions.transition), EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION))::resolve, "resolving heat and cool attributes");
+        DefinitionTransformer resolveHeatCoolAttribute = DefinitionTransformer.fromSentenceTransformer(new ResolveHeatCoolAttribute(EnumSet.of(HEAT_RESULT, COOL_RESULT_CONDITION, COOL_RESULT_INJECTION))::resolve, "resolving heat and cool attributes");
         DefinitionTransformer resolveAnonVars = DefinitionTransformer.fromSentenceTransformer(new ResolveAnonVar()::resolve, "resolving \"_\" vars");
         DefinitionTransformer guardOrs = DefinitionTransformer.fromSentenceTransformer(new GuardOrPatterns(false)::resolve, "resolving or patterns");
         DefinitionTransformer resolveSemanticCasts =

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -127,11 +127,6 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--bison-stack-max-depth", description="Maximum size of bison parsing stack (default: 10000).")
     public long bisonStackMaxDepth = 10000;
 
-    @Parameter(names="--transition", listConverter=StringListConverter.class, description="[DEPRECATED: java backend only] <string> is a whitespace-separated list of tags designating rules to become transitions.")
-    public List<String> transition = Collections.singletonList(DEFAULT_TRANSITION);
-
-    public static final String DEFAULT_TRANSITION = "transition";
-
     @Parameter(names="--top-cell", description="Choose the top configuration cell when more than one is provided. Does nothing if only one top cell exists.")
     public String topCell;
 }

--- a/kernel/src/test/java/org/kframework/kompile/KompileOptionsTest.java
+++ b/kernel/src/test/java/org/kframework/kompile/KompileOptionsTest.java
@@ -66,11 +66,4 @@ public class KompileOptionsTest {
         assertEquals("BAR-SYNTAX", options.syntaxModule(files));
     }
 
-    @Test
-    public void testTransitionSpaceSeparator() {
-        parse("--transition", "foo bar", "foo.k");
-        assertEquals(2, options.transition.size());
-        assertTrue(options.transition.contains("foo"));
-        assertTrue(options.transition.contains("bar"));
-    }
 }


### PR DESCRIPTION
Work in progress to fix #1936. Progress so far:

- [x] Remove `--transition` flag from the command-line interface, inlining its default value into uses.
- [ ] Update using code to reflect the fact that only "transition" is a valid transition (i.e. set contains / does not contain checks can be simplified).
- [ ] Update Makefiles and K definitions used in tutorials so that they build properly.
- [ ] Rewrite tutorial and documentation text to reflect new options.