### PR TITLE
Include git describe in output of kompile --version

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -232,6 +232,30 @@
         </configuration>
       </plugin>
       <plugin>
+        <artifactId>maven-antrun-plugin</artifactId>
+        <version>1.7</version>
+        <executions>
+          <execution>
+            <id>get-git-revision</id>
+            <phase>compile</phase>
+            <configuration>
+              <exportAntProperties>true</exportAntProperties>
+              <target>
+                <exec executable="git" outputproperty="git.describe.out" failifexecutionfails="false">
+                  <arg value="describe" />
+                  <arg value="--tags" />
+                  <arg value="--dirty" />
+                  <arg value="--long" />
+                </exec>
+              </target>
+            </configuration>
+            <goals>
+              <goal>run</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.5</version>
         <configuration>
@@ -241,6 +265,7 @@
               <Implementation-Branch>${scmBranch}</Implementation-Branch>
               <Implementation-Date>${timestamp}</Implementation-Date>
               <Implementation-Version>${project.version}</Implementation-Version>
+              <Implementation-Git-Describe>${git.describe.out}</Implementation-Git-Describe>
             </manifestEntries>
           </archive>
         </configuration>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -241,7 +241,10 @@
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
-                <exec executable="git" outputproperty="git.describe.out" failifexecutionfails="false">
+                <exec executable="git"
+                      outputproperty="git.describe.out"
+                      errorproperty="git.describe.err"
+                      failifexecutionfails="false">
                   <arg value="describe" />
                   <arg value="--tags" />
                   <arg value="--dirty" />

--- a/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
+++ b/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
@@ -81,9 +81,14 @@ public class JarInfo {
 
             String version     = FileUtils.readFileToString(new File(kBase + "/lib/version")).trim();
             String versionDate = new Date(Long.parseLong(mf.getMainAttributes().getValue("Implementation-Date"))).toString();
+            String gitRevision = mf.getMainAttributes().getValue("Implementation-Git-Describe");
 
             System.out.println("K version:    " + version);
             System.out.println("Build date:   " + versionDate);
+
+            if(!gitRevision.isEmpty()) {
+                System.out.println("Git revision: " + gitRevision);
+            }
         } catch (IOException e) {
             throw KEMException.internalError("Could not load version info.");
         }

--- a/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
+++ b/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
@@ -79,16 +79,17 @@ public class JarInfo {
             URLConnection conn = url.openConnection();
             Manifest      mf   = ((JarURLConnection)conn).getManifest();
 
-            String version     = FileUtils.readFileToString(new File(kBase + "/lib/version")).trim();
             String versionDate = new Date(Long.parseLong(mf.getMainAttributes().getValue("Implementation-Date"))).toString();
-            String gitRevision = mf.getMainAttributes().getValue("Implementation-Git-Describe");
+
+            // Use the output of 'git describe' if we're building K from a Git repository, or fall back to
+            // the release version if we're not (e.g. from a release tarball).
+            String version = mf.getMainAttributes().getValue("Implementation-Git-Describe");
+            if (version.isEmpty()) {
+                version = FileUtils.readFileToString(new File(kBase + "/lib/version")).trim();
+            }
 
             System.out.println("K version:    " + version);
             System.out.println("Build date:   " + versionDate);
-
-            if(!gitRevision.isEmpty()) {
-                System.out.println("Git revision: " + gitRevision);
-            }
         } catch (IOException e) {
             throw KEMException.internalError("Could not load version info.");
         }


### PR DESCRIPTION
When the project is compiled, the output of git describe is captured as
a Maven property; this property is then stored in the packaged .jar
file's manifest (similarly to existing properties like the build
timestamp).

This implementation doesn't rely on an external plugin, but does require
a git executable (other antrun tasks for copyright checks have similar
requirements). It will fail silently if the package is built from a
source distribution with no .git directory such as a tarball, and the
revision will not be printed.

Example output:
```
K version:    5.1.0
Build date:   Wed Sep 08 11:19:05 BST 2021
Git revision: v5.1.172-0-ge1a5b4f92-dirty
```

Fixes #2180 