### PR TITLE
Fix sed expression in test script on macos

### DIFF
--- a/k-distribution/tests/regression-new/issue-2146-duplicateModules/Makefile
+++ b/k-distribution/tests/regression-new/issue-2146-duplicateModules/Makefile
@@ -4,6 +4,6 @@ TESTDIR=.
 KOMPILE_FLAGS=--syntax-module TEST
 
 %.k %.md: dummy
-	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG_FAIL) $@ -d $(DEFDIR) 2>&1 | sed '0,/Source/ s!Source[^\n]*!Source...!' | sed 's!'`pwd`'/\(\./\)\{0,2\}!!g' $(CHECK) $@.out $(CHECK2)
+	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG_FAIL) $@ -d $(DEFDIR) 2>&1 | sed '1s!Source.*!Source...!' | sed 's!'`pwd`'/\(\./\)\{0,2\}!!g' $(CHECK) $@.out $(CHECK2)
 
 include ../../../include/kframework/ktest-fail.mak


### PR DESCRIPTION
The behaviour of sed expressions can be slightly different across
platforms - the new expression in this PR achieves the same effect
(substituting the long Source expression on the first line for
Source...), but works on macos.