### PR TITLE
kdep: fix broken -D option

### DIFF
--- a/k-distribution/include/kframework/ktest-kdep.mak
+++ b/k-distribution/include/kframework/ktest-kdep.mak
@@ -14,4 +14,4 @@ all: $(TESTS)
 dummy:
 
 %.k %.md: dummy
-	$(KDEP) $(OPTS) $@ $(CHECK) $@.out
+	$(KDEP) $(OPTS) $@ | sed 's!'`pwd`'/\(\./\)\{0,2\}!!g' $(CHECK) $@.out

--- a/k-distribution/include/kframework/ktest-kdep.mak
+++ b/k-distribution/include/kframework/ktest-kdep.mak
@@ -1,0 +1,17 @@
+# path to the current makefile
+MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
+# path to the kdep binary of this distribuition
+KDEP=$(abspath $(MAKEFILE_PATH)/../../bin/kdep)
+# all tests in test directory with matching file extension
+TESTS?=$(wildcard ./*.md) $(wildcard ./*.k)
+
+CHECK=| diff -
+
+.PHONY: all
+
+all: $(TESTS)
+
+dummy:
+
+%.k %.md: dummy
+	$(KDEP) $(OPTS) $@ $(CHECK) $@.out

--- a/k-distribution/tests/regression-new/kdep-options/Makefile
+++ b/k-distribution/tests/regression-new/kdep-options/Makefile
@@ -1,0 +1,3 @@
+OPTS= -d OutputDirectoryTest --no-prelude
+
+include ../../../include/kframework/ktest-kdep.mak

--- a/k-distribution/tests/regression-new/kdep-options/outDirTest.k
+++ b/k-distribution/tests/regression-new/kdep-options/outDirTest.k
@@ -1,0 +1,2 @@
+module OUTDIRTEST
+endmodule

--- a/k-distribution/tests/regression-new/kdep-options/outDirTest.k.out
+++ b/k-distribution/tests/regression-new/kdep-options/outDirTest.k.out
@@ -1,0 +1,3 @@
+OutputDirectoryTest/outDirTest-kompiled/timestamp : \
+    /home/erik/k/k-distribution/tests/regression-new/kdep-options/outDirTest.k \
+

--- a/k-distribution/tests/regression-new/kdep-options/outDirTest.k.out
+++ b/k-distribution/tests/regression-new/kdep-options/outDirTest.k.out
@@ -1,3 +1,3 @@
 OutputDirectoryTest/outDirTest-kompiled/timestamp : \
-    /home/erik/k/k-distribution/tests/regression-new/kdep-options/outDirTest.k \
+    outDirTest.k \
 

--- a/kernel/src/main/java/org/kframework/kdep/KDepModule.java
+++ b/kernel/src/main/java/org/kframework/kdep/KDepModule.java
@@ -41,5 +41,5 @@ public class KDepModule extends AbstractModule {
     OuterParsingOptions outerParsingOptions(KDepOptions options) { return options.outerParsing; }
 
     @Provides
-    OutputDirectoryOptions outputDirectoryOptions(KompileOptions options) { return options.outputDirectory; }
+    OutputDirectoryOptions outputDirectoryOptions(KDepOptions options) { return options.outputDirectory; }
 }


### PR DESCRIPTION
Commit 309f81b73c introduced a spelling error in KDepModule.java that
broke kdep's -D option. Fix this by providing the correct `OutputDirectoryOption` in the provider.

Fixes #2194 