### PR TITLE
Add more tests for kdep options

### DIFF
--- a/k-distribution/tests/regression-new/kdep-options/IncludeDirTest/d.k
+++ b/k-distribution/tests/regression-new/kdep-options/IncludeDirTest/d.k
@@ -1,0 +1,2 @@
+module D
+endmodule

--- a/k-distribution/tests/regression-new/kdep-options/Makefile
+++ b/k-distribution/tests/regression-new/kdep-options/Makefile
@@ -1,3 +1,3 @@
-OPTS= -d OutputDirectoryTest --no-prelude
+OPTS= -d OutputDirectoryTest --no-prelude -I IncludeDirTest
 
 include ../../../include/kframework/ktest-kdep.mak

--- a/k-distribution/tests/regression-new/kdep-options/a.k
+++ b/k-distribution/tests/regression-new/kdep-options/a.k
@@ -1,0 +1,7 @@
+require "b.k"
+require "c.k"
+
+module A
+  imports B
+  imports C
+endmodule

--- a/k-distribution/tests/regression-new/kdep-options/a.k.out
+++ b/k-distribution/tests/regression-new/kdep-options/a.k.out
@@ -1,0 +1,6 @@
+OutputDirectoryTest/a-kompiled/timestamp : \
+    IncludeDirTest/d.k \
+    c.k \
+    b.k \
+    a.k \
+

--- a/k-distribution/tests/regression-new/kdep-options/b.k
+++ b/k-distribution/tests/regression-new/kdep-options/b.k
@@ -1,0 +1,2 @@
+module B
+endmodule

--- a/k-distribution/tests/regression-new/kdep-options/b.k.out
+++ b/k-distribution/tests/regression-new/kdep-options/b.k.out
@@ -1,0 +1,3 @@
+OutputDirectoryTest/b-kompiled/timestamp : \
+    b.k \
+

--- a/k-distribution/tests/regression-new/kdep-options/c.k
+++ b/k-distribution/tests/regression-new/kdep-options/c.k
@@ -1,0 +1,5 @@
+require "d.k"
+
+module C
+  imports D
+endmodule

--- a/k-distribution/tests/regression-new/kdep-options/c.k.out
+++ b/k-distribution/tests/regression-new/kdep-options/c.k.out
@@ -1,0 +1,4 @@
+OutputDirectoryTest/c-kompiled/timestamp : \
+    IncludeDirTest/d.k \
+    c.k \
+


### PR DESCRIPTION
Per the list in #2195, this PR adds test cases that ensure:
* The correct root directory is specified for the timestamp file.
* The -I option is respected
* Transitive includes are computed properly
* Nothing gets dragged in that isn't in the inclusion graph

Closes #2196 