### PR TITLE
Add check for search executable in krun

### DIFF
--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -437,12 +437,6 @@ if [ ! -f "$kompiledDir/definition.kore" ]; then
   exit $?
 fi
 
-if $search; then
-  if [ ! -f "$kompiledDir/search" ] || [ ! -x "$kompiledDir/search" ]; then
-    error 'You must pass --enable-search to kompile to be able to use krun --search'
-  fi
-fi
-
 # Process configuration variables
 hasArgv=false
 if [[ "${#ARGV[@]}" -gt 0 ]]; then
@@ -547,6 +541,9 @@ if [ "$backendName" = "llvm" ]; then
 
   keepTempsIfDryRun "$tempDir" "$expanded_input_file" "$kore_output"
   if $search; then
+    if [ ! -f "$kompiledDir/search" ] || [ ! -x "$kompiledDir/search" ]; then
+      error 'You must pass --enable-search to kompile to be able to use krun --search with the LLVM backend'
+    fi
     if [ -n "$pattern" ]; then
       error "Backend llvm does not support search patterns yet."
     fi

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -437,6 +437,12 @@ if [ ! -f "$kompiledDir/definition.kore" ]; then
   exit $?
 fi
 
+if $search; then
+  if [ ! -f "$kompiledDir/search" ] || [ ! -x "$kompiledDir/search" ]; then
+    error 'You must pass --enable-search to kompile to be able to use krun --search'
+  fi
+fi
+
 # Process configuration variables
 hasArgv=false
 if [[ "${#ARGV[@]}" -gt 0 ]]; then


### PR DESCRIPTION
This stops the script from trying to execute something that doesn't
exist, and suggests to the user how they could change their invocation
of krun to fix the problem.

Closes #2173