### PR TITLE
Add explicit to_int cast to ^Int SMT hook

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -930,7 +930,7 @@ You can:
 ```k
   syntax Int ::= "~Int" Int                     [function, klabel(~Int_), symbol, functional, latex(\mathop{\sim_{\scriptstyle\it Int}}{#1}), hook(INT.not), smtlib(notInt)]
                > left:
-                 Int "^Int" Int                 [function, klabel(_^Int_), symbol, left, smt-hook((to_int (^ #1 #2))), latex({#1}\mathrel{{\char`\^}_{\!\scriptstyle\it Int}}{#2}), hook(INT.pow)]
+                 Int "^Int" Int                 [function, klabel(_^Int_), symbol, left, smt-hook((ite (< #2 0) 0 (to_int (^ #1 #2)))), latex({#1}\mathrel{{\char`\^}_{\!\scriptstyle\it Int}}{#2}), hook(INT.pow)]
                | Int "^%Int" Int Int            [function, klabel(_^%Int__), symbol, left, smt-hook((mod (^ #1 #2) #3)), hook(INT.powmod)]
                > left:
                  Int "*Int" Int                 [function, functional, klabel(_*Int_), symbol, left, smt-hook(*), latex({#1}\mathrel{\ast_{\scriptstyle\it Int}}{#2}), hook(INT.mul)]

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -930,7 +930,7 @@ You can:
 ```k
   syntax Int ::= "~Int" Int                     [function, klabel(~Int_), symbol, functional, latex(\mathop{\sim_{\scriptstyle\it Int}}{#1}), hook(INT.not), smtlib(notInt)]
                > left:
-                 Int "^Int" Int                 [function, klabel(_^Int_), symbol, left, smt-hook(^), latex({#1}\mathrel{{\char`\^}_{\!\scriptstyle\it Int}}{#2}), hook(INT.pow)]
+                 Int "^Int" Int                 [function, klabel(_^Int_), symbol, left, smt-hook((to_int (^ #1 #2))), latex({#1}\mathrel{{\char`\^}_{\!\scriptstyle\it Int}}{#2}), hook(INT.pow)]
                | Int "^%Int" Int Int            [function, klabel(_^%Int__), symbol, left, smt-hook((mod (^ #1 #2) #3)), hook(INT.powmod)]
                > left:
                  Int "*Int" Int                 [function, functional, klabel(_*Int_), symbol, left, smt-hook(*), latex({#1}\mathrel{\ast_{\scriptstyle\it Int}}{#2}), hook(INT.mul)]
@@ -1054,6 +1054,8 @@ module INT-SYMBOLIC [symbolic]
 
   rule X modInt N => X requires 0 <=Int X andBool X <Int N [simplification]
   rule X   %Int N => X requires 0 <=Int X andBool X <Int N [simplification]
+
+  rule X ^Int N => 0 requires N <Int 0 [simplification]
 
   // Bit-shifts
   rule X <<Int 0 => X [simplification]

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -1055,7 +1055,7 @@ module INT-SYMBOLIC [symbolic]
   rule X modInt N => X requires 0 <=Int X andBool X <Int N [simplification]
   rule X   %Int N => X requires 0 <=Int X andBool X <Int N [simplification]
 
-  rule X ^Int N => 0 requires N <Int 0 [simplification]
+  rule _ ^Int N => 0 requires N <Int 0 [simplification]
 
   // Bit-shifts
   rule X <<Int 0 => X [simplification]


### PR DESCRIPTION
This was recommended as a workaround for #2154 and #1957 by the Z3
maintainers (https://github.com/Z3Prover/z3/issues/5243).

The original issue arises because Z3 cannot assume that the exponent is
non-negative, and so must infer that the result could potentially have
type Real after evaluating the exponentiation. By adding the to_int
cast, we opt in to integer semantics everywhere ^Int is used.

Additionally, this commit adds a simplification rule for integer
exponentiation that sends negative exponents to zero directly from K.