### PR TITLE
kompile: add check for token sort productions

### DIFF
--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -64,6 +64,7 @@ object FlatModule {
         val newImports = m.imports.map(f)
         val newM = new Module(m.name, newImports, m.localSentences, m.att)
         newM.checkSorts()
+        newM.checkTokenSorts()
         newM
       })
     }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -364,12 +364,13 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
   }
 
   def checkTokenSorts () = {
-    val localTokens = localProductions
-      .collect({ case p if p.att.contains("token") => p })
+    val localTokens = productions
+      .filter(p => p.att.contains("token"))
       .groupBy(_.sort)
-      .map { case (s, ps) => (s, ps) }
     // Token sorts should only contain productions with function or token labels. Any other label is incorrect.
-    val nontokens = productions.filter(p => !p.att.contains("function") && !p.att.contains("token"))
+    val excluded = Set("KLabel", "KBott")
+    val nontokens = localProductions.filter(p => !p.att.contains("function") && !p.att.contains("token") && !p.sort.name.startsWith("#") &&
+    !excluded.contains(p.sort.name))
     val conflicts = nontokens.filter(p => localTokens.contains(p.sort))
     conflicts foreach {
       case p: Production => throw KEMException.compilerError(


### PR DESCRIPTION
Token sorts should only contain productions that have `token` or
`function` labels. Any other label (including subsorts) are illegal. Add
a check to ensure that token definitions are correct.

Fixes: #2119