### PR TITLE
Do not include .depend when make clean

### DIFF
--- a/k-distribution/include/kframework/ktest.mak
+++ b/k-distribution/include/kframework/ktest.mak
@@ -162,4 +162,6 @@ clean:
 	@$(KDEP) $(DEF).$(SOURCE_EXT) > .depend-tmp
 	@mv .depend-tmp .depend
 
+ifneq ($(MAKECMDGOALS),clean)
 -include .depend
+endif


### PR DESCRIPTION
This makes it much faster because it doesn't call kdep for no reason
Fixes: #2232 