### PR TITLE
Update LLVM backend and reorder tests

### DIFF
--- a/k-distribution/tests/regression-new/imp++-llvm/div.imp.out
+++ b/k-distribution/tests/regression-new/imp++-llvm/div.imp.out
@@ -5,8 +5,8 @@
           .
         </k>
         <env>
-          y |-> 1
           x |-> 0
+          y |-> 1
         </env>
         <id>
           0
@@ -14,8 +14,8 @@
       </thread>
     </threads>
     <store>
+      0 |-> 3
       1 |-> 1
-      0 |-> 3
     </store>
     <input>
       ListItem ( #buffer ( "\n" ~> . ) )
@@ -36,8 +36,8 @@
           .
         </k>
         <env>
-          y |-> 1
           x |-> 0
+          y |-> 1
         </env>
         <id>
           0
@@ -45,8 +45,8 @@
       </thread>
     </threads>
     <store>
+      0 |-> 3
       1 |-> 2
-      0 |-> 3
     </store>
     <input>
       ListItem ( #buffer ( "\n" ~> . ) )
@@ -67,8 +67,8 @@
           .
         </k>
         <env>
-          y |-> 1
           x |-> 0
+          y |-> 1
         </env>
         <id>
           0
@@ -76,8 +76,8 @@
       </thread>
     </threads>
     <store>
-      1 |-> 3
       0 |-> 3
+      1 |-> 3
     </store>
     <input>
       ListItem ( #buffer ( "\n" ~> . ) )

--- a/k-distribution/tests/regression-new/imp++-llvm/spawn.imp.out
+++ b/k-distribution/tests/regression-new/imp++-llvm/spawn.imp.out
@@ -6,19 +6,8 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
-        </env>
-        <id>
-          2
-        </id>
-      </thread> <thread>
-        <k>
-          .
-        </k>
-        <env>
-          t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           0
@@ -29,18 +18,29 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           4
         </id>
+      </thread> <thread>
+        <k>
+          .
+        </k>
+        <env>
+          t1 |-> 1
+          x |-> 0
+        </env>
+        <id>
+          2
+        </id>
       </thread>
     </threads>
     <store>
-      3 |-> 4
-      1 |-> 2
       0 |-> 11
+      1 |-> 2
+      3 |-> 4
     </store>
     <input>
       ListItem ( #buffer ( "" ~> . ) )
@@ -62,19 +62,8 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
-        </env>
-        <id>
-          2
-        </id>
-      </thread> <thread>
-        <k>
-          .
-        </k>
-        <env>
-          t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           0
@@ -85,18 +74,29 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           4
         </id>
+      </thread> <thread>
+        <k>
+          .
+        </k>
+        <env>
+          t1 |-> 1
+          x |-> 0
+        </env>
+        <id>
+          2
+        </id>
       </thread>
     </threads>
     <store>
-      3 |-> 4
-      1 |-> 2
       0 |-> 16
+      1 |-> 2
+      3 |-> 4
     </store>
     <input>
       ListItem ( #buffer ( "" ~> . ) )
@@ -118,19 +118,8 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
-        </env>
-        <id>
-          2
-        </id>
-      </thread> <thread>
-        <k>
-          .
-        </k>
-        <env>
-          t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           0
@@ -141,18 +130,29 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           4
         </id>
+      </thread> <thread>
+        <k>
+          .
+        </k>
+        <env>
+          t1 |-> 1
+          x |-> 0
+        </env>
+        <id>
+          2
+        </id>
       </thread>
     </threads>
     <store>
-      3 |-> 4
-      1 |-> 2
       0 |-> 21
+      1 |-> 2
+      3 |-> 4
     </store>
     <input>
       ListItem ( #buffer ( "" ~> . ) )
@@ -174,19 +174,8 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
-        </env>
-        <id>
-          2
-        </id>
-      </thread> <thread>
-        <k>
-          .
-        </k>
-        <env>
-          t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           0
@@ -197,18 +186,29 @@
         </k>
         <env>
           t1 |-> 1
-          x |-> 0
           t2 |-> 3
+          x |-> 0
         </env>
         <id>
           4
         </id>
+      </thread> <thread>
+        <k>
+          .
+        </k>
+        <env>
+          t1 |-> 1
+          x |-> 0
+        </env>
+        <id>
+          2
+        </id>
       </thread>
     </threads>
     <store>
-      3 |-> 4
-      1 |-> 2
       0 |-> 33
+      1 |-> 2
+      3 |-> 4
     </store>
     <input>
       ListItem ( #buffer ( "" ~> . ) )


### PR DESCRIPTION
This is a bit of history rewriting to get the collection-sorting PR
merged without requiring the new garbage collection work to also be
merged.