### PR TITLE
kompile: allow macros on productions

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/symbolic/JavaBackend.java
@@ -123,6 +123,7 @@ public class JavaBackend extends AbstractBackend {
                 //.andThen(ModuleTransformer.fromSentenceTransformer(new NormalizeAssoc(KORE.c()), "normalize assoc"))
                 .andThen(AddBottomSortForListsWithIdenticalLabels.singleton())
                 .andThen(ModuleTransformer.from(new GenerateSortProjections(false)::gen, "adding sort projections"))
+                .andThen(m2 -> ModuleTransformer.fromSentenceTransformer((mod, s) -> new PropagateMacro(mod).propagate(s), "propagate macro labels from production to rules").apply(m2))
                 .andThen(m2 -> {
                   ResolveFunctionWithConfig transformer = new ResolveFunctionWithConfig(m2, false);
                   return ModuleTransformer.fromSentenceTransformer((mod, s) -> new ExpandMacros(transformer, mod, files, kem, kompileOptions, false).expand(s), "expand macros").apply(m2);

--- a/k-distribution/tests/regression-new/checkClaimError/claim-spec.k.out
+++ b/k-distribution/tests/regression-new/checkClaimError/claim-spec.k.out
@@ -1,1 +1,4 @@
 #Top
+[Warning] Compiler: The attribute [macro] has been deprecated on rules. Use this label on syntax declarations instead.
+	Source(errorClaim.k)
+	Location(7,10,7,18)

--- a/k-distribution/tests/regression-new/checkClaimError/rule-spec.k.out
+++ b/k-distribution/tests/regression-new/checkClaimError/rule-spec.k.out
@@ -1,3 +1,6 @@
+[Warning] Compiler: The attribute [macro] has been deprecated on rules. Use this label on syntax declarations instead.
+	Source(errorClaim.k)
+	Location(7,10,7,18)
 [Error] Compiler: Use claim instead of rule to specify proof objectives.
 	Source(rule-spec.k)
 	Location(6,10,6,43)

--- a/k-distribution/tests/regression-new/checkClaimError/syntax-spec.k.out
+++ b/k-distribution/tests/regression-new/checkClaimError/syntax-spec.k.out
@@ -1,3 +1,6 @@
+[Warning] Compiler: The attribute [macro] has been deprecated on rules. Use this label on syntax declarations instead.
+	Source(errorClaim.k)
+	Location(7,10,7,18)
 [Error] Compiler: Found syntax declaration in proof module. Only tokens for existing sorts are allowed.
 	Source(syntax-spec.k)
 	Location(6,18,6,28)

--- a/k-distribution/tests/regression-new/checkWarnsClaim/warnClaim-spec.k.out
+++ b/k-distribution/tests/regression-new/checkWarnsClaim/warnClaim-spec.k.out
@@ -2,3 +2,6 @@
 [Warning] Compiler: Deprecated: use claim instead of rule to specify proof objectives.
 	Source(warnClaim-spec.k)
 	Location(6,10,6,43)
+[Warning] Compiler: The attribute [macro] has been deprecated on rules. Use this label on syntax declarations instead.
+	Source(warnClaim.k)
+	Location(9,10,9,18)

--- a/kernel/src/main/java/org/kframework/compile/PropagateMacro.java
+++ b/kernel/src/main/java/org/kframework/compile/PropagateMacro.java
@@ -1,0 +1,27 @@
+package org.kframework.compile;
+
+import org.kframework.attributes.Att;
+import org.kframework.definition.Module;
+import org.kframework.definition.Rule;
+import org.kframework.definition.Sentence;
+import org.kframework.kore.KLabel;
+
+/**
+ * Propagate macro, macro-rec, alias, and alias-rec labels from productions to rules that only contain that klabel on the LHS
+ * This prepares rules for macro expansion in ExpandMacros
+ */
+public class PropagateMacro {
+    private final Module m;
+
+    public PropagateMacro(Module m) {
+        this.m = m;
+    }
+
+    public Sentence propagate(Sentence s) {
+        if (s instanceof Rule && m.ruleLhsHasMacroKLabel((Rule) s)) {
+            Att macroAtt = m.attributesFor().apply(m.matchKLabel((Rule) s));
+            return Rule.apply(((Rule) s).body(), ((Rule) s).requires(), ((Rule) s).ensures(), s.att().add(macroAtt.getMacro().get()));
+        }
+        return s;
+    }
+}

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -21,7 +21,7 @@ import static org.kframework.Collections.*;
  * Created by dwightguth on 1/25/16.
  */
 public class CheckAtt {
-    private final Set<KLabel> macros;
+    private final scala.collection.Set<KLabel> macros;
     private final Set<KEMException> errors;
     private final Module m;
     private final boolean isSymbolicKast;
@@ -30,7 +30,7 @@ public class CheckAtt {
         this.errors = errors;
         this.m = m;
         this.isSymbolicKast = isSymbolicKast;
-        this.macros = stream(m.rulesFor()).filter(e -> stream(e._2()).filter(r -> ExpandMacros.isMacro(r)).findAny().isPresent()).map(e -> e._1()).collect(Collectors.toSet());
+        this.macros = m.macroKLabels();
     }
 
     public void check(Sentence sentence) {

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -4,18 +4,17 @@ package org.kframework.compile.checks;
 import org.kframework.attributes.Att;
 import org.kframework.attributes.HasLocation;
 import org.kframework.builtin.Sorts;
-import org.kframework.compile.ExpandMacros;
 import org.kframework.definition.Module;
 import org.kframework.definition.Production;
 import org.kframework.definition.Rule;
 import org.kframework.definition.Sentence;
 import org.kframework.kore.KLabel;
 import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.errorsystem.KException.ExceptionType;
+import org.kframework.utils.errorsystem.KExceptionManager;
 
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.kframework.Collections.*;
 
 /**
  * Created by dwightguth on 1/25/16.
@@ -23,11 +22,13 @@ import static org.kframework.Collections.*;
 public class CheckAtt {
     private final scala.collection.Set<KLabel> macros;
     private final Set<KEMException> errors;
+    private final KExceptionManager kem;
     private final Module m;
     private final boolean isSymbolicKast;
 
-    public CheckAtt(Set<KEMException> errors, Module m, boolean isSymbolicKast) {
+    public CheckAtt(Set<KEMException> errors, KExceptionManager kem, Module m, boolean isSymbolicKast) {
         this.errors = errors;
+        this.kem = kem;
         this.m = m;
         this.isSymbolicKast = isSymbolicKast;
         this.macros = m.macroKLabels();
@@ -36,6 +37,7 @@ public class CheckAtt {
     public void check(Sentence sentence) {
         if (sentence instanceof Rule) {
             check(((Rule) sentence).att(), sentence);
+            check((Rule) sentence);
         } else if (sentence instanceof Production) {
             check((Production) sentence);
         }
@@ -64,6 +66,13 @@ public class CheckAtt {
             } else if (!m.sortAttributesFor().get(prod.nonterminals().apply(0).sort().head()).getOrElse(() -> Att.empty()).getOptional(Att.HOOK()).orElse("").equals("KVAR.KVar")) {
                 errors.add(KEMException.compilerError("First child of binder must have a sort with the 'KVAR.KVar' hook attribute.", prod));
             }
+        }
+    }
+
+    private void check(Rule rule) {
+        if (rule.isMacro()) {
+            kem.registerCompilerWarning(ExceptionType.RULE_HAS_MACRO_ATT, errors,
+                    "The attribute [" + rule.att().getMacro().get() + "] has been deprecated on rules. Use this label on syntax declarations instead.", rule);
         }
     }
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -280,6 +280,8 @@ public class Kompile {
         DefinitionTransformer generateSortPredicateSyntax = DefinitionTransformer.from(new GenerateSortPredicateSyntax()::gen, "adding sort predicate productions");
         DefinitionTransformer generateSortProjections = DefinitionTransformer.from(new GenerateSortProjections(kompileOptions.coverage)::gen, "adding sort projections");
         DefinitionTransformer subsortKItem = DefinitionTransformer.from(Kompile::subsortKItem, "subsort all sorts to KItem");
+        Function1<Definition, Definition> propagateMacroToRules =
+                d -> DefinitionTransformer.fromSentenceTransformer((m, s) -> new PropagateMacro(m).propagate(s), "propagate macro labels from production to rules").apply(d);
         Function1<Definition, Definition> expandMacros = d -> {
           ResolveFunctionWithConfig transformer = new ResolveFunctionWithConfig(d, false);
           return DefinitionTransformer.fromSentenceTransformer((m, s) -> new ExpandMacros(transformer, m, files, kem, kompileOptions, false).expand(s), "expand macros").apply(d);
@@ -305,6 +307,7 @@ public class Kompile {
                 .andThen(subsortKItem)
                 .andThen(generateSortPredicateSyntax)
                 .andThen(generateSortProjections)
+                .andThen(propagateMacroToRules)
                 .andThen(expandMacros)
                 .andThen(guardOrs)
                 .andThen(Kompile::resolveFreshConstants)

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -429,7 +429,7 @@ public class Kompile {
         CheckRHSVariables checkRHSVariables = new CheckRHSVariables(errors, !isSymbolic);
         stream(modules).forEach(m -> stream(m.localSentences()).forEach(checkRHSVariables::check));
 
-        stream(modules).forEach(m -> stream(m.localSentences()).forEach(new CheckAtt(errors, mainModule, isSymbolic && isKast)::check));
+        stream(modules).forEach(m -> stream(m.localSentences()).forEach(new CheckAtt(errors, kem, mainModule, isSymbolic && isKast)::check));
 
         stream(modules).forEach(m -> stream(m.localSentences()).forEach(new CheckConfigurationCells(errors, m, isSymbolic && isKast)::check));
 

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -103,6 +103,7 @@ public class KException implements Serializable, HasLocation {
 
     public enum ExceptionType {
         ERROR,
+        RULE_HAS_MACRO_ATT,
         NON_EXHAUSTIVE_MATCH,
         UNDELETED_TEMP_DIR,
         MISSING_HOOK_OCAML,

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -26,6 +26,22 @@ class Att private (val att: Map[(String, String), Any]) extends AttributesToStri
     case _ => false
   }
 
+  def getMacro: Option[String] = {
+    if (contains(Att.MACRO)){
+      return Some(Att.MACRO)
+    }
+    if (contains(Att.MACRO_REC)) {
+      return Some(Att.MACRO_REC)
+    }
+    if (contains(Att.ALIAS)) {
+      return Some(Att.ALIAS)
+    }
+    if (contains(Att.ALIAS_REC)) {
+      return Some(Att.ALIAS_REC)
+    }
+    return None;
+  }
+
   def contains(cls: Class[_]): Boolean = att.contains((cls.getName, cls.getName))
   def contains(key: String): Boolean = att.contains((key, Att.stringClassName))
   def contains(key: String, cls: Class[_]): Boolean = att.contains((key, cls.getName))

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -234,14 +234,26 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
   lazy val rules: Set[Rule] = sentences collect { case r: Rule => r }
   lazy val rulesAndClaims: Set[RuleOrClaim] = Set[RuleOrClaim]().++(claims).++(rules)
   lazy val rulesFor: Map[KLabel, Set[Rule]] = rules.groupBy(r => matchKLabel(r))
-  lazy val macroKLabels: Set[KLabel] = rules.filter(r => r.isMacro).map(r => matchKLabel(r))
+  lazy val macroKLabels: Set[KLabel] = macroKLabelsFromRules++macroKLabelsFromProductions
+  lazy val macroKLabelsFromRules: Set[KLabel] = rules.filter(r => r.isMacro).map(r => matchKLabel(r))
+  lazy val macroKLabelsFromProductions: Set[KLabel] = productions.filter(p => p.isMacro).map(p => matchKLabel(p))
 
-  private def matchKLabel(r: Rule) = r.body match {
+  def matchKLabel(r: Rule) = r.body match {
     case Unapply.KApply(Unapply.KLabel("#withConfig"), Unapply.KApply(s, _) :: _) => s
     case Unapply.KApply(Unapply.KLabel("#withConfig"), Unapply.KRewrite(Unapply.KApply(s, _), _) :: _) => s
     case Unapply.KApply(s, _) => s
     case Unapply.KRewrite(Unapply.KApply(s, _), _) => s
     case _ => KORE.KLabel("")
+  }
+
+  private def matchKLabel(p: Production) = p.klabel match {
+    case Some(klabel) => klabel
+    case _ => KORE.KLabel("")
+  }
+
+  def ruleLhsHasMacroKLabel(r: Rule) = r.body match {
+    case Unapply.KRewrite(Unapply.KApply(l @ Unapply.KLabel(_), _), _) => macroKLabelsFromProductions.contains(l)
+    case _ => false
   }
 
   lazy val contexts: Set[Context] = sentences collect { case r: Context => r }


### PR DESCRIPTION
Before this change, macros were only allowed on rules like so:

syntax Int ::= "this"
rule this => 3 [macro]

This change allows macros on productions and removes the need for
the macro label on rules like so:

syntax Int ::= "this" [macro]
rule this => 3

This is done by propagating the macro label to the appropriate rule
before macro expansion.