### PR TITLE
Anonymous variables get their type directly

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
@@ -567,7 +567,7 @@ public class TypeInferencer implements AutoCloseable {
         Sort oldExpectedSort = expectedSort;
         Optional<ProductionReference> oldExpectedParams = expectedParams;
         TermCons tc = (TermCons)pr;
-        // traverse childrfen
+        // traverse children
         for (int i = 0, j = 0; i < tc.production().items().size(); i++) {
           if (tc.production().items().apply(i) instanceof NonTerminal) {
             NonTerminal nt = (NonTerminal)tc.production().items().apply(i);
@@ -617,6 +617,7 @@ public class TypeInferencer implements AutoCloseable {
         if (pr instanceof Constant && (pr.production().sort().equals(Sorts.KVariable()) || pr.production().sort().equals(Sorts.KConfigVar()))) {
           Constant c = (Constant) pr;
           String name;
+          boolean oldStrictEquality = isStrictEquality;
           if (!shared) {
             nextId++;
             variablesById.add(new ArrayList<>());
@@ -624,6 +625,7 @@ public class TypeInferencer implements AutoCloseable {
             pr.setId(Optional.of(id));
             if (isAnonVar(c)) {
               name = "Var" + c.value() + locStr(c);
+              isStrictEquality = true;
             } else {
               name = "Var" + c.value();
             }
@@ -635,6 +637,7 @@ public class TypeInferencer implements AutoCloseable {
             name = variablesById.get(id).get(0);
           }
           pushConstraint(name, c);
+          isStrictEquality = oldStrictEquality;
         } else if (isRealSort(pr.production().sort().head())) {
           pushConstraint(pr.production().sort(), Optional.of(pr));
         }
@@ -886,7 +889,10 @@ public class TypeInferencer implements AutoCloseable {
         int endIdx = result.length() - 2;
         result = result.substring(startIdx, endIdx);
       }
-      return new SmtSortParser(new StringReader(result)).Sort();
+      Sort r = new SmtSortParser(new StringReader(result)).Sort();
+      if (DEBUG)
+        sb.append("; ").append(r).append("\n");
+      return r;
     } catch (IOException e) {
       throw KEMException.internalError("Could not read from z3 process", e, currentTerm);
     } catch (ParseException e) {


### PR DESCRIPTION
from the above restriction
Partial fix for: #2247

Tested with evm proofs: `time make test-prove KPROVE_OPTS=--dry-run TEST_SYMBOLIC_BACKEND=haskell -j 12 -O`
z3-4.8.7
Before:
```
real	6m34,792s
user	83m29,499s
sys	1m38,575s
```
Slowest rule was **3m44s** - dsvalue-read-pass-summarize-spec.k. A few other rules over 1m.
After this change:
```
real	3m0,959s
user	73m1,389s
sys	1m32,802s
```
Slowest rule was **15s**.

Updated to z3-4.8.13 (latest master). Same command.
```
real     3m56,514s
user	79m20,607s
sys      1m35,394s
```
Slowest rule was **1m1s** - transferFrom-failure-1-a-spec.k. A few others between 15s and 1m.

It seems this optimization works pretty well for the old version of Z3, and it makes it somewhat acceptable for the latest Z3. I wouldn't update yet though. I still have some changes in mind which I find tricky to implement for now.

I would like to get this into master since it may save people a lot of time.