### PR TITLE
remove unneeded --depth 0 option

### DIFF
--- a/k-distribution/tests/regression-new/kprove-append/Makefile
+++ b/k-distribution/tests/regression-new/kprove-append/Makefile
@@ -2,6 +2,6 @@ DEF=def
 EXT=def
 KOMPILE_BACKEND=haskell
 TESTDIR=.
-KPROVE_FLAGS=--spec-module DEF-SPEC --depth 0
+KPROVE_FLAGS=--spec-module DEF-SPEC
 
 include ../../../include/kframework/ktest.mak


### PR DESCRIPTION
There is a regression introduced in the haskell backend from this
commit: https://github.com/kframework/kore/commit/ed422630f9383b2774f1ec8ea04eee86ea0afe1e

The regression causes some calls to kprove to hang. In order to avoid
the hang, the `--depth 0` option was added to this test. This change
removes this option from the Makefile so that the test can execute
without this band aid. This change should be merged after the regression
has been resolved.