### PR TITLE
Kompile: add check for existential variable in LHS

### DIFF
--- a/k-distribution/tests/regression-new/checks/existentialCheck.k
+++ b/k-distribution/tests/regression-new/checks/existentialCheck.k
@@ -1,0 +1,5 @@
+module EXISTENTIALCHECK
+
+    claim <k> ?X:Int => . </k>
+
+endmodule

--- a/k-distribution/tests/regression-new/checks/existentialCheck.k
+++ b/k-distribution/tests/regression-new/checks/existentialCheck.k
@@ -2,4 +2,6 @@ module EXISTENTIALCHECK
 
     claim <k> ?X:Int => . </k>
 
+    rule <k> ?X:Int => . </k>
+
 endmodule

--- a/k-distribution/tests/regression-new/checks/existentialCheck.k.out
+++ b/k-distribution/tests/regression-new/checks/existentialCheck.k.out
@@ -1,0 +1,10 @@
+[Error] Compiler: Claims are not allowed in the definition.
+	Source(existentialCheck.k)
+	Location(3,11,3,31)
+[Error] Compiler: Existential variable ?X found in LHS. Existential variables are only allowed in the RHS.
+	Source(existentialCheck.k)
+	Location(3,15,3,17)
+[Error] Compiler: Found existential variable not supported by concrete backend.
+	Source(existentialCheck.k)
+	Location(3,15,3,17)
+[Error] Compiler: Had 3 structural errors.

--- a/k-distribution/tests/regression-new/checks/existentialCheck.k.out
+++ b/k-distribution/tests/regression-new/checks/existentialCheck.k.out
@@ -7,4 +7,10 @@
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(existentialCheck.k)
 	Location(3,15,3,17)
-[Error] Compiler: Had 3 structural errors.
+[Error] Compiler: Existential variable ?X found in LHS. Existential variables are only allowed in the RHS.
+	Source(existentialCheck.k)
+	Location(5,14,5,16)
+[Error] Compiler: Found existential variable not supported by concrete backend.
+	Source(existentialCheck.k)
+	Location(5,14,5,16)
+[Error] Compiler: Had 5 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckRewrite.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckRewrite.java
@@ -77,6 +77,14 @@ public class CheckRewrite {
             }
 
             @Override
+            public void apply(KVariable k) {
+                if (!h.inRewriteRHS && k.name().startsWith("?")) {
+                    errors.add(KEMException.compilerError(
+                            "Existential variable " + k.name() + " found in LHS. Existential variables are only allowed in the RHS.", k));
+                }
+            }
+
+            @Override
             public void apply(KApply k) {
                 if (!(k.klabel() instanceof KVariable) && k.klabel().name().equals("#fun2") || k.klabel().name().equals("#fun3")) {
                     if (k.klabel().name().equals("#fun2")) {


### PR DESCRIPTION
Existential variables are not allowed in the LHS of rules/claims. They
are only allowed on the RHS.

Fixes: #2264 