### PR TITLE
Bump CI action versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v14.1
+        uses: cachix/install-nix-action@v12
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v13
+        uses: cachix/install-nix-action@v12
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v13
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v13
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           extraPullNames: kore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,10 +17,10 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v13
+        uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v8
         with:
           name: runtimeverification
           extraPullNames: kore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           extraPullNames: kore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v14.1
+        uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v13
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,10 +18,10 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v14.1
+        uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,10 +18,10 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v13
+        uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v10
+        uses: cachix/cachix-action@v8
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'


### PR DESCRIPTION
Similarly to https://github.com/kframework/llvm-backend/pull/451, this is an attempt to fix Nix errors in CI (see https://github.com/kframework/llvm-backend/runs/4078639614?check_suite_focus=true, for example)