### PR TITLE
Bump cachix to v10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
           submodules: recursive
 
       - name: Install Nix
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ jobs:
 
       - name: Install Nix
         uses: cachix/install-nix-action@v14.1
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,4 +37,4 @@ jobs:
         run: nix-shell --run "echo OK"
 
       - name: 'Run selected integration tests'
-        run: nix-build test.nix --argstr test help
+        run: GC_DONT_GC=1 nix-build test.nix --argstr test help

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           extraPullNames: kore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: 'Install Nix'
         uses: cachix/install-nix-action@v14.1
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10
@@ -37,4 +39,4 @@ jobs:
         run: nix-shell --run "echo OK"
 
       - name: 'Run selected integration tests'
-        run: GC_DONT_GC=1 nix-build test.nix --argstr test help
+        run: nix-build test.nix --argstr test help

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -18,7 +18,7 @@ jobs:
           submodules: recursive
 
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v12
+        uses: cachix/install-nix-action@v14.1
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
         uses: cachix/install-nix-action@v12
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v8
+        uses: cachix/cachix-action@v10
         with:
           name: runtimeverification
           signingKey: '${{ secrets.CACHIX_SIGNING_KEY }}'

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -19,6 +19,8 @@ jobs:
 
       - name: 'Install Nix'
         uses: cachix/install-nix-action@v14.1
+        with:
+          install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10


### PR DESCRIPTION
This PR pins the Nix version to 2.3.16 and bumps the action runner dependencies.