### PR TITLE
Make `krun` compatible with bash >= 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,15 +80,13 @@ If you install this list of dependencies, continue directly to the [Build and In
 On macOS using [Homebrew](https://brew.sh/):
 ```shell
 git submodule update --init --recursive
-brew install bash bison boost cmake flex gcc gmp openjdk jemalloc libyaml llvm make maven mpfr pkg-config python stack zlib z3
+brew install bison boost cmake flex gcc gmp openjdk jemalloc libyaml llvm make maven mpfr pkg-config python stack zlib z3
 ```
 
 ## The Long Version
 
 The following dependencies are needed either at build time or runtime:
 
-*   [bash](https://www.gnu.org/software/bash/) (K requires Bash version 4.4 or
-  newer.)
 *   [bison](https://www.gnu.org/software/bison/)
 *   [boost](https://www.boost.org/)
 *   [cmake](https://cmake.org/)

--- a/README.md
+++ b/README.md
@@ -80,13 +80,15 @@ If you install this list of dependencies, continue directly to the [Build and In
 On macOS using [Homebrew](https://brew.sh/):
 ```shell
 git submodule update --init --recursive
-brew install bison boost cmake flex gcc gmp openjdk jemalloc libyaml llvm make maven mpfr pkg-config python stack zlib z3
+brew install bash bison boost cmake flex gcc gmp openjdk jemalloc libyaml llvm make maven mpfr pkg-config python stack zlib z3
 ```
 
 ## The Long Version
 
 The following dependencies are needed either at build time or runtime:
 
+*   [bash](https://www.gnu.org/software/bash/) (K requires Bash version 4.4 or
+  newer.)
 *   [bison](https://www.gnu.org/software/bison/)
 *   [boost](https://www.boost.org/)
 *   [cmake](https://cmake.org/)

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -50,13 +50,13 @@ keepTempsIfDryRun () {
   # kepp files used by dry-run
   if $dryRun; then
     local newArray=()
-    for value in "${tempFiles[@]}"; do
+    for value in ${tempFiles[@]+"${tempFiles[@]}"}; do
         if [[ ! "$@" =~ ${value} ]]; then
           newArray+=($value)
         fi
     done
     tempFiles=()
-    tempFiles=${newArray[@]}
+    tempFiles=${newArray[@]+"${newArray[@]}"}
     unset newArray
   fi
 }
@@ -433,13 +433,13 @@ if ! $hasKompiledDir; then
 fi
 
 if [ ! -f "$kompiledDir/definition.kore" ]; then
-  "$(dirname "$0")/krun-legacy" "${ORIG_ARGV[@]}"
+  "$(dirname "$0")/krun-legacy" ${ORIG_ARGV[@]+"${ORIG_ARGV[@]}"}
   exit $?
 fi
 
 # Process configuration variables
 hasArgv=false
-if [[ "${#ARGV[@]}" -gt 0 ]]; then
+if [[ ${#ARGV[@]+"${#ARGV[@]}"} -gt 0 ]]; then
   config_var_PGM="${ARGV[0]}"
   hasArgv=true
   params+=("PGM")
@@ -461,11 +461,11 @@ if $term; then
   fi
 else
   for configVar in ${declaredConfigVars[@]+"${declaredConfigVars[@]}"}; do
-    if [[ $configVar != "IO" && $configVar != "STDIN" && ! "${params[@]}" =~ "$configVar" ]]; then
+    if [[ $configVar != "IO" && $configVar != "STDIN" && ! ${params[@]+"${params[@]}"} =~ "$configVar" ]]; then
       error "Configuration variable missing: \$$configVar. Use -c$configVar=<Value> in the command line to set."
     fi
   done
-  for name in "${params[@]}"; do
+  for name in ${params[@]+"${params[@]}"}; do
     parser_name="parser_$name"
     config_name="config_var_$name"
     tempFile="$(mktemp ${tempDir}/tmp.in."$name".XXXXXXXXXX)"
@@ -496,7 +496,7 @@ else
     else
       parser=("${!parser_name}")
     fi
-    execute ${parser[@]} "${!config_name}" > "$tempFile"
+    execute ${parser[@]+"${parser[@]}"} "${!config_name}" > "$tempFile"
     configVars="$configVars -c $name $(basename $tempFile) $sortName korefile"
   done
   if [[ ${declaredConfigVar_IO+unset} && "${declaredConfigVar_IO}" = "String" ]]; then

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -460,7 +460,7 @@ if $term; then
     execute $parser_PGM "$config_var_PGM" > "$input_file"
   fi
 else
-  for configVar in "${declaredConfigVars[@]}"; do
+  for configVar in ${declaredConfigVars[@]+"${declaredConfigVars[@]}"}; do
     if [[ $configVar != "IO" && $configVar != "STDIN" && ! "${params[@]}" =~ "$configVar" ]]; then
       error "Configuration variable missing: \$$configVar. Use -c$configVar=<Value> in the command line to set."
     fi
@@ -470,7 +470,7 @@ else
     config_name="config_var_$name"
     tempFile="$(mktemp ${tempDir}/tmp.in."$name".XXXXXXXXXX)"
     tempFiles+=("$tempFile")
-    if [[ ! "${declaredConfigVars[@]}" =~ "$name" ]]; then
+    if [[ ! ${declaredConfigVars[@]+"${declaredConfigVars[@]}"} =~ "$name" ]]; then
       if [ "$name" = "PGM" ]; then
         error "Configuration variable \$PGM does not exist. Do not pass a positional argument to $KRUN."
       else

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -439,7 +439,7 @@ fi
 
 # Process configuration variables
 hasArgv=false
-if [[ ${#ARGV[@]+"${#ARGV[@]}"} -gt 0 ]]; then
+if [[ "${#ARGV[@]}" -gt 0 ]]; then
   config_var_PGM="${ARGV[0]}"
   hasArgv=true
   params+=("PGM")


### PR DESCRIPTION
macOS ships an ancient version of bash by default, which breaks part of the `krun` config variable script [when handling empty arrays](https://stackoverflow.com/questions/7577052/bash-empty-array-expansion-with-set-u).

This PR fixes the places in `krun` where the faulty `set -u` behaviour is relied on, and replaces them with a portable expansion.

Closes #2313 