### PR TITLE
Check for existential variables in requires clause

### DIFF
--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/simple-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/simple-spec.k
@@ -43,7 +43,7 @@ claim
 </lambdaT>
 requires N1 ==Int N2
  andBool M1 ==Int M2
- andBool ?_Ks1 ==K ?_Ks2
+ andBool Ks1 ==K Ks2
 
 claim
 <k> check => . </k>

--- a/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/simple-spec.k
+++ b/k-distribution/tests/regression-new/bisimulation/examples/program-equivalence/imp-lambda/simple-spec.k
@@ -43,7 +43,7 @@ claim
 </lambdaT>
 requires N1 ==Int N2
  andBool M1 ==Int M2
- andBool Ks1 ==K Ks2
+ andBool _Ks1 ==K _Ks2
 
 claim
 <k> check => . </k>

--- a/k-distribution/tests/regression-new/checks/existentialCheck.k
+++ b/k-distribution/tests/regression-new/checks/existentialCheck.k
@@ -1,7 +1,21 @@
 module EXISTENTIALCHECK
 
-    claim <k> ?X:Int => . </k>
+  imports K-EQUAL
+  imports BOOL
 
-    rule <k> ?X:Int => . </k>
+  syntax Program ::= "stateA" | "stateB"
+  syntax Bool ::= isDone(Program) [function]
+
+  rule stateA => stateB
+
+  rule isDone(stateB) => true
+  rule isDone(_) => false [owise]
+
+  claim <k> ?X:Int => . </k>
+
+  rule <k> ?X:Int => . </k>
+
+  rule <k> stateA => ?STATE </k>
+    requires isDone(?STATE)
 
 endmodule

--- a/k-distribution/tests/regression-new/checks/existentialCheck.k.out
+++ b/k-distribution/tests/regression-new/checks/existentialCheck.k.out
@@ -1,16 +1,25 @@
 [Error] Compiler: Claims are not allowed in the definition.
 	Source(existentialCheck.k)
-	Location(3,11,3,31)
+	Location(14,9,14,29)
 [Error] Compiler: Existential variable ?X found in LHS. Existential variables are only allowed in the RHS.
 	Source(existentialCheck.k)
-	Location(3,15,3,17)
+	Location(14,13,14,15)
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(existentialCheck.k)
-	Location(3,15,3,17)
+	Location(14,13,14,15)
 [Error] Compiler: Existential variable ?X found in LHS. Existential variables are only allowed in the RHS.
 	Source(existentialCheck.k)
-	Location(5,14,5,16)
+	Location(16,12,16,14)
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(existentialCheck.k)
-	Location(5,14,5,16)
-[Error] Compiler: Had 5 structural errors.
+	Location(16,12,16,14)
+[Error] Compiler: Found existential variable not supported by concrete backend.
+	Source(existentialCheck.k)
+	Location(18,22,18,28)
+[Error] Compiler: Existential variable ?STATE found in LHS. Existential variables are only allowed in the RHS.
+	Source(existentialCheck.k)
+	Location(19,21,19,27)
+[Error] Compiler: Found existential variable not supported by concrete backend.
+	Source(existentialCheck.k)
+	Location(19,21,19,27)
+[Error] Compiler: Had 8 structural errors.

--- a/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k
+++ b/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k
@@ -10,7 +10,7 @@ module DEF02-SPEC
 
     claim <k> mid Y => end ?Z </k>
          <var> _ </var>
-      requires ?Z ==Int incPos(Y)
+      requires Z ==Int incPos(Y)
       [trusted]
 
 endmodule

--- a/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k
+++ b/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k
@@ -8,7 +8,7 @@ module DEF02-SPEC
          <var> _ </var>
        requires X >=Int 0
 
-    claim <k> mid Y => end ?Z </k>
+    claim <k> mid Y => end Z </k>
          <var> _ </var>
       requires Z ==Int incPos(Y)
       [trusted]

--- a/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k.out
+++ b/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k.out
@@ -1,8 +1,1 @@
-<T>
-  <k>
-    end V0
-  </k>
-  <var>
-    V1
-  </var>
-</T>
+#Top

--- a/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k.out
+++ b/k-distribution/tests/regression-new/spec-rule-application/def02-spec.k.out
@@ -1,1 +1,8 @@
-#Top
+<T>
+  <k>
+    end V0
+  </k>
+  <var>
+    V1
+  </var>
+</T>

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckRewrite.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckRewrite.java
@@ -29,11 +29,11 @@ public class CheckRewrite {
 
     public void check(Sentence sentence) {
         if (sentence instanceof RuleOrClaim) {
-            check(((RuleOrClaim) sentence).body(), sentence instanceof Claim);
+            check((RuleOrClaim) sentence, sentence instanceof Claim);
         }
     }
 
-    private void check(K body, boolean isClaim) {
+    private void check(RuleOrClaim sentence, boolean isClaim) {
         class Holder {
             boolean hasRewrite = false;
             boolean inRewrite = false;
@@ -43,7 +43,7 @@ public class CheckRewrite {
             boolean inFunctionBody = false;
         }
         Holder h = new Holder();
-        new VisitK() {
+        VisitK visitor = new VisitK() {
             @Override
             public void apply(KRewrite k) {
                 boolean inRewrite = h.inRewrite;
@@ -163,9 +163,11 @@ public class CheckRewrite {
                     super.apply(k);
                 }
             }
-        }.accept(body);
+        };
+        visitor.accept(sentence.requires());
+        visitor.accept(sentence.body());
         if (!h.hasRewrite && !isClaim) {
-            errors.add(KEMException.compilerError("Rules must have at least one rewrite.", body));
+            errors.add(KEMException.compilerError("Rules must have at least one rewrite.", sentence.body()));
         }
     }
 }


### PR DESCRIPTION
The `requires` clause is a part of the LHS of the rule. Since existential
variables are not allowed on LHS of the rule, these variables are not
allowed in the clause. Add a check to catch rules like this.

Fixes: https://github.com/kframework/k/issues/2324