### PR TITLE
Fix missing package in dockerfile

### DIFF
--- a/package/debian/Dockerfile
+++ b/package/debian/Dockerfile
@@ -31,6 +31,7 @@ RUN    apt-get update            \
         openjdk-11-jdk           \
         parallel                 \
         pkg-config               \
+        python                   \
         python3                  \
         python3-graphviz         \
         zlib1g-dev


### PR DESCRIPTION
This appears to fix the broken k release which occurred as a result of the `python3` package not installing the `python` binary on Ubuntu Focal.