### PR TITLE
add filename to yyerror

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
@@ -220,7 +220,7 @@ public class KSyntax2Bison {
     bison.append("\n%%\n");
     bison.append("\n" +
         "void yyerror (YYLTYPE *loc, void *scanner, const char *s) {\n" +
-        "    fprintf (stderr, \"%d:%d:%d:%d:%s\\n\", loc->first_line, loc->first_column, loc->last_line, loc->last_column, s);\n" +
+        "    fprintf (stderr, \"%s:%d:%d:%d:%d:%s\\n\", loc->filename, loc->first_line, loc->first_column, loc->last_line, loc->last_column, s);\n" +
         "}\n");
     try {
       FileUtils.write(path, bison);


### PR DESCRIPTION
Previously we were not adding the filename to the error message from yyerror. This is easy enough to add, so we do so.