### PR TITLE
Include named anonymous variables in typeInf optimizations

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/ResolveAnonVar.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveAnonVar.java
@@ -24,6 +24,14 @@ public class ResolveAnonVar {
         return var.equals(ANON_VAR) || var.equals(FRESH_ANON_VAR) || var.equals(FRESH_ANON_CONSTANT) || var.equals(FRESH_LIST_VAR);
     }
 
+    public static boolean isAnonVarOrNamedAnonVar(KVariable var) {
+        return var.name().startsWith(ANON_VAR.name())
+                || var.name().startsWith(FRESH_ANON_VAR.name())
+                || var.name().startsWith(FRESH_ANON_CONSTANT.name())
+                || var.name().startsWith(FRESH_LIST_VAR.name());
+    }
+
+
     private Set<KVariable> vars = new HashSet<>();
 
     void resetVars() {

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
@@ -653,7 +653,7 @@ public class TypeInferencer implements AutoCloseable {
     }
 
     boolean isAnonVar(Constant var) {
-      return ResolveAnonVar.isAnonVar(KVariable(var.value()));
+      return ResolveAnonVar.isAnonVarOrNamedAnonVar(KVariable(var.value()));
     }
 
     /**


### PR DESCRIPTION
Fixes: #2364
For the reported example the time spent in Z3 dropped from 82s to 9s.
I plan on adding more optimizations like this, but you should already see an improvement.