### PR TITLE
fix issue where characters are skipped during checking of format att

### DIFF
--- a/k-distribution/tests/regression-new/checks/formatatt.k
+++ b/k-distribution/tests/regression-new/checks/formatatt.k
@@ -1,0 +1,5 @@
+module FORMATATT
+  imports BOOL
+
+  syntax Stmt ::= "if" "(" Bool ")" Stmt "else" Stmt [avoid, colors(blue,red,red,blue), format(%1 %2%c%3%r%4 %5 %6 %7)]
+endmodule

--- a/k-distribution/tests/regression-new/checks/formatatt.k.out
+++ b/k-distribution/tests/regression-new/checks/formatatt.k.out
@@ -1,0 +1,4 @@
+[Error] Compiler: Invalid colors attribute: expected 5 colors, found 4 colors instead.
+	Source(formatatt.k)
+	Location(4,19,4,119)
+[Error] Compiler: Had 1 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -112,6 +112,7 @@ public class CheckAtt {
                         for (; i < format.length() && format.charAt(i) >= '0' && format.charAt(i) <= '9'; i++) {
                             sb.append(format.charAt(i));
                         }
+                        i--;
                         int idx = Integer.parseInt(sb.toString());
                         if (idx == 0 || idx > prod.items().size()) {
                             errors.add(KEMException.compilerError("Invalid format escape sequence '%" + sb.toString() + "'. Expected a number between 1 and " + prod.items().size(), prod));


### PR DESCRIPTION
There was a bug in our code in CheckAtt.java that checked the correctness of the format attribute that caused it to skip over the character immediately following a numerical escape sequence. In the example in the test, this character is another % that escapes a %c, thus leading to the number of %c sequences in the attribute being incorrectly counted. This was due to an omitted adjustment to i when the code was adapted from Formatter.java. We fix this issue and add a test to test that it is correctly fixed.

Fixes #2374 