### PR TITLE
Revert "Cache scanner after `kompile` and reuse during `k-compile-search-pattern`"

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -2439,9 +2439,6 @@ tutorial.
 
 ```k
   syntax Stream ::= #buffer(K)
-                  | #istream(Int)
-                  | #parseInput(String, String)
-                  | #ostream(Int)
 
 endmodule
 
@@ -2457,6 +2454,9 @@ module STDIN-STREAM
   imports LIST
   imports INT
   imports BOOL
+
+  syntax Stream ::= #istream(Int)
+  syntax Stream ::= #parseInput(String, String)
 
   configuration <stdin> ListItem(#buffer($STDIN:String)) ListItem($IO:String) ListItem(#istream(#stdin)) </stdin>
 
@@ -2551,6 +2551,8 @@ module STDOUT-STREAM
   imports K-IO
   imports LIST
   imports STRING
+
+  syntax Stream ::= #ostream(Int)
 
   configuration <stdout> ListItem(#ostream(#stdout)) ListItem($IO:String) ListItem(#buffer("")) </stdout>
 //configuration <stderr> ListItem(#ostream(#stderr)) ListItem($IO:String) ListItem(#buffer("")) </stderr>

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -549,7 +549,7 @@ if [ "$backendName" = "llvm" ]; then
     if [ -z "$pattern" ]; then
       echo '\and{SortGeneratedTopCell{}}(VarResult:SortGeneratedTopCell{},\top{SortGeneratedTopCell{}}())' > "$patternFile"
     else
-      execute k-compile-search-pattern --directory "$dir" "$pattern" > "$patternFile"
+      k-compile-search-pattern --directory "$dir" "$pattern" > "$patternFile"
     fi
 
     if [[ $searchType != "FINAL" ]]; then

--- a/k-distribution/tests/regression-new/bison-glr-bug/iele.k
+++ b/k-distribution/tests/regression-new/bison-glr-bug/iele.k
@@ -57,7 +57,7 @@ module IELE-SYNTAX
   syntax IeleNameToken  ::=
     Keyword [token]
   syntax NumericIeleName  ::=
-    r"[0-9]+" [token, prec(2)]
+    r"[0-9]+" [token]
   syntax StringIeleName  ::=
     r"\\\"(([^\\\"\\\\])|(\\\\[0-9a-fA-F]{2}))*\\\"" [token]
 endmodule

--- a/k-distribution/tests/regression-new/checks/invalidPrec.k
+++ b/k-distribution/tests/regression-new/checks/invalidPrec.k
@@ -1,5 +1,0 @@
-module INVALIDPREC
-
- syntax Foo ::= r"[0-9]+" [token]
-
-endmodule

--- a/k-distribution/tests/regression-new/checks/invalidPrec.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidPrec.k.out
@@ -1,3 +1,0 @@
-[Error] Compiler: Inconsistent token precedence detected.
-	Source(invalidPrec.k)
-	Location(3,17,3,33)

--- a/kernel/src/main/java/org/kframework/Parser.java
+++ b/kernel/src/main/java/org/kframework/Parser.java
@@ -1,0 +1,70 @@
+// Copyright (c) 2015-2019 K Team. All Rights Reserved.
+package org.kframework;
+
+import org.kframework.attributes.Source;
+import org.kframework.definition.Module;
+import org.kframework.kore.K;
+import org.kframework.kore.Sort;
+import org.kframework.parser.inner.ParseInModule;
+import org.kframework.parser.inner.generator.RuleGrammarGenerator;
+import org.kframework.utils.errorsystem.KEMException;
+import scala.Option;
+import scala.Tuple2;
+import scala.util.Either;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Parses a string with a particular start symbol/sort.
+ * Constructed via the static {@link #from methods}
+ */
+@API
+public class Parser {
+    private final ParseInModule parseInModule;
+
+    private Parser(Module module) {
+        // TODO: remove hack once the frontend is cleaner; also remove the IOException once the hack is cleared
+        if (module.name().endsWith(RuleGrammarGenerator.RULE_CELLS)) {
+            this.parseInModule = RuleGrammarGenerator.getCombinedGrammar(module, true);
+        } else {
+            this.parseInModule = new ParseInModule(module);
+        }
+    }
+
+    /**
+     * Parses a string with a particular start symbol/sort.
+     *
+     * @param startSymbol the start symbol/sort
+     * @param toParse     the String to parse
+     * @param fromSource  the Source of the String toParse
+     * @return a pair: the left projection is a parsed string as a K, if successful;
+     * the right projection is the set of issues encountered while parsing
+     */
+    @SuppressWarnings("unchecked")
+    public Tuple2<Option<K>, Set<Warning>> apply(Sort startSymbol, String toParse, Source fromSource) {
+        Tuple2<Either<Set<KEMException>, K>, Set<KEMException>> res = parseInModule.parseString(toParse, startSymbol, fromSource);
+
+        Set<Warning> problemSet = new HashSet<>();
+        problemSet.addAll((Set<Warning>) (Object) res._2());
+        if (res._1().isLeft())
+            problemSet.addAll((Set<Warning>) (Object) res._1().left().get());
+        return Tuple2.apply(res._1().right().toOption(), problemSet);
+    }
+
+    /**
+     * Parses a string with a particular start symbol/sort.
+     *
+     * @param startSymbol the start symbol/sort
+     * @param toParse     the String to parse
+     * @return a pair: the left projection is a parsed string as a K, if successful;
+     * the right projection is the set of issues encountered while parsing
+     */
+    public Tuple2<Option<K>, Set<Warning>> apply(Sort startSymbol, String toParse) {
+        return apply(startSymbol, toParse, Source.apply("generated"));
+    }
+
+    public static Parser from(Module module) {
+        return new Parser(module);
+    }
+}

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -378,7 +378,7 @@ public class DefinitionParsing {
         Module ruleParserModule = gen.getRuleGrammar(defWithCaches.mainModule());
         ParseCache cache = loadCache(ruleParserModule);
         try (ParseInModule parser = RuleGrammarGenerator.getCombinedGrammar(cache.getModule(), isStrict, profileRules, files, true)) {
-            parser.getScanner(globalOptions).serialize(files.resolveKompiled("scanner"));
+            parser.getScanner(globalOptions);
             Map<String, Module> parsed = defWithCaches.parMap(m -> this.resolveNonConfigBubbles(m, parser.getScanner(globalOptions), gen));
             return DefinitionTransformer.from(m -> Module(m.name(), m.imports(), parsed.get(m.name()).localSentences(), m.att()), "parsing rules").apply(defWithConfig);
         }
@@ -505,8 +505,7 @@ public class DefinitionParsing {
         errors = java.util.Collections.synchronizedSet(Sets.newHashSet());
         RuleGrammarGenerator gen = new RuleGrammarGenerator(compiledDef.kompiledDefinition);
         try (ParseInModule parser = RuleGrammarGenerator
-                .getCombinedGrammar(gen.getRuleGrammar(compiledDef.getParsedDefinition().mainModule()), isStrict, profileRules, false, true, files)) {
-            parser.setScanner(new Scanner(parser, globalOptions, files.resolveKompiled("scanner")));
+                .getCombinedGrammar(gen.getRuleGrammar(compiledDef.executionModule()), isStrict, profileRules, files)) {
             java.util.Set<K> res = parseBubble(parser, new HashMap<>(),
                     new Bubble(rule, contents, Att().add("contentStartLine", 1)
                             .add("contentStartColumn", 1).add(Source.class, source)))

--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -190,9 +190,6 @@ public class ParseInModule implements Serializable, AutoCloseable {
         }
         return scanner;
     }
-    public void setScanner(Scanner s) {
-        scanner = s;
-    }
 
     public Tuple2<Either<Set<KEMException>, K>, Set<KEMException>>
         parseString(String input, Sort startSymbol, Scanner scanner, Source source, int startLine, int startColumn, boolean inferSortChecks, boolean isAnywhere) {

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
@@ -25,8 +25,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.nio.file.StandardCopyOption;
-import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -62,21 +60,6 @@ public class Scanner implements AutoCloseable {
         this.tokens  = KSyntax2GrammarStatesFilter.getTokens(module.getParsingModule());
         this.module  = module.seedModule();
         this.scanner = getScanner();
-    }
-
-    public Scanner(ParseInModule module, GlobalOptions go, File scanner) {
-        this.go = go;
-        this.tokens  = KSyntax2GrammarStatesFilter.getTokens(module.getParsingModule());
-        this.module  = module.seedModule();
-        this.scanner = scanner;
-    }
-
-    public void serialize(File output) {
-        try {
-            Files.copy(scanner.toPath(), output.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        } catch (IOException e) {
-            throw KEMException.criticalError("Could not write to " + output, e);
-        }
     }
 
     public Module getModule() {

--- a/kernel/src/test/java/org/kframework/ParserTest.java
+++ b/kernel/src/test/java/org/kframework/ParserTest.java
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-2019 K Team. All Rights Reserved.
+package org.kframework;
+
+import static org.junit.Assert.*;
+
+import org.junit.Test;
+import org.kframework.definition.*;
+import org.kframework.definition.Module;
+import org.kframework.kore.K;
+import org.kframework.kore.Sort;
+import scala.Option;
+import scala.Tuple2;
+
+import java.util.Set;
+
+import static org.kframework.kore.KORE.*;
+import static org.kframework.definition.Constructors.*;
+import static org.kframework.Collections.*;
+
+public class ParserTest {
+    private static final Sort xSort = Sort("X");
+    Module m = Module.apply("TEST", Set(
+            Production(KLabel("x"), xSort, Seq(Terminal.apply("x")), Att())
+    ));
+
+    @Test
+    public void simpleNoWarning() {
+        Tuple2<Option<K>, Set<Warning>> actual = Parser.from(m).apply(xSort, "x");
+        assertTrue("The parse should succeed, but was " + actual, actual._1().isDefined());
+        assertTrue("There should be no warnings, but were: " + actual._2(), actual._2().isEmpty());
+        assertEquals(KApply(KLabel("x")), actual._1().get());
+    }
+
+    @Test
+    public void simpleFailedParse() {
+        Tuple2<Option<K>, Set<Warning>> actual = Parser.from(m).apply(xSort, "y");
+        assertTrue("The parse should fail, but was " + actual, actual._1().isEmpty());
+        assertTrue("There should be one error, but were: " + actual._2(), actual._2().size() == 1);
+    }
+}

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -3,7 +3,6 @@
 package org.kframework.definition
 
 import java.util.Optional
-import java.lang.Comparable
 import javax.annotation.Nonnull
 
 import dk.brics.automaton.{BasicAutomata, RegExp, RunAutomaton, SpecialOperations}
@@ -651,7 +650,7 @@ sealed trait ProductionItem extends OuterKORE
 
 // marker
 
-sealed trait TerminalLike extends ProductionItem with Comparable[TerminalLike] {
+sealed trait TerminalLike extends ProductionItem {
 }
 
 case class NonTerminal(sort: Sort, name: Option[String]) extends ProductionItem
@@ -666,22 +665,8 @@ case class RegexTerminal(precedeRegex: String, regex: String, followRegex: Strin
     SpecialOperations.reverse(unreversed)
     new RunAutomaton(unreversed, false)
   }
-
-  def compareTo(t: TerminalLike): Int = {
-    if (t.isInstanceOf[Terminal]) {
-      return 1;
-    }
-    return regex.compareTo(t.asInstanceOf[RegexTerminal].regex)
-  }
 }
 
 case class Terminal(value: String) extends TerminalLike // hooked
   with TerminalToString {
-
-  def compareTo(t: TerminalLike): Int = {
-    if (t.isInstanceOf[RegexTerminal]) {
-      return -1;
-    }
-    return value.compareTo(t.asInstanceOf[Terminal].value)
-  }
 }


### PR DESCRIPTION
Reverts kframework/k#2390

This pr needs more testing to handle the legacy kprove script and I don't want it to block the process of getting a release completed.