### PR TITLE
Try to fix master build failure on mac os

### DIFF
--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_5/Makefile.nondet
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_5/Makefile.nondet
@@ -3,5 +3,5 @@ TESTDIR=tests/nondeterministic
 DEFDIR=nondet
 include $(MAKEFILE_PATH)/../lesson_2/Makefile
 
-%/arithmetic-div-zero.lambda:
+tests/nondeterministic/arithmetic-div-zero.lambda:
 	true


### PR DESCRIPTION
It seems that the version of Make used on MacOS does not correctly apply this rule in order to prevent the makefile from trying to run the divide by zero test, which, of course, crashes. I believe that this change ought to fix it.