### PR TITLE
Fix parser segfault in test suite

### DIFF
--- a/k-distribution/tests/regression-new/issue-1602/Makefile
+++ b/k-distribution/tests/regression-new/issue-1602/Makefile
@@ -2,6 +2,6 @@ DEF=test
 EXT=test
 TESTDIR=.
 KOMPILE_FLAGS+=--gen-bison-parser --bison-stack-max-depth 12000
-KRUN_FLAGS=--dry-run 1>/dev/null
+KRUN_FLAGS=--dry-run 1>/dev/null --no-expand-macros
 
 include ../../../include/kframework/ktest.mak


### PR DESCRIPTION
The input to this test was deliberately constructed to exceed the stack size allocated to the bison parser by default. Unfortunately, it does the same to the Kore parser in the LLVM backend.

This PR fixes the issue by disabling macro expansion in the `krun` pipeline for this test. There are no macros in this test, so this is a safe workaround.

If this issue crops up again in the future, the workaround from a user perspective is to set a larger stack size using `ulimit -s`.