### PR TITLE
Fix version script when releases are missing

### DIFF
--- a/scripts/get-version-string.sh
+++ b/scripts/get-version-string.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-MERGE_BASE=$(git merge-base master HEAD)
+SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+RELEASE_TAG=$("$SCRIPTS_DIR/newest-release-tag.sh")
+
+MERGE_BASE=$(git merge-base "$RELEASE_TAG" HEAD)
 VERSION_TAG=$(git describe --contains --always "$MERGE_BASE" | sed 's/~.*//')
 
 VERSION_STRING=$VERSION_TAG

--- a/scripts/newest-release-tag.sh
+++ b/scripts/newest-release-tag.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+for sha in $(git rev-list origin/release); do
+  if tag=$(git describe --tags --exact-match $sha 2>/dev/null); then
+    echo $tag
+    break
+  fi
+done


### PR DESCRIPTION
This change walks back through the rev-list on the `release` branch to find the most recently tagged version, and uses this as the merge base from which version strings are constructed.

Doing so prevents the output from breaking if the most recent commits on `master` don't have releases branching from them (for example, if the release process has become broken).

Example output:
```console
$ kompile --version
K version:    v5.2.71-4-gc7b822b5d4
Build date:   Tue Feb 01 10:22:10 GMT 2022
```