### PR TITLE
Install make in Debian image

### DIFF
--- a/package/debian/Dockerfile
+++ b/package/debian/Dockerfile
@@ -26,6 +26,7 @@ RUN    apt-get update            \
         libz3-dev                \
         lld-$LLVM_VERSION        \
         llvm-$LLVM_VERSION-tools \
+        make                     \
         maven                    \
         openjdk-11-jdk           \
         parallel                 \


### PR DESCRIPTION
I'm not sure if this is the fix that we need for this issue, but it appears to be the Docker image that's manifesting the problems in CI that we've been seeing.

The immediate issue is that Make isn't installed at the time we run the tests, so this PR installs it explicitly in the image to see if that is the underlying problem as well.