### PR TITLE
Install make in empty test container

### DIFF
--- a/package/debian/Dockerfile
+++ b/package/debian/Dockerfile
@@ -26,7 +26,6 @@ RUN    apt-get update            \
         libz3-dev                \
         lld-$LLVM_VERSION        \
         llvm-$LLVM_VERSION-tools \
-        make                     \
         maven                    \
         openjdk-11-jdk           \
         parallel                 \

--- a/src/main/scripts/test-in-container-debian
+++ b/src/main/scripts/test-in-container-debian
@@ -3,5 +3,6 @@ K_VERSION=5.2.0
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get upgrade --yes
+apt-get install --yes make
 apt-get install --yes ./kframework_${K_VERSION}_amd64.deb
 "$(dirname "$0")/test-in-container"


### PR DESCRIPTION
I found that #2424 wasn't the right solution; it was installing Make in the container that _builds_ the K `.deb` file.

Instead, what we need to do is make sure that it's installed in the container that installs the `.deb` and runs the tests.

I'm not sure what's changed to cause us to no longer pull in Make on Ubuntu Focal, but I think this is the right solution, as it encodes the dependency on Make only for our own use case (rather than for all consumers of the package).