### PR TITLE
Add flag --emit-json-spec to kprovex

### DIFF
--- a/java-backend/src/main/java/org/kframework/backend/java/util/StateLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/StateLog.java
@@ -132,7 +132,16 @@ public class StateLog {
             String fileCode   = hash(contents);
             File   outputFile = new File(this.blobsDir, fileCode + "." + OutputModes.JSON.ext());
             if (! outputFile.exists()) {
-                FileUtil.save(outputFile, this.prettyPrinter.prettyPrintBytes(contents));
+                try {
+                    String out = new String(this.prettyPrinter.prettyPrintBytes(contents), StandardCharsets.UTF_8);
+                    PrintWriter fOut = new PrintWriter(outputFile);
+                    fOut.println(out);
+                    fOut.close();
+                    writtenHashes.put(objectHash,fileCode);
+                } catch (FileNotFoundException e) {
+                    System.err.println("Could not open node output file: " + outputFile.getAbsolutePath());
+                    e.printStackTrace();
+                }
             }
             return fileCode;
         }

--- a/java-backend/src/main/java/org/kframework/backend/java/util/StateLog.java
+++ b/java-backend/src/main/java/org/kframework/backend/java/util/StateLog.java
@@ -132,16 +132,7 @@ public class StateLog {
             String fileCode   = hash(contents);
             File   outputFile = new File(this.blobsDir, fileCode + "." + OutputModes.JSON.ext());
             if (! outputFile.exists()) {
-                try {
-                    String out = new String(this.prettyPrinter.prettyPrintBytes(contents), StandardCharsets.UTF_8);
-                    PrintWriter fOut = new PrintWriter(outputFile);
-                    fOut.println(out);
-                    fOut.close();
-                    writtenHashes.put(objectHash,fileCode);
-                } catch (FileNotFoundException e) {
-                    System.err.println("Could not open node output file: " + outputFile.getAbsolutePath());
-                    e.printStackTrace();
-                }
+                FileUtil.save(outputFile, this.prettyPrinter.prettyPrintBytes(contents));
             }
             return fileCode;
         }

--- a/k-distribution/tests/pyk/Makefile
+++ b/k-distribution/tests/pyk/Makefile
@@ -18,7 +18,8 @@ export PYTHONPATH
 
 .PHONY: all clean update-results pyk                                                \
         test test-defn test-defn-kast test-defn-prove                               \
-        test-kpyk test-kpyk-coverage-log test-kpyk-graphviz test-kpyk-minimize-term
+        test-kpyk test-kpyk-coverage-log test-kpyk-graphviz test-kpyk-minimize-term \
+		test-emit-json-spec
 
 all: test
 
@@ -49,7 +50,7 @@ kompile: $(llvm_imp_kompiled) $(haskell_imp_kompiled)
 
 # Tests
 
-test: test-unit test-defn test-kpyk
+test: test-unit test-defn test-kpyk test-emit-json-spec
 
 ## Unit Tests
 
@@ -108,3 +109,15 @@ test-kpyk-minimize-term: kpyk-tests/minimize/test.k
 	$(KPYK) kpyk-tests/minimize/test-kompiled prove kpyk-tests/minimize/test.k kpyk-tests/minimize/test.k TEST-SPEC \
 	    | $(KPYK) kpyk-tests/minimize/test-kompiled print /dev/stdin > kpyk-tests/minimize/test.k.out
 	$(CHECK) kpyk-tests/minimize/test.k.out kpyk-tests/minimize/test.k.expected
+
+
+## kprovex --emit-json-spec tests
+
+emit-json-spec-tests/verification-kompiled/timestamp: emit-json-spec-tests/verification.k imp.k
+	kompile $< --backend haskell -I . --emit-json
+
+emit-json-spec-tests/looping-spec.json: emit-json-spec-tests/looping-spec.k emit-json-spec-tests/verification-kompiled/timestamp
+	kprovex $< --backend haskell -I . --directory $(@D) --emit-json-spec $@ --dry-run
+
+test-emit-json-spec: emit-json-spec-tests/emit_json_spec_test.py emit-json-spec-tests/looping-spec.json
+	python3 -m unittest $<

--- a/k-distribution/tests/pyk/Makefile
+++ b/k-distribution/tests/pyk/Makefile
@@ -19,12 +19,12 @@ export PYTHONPATH
 .PHONY: all clean update-results pyk                                                \
         test test-defn test-defn-kast test-defn-prove                               \
         test-kpyk test-kpyk-coverage-log test-kpyk-graphviz test-kpyk-minimize-term \
-		test-emit-json-spec
+        test-emit-json-spec
 
 all: test
 
 clean:
-	rm -rf $(llvm_dir) $(haskell_dir)
+	rm -rf $(llvm_dir) $(haskell_dir) emit-json-spec-tests/verification-kompiled/timestamp emit-json-spec-tests/looping-spec.json
 
 llvm_dir          := llvm
 llvm_imp          := $(llvm_dir)/imp.k

--- a/k-distribution/tests/pyk/Makefile
+++ b/k-distribution/tests/pyk/Makefile
@@ -11,7 +11,7 @@ KPYK    = $(K_BIN)/kpyk
 
 export PATH := $(K_BIN):$(PATH)
 
-CHECK = git diff --no-index -R
+CHECK = git --no-pager diff --no-index -R
 
 PYTHONPATH := $(K_LIB)
 export PYTHONPATH

--- a/k-distribution/tests/pyk/Makefile
+++ b/k-distribution/tests/pyk/Makefile
@@ -24,7 +24,7 @@ export PYTHONPATH
 all: test
 
 clean:
-	rm -rf $(llvm_dir) $(haskell_dir) emit-json-spec-tests/verification-kompiled/timestamp emit-json-spec-tests/looping-spec.json
+	rm -rf $(llvm_dir) $(haskell_dir) emit-json-spec-tests/verification-kompiled emit-json-spec-tests/looping-spec.json
 
 llvm_dir          := llvm
 llvm_imp          := $(llvm_dir)/imp.k

--- a/k-distribution/tests/pyk/emit-json-spec-tests/emit_json_spec_test.py
+++ b/k-distribution/tests/pyk/emit-json-spec-tests/emit_json_spec_test.py
@@ -1,0 +1,83 @@
+import json
+import os
+import shutil
+import unittest
+from pathlib import Path
+
+from pyk.kast import KApply, KClaim, KDefinition, KRequire, KVariable
+from pyk.kastManip import rewriteAnywhereWith
+from pyk.ktool import KProve
+
+
+class EmitJsonSpecTest(unittest.TestCase):
+    TEST_DIR = 'emit-json-spec-tests'
+    MAIN_FILE = 'verification.k'
+    USE_DIR = f'{TEST_DIR}/.kprove'
+
+    def setUp(self):
+        shutil.rmtree(self.USE_DIR, ignore_errors=True)
+        os.makedirs(self.USE_DIR)
+
+        self.kprove = KProve(f'{self.TEST_DIR}/verification-kompiled', self.MAIN_FILE, self.USE_DIR)
+        self.kprove.proverArgs += ['-I', '.']
+        self._update_symbol_table(self.kprove)
+
+        with open(f'{self.TEST_DIR}/looping-spec.json', 'r') as spec_file:
+            module = json.load(spec_file)['term']
+
+        claim = extract_claims(module)[0]
+        self.claim = KClaim(
+            body=eliminate_generated_top(claim['body']),
+            requires=claim['requires'],
+            ensures=claim['ensures'],
+            att=None
+        )
+
+        module['localSentences'] = [self.claim]
+        self.module = module
+
+    def tearDown(self):
+        shutil.rmtree(self.USE_DIR)
+
+    @staticmethod
+    def _update_symbol_table(kprove):
+        def paren(f):
+            def unparse(*args):
+                return '(' + f(*args) + ')'
+            return unparse
+
+        kprove.symbolTable['_+Int_'] = paren(kprove.symbolTable['_+Int_'])
+
+    def test_prove_claim(self):
+        # When
+        result = self.kprove.proveClaim(self.claim, 'looping-1')
+
+        # Then
+        self.assertEqual(result['label'], '#Top')
+
+    def test_prove(self):
+        # Given
+        spec_name = 'looping-2-spec'
+        spec_path = Path(f'{self.USE_DIR}/{spec_name}.k')
+        spec_module_name = spec_name.upper()
+
+        self.module['name'] = spec_module_name
+        definition = KDefinition(self.module, [self.module], requires=[KRequire(self.MAIN_FILE)])
+
+        with open(spec_path, 'x') as spec_file:
+            spec_file.write(self.kprove.prettyPrint(definition))
+
+        # When
+        result = self.kprove.prove(spec_path, spec_module_name)
+
+        # Then
+        self.assertEqual(result['label'], '#Top')
+
+
+def extract_claims(module):
+    return [claim for claim in module['localSentences'] if claim['node'] == 'KClaim']
+
+
+def eliminate_generated_top(term):
+    rule = KApply('<generatedTop>', [KVariable('CONFIG'), KVariable('_')]), KVariable('CONFIG')
+    return rewriteAnywhereWith(rule, term)

--- a/k-distribution/tests/pyk/emit-json-spec-tests/looping-spec.k
+++ b/k-distribution/tests/pyk/emit-json-spec-tests/looping-spec.k
@@ -1,0 +1,18 @@
+requires "verification.k"
+
+module LOOPING-SPEC
+    imports VERIFICATION
+
+    claim <k> while ( 1 <= $n ) {
+                $s = $s + $n ;
+                $n = $n + -1 ;
+              }
+           => . ... </k>
+          <state> $s |-> (S:Int => S +Int ((N +Int 1) *Int N /Int 2))
+                  $n |-> (N:Int => 0)
+          </state>
+      requires N >=Int 0
+       andBool S >=Int 0
+
+endmodule
+

--- a/k-distribution/tests/pyk/emit-json-spec-tests/verification.k
+++ b/k-distribution/tests/pyk/emit-json-spec-tests/verification.k
@@ -1,0 +1,12 @@
+requires "imp.k"
+
+module VERIFICATION-SYNTAX
+    syntax Id ::= "$s" [token]
+                | "$n" [token]
+endmodule
+
+module VERIFICATION
+    imports VERIFICATION-SYNTAX
+    imports IMP
+endmodule
+

--- a/kernel/src/main/java/org/kframework/kprove/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProve.java
@@ -61,6 +61,9 @@ public class KProve {
         this.proofDefinitionBuilder = proofDefinitionBuilder;
         this.rewriterGenerator = rewriterGenerator;
         this.sw = sw;
+        if (kproveOptions.emitJsonSpec != null) {
+            throw KEMException.criticalError("Option `--emit-json-spec` only supported in kprovex tool!");
+        }
     }
 
     public int run() {

--- a/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
+++ b/kernel/src/main/java/org/kframework/kprove/KProveOptions.java
@@ -94,4 +94,7 @@ public class KProveOptions {
 
     @Parameter(names="--emit-json", description="Emit JSON serialized main definition for proving.")
     public boolean emitJson = false;
+
+    @Parameter(names="--emit-json-spec", description="If set, emit the JSON serialization of the spec module to the specified file.")
+    public String emitJsonSpec = null;
 }

--- a/kernel/src/main/java/org/kframework/kprovex/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprovex/KProve.java
@@ -87,7 +87,7 @@ public class KProve {
         }
 
         if (kproveOptions.emitJsonSpec != null) {
-            FileUtil.save(new File(kproveOptions.emitJsonSpec), ToJson.apply(specModule));
+            files.saveToWorkingDirectory(kproveOptions.emitJsonSpec, ToJson.apply(specModule));
         }
 
         RewriterResult results = rewriter.prove(specModule, boundaryPattern, true);

--- a/kernel/src/main/java/org/kframework/kprovex/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprovex/KProve.java
@@ -20,8 +20,7 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import scala.Tuple2;
 
-import java.io.FileNotFoundException;
-import java.io.PrintWriter;
+import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.util.function.Function;
 
@@ -88,15 +87,7 @@ public class KProve {
         }
 
         if (kproveOptions.emitJsonSpec != null) {
-            try {
-                String out = new String(ToJson.apply(specModule));
-                PrintWriter fOut = new PrintWriter(kproveOptions.emitJsonSpec);
-                fOut.println(out);
-                fOut.close();
-            } catch (FileNotFoundException e) {
-                System.err.println("Could not open node output file: " + kproveOptions.emitJsonSpec);
-                e.printStackTrace();
-            }
+            FileUtil.save(new File(kproveOptions.emitJsonSpec), ToJson.apply(specModule));
         }
 
         RewriterResult results = rewriter.prove(specModule, boundaryPattern, true);

--- a/kernel/src/main/java/org/kframework/kprovex/KProve.java
+++ b/kernel/src/main/java/org/kframework/kprovex/KProve.java
@@ -20,6 +20,8 @@ import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import scala.Tuple2;
 
+import java.io.FileNotFoundException;
+import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.util.function.Function;
 
@@ -82,6 +84,18 @@ public class KProve {
                 files.saveToKompiled("prove-definition.json", new String(ToJson.apply(compiled._1()), "UTF-8"));
             } catch (UnsupportedEncodingException e) {
                 throw KEMException.criticalError("Unsupported encoding `UTF-8` when saving JSON definition.");
+            }
+        }
+
+        if (kproveOptions.emitJsonSpec != null) {
+            try {
+                String out = new String(ToJson.apply(specModule));
+                PrintWriter fOut = new PrintWriter(kproveOptions.emitJsonSpec);
+                fOut.println(out);
+                fOut.close();
+            } catch (FileNotFoundException e) {
+                System.err.println("Could not open node output file: " + kproveOptions.emitJsonSpec);
+                e.printStackTrace();
             }
         }
 

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -66,6 +66,7 @@ public class JsonParser {
                              , KNONTERMINAL         = "KNonTerminal"
                              , KMODULE              = "KModule"
                              , KFLATMODULE          = "KFlatModule"
+                             , KIMPORT              = "KImport"
                              , KPRODUCTION          = "KProduction"
                              , KREGEXTERMINAL       = "KRegexTerminal"
                              , KREWRITE             = "KRewrite"

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -163,6 +163,7 @@ public class ToJson {
         JsonArrayBuilder imports = Json.createArrayBuilder();
         stream(mod.imports()).forEach(i -> {
           JsonObjectBuilder jimp = Json.createObjectBuilder();
+          jimp.add("node", JsonParser.KIMPORT);
           jimp.add("name", i.name());
           jimp.add("isPublic", i.isPublic());
           imports.add(jimp.build());

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -98,6 +98,26 @@ public class ToJson {
         return out.toByteArray();
     }
 
+    public static byte[] apply(Module mod) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try {
+            DataOutputStream data = new DataOutputStream(out);
+            JsonWriter jsonWriter = Json.createWriter(data);
+
+            JsonObjectBuilder term = Json.createObjectBuilder();
+            term.add("format", "KAST");
+            term.add("version", 1);
+            term.add("term", toJson(mod));
+
+            jsonWriter.write(term.build());
+            jsonWriter.close();
+            data.close();
+        } catch (IOException e) {
+            throw KEMException.criticalError("Could not write Module to Json", e);
+        }
+        return out.toByteArray();
+    }
+
     public static JsonStructure toJson(Definition def) {
         JsonObjectBuilder jdef = Json.createObjectBuilder();
 


### PR DESCRIPTION
Fixes: #2288 

This PR does:

- Add flag to `kprovex` called `--emit-json-spec` which emits the spec module as JSON to the specified file.
- Fixes the JSON serialization of `KImport` to include the `node` header (all KAST JSON terms must have `node` header).
- Adds unit tests of the pyk library which do:
  - Serialize pretty proof to json using new flag -> read json proof in pyk and write out as pretty to file -> run kprovex on the newly serialized proof using pyks `KProve.prove()`
  - Serialize pretty proof to json using new flag -> read json proof in pyk and prove using `KProve.proveClaim()`.