### PR TITLE
Fix for `--version` when `.git` is missing

### DIFF
--- a/scripts/get-version-string.sh
+++ b/scripts/get-version-string.sh
@@ -1,6 +1,17 @@
 #!/bin/bash
 
 SCRIPTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Output should be empty if git isn't available; the output gets baked into the
+# jar file and checked in the application code.
+if ! command -v git &>/dev/null ; then
+  exit
+fi
+
+if [ ! -d "$SCRIPTS_DIR/../.git" ]; then
+  exit
+fi
+
 RELEASE_TAG=$("$SCRIPTS_DIR/newest-release-tag.sh")
 
 MERGE_BASE=$(git merge-base "$RELEASE_TAG" HEAD)


### PR DESCRIPTION
This makes sure that the version string script outputs an empty string if git isn't installed, or there is no git directory alongside the source code. Doing so means that the package version file gets used instead when building release packages (`dpkg` or `brew`).