### PR TITLE
Add test for the format of `--version`

### DIFF
--- a/k-distribution/tests/regression-new/help/Makefile
+++ b/k-distribution/tests/regression-new/help/Makefile
@@ -11,6 +11,7 @@ KPARSE_GEN=${K_BIN}/kparse-gen
 KORE_PRINT=${K_BIN}/kore-print
 
 1.test:
+	./check-git-revision-format "$(GIT_REVISION)"
 	${KAST}       --help    | grep -q -- "--version"
 	${KDEP}       --help    | grep -q -- "--version"
 	${KEQ}        --help    | grep -q -- "--version"

--- a/k-distribution/tests/regression-new/help/check-git-revision-format
+++ b/k-distribution/tests/regression-new/help/check-git-revision-format
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+GIT_REVISION="$1"
+shift
+
+if [ -z "$GIT_REVISION" ]; then
+  exit 0
+fi
+
+VERSION_REGEX='v\d+\.\d+\.\d+-\d+-g[0-9a-z]+(-dirty)?$'
+echo "$GIT_REVISION" | grep -Pq "$VERSION_REGEX"

--- a/scripts/get-version-string.sh
+++ b/scripts/get-version-string.sh
@@ -13,6 +13,9 @@ if [ ! -d "$SCRIPTS_DIR/../.git" ]; then
 fi
 
 RELEASE_TAG=$("$SCRIPTS_DIR/newest-release-tag.sh")
+if [ -z "$RELEASE_TAG" ]; then
+  exit
+fi
 
 MERGE_BASE=$(git merge-base "$RELEASE_TAG" HEAD)
 VERSION_TAG=$(git describe --contains --always "$MERGE_BASE" | sed 's/~.*//')


### PR DESCRIPTION
Currently, the test only tests that the `--version` flag matches the package file or the `get-version-string` script. 

This PR adds an extra test to make sure that the output of that script matches the _format_ that we expect it to. It also adds a check to the version string script to handle the CI scenario properly (where we can get commit SHAs but not release tags).

This would have caught the issue in #2440.