### PR TITLE
Fix `-v` flag for K utils

### DIFF
--- a/k-distribution/src/main/scripts/lib/k-util.sh
+++ b/k-distribution/src/main/scripts/lib/k-util.sh
@@ -53,7 +53,7 @@ do
       profile=true
       ;;
 
-      --verbose)
+      -v|--verbose)
       verbose=true
       ;;
 


### PR DESCRIPTION
The refactored K utility script didn't correctly parse the `-v` option, despite it being mentioned in the usage documentation.

This PR reinstates `-v` as a shorthand for `--verbose` in scripts based on `k-utils`.