### PR TITLE
Fix for multiplicity star cells generated by a function

### DIFF
--- a/k-distribution/tests/regression-new/star-multiplicity/1.test
+++ b/k-distribution/tests/regression-new/star-multiplicity/1.test
@@ -1,0 +1,1 @@
+#putCells

--- a/k-distribution/tests/regression-new/star-multiplicity/1.test.out
+++ b/k-distribution/tests/regression-new/star-multiplicity/1.test.out
@@ -1,0 +1,22 @@
+<generatedTop>
+  <k>
+    .
+  </k>
+  <cells>
+    <cell>
+      <num>
+        0
+      </num>
+      <data>
+        1
+      </data>
+    </cell> <cell>
+      <num>
+        5
+      </num>
+      <data>
+        6
+      </data>
+    </cell>
+  </cells>
+</generatedTop>

--- a/k-distribution/tests/regression-new/star-multiplicity/Makefile
+++ b/k-distribution/tests/regression-new/star-multiplicity/Makefile
@@ -1,0 +1,8 @@
+DEF=test
+EXT=test
+TESTDIR=.
+KOMPILE_BACKEND=llvm
+KRUN_FLAGS=--parser ./test-parser
+KOMPILE_FLAGS=--syntax-module TEST
+
+include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/star-multiplicity/test-parser
+++ b/k-distribution/tests/regression-new/star-multiplicity/test-parser
@@ -1,0 +1,1 @@
+cat "$1" | kast - --output kore

--- a/k-distribution/tests/regression-new/star-multiplicity/test.k
+++ b/k-distribution/tests/regression-new/star-multiplicity/test.k
@@ -1,0 +1,25 @@
+module TEST
+  imports INT
+
+  configuration
+    <k> $PGM:K </k>
+    <cells>
+      <cell multiplicity="*" type="Map">
+        <num> 0 </num>
+        <data> 0 </data>
+      </cell>
+    </cells>
+
+    syntax CellCell ::= #makeCell( Int, Int ) [function]
+ // -----------------------------------------------
+    rule #makeCell( X, Y ) => (<cell> <num> X </num> <data> Y </data> </cell>)
+
+    syntax KItem ::= "#putCells"
+ // ----------------------------
+    rule <k> #putCells => . ... </k>
+         <cells>
+           (.Bag => #makeCell(0, 1))
+           (.Bag => <cell> <num> 5 </num> <data> 6 </data> </cell>)
+           ...
+         </cells>
+endmodule

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -46,6 +46,7 @@ public class AddSortInjections {
 
     private final Module mod;
     private final Map<KLabel, KLabel> collectionFor;
+    private final ConfigurationInfoFromModule configurationInfo;
 
     private int freshSortParamCounter = 0;
     private Set<String> sortParams = new HashSet<>();
@@ -55,6 +56,7 @@ public class AddSortInjections {
     public AddSortInjections(Module mod) {
         this.mod = mod;
         this.collectionFor = ConvertDataStructureToLookup.collectionFor(mod);
+        this.configurationInfo = new ConfigurationInfoFromModule(mod);
     }
 
     public Sentence addInjections(Sentence s) {
@@ -117,11 +119,6 @@ public class AddSortInjections {
         return internalAddSortInjections(body, sort);
     }
 
-    private Sort getCellSort(KLabel klabel) {
-        ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(mod);
-        return configInfo.getCellSort(klabel);
-    }
-
     private K internalAddSortInjections(K term, Sort expectedSort) {
         Sort actualSort = sort(term, expectedSort);
         if (actualSort == null) {
@@ -144,7 +141,7 @@ public class AddSortInjections {
                         KLabel wrappedLabel = KLabel(wrapElement.get());
                         KLabel elementLabel = KLabel(mod.attributesFor().apply(collectionLabel).get("element"));
                         KApply k = (KApply)term;
-                        if (getCellSort(wrappedLabel).equals(actualSort)) {
+                        if (configurationInfo.getCellSort(wrappedLabel).equals(actualSort)) {
                             if (collectionIsMap(collectionLabel)) {
                                 // Map
                                 K key;

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -117,6 +117,11 @@ public class AddSortInjections {
         return internalAddSortInjections(body, sort);
     }
 
+    private Sort getCellSort(KLabel klabel) {
+        ConfigurationInfoFromModule configInfo = new ConfigurationInfoFromModule(mod);
+        return configInfo.getCellSort(klabel);
+    }
+
     private K internalAddSortInjections(K term, Sort expectedSort) {
         Sort actualSort = sort(term, expectedSort);
         if (actualSort == null) {
@@ -139,10 +144,15 @@ public class AddSortInjections {
                         KLabel wrappedLabel = KLabel(wrapElement.get());
                         KLabel elementLabel = KLabel(mod.attributesFor().apply(collectionLabel).get("element"));
                         KApply k = (KApply)term;
-                        if (k.klabel().equals(wrappedLabel)) {
+                        if (getCellSort(wrappedLabel).equals(actualSort)) {
                             if (collectionIsMap(collectionLabel)) {
                                 // Map
-                                K key = k.klist().items().get(0);
+                                K key;
+                                if (k.klabel().equals(wrappedLabel)) {
+                                    key = k.klist().items().get(0);
+                                } else {
+                                    key = KApply(KLabel(expectedSort.name() + "Key"), KList(visitChildren(k, actualSort, expectedSort)));
+                                }
                                 Sort adjustedExpectedSort = expectedSort;
                                 if (k.att().contains(Sort.class)) {
                                     adjustedExpectedSort = k.att().get(Sort.class);

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -426,7 +426,13 @@ public class GenerateSentencesFromConfigDecl {
             // syntax CellSet ::= Cell
             // syntax CellSet ::= ".CellSet" [hook(SET.unit), function]
             // syntax CellSet ::= CellSetItem(Cell) [hook(SET.element), function]
-            // syntax CellSet ::= CellSet CellSet [assoc, conmm, idem, unit(.CellSet), element(CellSetItem), wrapElement(<cell>), hook(SET.concat), avoid, function]
+            // syntax CellSet ::= CellSet CellSet [assoc, comm, idem, unit(.CellSet), element(CellSetItem), wrapElement(<cell>), hook(SET.concat), avoid, function]
+            // -or-
+            // syntax CellMap [hook(MAP.Map)]
+            // syntax CellMap ::= Cell
+            // syntax CellMap ::= ".CellMap" [hook(MAP.unit), function]
+            // syntax CellMap ::= CellMapItem(KeyCell, Cell) [hook(MAP.element), function]
+            // syntax CellMap ::= CellMap CellMap [assoc, comm, unit(.CellMap), element(CellMapItem), wrapElement(<cell>), hook(MAP.concat), avoid, function]
             // -or-
             // syntax CellList [hook(LIST.List)]
             // syntax CellList ::= Cell
@@ -488,7 +494,17 @@ public class GenerateSentencesFromConfigDecl {
             sentences.add(bagUnit);
             sentences.add(bag);
             if (type.equals("Map")) {
+                // syntax Bool ::= KeyCell "in_keys" "(" CellMap ")" [function, functional, hook(MAP.in_keys)]
                 sentences.add(Production(KLabel(bagSort.name() + ":in_keys"), Sorts.Bool(), Seq(NonTerminal(childSorts.get(0)), Terminal("in_keys"), Terminal("("), NonTerminal(bagSort), Terminal(")")), Att().add(Att.HOOK(), "MAP.in_keys").add(Att.FUNCTION()).add(Att.FUNCTIONAL())));
+
+                // syntax KeyCell ::= CellMapKey(Cell) [function, functional]
+                // rule CellMapKey(<cell> K ...<\cell>) => K
+                KLabel cellMapKeyLabel = KLabel(bagSort.name() + "Key");
+                Production cellMapKeyProduction = Production(cellMapKeyLabel, childSorts.get(0), Seq(Terminal(bagSort.name() + "Key"), Terminal("("), NonTerminal(sort), Terminal(")")), Att().add(Att.FUNCTION()).add(Att.FUNCTIONAL()));
+                KVariable key = KVariable("Key", Att.empty().add(Sort.class, childSorts.get(0)));
+                Rule cellMapKeyRule = Rule(KRewrite(KApply(cellMapKeyLabel, IncompleteCellUtils.make(KLabel(klabel), false, key, true)), key),  BooleanUtils.TRUE, BooleanUtils.TRUE);
+                sentences.add(cellMapKeyProduction);
+                sentences.add(cellMapKeyRule);
             }
             // rule initCell => .CellBag
             // -or-


### PR DESCRIPTION
This PR addresses https://github.com/runtimeverification/llvm-backend/issues/488.

When a cell with multiplicity star that belongs to a map cell collection is generated by a function instead of using the singleton cell constructor and then is passed to a function expecting a collection, the generated KORE would contain an injection from the cell type to the cell collection type instead of a call to the singleton cell collection constructor. The PR fixes this by making sure that the call to the singleton cell collection constructor is generated in this case.