### PR TITLE
Print source lines in error messages

### DIFF
--- a/k-distribution/tests/regression-new/cell-bag-sort-llvm/test.k.out
+++ b/k-distribution/tests/regression-new/cell-bag-sort-llvm/test.k.out
@@ -1,4 +1,9 @@
 [Error] Compiler: Cell bags are only supported on the Java backend. If you want this feature, comment on https://github.com/runtimeverification/k/issues/1419 . As a workaround, you can add the attribute type="Set" and add a unique identifier to each element in the set.
 	Source(test.k)
 	Location(18,17,32,21)
+	   .	                v~~~~~~~~~~~~~~~~~
+	18 |	  configuration <T color="yellow">
+	   |		...
+	32 |	                </T>
+	   .	                ~~~^
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checkClaimError/rule-spec.k.out
+++ b/k-distribution/tests/regression-new/checkClaimError/rule-spec.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Only claims and simplification rules are allowed in proof modules.
 	Source(rule-spec.k)
 	Location(6,10,6,43)
+	6 |	    rule <k> doIt(foo) => doIt(0) ... </k>
+	  .	         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checkClaimError/syntax-spec.k.out
+++ b/k-distribution/tests/regression-new/checkClaimError/syntax-spec.k.out
@@ -1,7 +1,11 @@
 [Error] Compiler: Found syntax declaration in proof module. Only tokens for existing sorts are allowed.
 	Source(syntax-spec.k)
 	Location(6,18,6,29)
+	6 |	    syntax X ::= "errorHere"
+	  .	                 ^~~~~~~~~~~
 [Error] Compiler: Found syntax declaration in proof module. Only tokens for existing sorts are allowed.
 	Source(syntax-spec.k)
 	Location(7,5,7,13)
+	7 |	    syntax Y
+	  .	    ^~~~~~~~
 [Error] Compiler: Had 2 structural errors.

--- a/k-distribution/tests/regression-new/checkWarns/checkUnusedSymbol.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/checkUnusedSymbol.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Symbol 'foo(_)_CHECKUNUSEDSYMBOL_Foo_Int' defined but not used. Add the 'unused' attribute if this is intentional.
 	Source(checkUnusedSymbol.k)
 	Location(9,18,9,26)
+	9 |	  syntax Foo ::= foo(Int)
+	  .	                 ^~~~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checkWarns/checkUnusedVar.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/checkUnusedVar.k.out
@@ -1,10 +1,16 @@
 [Error] Compiler: Variable 'X' defined but not used. Prefix variable name with underscore if this is intentional.
 	Source(checkUnusedVar.k)
 	Location(16,12,16,13)
+	16 |	  rule foo(X) => 0
+	   .	           ^
 [Error] Compiler: Variable 'X' defined but not used. Prefix variable name with underscore if this is intentional.
 	Source(checkUnusedVar.k)
 	Location(21,12,21,13)
+	21 |	  rule foo(X) => 1
+	   .	           ^
 [Error] Compiler: Variable '?X' defined but not used. Prefix variable name with underscore if this is intentional.
 	Source(checkUnusedVar.k)
 	Location(24,18,24,20)
+	24 |	  rule foo(X) => ?X:Int
+	   .	                 ^~
 [Error] Compiler: Had 3 structural errors.

--- a/k-distribution/tests/regression-new/checkWarns/requireBuiltinK.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/requireBuiltinK.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: Requiring a K file in the K builtin directory via a deprecated filename. Please replace "ffi.k" with "ffi.md".
 	Source(requireBuiltinK.k)
 	Location(1,1,1,16)
+	1 |	require "ffi.k"
+	  .	^~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checkWarnsClaim/warnClaim-spec.k.out
+++ b/k-distribution/tests/regression-new/checkWarnsClaim/warnClaim-spec.k.out
@@ -2,6 +2,10 @@
 [Warning] Compiler: Deprecated: use claim instead of rule to specify proof objectives.
 	Source(warnClaim-spec.k)
 	Location(6,10,6,43)
+	6 |	    rule <k> doIt(foo) => doIt(0) ... </k>
+	  .	         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Warning] Compiler: The attribute [macro] has been deprecated on rules. Use this label on syntax declarations instead.
 	Source(warnClaim.k)
 	Location(9,10,9,18)
+	9 |	    rule foo => 3 [macro]
+	  .	         ^~~~~~~~

--- a/k-distribution/tests/regression-new/checks/badFunctionRuleWithContext.k.out
+++ b/k-distribution/tests/regression-new/checks/badFunctionRuleWithContext.k.out
@@ -1,4 +1,6 @@
 [Error] Inner Parser: Unexpected sort Bool for term parsed as production syntax Bool ::= "false" [token]. Expected: Int
 	Source(badFunctionRuleWithContext.k)
 	Location(10,23,10,28)
+	10 |	rule [[ foo(I:Int) => false ]]
+	   .	                      ^~~~~
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/binder.k.out
+++ b/k-distribution/tests/regression-new/checks/binder.k.out
@@ -1,10 +1,16 @@
 [Error] Compiler: Binder productions must have at least two nonterminals.
 	Source(binder.k)
 	Location(6,20,6,34)
+	6 |	  syntax Error ::= foo() [binder]
+	  .	                   ^~~~~~~~~~~~~~
 [Error] Compiler: Attribute value for 'binder' attribute is not supported.
 	Source(binder.k)
 	Location(8,20,8,53)
+	8 |	  syntax Error ::= foo(KVar, Error) [binder(1 -> 2)]
+	  .	                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: First child of binder must have a sort with the 'KVAR.KVar' hook attribute.
 	Source(binder.k)
 	Location(10,20,10,46)
+	10 |	  syntax Error ::= foo(Error, Error) [binder]
+	   .	                   ^~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 3 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkBracket.k.out
+++ b/k-distribution/tests/regression-new/checks/checkBracket.k.out
@@ -1,3 +1,5 @@
 [Error] Outer Parser: bracket productions should have exactly one non-terminal of the same sort as the production.
 	Source(checkBracket.k)
 	Location(2,18,2,43)
+	2 |	  syntax Exp ::= "(" Exp Exp ")" [bracket]
+	  .	                 ^~~~~~~~~~~~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkBracketSubsort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkBracketSubsort.k.out
@@ -1,3 +1,5 @@
 [Error] Outer Parser: bracket productions should have exactly one non-terminal of the same sort as the production.
 	Source(checkBracketSubsort.k)
 	Location(4,18,4,37)
+	4 |	  syntax Exp ::= "(" A ")" [bracket]
+	  .	                 ^~~~~~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkBracketSupersort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkBracketSupersort.k.out
@@ -1,3 +1,5 @@
 [Error] Outer Parser: bracket productions should have exactly one non-terminal of the same sort as the production.
 	Source(checkBracketSupersort.k)
 	Location(4,16,4,37)
+	4 |	  syntax A ::= "(" Exp ")" [bracket]
+	  .	               ^~~~~~~~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkBracketUnrelatedsort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkBracketUnrelatedsort.k.out
@@ -1,3 +1,5 @@
 [Error] Outer Parser: bracket productions should have exactly one non-terminal of the same sort as the production.
 	Source(checkBracketUnrelatedsort.k)
 	Location(3,18,3,37)
+	3 |	  syntax Exp ::= "(" A ")" [bracket]
+	  .	                 ^~~~~~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkCellSortDeclFail.k.out
+++ b/k-distribution/tests/regression-new/checks/checkCellSortDeclFail.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Could not find sorts: [MisTypedCell]
 	Source(checkCellSortDeclFail.k)
 	Location(12,16,12,28)
+	12 |	syntax Pgm ::= MisTypedCell
+	   .	               ^~~~~~~~~~~~
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
+++ b/k-distribution/tests/regression-new/checks/checkFuncRuleAtt.k.out
@@ -1,16 +1,28 @@
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on function rules.
 	Source(checkFuncRuleAtt.k)
 	Location(10,10,10,18)
+	10 |	    rule foo => 0 [macro]
+	   .	         ^~~~~~~~
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on function rules.
 	Source(checkFuncRuleAtt.k)
 	Location(11,10,11,18)
+	11 |	    rule foo => 1 [macro-rec]
+	   .	         ^~~~~~~~
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on function rules.
 	Source(checkFuncRuleAtt.k)
 	Location(12,10,12,18)
+	12 |	    rule foo => 2 [alias]
+	   .	         ^~~~~~~~
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on function rules.
 	Source(checkFuncRuleAtt.k)
 	Location(13,10,13,18)
+	13 |	    rule foo => 3 [alias-rec]
+	   .	         ^~~~~~~~
 [Error] Compiler: Attributes macro|macro-rec|alias|alias-rec are not allowed on function rules.
 	Source(checkFuncRuleAtt.k)
 	Location(16,10,17,26)
+	   .	         v~~~~~~~~~~~~~
+	16 |	    rule [[ foo => 6 ]]
+	17 |	         <notk> 7 </notk> [macro]
+	   .	         ~~~~~~~~~~~~~~~^
 [Error] Compiler: Had 5 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkInstantiation.k.out
+++ b/k-distribution/tests/regression-new/checks/checkInstantiation.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: Could not find sorts: [MInt{6}]
 	Source(checkInstantiation.k)
 	Location(9,20,9,32)
+	9 |	  syntax KItem ::= foo(MInt{6})
+	  .	                   ^~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkListDecl1.k.out
+++ b/k-distribution/tests/regression-new/checks/checkListDecl1.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: KItem can not be extended to be a list sort.
 	Source(checkListDecl1.k)
 	Location(12,18,12,30)
+	12 |	syntax KItem ::= List{Int,""}
+	   .	                 ^~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkListDecl2.k.out
+++ b/k-distribution/tests/regression-new/checks/checkListDecl2.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: Circular lists are not allowed.
 	Source(checkListDecl2.k)
 	Location(12,16,12,28)
+	12 |	syntax Int ::= List{Int,""}
+	   .	               ^~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkListDecl3.k.out
+++ b/k-distribution/tests/regression-new/checks/checkListDecl3.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: Inline list declarations are not allowed.
 	Source(checkListDecl3.k)
 	Location(12,26,12,38)
+	12 |	syntax KItem ::= Int "+" List{Int,""}
+	   .	                         ^~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/checkMIntLiteral.k.out
+++ b/k-distribution/tests/regression-new/checks/checkMIntLiteral.k.out
@@ -1,4 +1,6 @@
 [Error] Inner Parser: Unexpected sort MInt{32} for term parsed as production syntax MInt{32} ::= r"[\\+-]?[0-9]+[pP][0-9]+" [hook(MINT.literal), prec(2), token]. Expected: MInt{6}
 	Source(checkMIntLiteral.k)
 	Location(13,12,13,16)
+	13 |	  rule foo(0p32) => 0
+	   .	           ^~~~
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/checkPriorityBlocks.k.out
+++ b/k-distribution/tests/regression-new/checks/checkPriorityBlocks.k.out
@@ -1,4 +1,6 @@
 [Error] Inner Parser: Priority filter exception. Cannot use _+__CHECKPRIORITYBLOCKS_Exp_Exp_Exp as an immediate child of [_]_CHECKPRIORITYBLOCKS_Exp_Exp. Consider using parentheses around _+__CHECKPRIORITYBLOCKS_Exp_Exp_Exp
 	Source(checkPriorityBlocks.k)
 	Location(7,9,7,14)
+	7 |	  rule [1 + 2] => .K
+	  .	        ^~~~~
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/checkRecordProdDuplicateLabels.k.out
+++ b/k-distribution/tests/regression-new/checks/checkRecordProdDuplicateLabels.k.out
@@ -1,7 +1,11 @@
 [Error] Inner Parser: Duplicate record production key: p1
 	Source(checkRecordProdDuplicateLabels.k)
 	Location(41,7,41,41)
+	41 |	 rule invariantStateFull(... p1:X, p1:Y) => 1 // duplicate keys here, rest should be fine
+	   .	      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Inner Parser: Duplicate record production key: p2
 	Source(checkRecordProdDuplicateLabels.k)
 	Location(42,7,42,57)
+	42 |	 rule invariantStateFull(... p2:X, numUsers:_Gen0, p2:Y) => 1 // duplicate keys here, rest should be fine
+	   .	      ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/checkUndeclaredTags.k.out
+++ b/k-distribution/tests/regression-new/checks/checkUndeclaredTags.k.out
@@ -1,3 +1,5 @@
 [Error] Outer Parser: Could not find any productions for tag: a
 	Source(checkUndeclaredTags.k)
 	Location(2,3,2,26)
+	2 |	  syntax priorities a > b
+	  .	  ^~~~~~~~~~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/claimInDef.k.out
+++ b/k-distribution/tests/regression-new/checks/claimInDef.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Claims are not allowed in the definition.
 	Source(claimInDef.k)
 	Location(5,11,5,17)
+	5 |	    claim _ => .
+	  .	          ^~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/concrete.k.out
+++ b/k-distribution/tests/regression-new/checks/concrete.k.out
@@ -1,19 +1,31 @@
 [Error] Compiler: Found symbolic attribute without simplification attribute on function with one or more non-symbolic rules.
 	Source(concrete.k)
 	Location(6,8,6,21)
+	6 |	  rule 0 *Int X => 0 [symbolic]
+	  .	       ^~~~~~~~~~~~~
 [Error] Compiler: Found concrete attribute without simplification attribute on function with one or more non-concrete rules.
 	Source(concrete.k)
 	Location(7,8,7,21)
+	7 |	  rule 1 *Int X => X [concrete]
+	  .	       ^~~~~~~~~~~~~
 [Error] Compiler: Rule cannot be both concrete and symbolic in the same variable.
 	Source(concrete.k)
 	Location(10,8,10,19)
+	10 |	  rule foo(0) => 0 [symbolic, concrete]
+	   .	       ^~~~~~~~~~~
 [Error] Compiler: Found symbolic attribute without simplification attribute on function with one or more non-symbolic rules.
 	Source(concrete.k)
 	Location(16,8,16,20)
+	16 |	  rule bar2(0) => 0 [symbolic]
+	   .	       ^~~~~~~~~~~~
 [Error] Compiler: Found concrete attribute without simplification attribute on function with one or more non-concrete rules.
 	Source(concrete.k)
 	Location(25,8,25,20)
+	25 |	  rule baz2(0) => 0 [concrete]
+	   .	       ^~~~~~~~~~~~
 [Error] Compiler: Found concrete attribute without simplification attribute on function with one or more non-concrete rules.
 	Source(concrete.k)
 	Location(29,8,29,20)
+	29 |	  rule baz3(X) => 0 [concrete(X)]
+	   .	       ^~~~~~~~~~~~
 [Error] Compiler: Had 6 structural errors.

--- a/k-distribution/tests/regression-new/checks/duplicateModule.k.out
+++ b/k-distribution/tests/regression-new/checks/duplicateModule.k.out
@@ -1,4 +1,9 @@
 [Error] Outer Parser: Module DUPLICATEMODULE previously declared at Source(duplicateModule.k) and Location(1,1,3,10)
 	Source(duplicateModule.k)
 	Location(5,1,7,10)
+	  .	v~~~~~~~~~~~~~~~~~~~~~
+	5 |	module DUPLICATEMODULE
+	6 |	
+	7 |	endmodule
+	  .	~~~~~~~~^
 [Error] Outer Parser: Had 1 outer parsing errors.

--- a/k-distribution/tests/regression-new/checks/duplicateRules.k.out
+++ b/k-distribution/tests/regression-new/checks/duplicateRules.k.out
@@ -1,10 +1,16 @@
 [Error] Compiler: Claims are not allowed in the definition.
 	Source(duplicateRules.k)
 	Location(6,9,6,15)
+	6 |	  claim A => 0
+	  .	        ^~~~~~
 [Error] Compiler: Claims are not allowed in the definition.
 	Source(duplicateRules.k)
 	Location(7,9,7,15)
+	7 |	  claim A => 0
+	  .	        ^~~~~~
 [Error] Compiler: Claims are not allowed in the definition.
 	Source(duplicateRules.k)
 	Location(8,9,8,15)
+	8 |	  claim A => 0
+	  .	        ^~~~~~
 [Error] Compiler: Had 3 structural errors.

--- a/k-distribution/tests/regression-new/checks/errorExistential.k.out
+++ b/k-distribution/tests/regression-new/checks/errorExistential.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(errorExistential.k)
 	Location(4,11,4,13)
+	4 |	rule 0 => ?I:Int
+	  .	          ^~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/existentialCheck.k.out
+++ b/k-distribution/tests/regression-new/checks/existentialCheck.k.out
@@ -1,25 +1,41 @@
 [Error] Compiler: Claims are not allowed in the definition.
 	Source(existentialCheck.k)
 	Location(14,9,14,29)
+	14 |	  claim <k> ?X:Int => . </k>
+	   .	        ^~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Existential variable ?X found in LHS. Existential variables are only allowed in the RHS.
 	Source(existentialCheck.k)
 	Location(14,13,14,15)
+	14 |	  claim <k> ?X:Int => . </k>
+	   .	            ^~
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(existentialCheck.k)
 	Location(14,13,14,15)
+	14 |	  claim <k> ?X:Int => . </k>
+	   .	            ^~
 [Error] Compiler: Existential variable ?X found in LHS. Existential variables are only allowed in the RHS.
 	Source(existentialCheck.k)
 	Location(16,12,16,14)
+	16 |	  rule <k> ?X:Int => . </k>
+	   .	           ^~
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(existentialCheck.k)
 	Location(16,12,16,14)
+	16 |	  rule <k> ?X:Int => . </k>
+	   .	           ^~
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(existentialCheck.k)
 	Location(18,22,18,28)
+	18 |	  rule <k> stateA => ?STATE </k>
+	   .	                     ^~~~~~
 [Error] Compiler: Existential variable ?STATE found in LHS. Existential variables are only allowed in the RHS.
 	Source(existentialCheck.k)
 	Location(19,21,19,27)
+	19 |	    requires isDone(?STATE)
+	   .	                    ^~~~~~
 [Error] Compiler: Found existential variable not supported by concrete backend.
 	Source(existentialCheck.k)
 	Location(19,21,19,27)
+	19 |	    requires isDone(?STATE)
+	   .	                    ^~~~~~
 [Error] Compiler: Had 8 structural errors.

--- a/k-distribution/tests/regression-new/checks/formatatt.k.out
+++ b/k-distribution/tests/regression-new/checks/formatatt.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Invalid colors attribute: expected 5 colors, found 4 colors instead.
 	Source(formatatt.k)
 	Location(4,19,4,120)
+	4 |	  syntax Stmt ::= "if" "(" Bool ")" Stmt "else" Stmt [avoid, colors(blue,red,red,blue), format(%1 %2%c%3%r%4 %5 %6 %7)]
+	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/functionContextInRewrite.k.out
+++ b/k-distribution/tests/regression-new/checks/functionContextInRewrite.k.out
@@ -1,4 +1,6 @@
 [Error] Inner Parser: Parse error: unexpected token '[' following token '('.
 	Source(functionContextInRewrite.k)
 	Location(8,12,8,13)
+	8 |	rule 0 => ([[ 1 ]] <bar> 0 </bar>)
+	  .	           ^
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/intOperationInLHS.k.out
+++ b/k-distribution/tests/regression-new/checks/intOperationInLHS.k.out
@@ -1,10 +1,16 @@
 [Error] Compiler: Illegal function symbol _+Int_ on LHS of rule. Consider adding `simplification` attribute to the rule if this is intended.
 	Source(intOperationInLHS.k)
 	Location(7,10,7,18)
+	7 |	rule foo(_ +Int 1) => 0
+	  .	         ^~~~~~~~
 [Error] Compiler: Illegal function symbol foo(_)_INTOPERATIONINLHS_Int_Int on LHS of rule. Consider adding `simplification` attribute to the rule if this is intended.
 	Source(intOperationInLHS.k)
 	Location(17,10,17,16)
+	17 |	     <k> foo(0) </k>
+	   .	         ^~~~~~
 [Error] Compiler: Illegal function symbol foo(_)_INTOPERATIONINLHS_Int_Int on LHS of rule. Consider adding `simplification` attribute to the rule if this is intended.
 	Source(intOperationInLHS.k)
 	Location(19,19,19,25)
+	19 |	rule [[ bar(0 |-> foo(0)) => foo(0) ]]
+	   .	                  ^~~~~~
 [Error] Compiler: Had 3 structural errors.

--- a/k-distribution/tests/regression-new/checks/invalidAs.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidAs.k.out
@@ -1,10 +1,16 @@
 [Error] Compiler: Found #as pattern where the right side is not a variable.
 	Source(invalidAs.k)
 	Location(4,9,4,16)
+	4 |	  rule (0 #as 0) => 0 // Found #as pattern where the right side is not a variable.
+	  .	        ^~~~~~~
 [Error] Compiler: #as is not allowed in the RHS of a rule.
 	Source(invalidAs.k)
 	Location(5,14,5,21)
+	5 |	  rule Y => (0 #as Y) // #as is not allowed in the RHS of a rule. - issue #753
+	  .	             ^~~~~~~
 [Error] Compiler: Rewrites are not allowed inside an #as pattern.
 	Source(invalidAs.k)
 	Location(6,9,6,15)
+	6 |	  rule (0 => 1) #as X // Rewrites are not allowed inside an #as pattern.
+	  .	        ^~~~~~
 [Error] Compiler: Had 3 structural errors.

--- a/k-distribution/tests/regression-new/checks/invalidConstantExp.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidConstantExp.k.out
@@ -4,3 +4,5 @@
 	Location(4,8,4,21)
 	Source(invalidConstantExp.k)
 	Location(4,13,4,21)
+	4 |	  rule 0 => 1 /Int 0
+	  .	            ^~~~~~~~

--- a/k-distribution/tests/regression-new/checks/invalidConstructor.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidConstructor.k.out
@@ -1,10 +1,16 @@
 [Error] Compiler: Cannot add new constructors to hooked sort K
 	Source(invalidConstructor.k)
 	Location(3,16,3,21)
+	3 |	  syntax K ::= foo()
+	  .	               ^~~~~
 [Error] Compiler: Cannot add new constructors to hooked sort Int
 	Source(invalidConstructor.k)
 	Location(4,18,4,23)
+	4 |	  syntax Int ::= bar()
+	  .	                 ^~~~~
 [Error] Compiler: Sort Int was declared as a token. Productions of this sort can only contain [function] or [token] labels.
 	Source(invalidConstructor.k)
 	Location(4,18,4,23)
+	4 |	  syntax Int ::= bar()
+	  .	                 ^~~~~
 [Error] Compiler: Had 3 structural errors.

--- a/k-distribution/tests/regression-new/checks/invalidFormat.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidFormat.k.out
@@ -1,22 +1,36 @@
 [Error] Compiler: Invalid format attribute: unfinished escape sequence.
 	Source(invalidFormat.k)
 	Location(3,18,3,35)
+	3 |	  syntax Foo ::= "foo" [format(%)]
+	  .	                 ^~~~~~~~~~~~~~~~~
 [Error] Compiler: Invalid colors attribute: expected 2 colors, found 1 colors instead.
 	Source(invalidFormat.k)
 	Location(5,18,5,51)
+	5 |	  syntax Bar ::= "bar" [format(%c), colors(black)]
+	  .	                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Invalid format escape sequence '%0'. Expected a number between 1 and 1
 	Source(invalidFormat.k)
 	Location(9,16,9,32)
+	9 |	  syntax A ::= "a" [format(%0)]
+	  .	               ^~~~~~~~~~~~~~~~
 [Error] Compiler: Invalid format escape sequence '%2'. Expected a number between 1 and 1
 	Source(invalidFormat.k)
 	Location(11,16,11,32)
+	11 |	  syntax B ::= "b" [format(%2)]
+	   .	               ^~~~~~~~~~~~~~~~
 [Error] Compiler: Invalid format escape sequence referring to regular expression terminal 'r"c"'.
 	Source(invalidFormat.k)
 	Location(13,16,13,33)
+	13 |	  syntax C ::= r"c" [format(%1)]
+	   .	               ^~~~~~~~~~~~~~~~~
 [Error] Compiler: Expected format attribute on production with regular expression terminal. Did you forget the 'token' attribute?
 	Source(invalidFormat.k)
 	Location(15,16,15,20)
+	15 |	  syntax D ::= r"d"
+	   .	               ^~~~
 [Error] Compiler: Expected format attribute on production with regular expression terminal.
 	Source(invalidFormat.k)
 	Location(17,16,17,24)
+	17 |	  syntax E ::= r"e" "f"
+	   .	               ^~~~~~~~
 [Error] Compiler: Had 7 structural errors.

--- a/k-distribution/tests/regression-new/checks/invalidPrec.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidPrec.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: Inconsistent token precedence detected.
 	Source(invalidPrec.k)
 	Location(3,17,3,34)
+	3 |	 syntax Foo ::= r"[0-9]+" [token]
+	  .	                ^~~~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/invalidSortPredicate.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidSortPredicate.k.out
@@ -4,3 +4,5 @@
 	Location(7,8,7,53)
 	Source(invalidSortPredicate.k)
 	Location(7,8,7,16)
+	7 |	  rule isExp(I) => isInt(I) andBool configFunction()
+	  .	       ^~~~~~~~

--- a/k-distribution/tests/regression-new/checks/invalidStrict.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidStrict.k.out
@@ -1,25 +1,41 @@
 [Error] Compiler: Cannot put a strict attribute on a production with no nonterminals
 	Source(invalidStrict.k)
 	Location(4,16,4,33)
+	4 |	syntax Foo ::= foo() [strict(1)]
+	  .	               ^~~~~~~~~~~~~~~~~
 [Error] Compiler: Expecting a number between 1 and 1, but found 2 as a strict position in [2]
 	Source(invalidStrict.k)
 	Location(6,16,6,36)
+	6 |	syntax Foo ::= foo(Foo) [strict(2)]
+	  .	               ^~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Invalid strict attribute containing invalid semicolons. Must contain 0, 1, 2, or an even number of components.
 	Source(invalidStrict.k)
 	Location(8,16,8,46)
+	8 |	syntax Foo ::= bar(Foo) [strict(foo; bar; 1)]
+	  .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Cannot heat a nonterminal of sort K. Did you mean KItem?
 	Source(invalidStrict.k)
 	Location(10,16,10,31)
+	10 |	syntax Bar ::= baz(K) [strict]
+	   .	               ^~~~~~~~~~~~~~~
 [Error] Compiler: Cannot heat a nonterminal of sort K. Did you mean KItem?
 	Source(invalidStrict.k)
 	Location(12,16,12,41)
+	12 |	syntax Bar ::= stuff(K, Foo) [strict(1)]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Cannot heat a HOLE of sort K. Did you mean to sort it to KItem?
 	Source(invalidStrict.k)
 	Location(20,15,20,21)
+	20 |	context plugh(HOLE:K)
+	   .	              ^~~~~~
 [Error] Compiler: Cannot heat a HOLE of sort K. Did you mean to sort it to KItem?
 	Source(invalidStrict.k)
 	Location(22,15,22,19)
+	22 |	context plugh(HOLE)
+	   .	              ^~~~
 [Error] Compiler: Cannot heat a nonterminal of sort K. Did you mean KItem?
 	Source(invalidStrict.k)
 	Location(26,16,26,40)
+	26 |	syntax Baz ::= thingy(K) [seqstrict(x)]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 8 structural errors.

--- a/k-distribution/tests/regression-new/checks/invalidSymbol.k.out
+++ b/k-distribution/tests/regression-new/checks/invalidSymbol.k.out
@@ -1,7 +1,11 @@
 [Error] Compiler: Symbol #KToken is not unique. Previously defined as: syntax KBott ::= "#token" "(" KString "," KString ")" [klabel(#KToken), symbol]
 	Source(invalidSymbol.k)
 	Location(3,16,3,47)
+	3 |	syntax Foo ::= foo() [klabel(#KToken), symbol]
+	  .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Symbol foo is not unique. Previously defined as: syntax Bar ::= "bar" "(" ")" [klabel(foo), symbol]
 	Source(invalidSymbol.k)
 	Location(6,16,6,43)
+	6 |	syntax Baz ::= baz() [klabel(foo), symbol]
+	  .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 2 structural errors.

--- a/k-distribution/tests/regression-new/checks/macroWithFunction.k.out
+++ b/k-distribution/tests/regression-new/checks/macroWithFunction.k.out
@@ -1,6 +1,8 @@
 [Error] Compiler: Illegal function symbol _*Int_ on LHS of rule. Consider adding `simplification` attribute to the rule if this is intended.
 	Source(macroWithFunction.k)
 	Location(13,25,13,35)
+	13 |	    rule wad(I) => FInt(I *Int WAD, WAD) [macro]
+	   .	                        ^~~~~~~~~~
 [Error] Compiler: Had 1 structural errors after macro expansion.
   while executing phase "expand macros" on sentence at
 	Source(macroWithFunction.k)

--- a/k-distribution/tests/regression-new/checks/markdownErrorLocation.md.out
+++ b/k-distribution/tests/regression-new/checks/markdownErrorLocation.md.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Rules must have at least one rewrite.
 	Source(markdownErrorLocation.md)
 	Location(22,8,22,10)
+	22 |	  rule 21 // pandoc would think this is line 20, column 7
+	   .	       ^~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/missingBar.k.out
+++ b/k-distribution/tests/regression-new/checks/missingBar.k.out
@@ -2,3 +2,5 @@
 Was expecting one of: ["rule", "context", "configuration", "claim", "syntax", "endmodule", "[", ">", "|"]
 	Source(missingBar.k)
 	Location(4,18,4,20)
+	4 |	                 bar ()
+	  .	                 ^~

--- a/k-distribution/tests/regression-new/checks/missingModule.k.out
+++ b/k-distribution/tests/regression-new/checks/missingModule.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: Could not find module: FOO
 	Source(missingModule.k)
 	Location(2,3,2,14)
+	2 |	  imports FOO
+	  .	  ^~~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/nestedFunctionContext.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedFunctionContext.k.out
@@ -1,7 +1,11 @@
 [Error] Inner Parser: Parse error: unexpected token '[' following token '['.
 	Source(nestedFunctionContext.k)
 	Location(14,8,14,9)
+	14 |	rule [[[[foo(0) => 1]]
+	   .	       ^
 [Error] Inner Parser: Parse error: unexpected token '<baz>' following token '1'.
 	Source(nestedFunctionContext.k)
 	Location(19,6,19,11)
+	19 |	     <baz> [[foo(0)]] <baz> .K </baz> </baz>
+	   .	     ^~~~~
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/nestedFunctionContextInFun.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedFunctionContextInFun.k.out
@@ -1,7 +1,11 @@
 [Error] Inner Parser: Parse error: unexpected token '[' following token '('.
 	Source(nestedFunctionContextInFun.k)
 	Location(8,16,8,17)
+	8 |	rule 0 => #fun([[0 => 1]] <bar> 0 </bar>)(0)
+	  .	               ^
 [Error] Inner Parser: Parse error: unexpected token '[' following token '('.
 	Source(nestedFunctionContextInFun.k)
 	Location(10,16,10,17)
+	10 |	rule 0 => #fun([[[[0 => 1]] <bar> 0 </bar>]] <bar> 0 </bar>)(0)
+	   .	               ^
 [Error] Compiler: Had 2 parsing errors.

--- a/k-distribution/tests/regression-new/checks/nestedRewrite.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedRewrite.k.out
@@ -1,7 +1,11 @@
 [Error] Compiler: Rewrites are not allowed to be nested.
 	Source(nestedRewrite.k)
 	Location(4,7,4,13)
+	4 |	rule (1 => 2) => 3
+	  .	      ^~~~~~
 [Error] Compiler: Rewrites are not allowed to be nested.
 	Source(nestedRewrite.k)
 	Location(5,12,5,18)
+	5 |	rule 1 => (2 => 3)
+	  .	           ^~~~~~
 [Error] Compiler: Had 2 structural errors.

--- a/k-distribution/tests/regression-new/checks/nestedRewriteInFun.k.out
+++ b/k-distribution/tests/regression-new/checks/nestedRewriteInFun.k.out
@@ -1,13 +1,21 @@
 [Error] Compiler: Rewrites are not allowed to be nested.
 	Source(nestedRewriteInFun.k)
 	Location(5,22,5,28)
+	5 |	rule 0 => #fun(0 => (1 => 2))(0)
+	  .	                     ^~~~~~
 [Error] Compiler: Rewrites are not allowed to be nested.
 	Source(nestedRewriteInFun.k)
 	Location(6,17,6,23)
+	6 |	rule 0 => #fun((0 => 1) => 2)(0)
+	  .	                ^~~~~~
 [Error] Compiler: Rewrites are not allowed to be nested.
 	Source(nestedRewriteInFun.k)
 	Location(11,26,11,32)
+	11 |	rule 1 => #fun(foo(0 => (1 => 2)))(0)
+	   .	                         ^~~~~~
 [Error] Compiler: Rewrites are not allowed to be nested.
 	Source(nestedRewriteInFun.k)
 	Location(12,21,12,27)
+	12 |	rule 1 => #fun(foo((0 => 1) => 2))(0)
+	   .	                    ^~~~~~
 [Error] Compiler: Had 4 structural errors.

--- a/k-distribution/tests/regression-new/checks/noImportFloat.k.out
+++ b/k-distribution/tests/regression-new/checks/noImportFloat.k.out
@@ -1,3 +1,5 @@
 [Error] Compiler: Could not find sorts: [Float]
 	Source(noImportFloat.k)
 	Location(3,19,3,29)
+	3 |	   syntax Pgm ::= foo(Float) | bar()
+	  .	                  ^~~~~~~~~~

--- a/k-distribution/tests/regression-new/checks/noRewrite.k.out
+++ b/k-distribution/tests/regression-new/checks/noRewrite.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Rules must have at least one rewrite.
 	Source(noRewrite.k)
 	Location(4,6,4,7)
+	4 |	rule 0
+	  .	     ^
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/noRewriteInFun.k.out
+++ b/k-distribution/tests/regression-new/checks/noRewriteInFun.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: #fun expressions must have at least one rewrite.
 	Source(noRewriteInFun.k)
 	Location(4,11,4,21)
+	4 |	rule 0 => #fun(0)(0)
+	  .	          ^~~~~~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/paramAmb.k.out
+++ b/k-distribution/tests/regression-new/checks/paramAmb.k.out
@@ -7,4 +7,6 @@
     #KRewrite(#SemanticCastToA(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToA(#token("X","#KVariable")),`wrap__PARAMAMB_T_M`(#SemanticCastToA(#token("X","#KVariable")))))
 	Source(paramAmb.k)
 	Location(11,8,11,29)
+	11 |	  rule X => label(X, wrap X)
+	   .	       ^~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
+++ b/k-distribution/tests/regression-new/checks/parseErrorExpected.k.out
@@ -1,10 +1,16 @@
 [Error] Inner Parser: Parse error: unexpected token '=>'.
 	Source(parseErrorExpected.k)
 	Location(4,6,4,8)
+	4 |	rule => false
+	  .	     ^~
 [Error] Inner Parser: Parse error: unexpected end of file following token 'true'.
 	Source(parseErrorExpected.k)
 	Location(5,15,5,16)
+	5 |	rule 0 => true
+	  .	              ^
 [Error] Inner Parser: Parse error: unexpected token '</k>' following token 'true'.
 	Source(parseErrorExpected.k)
 	Location(6,20,6,24)
+	6 |	rule <k> 0 => true </k>
+	  .	                   ^~~~
 [Error] Compiler: Had 3 parsing errors.

--- a/k-distribution/tests/regression-new/checks/priorityError.k.out
+++ b/k-distribution/tests/regression-new/checks/priorityError.k.out
@@ -1,9 +1,13 @@
 [Error] Inner Parser: Priority filter exception. Cannot use lguard as an immediate child of plus. Consider using parentheses around lguard
 	Source(priorityError.k)
 	Location(19,19,19,22)
+	19 |	    rule . => 1 + l 2 // unable to disambiguate - error
+	   .	                  ^~~
 [Error] Inner Parser: Priority filter exception. Cannot use rguard as an immediate child of plus. Consider using parentheses around rguard
 	Source(priorityError.k)
 	Location(20,15,20,18)
+	20 |	    rule . => 1 r + 2 // unable to disambiguate - error
+	   .	              ^~~
 [Error] Inner Parser: Parsing ambiguity.
 1: syntax Exp ::= Exp "r" [klabel(rguard), symbol]
     rguard(lguard(#token("1","Int")))
@@ -11,4 +15,6 @@
     lguard(rguard(#token("1","Int")))
 	Source(priorityError.k)
 	Location(21,15,21,20)
+	21 |	    rule . => l 1 r   // ambiguous - error
+	   .	              ^~~~~
 [Error] Compiler: Had 3 parsing errors.

--- a/k-distribution/tests/regression-new/checks/recordOnRhs.k.out
+++ b/k-distribution/tests/regression-new/checks/recordOnRhs.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Found variable _Gen1 on right hand side of rule, not bound on left hand side. Did you mean "?_Gen1"?
 	Source(recordOnRhs.k)
 	Location(6,15,6,23)
+	6 |	rule _Gen0 => foo(...)
+	  .	              ^~~~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/rewriteInFunctionContext.k.out
+++ b/k-distribution/tests/regression-new/checks/rewriteInFunctionContext.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: Rewrites are not allowed in the context of a function rule.
 	Source(rewriteInFunctionContext.k)
 	Location(11,12,11,18)
+	11 |	     <bar> 0 => 1 </bar>
+	   .	           ^~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/signature.k.out
+++ b/k-distribution/tests/regression-new/checks/signature.k.out
@@ -1,31 +1,51 @@
 [Error] Inner Parser: Parse error: unexpected token 'foo'.
 	Source(signature.k)
 	Location(24,8,24,11)
+	24 |	  rule foo() => .K
+	   .	       ^~~
 [Error] Inner Parser: Parse error: unexpected token 'fu'.
 	Source(signature.k)
 	Location(26,8,26,10)
+	26 |	  rule fu() => .K
+	   .	       ^~
 [Error] Inner Parser: Parse error: unexpected token 'baz'.
 	Source(signature.k)
 	Location(28,8,28,11)
+	28 |	  rule baz => .K
+	   .	       ^~~
 [Error] Inner Parser: Parse error: unexpected token 'foo'.
 	Source(signature.k)
 	Location(36,8,36,11)
+	36 |	  rule foo() => .K
+	   .	       ^~~
 [Error] Inner Parser: Parse error: unexpected token 'bam'.
 	Source(signature.k)
 	Location(37,8,37,11)
+	37 |	  rule bam() => .K
+	   .	       ^~~
 [Error] Inner Parser: Parse error: unexpected token 'fu'.
 	Source(signature.k)
 	Location(38,8,38,10)
+	38 |	  rule fu() => .K
+	   .	       ^~
 [Error] Inner Parser: Parse error: unexpected token 'bar'.
 	Source(signature.k)
 	Location(39,8,39,11)
+	39 |	  rule bar => .K
+	   .	       ^~~
 [Error] Inner Parser: Parse error: unexpected token 'baz'.
 	Source(signature.k)
 	Location(40,8,40,11)
+	40 |	  rule baz => .K
+	   .	       ^~~
 [Error] Inner Parser: Parse error: unexpected token 'b'.
 	Source(signature.k)
 	Location(42,8,42,9)
+	42 |	  rule b() => .K
+	   .	       ^
 [Error] Inner Parser: Parse error: unexpected token 'a'.
 	Source(signature.k)
 	Location(54,8,54,9)
+	54 |	  rule a() => .K
+	   .	       ^
 [Error] Compiler: Had 10 parsing errors.

--- a/k-distribution/tests/regression-new/checks/smtLemmaCheck.k.out
+++ b/k-distribution/tests/regression-new/checks/smtLemmaCheck.k.out
@@ -1,6 +1,8 @@
 [Error] Compiler: Invalid term in smt-lemma detected. All terms in smt-lemma rules require smt-hook or smtlib labels
 	Source(smtLemmaCheck.k)
 	Location(12,8,12,12)
+	12 |	  rule f(_) >Int -1 andBool false => true  [simplification, smt-lemma]
+	   .	       ^~~~
 [Error] Compiler: Had 1 structural errors after macro expansion.
   while executing phase "expand macros" on sentence at
 	Source(smtLemmaCheck.k)

--- a/k-distribution/tests/regression-new/checks/tokenCheck.k.out
+++ b/k-distribution/tests/regression-new/checks/tokenCheck.k.out
@@ -1,7 +1,11 @@
 [Error] Compiler: Sort X was declared as a token. Productions of this sort can only contain [function] or [token] labels.
 	Source(tokenCheck.k)
 	Location(10,16,10,22)
+	10 |	  syntax X ::= fail()
+	   .	               ^~~~~~
 [Error] Compiler: Sort Y was declared as a token. Productions of this sort can only contain [function] or [token] labels.
 	Source(tokenCheck.k)
 	Location(13,16,13,17)
+	13 |	  syntax Y ::= Z
+	   .	               ^
 [Error] Compiler: Had 2 structural errors.

--- a/k-distribution/tests/regression-new/checks/unexpandedMacro.k.out
+++ b/k-distribution/tests/regression-new/checks/unexpandedMacro.k.out
@@ -1,6 +1,8 @@
 [Error] Compiler: Rule contains macro symbol that was not expanded
 	Source(unexpandedMacro.k)
 	Location(5,8,5,27)
+	5 |	  rule A ( N ) +Int 4 => N
+	  .	       ^~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 structural errors after macro expansion.
   while executing phase "expand macros" on sentence at
 	Source(unexpandedMacro.k)

--- a/k-distribution/tests/regression-new/checks/wideningAnywhere.k.out
+++ b/k-distribution/tests/regression-new/checks/wideningAnywhere.k.out
@@ -1,4 +1,6 @@
 [Error] Inner Parser: Unexpected sort KItem for term parsed as production syntax KItem ::= "bar". Expected: Foo
 	Source(wideningAnywhere.k)
 	Location(6,13,6,16)
+	6 |	rule foo => bar [anywhere]
+	  .	            ^~~
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/issue-1175/test-broken-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-1175/test-broken-spec.k.out
@@ -1,4 +1,6 @@
 [Error] Inner Parser: Scanner error: unexpected character sequence '<'.
 	Source(test-broken-spec.k)
 	Location(3,10,3,11)
+	3 |	    rule <k> inc X => X +Int 1 ... </k>
+	  .	         ^
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/issue-1471-proofSyntaxWarning/proofSyntax-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-1471-proofSyntaxWarning/proofSyntax-spec.k.out
@@ -5,6 +5,10 @@ kore-exec: [] Warning (WarnTrivialClaim):
 [Warning] Compiler: Found syntax declaration in proof module. This will not be visible from the main module.
 	Source(proofSyntax-spec.k)
 	Location(16,16,16,19)
+	16 |	  syntax S ::= "g" // warning
+	   .	               ^~~
 [Warning] Compiler: Found syntax declaration in proof module. This will not be visible from the main module.
 	Source(proofSyntax-spec.k)
 	Location(22,16,22,19)
+	22 |	  syntax S ::= "h" // warning
+	   .	               ^~~

--- a/k-distribution/tests/regression-new/issue-1545-func-in-simplification/test.k.out
+++ b/k-distribution/tests/regression-new/issue-1545-func-in-simplification/test.k.out
@@ -1,8 +1,12 @@
 [Error] Compiler: Illegal function symbol _+Int_ on LHS of rule. Consider adding `simplification` attribute to the rule if this is intended.
 	Source(test.k)
 	Location(5,11,5,20)
+	5 |	    rule (A +Int I2) +Int (I3 -Int A) => I2 +Int I3
+	  .	          ^~~~~~~~~
 [Error] Compiler: Illegal function symbol _-Int_ on LHS of rule. Consider adding `simplification` attribute to the rule if this is intended.
 	Source(test.k)
 	Location(5,28,5,37)
+	5 |	    rule (A +Int I2) +Int (I3 -Int A) => I2 +Int I3
+	  .	                           ^~~~~~~~~
 [Error] Compiler: Had 2 structural errors.
 [Warning] Compiler: Could not find main syntax module with name TEST-SYNTAX in definition.  Use --syntax-module to specify one. Using TEST as default.

--- a/k-distribution/tests/regression-new/issue-1760/test.k.out
+++ b/k-distribution/tests/regression-new/issue-1760/test.k.out
@@ -1,12 +1,20 @@
 [Warning] Compiler: Non exhaustive match detected: `.Kat_TEST-SYNTAX_Kat`(.KList)
 	Source(test.k)
 	Location(7,18,7,72)
+	7 |	  syntax Kat ::= ".Kat" [function, functional, hook(KAT.empty), impure]
+	  .	                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Warning] Compiler: Non exhaustive match detected: `notKat_`(_)
 	Source(test.k)
 	Location(20,19,20,172)
+	20 |	                | "notKat" Kat          [function, functional, klabel(notKat_), symbol, smt-hook(not), boolOperation, latex(\neg_{\scriptstyle\it Kat}{#1}), hook(KAT.not)]
+	   .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Warning] Compiler: Non exhaustive match detected: `_andKat_`(_,_)
 	Source(test.k)
 	Location(21,19,21,184)
+	21 |	                > Kat "andKat" Kat     [function, functional, klabel(_andKat_), symbol, left, smt-hook(and), boolOperation, latex({#1}\wedge_{\scriptstyle\it Kat}{#2}), hook(KAT.and)]
+	   .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Warning] Compiler: Non exhaustive match detected: `_orKat__TEST_Kat_Kat_Kat`(_,_)
 	Source(test.k)
 	Location(22,19,22,171)
+	22 |	                | Kat "orKat" Kat      [function, functional, klabel(_orKat_), left, smt-hook(or), boolOperation, latex({#1}\vee_{\scriptstyle\it Kat}{#2}), hook(KAT.or)]
+	   .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/k-distribution/tests/regression-new/issue-2146-duplicateModules/test.k.out
+++ b/k-distribution/tests/regression-new/issue-2146-duplicateModules/test.k.out
@@ -1,4 +1,9 @@
 [Error] Outer Parser: Module LIST previously declared at Source...
 	Source(test.k)
 	Location(1,1,3,10)
+	  .	v~~~~~~~~~~
+	1 |	module LIST
+	2 |	
+	3 |	endmodule
+	  .	~~~~~~~~^
 [Error] Outer Parser: Had 1 outer parsing errors.

--- a/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-2174-kprovexParseError/test-spec.k.out
@@ -1,4 +1,6 @@
 [Error] Inner Parser: Parse error: unexpected token '...' following token 'asdf'.
 	Source(test-spec.k)
 	Location(8,20,8,23)
+	8 |	    claim <k> asdf ... </k>
+	  .	                   ^~~
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k.out
@@ -1,7 +1,11 @@
 [Error] Compiler: Simplification rules need to be function/functional like.
 	Source(a2-spec.k)
 	Location(7,8,7,55)
+	7 |	  rule <k> (X +Int Y) +Int Z => Z +Int (X +Int Y) </k> [simplification, symbolic(X), concrete(Y, Z)]
+	  .	       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Simplification rules need to be function/functional like.
 	Source(a2-spec.k)
 	Location(8,8,8,25)
+	8 |	  rule notAFunction => 1 [simplification]
+	  .	       ^~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 2 structural errors.

--- a/k-distribution/tests/regression-new/kprove-java/rhs-vars-broken-spec.k.out
+++ b/k-distribution/tests/regression-new/kprove-java/rhs-vars-broken-spec.k.out
@@ -1,10 +1,16 @@
 [Error] Compiler: Found variable _ on right hand side of rule, not bound on left hand side. Did you mean "?_"?
 	Source(rhs-vars-broken-spec.k)
 	Location(12,20,12,21)
+	12 |	   claim <k> .K => _ </k>
+	   .	                   ^
 [Error] Compiler: Found variable A on right hand side of rule, not bound on left hand side. Did you mean "?A"?
 	Source(rhs-vars-broken-spec.k)
 	Location(14,20,14,21)
+	14 |	   claim <k> .K => A </k>
+	   .	                   ^
 [Warning] Compiler: Variable 'A' defined but not used. Prefix variable name with underscore if this is intentional.
 	Source(rhs-vars-broken-spec.k)
 	Location(14,20,14,21)
+	14 |	   claim <k> .K => A </k>
+	   .	                   ^
 [Error] Compiler: Had 2 structural errors.

--- a/k-distribution/tests/regression-new/non-executable/rewrite-check/test.k.out
+++ b/k-distribution/tests/regression-new/non-executable/rewrite-check/test.k.out
@@ -1,4 +1,6 @@
 [Error] Compiler: non-executable attribute is only supported on function rules.
 	Source(test.k)
 	Location(16,8,16,27)
+	16 |	  rule g(X, Y) => X +Int Y [non-executable, priority(1)]
+	   .	       ^~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/nonexhaustive/test.k.out
+++ b/k-distribution/tests/regression-new/nonexhaustive/test.k.out
@@ -1,34 +1,56 @@
 [Error] Compiler: Non exhaustive match detected: `foo(_)_TEST_Int_Int`(#token("3","Int"))
 	Source(test.k)
 	Location(19,16,19,47)
+	19 |	syntax Int ::= foo(Int) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo2(_)_TEST_Int_Foo`(`baz()_TEST_Foo`(.KList))
 	Source(test.k)
 	Location(24,16,24,48)
+	24 |	syntax Int ::= foo2(Foo) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo2a(_)_TEST_Int_Bar`(`stuff(_)_TEST_Bar_Foo`(`baz()_TEST_Foo`(.KList)))
 	Source(test.k)
 	Location(29,16,29,49)
+	29 |	syntax Int ::= foo2a(Bar) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo3(_)_TEST_Int_String`(#token("\"3\"","String"))
 	Source(test.k)
 	Location(35,16,35,51)
+	35 |	syntax Int ::= foo3(String) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo4(_)_TEST_Int_Bytes`(_)
 	Source(test.k)
 	Location(41,16,41,50)
+	41 |	syntax Int ::= foo4(Bytes) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo10(_)_TEST_Int_Float`(#token("3.0","Float"))
 	Source(test.k)
 	Location(89,16,89,51)
+	89 |	syntax Int ::= foo10(Float) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo10a(_)_TEST_Int_Float`(#token("0.0","Float"))
 	Source(test.k)
 	Location(96,16,96,52)
+	96 |	syntax Int ::= foo10a(Float) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo11(_)_TEST_Int_Bool`(#token("false","Bool"))
 	Source(test.k)
 	Location(99,16,99,50)
+	99 |	syntax Int ::= foo11(Bool) [function, functional]
+	   .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo11a(_)_TEST_Int_Bool`(#token("true","Bool"))
 	Source(test.k)
 	Location(102,16,102,51)
+	102 |	syntax Int ::= foo11a(Bool) [function, functional]
+	    .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo12(_)_TEST_Int_KVar`(#token("_3","KVar"))
 	Source(test.k)
 	Location(106,16,106,50)
+	106 |	syntax Int ::= foo12(KVar) [function, functional]
+	    .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Non exhaustive match detected: `foo13(_)_TEST_Int_StringBuffer`(_)
 	Source(test.k)
 	Location(111,16,111,58)
+	111 |	syntax Int ::= foo13(StringBuffer) [function, functional]
+	    .	               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 11 pattern matching errors.

--- a/k-distribution/tests/regression-new/useless/test.k.out
+++ b/k-distribution/tests/regression-new/useless/test.k.out
@@ -1,64 +1,106 @@
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(20,6,20,17)
+	20 |	rule foo(A) => A
+	   .	     ^~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(21,6,21,17)
+	21 |	rule foo(B) => B
+	   .	     ^~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(26,6,26,22)
+	26 |	rule foo2(bar()) => 0
+	   .	     ^~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(30,6,30,19)
+	30 |	rule foo3("") => 0
+	   .	     ^~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(34,6,34,35)
+	34 |	rule foo4(BAR) => lengthBytes(BAR)
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(35,6,35,35)
+	35 |	rule foo4(BAZ) => lengthBytes(BAZ)
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(38,6,38,28)
+	38 |	rule foo5(ListItem(_)) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(46,6,46,24)
+	46 |	rule foo7(_ |-> _) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(50,6,50,27)
+	50 |	rule foo8(X |-> _, X) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(51,6,51,27)
+	51 |	rule foo8(_ |-> _, _) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(59,6,59,27)
+	59 |	rule foo7(SetItem(_)) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(63,6,63,30)
+	63 |	rule foo8(SetItem(X), X) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(64,6,64,30)
+	64 |	rule foo8(SetItem(_), _) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(69,6,69,22)
+	69 |	rule foo10(0.0F) => 0
+	   .	     ^~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(70,6,70,22)
+	70 |	rule foo10(0.0f) => 0
+	   .	     ^~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(73,6,73,22)
+	73 |	rule foo10a(0.0) => 0
+	   .	     ^~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(75,6,75,28)
+	75 |	rule foo10a(0.0p53x11) => 0
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(78,6,78,22)
+	78 |	rule foo11(true) => 0
+	   .	     ^~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(83,6,83,19)
+	83 |	rule foo12(x) => 0
+	   .	     ^~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(87,6,87,58)
+	87 |	rule foo13(BAR) => lengthString(StringBuffer2String(BAR))
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Potentially useless rule detected.
 	Source(test.k)
 	Location(88,6,88,58)
+	88 |	rule foo13(BAZ) => lengthString(StringBuffer2String(BAZ))
+	   .	     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 21 pattern matching errors.

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -1,12 +1,16 @@
 // Copyright (c) 2012-2019 K Team. All Rights Reserved.
 package org.kframework.utils.errorsystem;
 
+import org.apache.commons.lang3.StringUtils;
 import org.kframework.attributes.HasLocation;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
 
 import java.io.Serializable;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.*;
+import java.util.stream.Stream;
 
 public class KException implements Serializable, HasLocation {
     protected final ExceptionType type;
@@ -16,6 +20,7 @@ public class KException implements Serializable, HasLocation {
     private final String message;
     private final Throwable exception;
     private final boolean printException;
+    private final String sourceText;
     private StringBuilder trace = new StringBuilder();
 
     private static final Map<KExceptionGroup, String> labels;
@@ -65,6 +70,7 @@ public class KException implements Serializable, HasLocation {
         this.source = source;
         this.location = location;
         this.exception = exception;
+        this.sourceText = getSourceLineText();
         this.printException = printException;
     }
 
@@ -132,7 +138,8 @@ public class KException implements Serializable, HasLocation {
                 + (exception != null && printException ? " (" + exception.getClass().getSimpleName() + ": " + exception.getMessage() + ")" : "")
                 + trace.toString() + traceTail()
                 + (source == null ? "" : "\n\t" + source)
-                + (location == null ? "" : "\n\t" + location);
+                + (location == null ? "" : "\n\t" + location)
+                + (sourceText == null ? "" : sourceText);
     }
 
     public String getMessage() {
@@ -177,6 +184,103 @@ public class KException implements Serializable, HasLocation {
         StringBuilder sb = new StringBuilder();
         new Formatter(sb).format(format, args);
         addTraceFrame(sb);
+    }
+
+    private boolean locationIsValid() {
+        return (location != null && location.startLine() > 0 && location.endLine() > 0);
+    }
+
+    private String getSourceLineText() {
+        if (!locationIsValid()) {
+            return null;
+        }
+        try {
+            String sourceLineText;
+            int errorLineCount = location.endLine() - location.startLine() + 1;
+
+            if (errorLineCount == 1) {
+                sourceLineText = getSourceLine();
+            } else if (errorLineCount > 1) {
+                // generate line info for multiple lines
+                sourceLineText = getSourceLine(errorLineCount);
+            } else {
+                sourceLineText = null;
+            }
+            return sourceLineText;
+        } catch (java.io.IOException e) {
+            return null;
+        }
+    }
+
+    private String getSourceLine() throws java.io.IOException {
+        int lineNumberPadding = String.valueOf(location.startLine()).length();
+        StringBuilder sourceText = new StringBuilder();
+
+        sourceText.append("\n\t");
+        sourceText.append(String.valueOf(location.startLine()) + " |\t");
+        Stream lines = Files.lines(Paths.get(getSource().source()));
+        sourceText.append((String) lines.skip(location.startLine() - 1).findFirst().get());
+
+        /* generate a line below the source file that underlines the location of the error */
+
+        sourceText.append("\n\t" + StringUtils.repeat(' ', lineNumberPadding) + " .\t");
+        sourceText.append(StringUtils.repeat(' ', location.startColumn() - 1));
+        sourceText.append('^');
+        sourceText.append(StringUtils.repeat('~', location.endColumn() - location.startColumn() - 1));
+
+        return sourceText.toString();
+    }
+
+    private String getSourceLine(int errorLineCount)  throws java.io.IOException {
+
+        /* The line number padding is based on the endline because this is the largest number of padding needed */
+
+        int lineNumberPadding = String.valueOf(location.endLine()).length();
+        StringBuilder sourceText = new StringBuilder();
+
+        /* generate a line above the source file that indicates the location of the error */
+
+        sourceText.append("\n\t" + StringUtils.repeat(' ', lineNumberPadding) + " .\t");
+        sourceText.append(StringUtils.repeat(' ', location.startColumn() - 1));
+        sourceText.append('v');
+
+        Stream lines = Files.lines(Paths.get(getSource().source()));
+        String firstLine = (String) lines.skip(location.startLine() - 1).findFirst().get();
+
+        if (firstLine.length() - location.startColumn() > 0) {
+            sourceText.append(StringUtils.repeat('~', firstLine.length() - location.startColumn()));
+        }
+        sourceText.append("\n\t");
+        sourceText.append(String.valueOf(location.startLine()) + " |\t");
+        sourceText.append(firstLine);
+
+        if (errorLineCount == 3) {
+            sourceText.append("\n\t");
+            sourceText.append(String.valueOf(location.startLine() + 1) + " |\t");
+            Stream secondline = Files.lines(Paths.get(getSource().source()));
+            sourceText.append((String) secondline.skip(location.startLine()).findFirst().get());
+        } else if (errorLineCount > 3) {
+            /*
+             * If the error message spans more than 3 lines, indicate this line with "...".
+             * For errors that span many lines, this is sufficient to get the point across.
+             */
+            sourceText.append("\n\t" + StringUtils.repeat(' ', lineNumberPadding) + " |\t\t...");
+        }
+
+        sourceText.append("\n\t");
+        sourceText.append(String.valueOf(location.endLine()) + " |\t");
+        String lastLine = (String)Files.lines(Paths.get(getSource().source())).skip(location.endLine() -1).findFirst().get();
+        int firstCharIndex = lastLine.indexOf(lastLine.trim());
+        sourceText.append(lastLine);
+
+        /* generate a line below the source file that underlines the location of the error */
+
+        sourceText.append("\n\t" + StringUtils.repeat(' ', lineNumberPadding) + " .\t");
+        sourceText.append(StringUtils.repeat(' ', firstCharIndex));
+        sourceText.append(StringUtils.repeat('~', location.endColumn() - firstCharIndex - 2));
+        sourceText.append('^');
+
+        return sourceText.toString();
     }
 
     public Source getSource() {


### PR DESCRIPTION
At the time of writing, error messages display location information like
so:
```
[Error] Compiler: Found existential variable not supported by concrete backend.
        Source(/home/erik/error/test.k)
        Location(11,39,11,41)
```

Sometimes these messages can be difficult to decipher due to the lack of
information from the actual source code. Add this information in the
error message so that the errors look like this:

```
[Error] Compiler: Found existential variable not supported by concrete backend.
        Source(/home/erik/error/test.k)
        Location(11,39,11,41)
        |    rule <k> a => b ... </k> requires ?_ ==Int _
        |                                      ^~~
```

For longer lines, error messages look like this:

```
[Error] Compiler: Claims are not allowed in the definition.
        Source(/home/erik/error/test.k)
        Location(15,11,17,13)
           .          v~~~
        15 |    claim _
        16 |          =>
        17 |           .
           .         ~~^
```

If error messages span more than 3 lines, the lines between the first
and last line are replaced with a single line containing `...` to avoid
taking up too much space on the terminal.