### PR TITLE
Fix for the regression caused by #2502

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -102,12 +102,14 @@ public class ModuleToKORE {
     public static final String ALL_PATH_OP = KLabels.RL_wAF.name();
     public static final String HAS_DOMAIN_VALUES = "hasDomainValues";
     private final Module module;
+    private final AddSortInjections addSortInjections;
     private final KLabel topCellInitializer;
     private final Set<String> mlBinders = new HashSet<>();
     private final KompileOptions options;
 
     public ModuleToKORE(Module module, KLabel topCellInitializer, KompileOptions options) {
         this.module = module;
+        this.addSortInjections = new AddSortInjections(module);
         this.topCellInitializer = topCellInitializer;
         this.options = options;
         for (Production prod : iterable(module.sortedProductions())) {
@@ -922,7 +924,7 @@ public class ModuleToKORE {
         SentenceType sentenceType = getSentenceType(rule.att()).orElse(defaultSentenceType);
         // injections should already be present, but this is an ugly hack to get around the
         // cache persistence issue that means that Sort attributes on k terms might not be present.
-        rule = new AddSortInjections(module).addInjections(rule);
+        rule = addSortInjections.addInjections(rule);
         Set<KVariable> existentials = getExistentials(rule);
         ConstructorChecks constructorChecks = new ConstructorChecks(module);
         K left = RewriteToTop.toLeft(rule.body());

--- a/kernel/src/main/java/org/kframework/compile/MinimizeTermConstruction.java
+++ b/kernel/src/main/java/org/kframework/compile/MinimizeTermConstruction.java
@@ -25,9 +25,11 @@ public class MinimizeTermConstruction {
     private final Set<K> usedOnRhs = new HashSet<>();
 
     private final Module module;
+    private final AddSortInjections sorts;
 
     public MinimizeTermConstruction(Module module) {
         this.module = module;
+        this.sorts = new AddSortInjections(module);
     }
 
     void resetVars() {
@@ -93,7 +95,6 @@ public class MinimizeTermConstruction {
    }
 
    void gatherTerms(K term, boolean body) {
-        AddSortInjections sorts = new AddSortInjections(module);
         new RewriteAwareVisitor(body, new HashSet<>()) {
             @Override
             public void apply(K k) {
@@ -150,7 +151,6 @@ public class MinimizeTermConstruction {
     }
 
     K transform(K term, boolean body) {
-        AddSortInjections sorts = new AddSortInjections(module);
         return new RewriteAwareTransformer(body) {
             @Override
             public K apply(K k) {

--- a/kernel/src/main/java/org/kframework/compile/ResolveFun.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFun.java
@@ -64,6 +64,7 @@ public class ResolveFun {
     private final Set<Production> funProds = new HashSet<>();
     private final Set<Rule> funRules = new HashSet<>();
     private Module module;
+    private AddSortInjections inj;
     private final Set<KLabel> klabels = new HashSet<>();
 
     private KLabel getUniqueLambdaLabel(String nameHint1, String nameHint2) {
@@ -215,7 +216,6 @@ public class ResolveFun {
             return ((KToken) k).sort();
         if (k instanceof KApply) {
             if (kore) {
-                AddSortInjections inj = new AddSortInjections(module);
                 return inj.sort(k, Sorts.K());
             } else {
                 return k.att().get(Production.class).sort();
@@ -254,6 +254,7 @@ public class ResolveFun {
 
     public Module resolve(Module m) {
         module = Kompile.subsortKItem(m);
+        inj = new AddSortInjections(module);
         funProds.clear();
         funRules.clear();
         Set<Sentence> newSentences = stream(m.localSentences()).map(this::resolve).collect(Collectors.toSet());

--- a/kernel/src/main/java/org/kframework/ksearchpattern/KSearchPatternFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/ksearchpattern/KSearchPatternFrontEnd.java
@@ -94,11 +94,12 @@ public class KSearchPatternFrontEnd extends FrontEnd {
           K patternTerm = RewriteToTop.toLeft(pattern.body());
           K patternCondition = pattern.requires();
           org.kframework.definition.Module mod = compiledDef.executionModule();
+          AddSortInjections addSortInjections = new AddSortInjections(mod);
           ModuleToKORE converter = new ModuleToKORE(mod, compiledDef.topCellInitializer, kompileOptions);
           StringBuilder sb = new StringBuilder();
           ExpandMacros macroExpander = ExpandMacros.forNonSentences(mod, files, kompileOptions, false);
           K withMacros = macroExpander.expand(patternTerm);
-          K kWithInjections = new AddSortInjections(mod).addInjections(withMacros);
+          K kWithInjections = addSortInjections.addInjections(withMacros);
           sb.append("\\and{SortGeneratedTopCell{}}(");
           converter.convert(kWithInjections, sb);
           sb.append(", ");
@@ -107,7 +108,7 @@ public class KSearchPatternFrontEnd extends FrontEnd {
           } else {
             sb.append("\\equals{SortBool{},SortGeneratedTopCell{}}(");
             withMacros = macroExpander.expand(patternCondition);
-            kWithInjections = new AddSortInjections(mod).addInjections(withMacros);
+            kWithInjections = addSortInjections.addInjections(withMacros);
             converter.convert(kWithInjections, sb);
             sb.append(", \\dv{SortBool{}}(\"true\"))");
           }

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -67,6 +67,8 @@ public class KPrint {
 
     @Nullable
     private final CompiledDefinition compiledDefinition;
+    private final Module executionModule;
+    private final AddSortInjections addSortInjections;
 
     public KPrint() {
         this(new KExceptionManager(new GlobalOptions()), FileUtil.testFileUtil(), new TTYInfo(false, false, false),
@@ -81,6 +83,14 @@ public class KPrint {
         this.tty = tty;
         this.options = options;
         this.compiledDefinition = compiledDefinition;
+        if (compiledDefinition != null) {
+            this.executionModule = compiledDefinition.executionModule();
+            this.addSortInjections = new AddSortInjections(executionModule);
+        } else {
+            this.executionModule = null;
+            this.addSortInjections = null;
+        }
+
         this.kompileOptions = kompileOptions;
     }
 
@@ -140,8 +150,8 @@ public class KPrint {
                     throw KEMException.criticalError("KORE output requires a compiled definition.");
                 }
                 ModuleToKORE converter = new ModuleToKORE(module, compiledDefinition.topCellInitializer, kompileOptions);
-                result = ExpandMacros.forNonSentences(compiledDefinition.executionModule(), files, kompileOptions, false).expand(result);
-                result = new AddSortInjections(compiledDefinition.executionModule()).addSortInjections(result, s);
+                result = ExpandMacros.forNonSentences(executionModule, files, kompileOptions, false).expand(result);
+                result = addSortInjections.addSortInjections(result, s);
                 StringBuilder sb = new StringBuilder();
                 converter.convert(result, sb);
                 return sb.toString().getBytes();


### PR DESCRIPTION
This fixes a performance regression that was introduced by #2502. That PR added a construction of a `ConfigurationInfoFromModule` object to the constructor of the `AddSortInjections` class. As a result, objects of the latter class have now a significant performance cost to construct. This PR refactors various instances of redundancy on constructing such objects.

fixes #2523 