### PR TITLE
Add `#trace` debugging hook

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -2427,7 +2427,8 @@ logged, which requires re-parsing the underlying K definition. Subsequent calls
 do not incur this overhead again; the definition is cached.
 
 ```k
-  syntax {Sort} K ::= #trace(value: Sort) [function, functional, hook(IO.traceTerm), impure, returnsUnit, symbol]
+  syntax K ::= #trace(value: KItem) [function, functional, hook(IO.traceTerm), impure, returnsUnit, symbol]
+             | #traceK(value: K)    [function, functional, hook(IO.traceTerm), impure, returnsUnit, symbol]
 ```
 
 ### Implementation of high-level I/O streams in K

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -2419,6 +2419,17 @@ finishes.
   syntax K ::= #logToFile(name: String, value: String) [function, functional, hook(IO.log), impure, returnsUnit, symbol]
 ```
 
+Terms can also be logged to standard error in _surface syntax_, rather than as
+KORE using `#trace`. This operator has similar semantics to `#logToFile` (i.e.
+it returns `.K`, but prints as an impure side effect). Note that calling
+`#trace` is equivalent to invoking the `kprint` tool for **each** term that is
+logged, which requires that the underlying K definition is re-parsed. Doing so
+is expensive, and so `#trace` should only be used as a debugging aid.
+
+```k
+  syntax {Sort} K ::= #trace(value: Sort) [function, functional, hook(IO.traceTerm), impure, returnsUnit, symbol]
+```
+
 ### Implementation of high-level I/O streams in K
 
 Below is an implementation of the `stream="stdin"` and `stream="stdout"`

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -2422,9 +2422,9 @@ finishes.
 Terms can also be logged to standard error in _surface syntax_, rather than as
 KORE using `#trace`. This operator has similar semantics to `#logToFile` (i.e.
 it returns `.K`, but prints as an impure side effect). Note that calling
-`#trace` is equivalent to invoking the `kprint` tool for **each** term that is
-logged, which requires that the underlying K definition is re-parsed. Doing so
-is expensive, and so `#trace` should only be used as a debugging aid.
+`#trace` is equivalent to invoking the `kprint` tool for the first term that is
+logged, which requires re-parsing the underlying K definition. Subsequent calls
+do not incur this overhead again; the definition is cached.
 
 ```k
   syntax {Sort} K ::= #trace(value: Sort) [function, functional, hook(IO.traceTerm), impure, returnsUnit, symbol]

--- a/k-distribution/tests/regression-new/trace/1.test
+++ b/k-distribution/tests/regression-new/trace/1.test
@@ -1,0 +1,1 @@
+bar foo(34) * frob("Hello", false)

--- a/k-distribution/tests/regression-new/trace/1.test.out
+++ b/k-distribution/tests/regression-new/trace/1.test.out
@@ -1,0 +1,7 @@
+foo ( 34 )
+frob ( "Hello" , false )
+bar
+  foo ( 2 ) * foo ( 0 )
+<k>
+  .
+</k>

--- a/k-distribution/tests/regression-new/trace/1.test.out
+++ b/k-distribution/tests/regression-new/trace/1.test.out
@@ -1,5 +1,6 @@
 foo ( 34 )
 frob ( "Hello" , false )
+"builtin"
 bar
   foo ( 2 ) * foo ( 0 )
 <k>

--- a/k-distribution/tests/regression-new/trace/Makefile
+++ b/k-distribution/tests/regression-new/trace/Makefile
@@ -1,0 +1,8 @@
+DEF=test
+EXT=test
+TESTDIR=.
+KOMPILE_FLAGS=--syntax-module TEST
+
+CHECK=2>&1 | diff -
+
+include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/trace/test.k
+++ b/k-distribution/tests/regression-new/trace/test.k
@@ -1,0 +1,14 @@
+module TEST
+  imports DOMAINS
+  imports K-IO
+
+  syntax Foo ::= foo(Int)
+               | frob(String, Bool)
+
+  syntax Bar ::= "bar" Foo "*" Foo [format(%1%i%n%2 %3 %4)]
+               | "(" Bar ")" [bracket]
+
+  rule bar F1 * F2 =>
+    #let _ = #trace(F1) #in
+    (#trace(F2) ~> #trace(bar foo(2) * foo(0)) ~> .K)
+endmodule

--- a/k-distribution/tests/regression-new/trace/test.k
+++ b/k-distribution/tests/regression-new/trace/test.k
@@ -10,5 +10,5 @@ module TEST
 
   rule bar F1 * F2 =>
     #let _ = #trace(F1) #in
-    (#trace(F2) ~> #trace(bar foo(2) * foo(0)) ~> .K)
+    (#trace(F2) ~> #trace("builtin") ~> #trace(bar foo(2) * foo(0)) ~> .K)
 endmodule


### PR DESCRIPTION
This hook exposes the implementation in https://github.com/runtimeverification/llvm-backend/pull/513, along with a note explaining that calling it is expensive and should only be done as a debugging aid.

Additionally, an integration test for the hook is added to ensure that it's printing the expected syntax.

Requires https://github.com/runtimeverification/llvm-backend/pull/513 to be merged, and the corresponding submodule update to go through.