### PR TITLE
Remove temporary `kprove` shim script

### DIFF
--- a/k-distribution/src/main/scripts/bin/kprove
+++ b/k-distribution/src/main/scripts/bin/kprove
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-"$(dirname "$0")/kprove-legacy" "$@"


### PR DESCRIPTION
The WASM and Michelson semantics have both been updated to use the new `kprove-legacy` name for `kprove`:
* https://github.com/runtimeverification/michelson-semantics/pull/355
* https://github.com/runtimeverification/wasm-semantics/pull/451

Now that this has happened, we can safely remove the old name in preparation for the rename of `kprovex`.