### PR TITLE
Nix improvements

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,6 @@ in
 # Build an optimized release package.
 # Currently requires dependents to use LTO. Use sparingly.
 , release ? false
-, haskell-backend ? null
 }:
 
 let
@@ -16,17 +15,6 @@ let
 
   mavenix = import sources."mavenix" { inherit pkgs; };
   ttuegel = import sources."ttuegel" { inherit pkgs; };
-  haskell-backend-project = 
-    if haskell-backend != null then 
-      import haskell-backend { inherit release; }
-    else 
-      import ./haskell-backend/src/main/native/haskell-backend {
-        inherit release;
-        src = ttuegel.cleanGitSubtree {
-          src = ./.;
-          subDir = "haskell-backend/src/main/native/haskell-backend";
-        };
-      };
 
   llvm-backend-project = import ./llvm-backend/src/main/native/llvm-backend {
     inherit pkgs;
@@ -40,15 +28,21 @@ let
   inherit (llvm-backend-project) clang llvm-backend;
 
   k = callPackage ./nix/k.nix {
-    haskell-backend = haskell-backend-project.kore;
-    prelude-kore = haskell-backend-project.prelude-kore;
-    inherit llvm-backend mavenix;
+    inherit haskell-backend llvm-backend mavenix prelude-kore;
     inherit (ttuegel) cleanGit cleanSourceWith;
   };
 
+  haskell-backend-project = import ./haskell-backend/src/main/native/haskell-backend {
+    src = ttuegel.cleanGitSubtree {
+      src = ./.;
+      subDir = "haskell-backend/src/main/native/haskell-backend";
+    };
+  };
+  haskell-backend = haskell-backend-project.kore;
+  inherit (haskell-backend-project) prelude-kore;
+
   self = {
-    inherit k clang llvm-backend;
-    haskell-backend = haskell-backend-project.kore;
+    inherit k clang llvm-backend haskell-backend;
     inherit mavenix;
     inherit (pkgs) mkShell;
   };

--- a/default.nix
+++ b/default.nix
@@ -27,7 +27,6 @@ let
           subDir = "haskell-backend/src/main/native/haskell-backend";
         };
       };
-  inherit (haskell-backend-project) ;
 
   llvm-backend-project = import ./llvm-backend/src/main/native/llvm-backend {
     inherit pkgs;

--- a/default.nix
+++ b/default.nix
@@ -1,6 +1,6 @@
 let
   sources = import ./nix/sources.nix;
-  pinned = import sources."nixpkgs" { config = {}; overlays = []; };
+  pinned = import sources."nixpkgs" { config = {}; overlays = [ ( import ./nix/overlays/z3.nix ) ]; };
 in
 
 { pkgs ? pinned
@@ -8,6 +8,7 @@ in
 # Build an optimized release package.
 # Currently requires dependents to use LTO. Use sparingly.
 , release ? false
+, haskell-backend ? null,
 }:
 
 let
@@ -15,6 +16,18 @@ let
 
   mavenix = import sources."mavenix" { inherit pkgs; };
   ttuegel = import sources."ttuegel" { inherit pkgs; };
+  haskell-backend-project = 
+    if haskell-backend != null then 
+      import haskell-backend { inherit release; }
+    else 
+      import ./haskell-backend/src/main/native/haskell-backend {
+        inherit release;
+        src = ttuegel.cleanGitSubtree {
+          src = ./.;
+          subDir = "haskell-backend/src/main/native/haskell-backend";
+        };
+      };
+  inherit (haskell-backend-project) ;
 
   llvm-backend-project = import ./llvm-backend/src/main/native/llvm-backend {
     inherit pkgs;
@@ -28,21 +41,15 @@ let
   inherit (llvm-backend-project) clang llvm-backend;
 
   k = callPackage ./nix/k.nix {
-    inherit haskell-backend llvm-backend mavenix prelude-kore;
+    haskell-backend = haskell-backend-project.kore;
+    prelude-kore = haskell-backend-project.prelude-kore;
+    inherit llvm-backend mavenix;
     inherit (ttuegel) cleanGit cleanSourceWith;
   };
 
-  haskell-backend-project = import ./haskell-backend/src/main/native/haskell-backend {
-    src = ttuegel.cleanGitSubtree {
-      src = ./.;
-      subDir = "haskell-backend/src/main/native/haskell-backend";
-    };
-  };
-  haskell-backend = haskell-backend-project.kore;
-  inherit (haskell-backend-project) prelude-kore;
-
   self = {
-    inherit k clang llvm-backend haskell-backend;
+    inherit k clang llvm-backend;
+    haskell-backend = haskell-backend-project.kore;
     inherit mavenix;
     inherit (pkgs) mkShell;
   };

--- a/default.nix
+++ b/default.nix
@@ -8,7 +8,7 @@ in
 # Build an optimized release package.
 # Currently requires dependents to use LTO. Use sparingly.
 , release ? false
-, haskell-backend ? null,
+, haskell-backend ? null
 }:
 
 let

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -45,8 +45,12 @@ let
       patchShebangs k-distribution/src/main/scripts/lib
     '';
 
+    # Make sure to link the cmake/ and include/ folders from the llvm-backend source repo and the llvm-backend derivation, 
+    # as these may be expected/required when compiling other projects, e.g. the evm-semantics repo
     postInstall = ''
       cp -r k-distribution/target/release/k/{bin,include,lib} $out/
+      mkdir -p $out/lib/cmake/kframework && ln -s ${llvm-backend.src}/cmake/* $out/lib/cmake/kframework/
+      ln -s ${llvm-backend}/include/kllvm $out/include/
 
       prelude_kore="$out/include/kframework/kore/prelude.kore"
       mkdir -p "$(dirname "$prelude_kore")"

--- a/nix/overlays/z3.nix
+++ b/nix/overlays/z3.nix
@@ -1,0 +1,10 @@
+let
+  sources = import ../sources.nix;
+in
+
+self: super: {
+  z3 = super.z3.overrideAttrs (old: {
+    src = sources.z3;
+    version = builtins.replaceStrings ["z3-"] [""] sources.z3.branch;
+  });
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -46,5 +46,17 @@
         "type": "tarball",
         "url": "https://github.com/ttuegel/nix-lib/archive/66bb0ab890ff4d828a2dcfc7d5968465d0c7084f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
+    "z3": {
+        "branch": "z3-4.8.15",
+        "description": "The Z3 Theorem Prover",
+        "homepage": null,
+        "owner": "Z3Prover",
+        "repo": "z3",
+        "rev": "f1806d32d6f21fd4df7a08719abbc1f6493d9dc5",
+        "sha256": "0xkwqz0y5d1lfb6kfqy8wn8n2dqalzf4c8ghmjsajc1bpdl70yc5",
+        "type": "tarball",
+        "url": "https://github.com/Z3Prover/z3/archive/f1806d32d6f21fd4df7a08719abbc1f6493d9dc5.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }


### PR DESCRIPTION
This PR introduces imporvements mentioned in #2577, namely:

* pins Z3 to version 4.8.15
* links missing `cmake/` and `include/` folders from the `llvm-backend` derivation to the `k` derivation