### PR TITLE
Force manual Z3 installation in published docker images

### DIFF
--- a/package/debian/control.bionic
+++ b/package/debian/control.bionic
@@ -10,7 +10,8 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-10 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-10 , pkg-config , z3
+Depends: bison , clang-10 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-10 , pkg-config
+Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter
  and prover for programs written in languages defined in K.

--- a/package/debian/control.debian
+++ b/package/debian/control.debian
@@ -10,7 +10,8 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-11 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , z3
+Depends: bison , clang-11 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config
+Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter
  and prover for programs written in languages defined in K.

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -10,7 +10,8 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-12 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-12 , pkg-config , z3
+Depends: bison , clang-12 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-12 , pkg-config
+Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter
  and prover for programs written in languages defined in K.

--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -22,6 +22,6 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
 COPY kframework_amd64_bionic.deb /kframework_amd64_bionic.deb
 RUN    apt-get update                                     \
     && apt-get upgrade --yes                              \
-    && apt-get install --yes /kframework_amd64_bionic.deb
+    && apt-get install --yes --no-install-recommends /kframework_amd64_bionic.deb
 
 RUN rm -rf /kframework_amd64_bionic.deb

--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -10,6 +10,14 @@ RUN    apt-get update                   \
                         git             \
                         python
 
+COPY kframework_amd64_bionic.deb /kframework_amd64_bionic.deb
+RUN    apt-get update                                     \
+    && apt-get upgrade --yes                              \
+    && apt-get install --yes /kframework_amd64_bionic.deb \
+    && dpkg --remove --force-depends z3
+
+RUN rm -rf /kframework_amd64_bionic.deb
+
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && cd z3                                                         \
     && python scripts/mk_make.py                                     \
@@ -18,10 +26,3 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && make install                                                  \
     && cd ../..                                                      \
     && rm -rf z3
-
-COPY kframework_amd64_bionic.deb /kframework_amd64_bionic.deb
-RUN    apt-get update                                     \
-    && apt-get upgrade --yes                              \
-    && apt-get install --yes /kframework_amd64_bionic.deb
-
-RUN rm -rf /kframework_amd64_bionic.deb

--- a/package/docker/Dockerfile.ubuntu-bionic
+++ b/package/docker/Dockerfile.ubuntu-bionic
@@ -10,14 +10,6 @@ RUN    apt-get update                   \
                         git             \
                         python
 
-COPY kframework_amd64_bionic.deb /kframework_amd64_bionic.deb
-RUN    apt-get update                                     \
-    && apt-get upgrade --yes                              \
-    && apt-get install --yes /kframework_amd64_bionic.deb \
-    && dpkg --remove --force-depends z3
-
-RUN rm -rf /kframework_amd64_bionic.deb
-
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && cd z3                                                         \
     && python scripts/mk_make.py                                     \
@@ -26,3 +18,10 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && make install                                                  \
     && cd ../..                                                      \
     && rm -rf z3
+
+COPY kframework_amd64_bionic.deb /kframework_amd64_bionic.deb
+RUN    apt-get update                                     \
+    && apt-get upgrade --yes                              \
+    && apt-get install --yes /kframework_amd64_bionic.deb
+
+RUN rm -rf /kframework_amd64_bionic.deb

--- a/package/docker/Dockerfile.ubuntu-focal
+++ b/package/docker/Dockerfile.ubuntu-focal
@@ -11,6 +11,14 @@ RUN    apt-get update                   \
                         python          \
                         python3-pip
 
+COPY kframework_amd64_focal.deb /kframework_amd64_focal.deb
+RUN    apt-get update                                     \
+    && apt-get upgrade --yes                              \
+    && apt-get install --yes /kframework_amd64_focal.deb  \
+    && dpkg --remove --force-depends z3
+
+RUN rm -rf /kframework_amd64_focal.deb
+
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && cd z3                                                         \
     && python scripts/mk_make.py                                     \
@@ -19,13 +27,6 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && make install                                                  \
     && cd ../..                                                      \
     && rm -rf z3
-
-COPY kframework_amd64_focal.deb /kframework_amd64_focal.deb
-RUN    apt-get update                                     \
-    && apt-get upgrade --yes                              \
-    && apt-get install --yes /kframework_amd64_focal.deb
-
-RUN rm -rf /kframework_amd64_focal.deb
 
 COPY pyk/ /pyk
 RUN    pip3 install /pyk \

--- a/package/docker/Dockerfile.ubuntu-focal
+++ b/package/docker/Dockerfile.ubuntu-focal
@@ -11,14 +11,6 @@ RUN    apt-get update                   \
                         python          \
                         python3-pip
 
-COPY kframework_amd64_focal.deb /kframework_amd64_focal.deb
-RUN    apt-get update                                     \
-    && apt-get upgrade --yes                              \
-    && apt-get install --yes /kframework_amd64_focal.deb  \
-    && dpkg --remove --force-depends z3
-
-RUN rm -rf /kframework_amd64_focal.deb
-
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && cd z3                                                         \
     && python scripts/mk_make.py                                     \
@@ -27,6 +19,13 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && make install                                                  \
     && cd ../..                                                      \
     && rm -rf z3
+
+COPY kframework_amd64_focal.deb /kframework_amd64_focal.deb
+RUN    apt-get update                                     \
+    && apt-get upgrade --yes                              \
+    && apt-get install --yes /kframework_amd64_focal.deb
+
+RUN rm -rf /kframework_amd64_focal.deb
 
 COPY pyk/ /pyk
 RUN    pip3 install /pyk \

--- a/package/docker/Dockerfile.ubuntu-focal
+++ b/package/docker/Dockerfile.ubuntu-focal
@@ -23,7 +23,7 @@ RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
 COPY kframework_amd64_focal.deb /kframework_amd64_focal.deb
 RUN    apt-get update                                     \
     && apt-get upgrade --yes                              \
-    && apt-get install --yes /kframework_amd64_focal.deb
+    && apt-get install --yes --no-install-recommends /kframework_amd64_focal.deb
 
 RUN rm -rf /kframework_amd64_focal.deb
 


### PR DESCRIPTION
We specify that users should install Z3 version 4.8.15 when using K. However, in our published Docker images, we supply 4.8.7 because that's the version supplied by Ubuntu's package repositories.

#2583 identifies that the intent of our Dockerfiles is not reflected by the end result - we install Z3 from source, then immediately trample on it by installing the dependency from apt.

This PR addresses the issue by making Z3 a `Recommended` package in our debian packaging scripts. This means that _some_ version of Z3 (4.8.7) will be installed by default when users install K from `apt`, but in our Docker images we can override this and install the correct version from source.