### PR TITLE
Use Release again for packaging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
     <skipCheckstyleOnWindows>true</skipCheckstyleOnWindows>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <scala.version>2.12.14</scala.version>
-    <project.build.type>FastBuild</project.build.type>
+    <project.build.type>Release</project.build.type>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
The build for the K package was changed to FastBuild in #1185 because of an llvm bug with LTO and tail call optimization. We require a minimum version of llvm now that no longer has this bug, so we should be able to change it back without issue.

Relevant issues:
https://github.com/runtimeverification/firefly/issues/374
https://github.com/runtimeverification/evm-semantics/pull/696