### PR TITLE
add explicit dependency on llvm

### DIFF
--- a/package/debian/control.bionic
+++ b/package/debian/control.bionic
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-10 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-10 , pkg-config
+Depends: bison , clang-10 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-10 , pkg-config , llvm-10
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.debian
+++ b/package/debian/control.debian
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-11 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config
+Depends: bison , clang-11 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , llvm-11
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-12 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-12 , pkg-config
+Depends: bison , clang-12 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-12 , pkg-config , llvm-12
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter


### PR DESCRIPTION
The release job is failing because we are now passing --no-install-recommends to apt when we install K, and it turns out that we were (incorrectly) implicitly depending on some recommended packages that were actually required. This is bad because it breaks things like what we were trying to do when we passed that flag in the first place, so I add the missing dependency explicitly.