### PR TITLE
Reverse pyk match operator

### DIFF
--- a/pyk/src/pyk/cterm.py
+++ b/pyk/src/pyk/cterm.py
@@ -47,8 +47,8 @@ class CTerm:
     def hash(self) -> str:
         return self.term.hash
 
-    def match(self, term: 'CTerm') -> Optional[Subst]:
-        match_res = self.match_with_constraint(term)
+    def match(self, cterm: 'CTerm') -> Optional[Subst]:
+        match_res = self.match_with_constraint(cterm)
 
         if not match_res:
             return None
@@ -60,13 +60,13 @@ class CTerm:
 
         return subst
 
-    def match_with_constraint(self, term: 'CTerm') -> Optional[Tuple[Subst, KInner]]:
-        subst = match(pattern=self.config, term=term.config)
+    def match_with_constraint(self, cterm: 'CTerm') -> Optional[Tuple[Subst, KInner]]:
+        subst = match(pattern=self.config, term=cterm.config)
 
         if subst is None:
             return None
 
-        constraint = self._ml_impl(term.constraints, map(subst, self.constraints))
+        constraint = self._ml_impl(cterm.constraints, map(subst, self.constraints))
 
         return subst, constraint
 

--- a/pyk/src/pyk/cterm.py
+++ b/pyk/src/pyk/cterm.py
@@ -47,8 +47,8 @@ class CTerm:
     def hash(self) -> str:
         return self.term.hash
 
-    def match(self, pattern: 'CTerm') -> Optional[Subst]:
-        match_res = self.match_with_constraint(pattern)
+    def match(self, term: 'CTerm') -> Optional[Subst]:
+        match_res = self.match_with_constraint(term)
 
         if not match_res:
             return None
@@ -60,13 +60,13 @@ class CTerm:
 
         return subst
 
-    def match_with_constraint(self, pattern: 'CTerm') -> Optional[Tuple[Subst, KInner]]:
-        subst = match(pattern=pattern.config, term=self.config)
+    def match_with_constraint(self, term: 'CTerm') -> Optional[Tuple[Subst, KInner]]:
+        subst = match(pattern=self.config, term=term.config)
 
         if subst is None:
             return None
 
-        constraint = self._ml_impl(self.constraints, map(subst, pattern.constraints))
+        constraint = self._ml_impl(term.constraints, map(subst, self.constraints))
 
         return subst, constraint
 

--- a/pyk/src/pyk/kcfg.py
+++ b/pyk/src/pyk/kcfg.py
@@ -75,7 +75,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Edge', 'KCFG.Cover']]):
             object.__setattr__(self, 'source', source)
             object.__setattr__(self, 'target', target)
 
-            match_res = source.cterm.match_with_constraint(target.cterm)
+            match_res = target.cterm.match_with_constraint(source.cterm)
             if not match_res:
                 raise ValueError(f'No matching between: {source.id} and {target.id}')
 

--- a/pyk/src/pyk/tests/test_cterm.py
+++ b/pyk/src/pyk/tests/test_cterm.py
@@ -2,16 +2,21 @@ from functools import partial
 from typing import Final, Tuple
 from unittest import TestCase
 
-from ..kast import KApply, KInner, KVariable, match
+from ..cterm import CTerm
+from ..kast import KApply, KInner, KVariable
 
 a, b, c = (KApply(label) for label in ['a', 'b', 'c'])
 x, y, z = (KVariable(name) for name in ['x', 'y', 'z'])
 f, g, h = (partial(KApply.of, label) for label in ['f', 'g', 'h'])
 
 
-class MatchTest(TestCase):
+def _as_cterm(term: KInner) -> CTerm:
+    return CTerm(KApply('<k>', [term]))
 
-    def test_match_and_subst(self):
+
+class CTermTest(TestCase):
+
+    def test_cterm_match_and_subst(self):
         # Given
         TEST_DATA: Final[Tuple[Tuple[KInner, KInner], ...]] = (
             (a, a),
@@ -29,13 +34,13 @@ class MatchTest(TestCase):
         for i, [term, pattern] in enumerate(TEST_DATA):
             with self.subTest(i=i):
                 # When
-                subst = match(pattern, term)
+                subst_cterm = _as_cterm(pattern).match(_as_cterm(term))
 
                 # Then
-                self.assertIsNotNone(subst)
-                self.assertEqual(subst(pattern), term)
+                self.assertIsNotNone(subst_cterm)
+                self.assertEqual(subst_cterm(pattern), term)
 
-    def test_no_match(self):
+    def test_no_cterm_match(self):
         # Given
         TEST_DATA: Final[Tuple[Tuple[KInner, KInner], ...]] = (
             (f(x, x), f(x, a)),
@@ -44,7 +49,7 @@ class MatchTest(TestCase):
         for i, [term, pattern] in enumerate(TEST_DATA):
             with self.subTest(i=i):
                 # When
-                subst = match(pattern, term)
+                subst_cterm = _as_cterm(pattern).match(_as_cterm(term))
 
                 # Then
-                self.assertIsNone(subst)
+                self.assertIsNone(subst_cterm)

--- a/pyk/src/pyk/tests/test_match.py
+++ b/pyk/src/pyk/tests/test_match.py
@@ -2,11 +2,16 @@ from functools import partial
 from typing import Final, Tuple
 from unittest import TestCase
 
+from ..cterm import CTerm
 from ..kast import KApply, KInner, KVariable, match
 
 a, b, c = (KApply(label) for label in ['a', 'b', 'c'])
 x, y, z = (KVariable(name) for name in ['x', 'y', 'z'])
 f, g, h = (partial(KApply.of, label) for label in ['f', 'g', 'h'])
+
+
+def _as_cterm(term: KInner) -> CTerm:
+    return CTerm(KApply('<k>', [term]))
 
 
 class MatchTest(TestCase):
@@ -30,10 +35,13 @@ class MatchTest(TestCase):
             with self.subTest(i=i):
                 # When
                 subst = match(pattern, term)
+                subst_cterm = _as_cterm(pattern).match(_as_cterm(term))
 
                 # Then
                 self.assertIsNotNone(subst)
                 self.assertEqual(subst(pattern), term)
+                self.assertIsNotNone(subst_cterm)
+                self.assertEqual(subst_cterm(pattern), term)
 
     def test_no_match(self):
         # Given
@@ -45,6 +53,8 @@ class MatchTest(TestCase):
             with self.subTest(i=i):
                 # When
                 subst = match(pattern, term)
+                subst_cterm = _as_cterm(pattern).match(_as_cterm(term))
 
                 # Then
                 self.assertIsNone(subst)
+                self.assertIsNone(subst_cterm)


### PR DESCRIPTION
I was trying to explain the algorithm behind summarization to @xc93 and realized that on this line:

https://github.com/runtimeverification/erc20-verification/blob/master/ksummarize/src/ksummarize/kevm_summarize.py#L211

we are saying `term.match(pattern)`. I would much prefer for us to say `pattern.match(term)`, it matches the same direction as `match(pattern, term)` that I'm used to for a long time and makes more sense in my head. I can't provide a better justification for it than this, but I did confirm that this is the only use that needs to change.