### PR TITLE
Small optimization in OuterParsing markdown

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/outer/ExtractFencedKCodeFromMarkdown.java
+++ b/kernel/src/main/java/org/kframework/parser/outer/ExtractFencedKCodeFromMarkdown.java
@@ -75,7 +75,8 @@ public class ExtractFencedKCodeFromMarkdown {
             if (TagSelector.eval(mdSelector, tags)) {
                 // navigate from previous offset to the current one and
                 // make everything whitespace to preserve location info
-                while (lastOffset < block.getContentChars().getStartOffset()) {
+                long offset = block.getContentChars().getStartOffset();
+                while (lastOffset < offset) {
                     if (Character.isWhitespace(mdText.charAt(lastOffset))) {
                         kCodeSb.append(mdText.charAt(lastOffset));
                         blankSb.append(mdText.charAt(lastOffset));
@@ -84,7 +85,7 @@ public class ExtractFencedKCodeFromMarkdown {
                     lastOffset++;
                 }
                 // copy each character because block.getContentChars() removes indentation and can offset location info
-                while (lastOffset < block.getContentChars().getEndOffset()) {
+                while (lastOffset < block.getClosingMarker().getStartOffset()) {
                     kCodeSb.append(mdText.charAt(lastOffset));
                     if (Character.isWhitespace(mdText.charAt(lastOffset)))
                         blankSb.append(mdText.charAt(lastOffset));

--- a/kernel/src/main/java/org/kframework/parser/outer/ExtractFencedKCodeFromMarkdown.java
+++ b/kernel/src/main/java/org/kframework/parser/outer/ExtractFencedKCodeFromMarkdown.java
@@ -85,7 +85,8 @@ public class ExtractFencedKCodeFromMarkdown {
                     lastOffset++;
                 }
                 // copy each character because block.getContentChars() removes indentation and can offset location info
-                while (lastOffset < block.getClosingMarker().getStartOffset()) {
+                offset = block.getContentChars().getEndOffset();
+                while (lastOffset < offset) {
                     kCodeSb.append(mdText.charAt(lastOffset));
                     if (Character.isWhitespace(mdText.charAt(lastOffset)))
                         blankSb.append(mdText.charAt(lastOffset));


### PR DESCRIPTION
Probably 100ms faster on some definitions.
```
Outer parsing [65 modules]                                   =  0.592s
```
I tried to measure hot spots in the outer parsing step, but it seems time is being spent a little bit everywhere.