### PR TITLE
Drop `kprovex` script

### DIFF
--- a/k-distribution/src/main/scripts/bin/kprovex
+++ b/k-distribution/src/main/scripts/bin/kprovex
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-"$(dirname "$0")/../lib/kframework/k" -kprove "$@"


### PR DESCRIPTION
This PR is the final step in the `kprovex` renaming process; once it is merged, downstream projects will no longer be able to call `kprovex`.