### PR TITLE
[pyk] Proof rule-profiling, several renames and simplifications

### DIFF
--- a/pyk/requirements/base.txt
+++ b/pyk/requirements/base.txt
@@ -1,1 +1,3 @@
 graphviz==0.19.1
+tabulate==0.8.6
+types-tabulate==0.8.6

--- a/pyk/setup.cfg
+++ b/pyk/setup.cfg
@@ -9,6 +9,8 @@ package_dir =
     =src
 install_requires =
     graphviz == 0.19.1
+    tabulate == 0.8.6
+    types-tabulate == 0.8.6
 
 [options.package_data]
 * = py.typed

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -11,7 +11,7 @@ from .kast import KApply, KAst, KLabel, flattenLabel, readKastTerm
 from .kastManip import (
     minimize_term,
     minimizeRule,
-    propagateUpConstraints,
+    propagate_up_constraints,
     removeSourceMap,
     splitConfigAndConstraints,
 )
@@ -55,7 +55,7 @@ def main(extraMain=None):
                         minimizedDisjuncts.append(KApply(KLabel('#And', Sorts.GENERATED_TOP_CELL), [dConfig, dConstraint]))
                     else:
                         minimizedDisjuncts.append(dConfig)
-                term = propagateUpConstraints(mlOr(minimizedDisjuncts, sort=Sorts.GENERATED_TOP_CELL))
+                term = propagate_up_constraints(mlOr(minimizedDisjuncts, sort=Sorts.GENERATED_TOP_CELL))
             args['output_file'].write(printer.pretty_print(term))
 
     elif args['command'] == 'prove':

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -7,7 +7,7 @@ from typing import Final
 from graphviz import Digraph
 
 from .coverage import getRuleById, stripCoverageLogger
-from .kast import KApply, KAst, KLabel, flattenLabel, readKastTerm
+from .kast import KAst, flattenLabel, readKastTerm
 from .kastManip import (
     minimize_term,
     minimizeRule,
@@ -16,7 +16,7 @@ from .kastManip import (
     splitConfigAndConstraints,
 )
 from .ktool import KPrint, KProve, build_symbol_table, prettyPrintKast
-from .prelude import Sorts, mlOr, mlTop
+from .prelude import Sorts, mlAnd, mlOr, mlTop
 
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
@@ -52,7 +52,7 @@ def main(extraMain=None):
                     dMinimized = minimize_term(d, abstract_labels=abstractLabels)
                     dConfig, dConstraint = splitConfigAndConstraints(dMinimized)
                     if dConstraint != mlTop():
-                        minimizedDisjuncts.append(KApply(KLabel('#And', Sorts.GENERATED_TOP_CELL), [dConfig, dConstraint]))
+                        minimizedDisjuncts.append(mlAnd([dConfig, dConstraint], sort=Sorts.GENERATED_TOP_CELL))
                     else:
                         minimizedDisjuncts.append(dConfig)
                 term = propagate_up_constraints(mlOr(minimizedDisjuncts, sort=Sorts.GENERATED_TOP_CELL))

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -7,7 +7,7 @@ from typing import Final
 from graphviz import Digraph
 
 from .coverage import getRuleById, stripCoverageLogger
-from .kast import KApply, KAst, flattenLabel, readKastTerm
+from .kast import KApply, KAst, KLabel, flattenLabel, readKastTerm
 from .kastManip import (
     minimize_term,
     minimizeRule,
@@ -16,7 +16,7 @@ from .kastManip import (
     splitConfigAndConstraints,
 )
 from .ktool import KPrint, KProve, build_symbol_table, prettyPrintKast
-from .prelude import build_assoc, mlBottom, mlTop
+from .prelude import Sorts, mlOr, mlTop
 
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
@@ -52,10 +52,10 @@ def main(extraMain=None):
                     dMinimized = minimize_term(d, abstract_labels=abstractLabels)
                     dConfig, dConstraint = splitConfigAndConstraints(dMinimized)
                     if dConstraint != mlTop():
-                        minimizedDisjuncts.append(KApply('#And', [dConfig, dConstraint]))
+                        minimizedDisjuncts.append(KApply(KLabel('#And', Sorts.GENERATED_TOP_CELL), [dConfig, dConstraint]))
                     else:
                         minimizedDisjuncts.append(dConfig)
-                term = propagateUpConstraints(build_assoc(mlBottom(), '#Or', minimizedDisjuncts))
+                term = propagateUpConstraints(mlOr(minimizedDisjuncts, sort=Sorts.GENERATED_TOP_CELL))
             args['output_file'].write(printer.pretty_print(term))
 
     elif args['command'] == 'prove':

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -60,7 +60,7 @@ def main(extraMain=None):
 
     elif args['command'] == 'prove':
         kprover = KProve(kompiled_dir, args['main-file'])
-        finalState = kprover.prove(Path(args['spec-file']), args['spec-module'], args=args['kArgs'])
+        finalState = kprover.prove(Path(args['spec-file']), spec_module_name=args['spec-module'], args=args['kArgs'])
         args['output_file'].write(finalState.to_json())
 
     elif args['command'] == 'graph-imports':

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -16,7 +16,7 @@ from .kastManip import (
     splitConfigAndConstraints,
 )
 from .ktool import KPrint, KProve, build_symbol_table, prettyPrintKast
-from .prelude import buildAssoc, mlBottom, mlTop
+from .prelude import build_assoc, mlBottom, mlTop
 
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
@@ -55,7 +55,7 @@ def main(extraMain=None):
                         minimizedDisjuncts.append(KApply('#And', [dConfig, dConstraint]))
                     else:
                         minimizedDisjuncts.append(dConfig)
-                term = propagateUpConstraints(buildAssoc(mlBottom(), '#Or', minimizedDisjuncts))
+                term = propagateUpConstraints(build_assoc(mlBottom(), '#Or', minimizedDisjuncts))
             args['output_file'].write(printer.pretty_print(term))
 
     elif args['command'] == 'prove':

--- a/pyk/src/pyk/integration_tests/test_configuration.py
+++ b/pyk/src/pyk/integration_tests/test_configuration.py
@@ -14,7 +14,6 @@ from ..kastManip import (
     collapseDots,
     getCell,
     remove_generated_cells,
-    structurallyFrameKCell,
     substitute,
 )
 from ..ktool import KompileBackend
@@ -40,19 +39,6 @@ class ConfigurationTest(KompiledTest, ABC):
         super().setUp()
         self.definition = readKastTerm(self.COMPILED_JSON_PATH)
         self.assertIsInstance(self.definition, KDefinition)
-
-
-class StructurallyFrameKCellTest(ConfigurationTest):
-
-    def test(self):
-        # Given
-        config_expected = substitute(self.GENERATED_TOP_CELL_1, {'_DotVar0': ktokenDots})
-
-        # When
-        config_actual = structurallyFrameKCell(self.GENERATED_TOP_CELL_1)
-
-        # Then
-        self.assertEqual(config_actual, config_expected)
 
 
 class RemoveGeneratedCellsTest(ConfigurationTest):

--- a/pyk/src/pyk/integration_tests/test_emit_json_spec.py
+++ b/pyk/src/pyk/integration_tests/test_emit_json_spec.py
@@ -63,7 +63,7 @@ class EmitJsonSpecTest(KProveTest):
             f.write(self.kprove.pretty_print(definition))
 
         # When
-        result = self.kprove.prove(spec_file, spec_module_name)
+        result = self.kprove.prove(spec_file, spec_module_name=spec_module_name)
 
         # Then
         self.assertTop(result)

--- a/pyk/src/pyk/integration_tests/test_proofs.py
+++ b/pyk/src/pyk/integration_tests/test_proofs.py
@@ -27,3 +27,17 @@ class SimpleProofTest(KProveTest):
         # Then
         self.assertNotTop(result1)
         self.assertTop(result2)
+
+    def test_prove_claim_rule_profile(self):
+        # Given
+        new_lemma = KRule(KToken('pred1(3) => true', BOOL), requires=KToken('pred1(4)', BOOL), att=KAtt(atts={'simplification': ''}))
+        new_claim = KClaim(KToken('<k> foo => bar ... </k> <state> 3 |-> 3 </state>', 'TCellFragment'), requires=KToken('pred1(4)', BOOL))
+        rule_profile = self.KPROVE_USE_DIR + '/rule-profile'
+
+        # When
+        _ = self.kprove.prove_claim(new_claim, 'claim-with-lemma', lemmas=[new_lemma], rule_profile=rule_profile)
+
+        # Then
+        with open(rule_profile, 'r') as rp:
+            lines = rp.read().split('\n')
+            self.assertEqual(len(lines), 4)

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -85,7 +85,7 @@ def bool_to_ml_pred(kast: KInner) -> KInner:
 
 def ml_pred_to_bool(kast: KInner) -> KInner:
 
-    def _ml_constraint_to_bool(_kast: KInner) -> Optional[KInner]:
+    def _ml_constraint_to_bool(_kast: KInner) -> KInner:
         if type(_kast) is KApply and _kast.label.params[0] == KSort('Bool'):
             if _kast.label.name == '#Top':
                 return TRUE
@@ -96,14 +96,9 @@ def ml_pred_to_bool(kast: KInner) -> KInner:
                     return _kast.args[1]
                 if _kast.args[0] == FALSE:
                     return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
-        return None
+        raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 
-    constraints = flattenLabel('#And', kast)
-    bool_constraints: List[KInner] = []
-    for constraint in constraints:
-        if bool_constraint := _ml_constraint_to_bool(constraint):
-            bool_constraints.append(bool_constraint)
-
+    bool_constraints = [_ml_constraint_to_bool(constraint) for constraint in flattenLabel('#And', kast)]
     return buildAssoc(TRUE, KLabel('_andBool_', [KSort('Bool'), KSort('Bool'), KSort('Bool')]), bool_constraints)
 
 

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -86,12 +86,12 @@ def bool_to_ml_pred(kast: KInner) -> KInner:
 def ml_pred_to_bool(kast: KInner) -> KInner:
 
     def _ml_constraint_to_bool(_kast: KInner) -> KInner:
-        if type(_kast) is KApply and _kast.label.params[0] == KSort('Bool'):
+        if type(_kast) is KApply:
             if _kast.label.name == '#Top':
                 return TRUE
             if _kast.label.name == '#Bottom':
                 return FALSE
-            if _kast.label.name == '#Equals':
+            if _kast.label.name == '#Equals' and len(_kast.label.params) > 0 and _kast.label.params[0] == KSort('Bool'):
                 if _kast.args[0] == TRUE:
                     return _kast.args[1]
                 if _kast.args[0] == FALSE:

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -745,17 +745,6 @@ def removeDisjuncts(constrainedTerm):
     return constrainedTerm
 
 
-def abstractCell(constrainedTerm, cellName):
-    (state, constraint) = splitConfigAndConstraints(constrainedTerm)
-    constraints = flattenLabel('#And', constraint)
-    cell = getCell(state, cellName)
-    cellVar = KVariable(cellName)
-    if type(cell) is not KVariable:
-        state = setCell(state, cellName, cellVar)
-        constraints.append(KApply('#Equals', [cellVar, cell]))
-    return mlAnd([state] + constraints)
-
-
 def applyExistentialSubstitutions(constrainedTerm):
     (state, constraint) = splitConfigAndConstraints(constrainedTerm)
     constraints = flattenLabel('#And', constraint)

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -91,6 +91,8 @@ def ml_pred_to_bool(kast: KInner) -> KInner:
                 return TRUE
             if _kast.label.name == '#Bottom':
                 return FALSE
+            if _kast.label.name == '#Not':
+                return KApply('notBool_', [_ml_constraint_to_bool(_kast.args[0])])
             if _kast.label.name == '#Equals':
                 if _kast.args[0] == TRUE:
                     return _kast.args[1]

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -92,12 +92,12 @@ def ml_pred_to_bool(kast: KInner) -> KInner:
             if _kast.label.name == '#Bottom':
                 return FALSE
             if _kast.label.name == '#Equals':
-                if type(_kast.args[0]) is KVariable:
-                    return KApply('_==K_', _kast.args)
                 if _kast.args[0] == TRUE:
                     return _kast.args[1]
                 if _kast.args[0] == FALSE:
                     return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
+                if type(_kast.args[0]) in [KVariable, KToken]:
+                    return KApply('_==K_', _kast.args)
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 
     bool_constraints = [_ml_constraint_to_bool(constraint) for constraint in flattenLabel('#And', kast)]

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -92,7 +92,13 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
             if _kast.label.name == '#Bottom':
                 return FALSE
             if _kast.label.name == '#Not':
-                return KApply('notBool_', [_ml_constraint_to_bool(_kast.args[0])])
+                return KApply('notBool_', map(_ml_constraint_to_bool, _kast.args))
+            if _kast.label.name == '#And':
+                return KApply('_andBool_', map(_ml_constraint_to_bool, _kast.args))
+            if _kast.label.name == '#Or':
+                return KApply('_orBool_', map(_ml_constraint_to_bool, _kast.args))
+            if _kast.label.name == '#Implies':
+                return KApply('_impliesBool_', map(_ml_constraint_to_bool, _kast.args))
             if _kast.label.name == '#Equals':
                 if _kast.args[0] == TRUE:
                     return _kast.args[1]
@@ -104,8 +110,7 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
                     return KApply('_==K_', _kast.args)
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 
-    bool_constraints = [_ml_constraint_to_bool(constraint) for constraint in flattenLabel('#And', kast)]
-    return buildAssoc(TRUE, '_andBool_', bool_constraints)
+    return _ml_constraint_to_bool(kast)
 
 
 def simplifyBool(k):

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -91,11 +91,14 @@ def ml_pred_to_bool(kast: KInner) -> KInner:
                 return TRUE
             if _kast.label.name == '#Bottom':
                 return FALSE
-            if _kast.label.name == '#Equals' and len(_kast.label.params) > 0 and _kast.label.params[0] == KSort('Bool'):
-                if _kast.args[0] == TRUE:
-                    return _kast.args[1]
-                if _kast.args[0] == FALSE:
-                    return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
+            if _kast.label.name == '#Equals':
+                if type(_kast.args[0]) is KVariable:
+                    return KApply('_==K_', _kast.args)
+                if len(_kast.label.params) > 0 and _kast.label.params[0] == KSort('Bool'):
+                    if _kast.args[0] == TRUE:
+                        return _kast.args[1]
+                    if _kast.args[0] == FALSE:
+                        return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 
     bool_constraints = [_ml_constraint_to_bool(constraint) for constraint in flattenLabel('#And', kast)]

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -25,7 +25,6 @@ from .kast import (
     KRule,
     KRuleLike,
     KSequence,
-    KSort,
     KToken,
     KVariable,
     Subst,
@@ -103,7 +102,7 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
                 if _kast.args[0] == TRUE:
                     return _kast.args[1]
                 if _kast.args[0] == FALSE:
-                    return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
+                    return KApply(KLabel('notBool_'), [_kast.args[1]])
                 if type(_kast.args[0]) in [KVariable, KToken]:
                     return KApply('_==K_', _kast.args)
                 if unsafe:

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -38,7 +38,7 @@ from .kast import (
 )
 from .prelude import (
     boolToken,
-    buildAssoc,
+    build_assoc,
     mlAnd,
     mlBottom,
     mlEquals,
@@ -263,7 +263,7 @@ def splitConfigAndConstraints(kast):
             term = c
         else:
             constraints.append(c)
-    constraint = buildAssoc(mlTop(), '#And', constraints)
+    constraint = build_assoc(mlTop(), '#And', constraints)
     if not term:
         raise ValueError(f'Could not find configuration for: {kast}')
     return (term, constraint)
@@ -285,10 +285,10 @@ def propagateUpConstraints(k):
         common = common1 + common2
         if len(common) == 0:
             return _k
-        conjunct1 = buildAssoc(mlTop(), '#And', l2)
-        conjunct2 = buildAssoc(mlTop(), '#And', r2)
+        conjunct1 = build_assoc(mlTop(), '#And', l2)
+        conjunct2 = build_assoc(mlTop(), '#And', r2)
         disjunct = KApply('#Or', [conjunct1, conjunct2])
-        return buildAssoc(mlTop(), '#And', [disjunct] + common)
+        return build_assoc(mlTop(), '#And', [disjunct] + common)
     return bottom_up(_propagateUpConstraints, k)
 
 
@@ -509,10 +509,10 @@ def minimizeRule(rule, keepVars=[]):
     ruleRequires = rule.requires
     ruleEnsures = rule.ensures
 
-    ruleRequires = buildAssoc(TRUE, '_andBool_', unique(flattenLabel('_andBool_', ruleRequires)))
+    ruleRequires = build_assoc(TRUE, '_andBool_', unique(flattenLabel('_andBool_', ruleRequires)))
     ruleRequires = simplifyBool(ruleRequires)
 
-    ruleEnsures = buildAssoc(TRUE, '_andBool_', unique(flattenLabel('_andBool_', ruleEnsures)))
+    ruleEnsures = build_assoc(TRUE, '_andBool_', unique(flattenLabel('_andBool_', ruleEnsures)))
     ruleEnsures = simplifyBool(ruleEnsures)
 
     constrainedVars = [] if keepVars is None else keepVars
@@ -816,7 +816,7 @@ def substToMlPred(subst):
 
 def substToMap(subst):
     mapItems = [KApply('_|->_', [KVariable(k), subst[k]]) for k in subst]
-    return buildAssoc(KApply('.Map'), '_Map_', mapItems)
+    return build_assoc(KApply('.Map'), '_Map_', mapItems)
 
 
 def undoAliases(definition, kast):

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -221,14 +221,10 @@ def splitConfigAndConstraints(kast, sort: Union[str, KSort] = Sorts.K):
 
 
 def propagateUpConstraints(k):
-    """Try to propagate common constraints up disjuncts.
-
-    -   Input: kast disjunct of constrained terms (conjuncts).
-    -   Output: kast where common constraints in the disjunct have been propagated up.
-    """
     def _propagateUpConstraints(_k):
         if not (type(_k) is KApply and _k.label.name == '#Or'):
             return _k
+        top_sort = _k.label.params[0]
         conjuncts1 = flattenLabel('#And', _k.args[0])
         conjuncts2 = flattenLabel('#And', _k.args[1])
         (common1, l1, r1) = find_common_items(conjuncts1, conjuncts2)
@@ -236,10 +232,10 @@ def propagateUpConstraints(k):
         common = common1 + common2
         if len(common) == 0:
             return _k
-        conjunct1 = build_assoc(mlTop(), '#And', l2)
-        conjunct2 = build_assoc(mlTop(), '#And', r2)
-        disjunct = KApply('#Or', [conjunct1, conjunct2])
-        return build_assoc(mlTop(), '#And', [disjunct] + common)
+        conjunct1 = mlAnd(l2, sort=top_sort)
+        conjunct2 = mlAnd(r2, sort=top_sort)
+        disjunct = mlOr([conjunct1, conjunct2], sort=top_sort)
+        return mlAnd([disjunct] + common, sort=top_sort)
     return bottom_up(_propagateUpConstraints, k)
 
 

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -220,8 +220,9 @@ def splitConfigAndConstraints(kast, sort: Union[str, KSort] = Sorts.K):
     return (term, constraint)
 
 
-def propagateUpConstraints(k):
-    def _propagateUpConstraints(_k):
+def propagate_up_constraints(k):
+
+    def _propagat_up_constraints(_k):
         if not (type(_k) is KApply and _k.label.name == '#Or'):
             return _k
         top_sort = _k.label.params[0]
@@ -236,7 +237,8 @@ def propagateUpConstraints(k):
         conjunct2 = mlAnd(r2, sort=top_sort)
         disjunct = mlOr([conjunct1, conjunct2], sort=top_sort)
         return mlAnd([disjunct] + common, sort=top_sort)
-    return bottom_up(_propagateUpConstraints, k)
+
+    return bottom_up(_propagat_up_constraints, k)
 
 
 def splitConfigFrom(configuration):

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -89,8 +89,8 @@ def unsafeMlPredToBool(k):
     """
     if k is None:
         return None
-    mlPredToBoolRules = [ (KApply('#Top')                                            , TRUE)                                                            # noqa
-                        , (KApply('#Bottom')                                         , FALSE)                                                           # noqa
+    mlPredToBoolRules = [ (mlTop()                                                   , TRUE)                                                            # noqa
+                        , (mlBottom()                                                , FALSE)                                                           # noqa
                         , (KApply('#And'     , [KVariable('#V1'), KVariable('#V2')]) , KApply('_andBool_'     , [KVariable('#V1'), KVariable('#V2')]))  # noqa
                         , (KApply('#Or'      , [KVariable('#V1'), KVariable('#V2')]) , KApply('_orBool_'      , [KVariable('#V1'), KVariable('#V2')]))  # noqa
                         , (KApply('#Not'     , [KVariable('#V1')])                   , KApply('notBool_'      , [KVariable('#V1')]))                    # noqa

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -222,7 +222,7 @@ def splitConfigAndConstraints(kast, sort: Union[str, KSort] = Sorts.K):
 
 def propagate_up_constraints(k):
 
-    def _propagat_up_constraints(_k):
+    def _propagate_up_constraints(_k):
         if not (type(_k) is KApply and _k.label.name == '#Or'):
             return _k
         top_sort = _k.label.params[0]
@@ -238,7 +238,7 @@ def propagate_up_constraints(k):
         disjunct = mlOr([conjunct1, conjunct2], sort=top_sort)
         return mlAnd([disjunct] + common, sort=top_sort)
 
-    return bottom_up(_propagat_up_constraints, k)
+    return bottom_up(_propagate_up_constraints, k)
 
 
 def splitConfigFrom(configuration):

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -83,7 +83,7 @@ def bool_to_ml_pred(kast: KInner) -> KInner:
     return mlAnd([mlEqualsTrue(cond) for cond in flattenLabel('_andBool_', kast)])
 
 
-def ml_pred_to_bool(kast: KInner) -> KInner:
+def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
 
     def _ml_constraint_to_bool(_kast: KInner) -> KInner:
         if type(_kast) is KApply:
@@ -99,6 +99,8 @@ def ml_pred_to_bool(kast: KInner) -> KInner:
                 if _kast.args[0] == FALSE:
                     return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
                 if type(_kast.args[0]) in [KVariable, KToken]:
+                    return KApply('_==K_', _kast.args)
+                if unsafe:
                     return KApply('_==K_', _kast.args)
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -94,11 +94,10 @@ def ml_pred_to_bool(kast: KInner) -> KInner:
             if _kast.label.name == '#Equals':
                 if type(_kast.args[0]) is KVariable:
                     return KApply('_==K_', _kast.args)
-                if len(_kast.label.params) > 0 and _kast.label.params[0] == KSort('Bool'):
-                    if _kast.args[0] == TRUE:
-                        return _kast.args[1]
-                    if _kast.args[0] == FALSE:
-                        return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
+                if _kast.args[0] == TRUE:
+                    return _kast.args[1]
+                if _kast.args[0] == FALSE:
+                    return KApply(KLabel('notBool_', [KSort('Bool'), KSort('Bool')]), [_kast.args[1]])
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 
     bool_constraints = [_ml_constraint_to_bool(constraint) for constraint in flattenLabel('#And', kast)]

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -101,7 +101,7 @@ def ml_pred_to_bool(kast: KInner) -> KInner:
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 
     bool_constraints = [_ml_constraint_to_bool(constraint) for constraint in flattenLabel('#And', kast)]
-    return buildAssoc(TRUE, KLabel('_andBool_', [KSort('Bool'), KSort('Bool'), KSort('Bool')]), bool_constraints)
+    return buildAssoc(TRUE, '_andBool_', bool_constraints)
 
 
 def simplifyBool(k):

--- a/pyk/src/pyk/kcfg.py
+++ b/pyk/src/pyk/kcfg.py
@@ -22,7 +22,7 @@ from graphviz import Digraph
 
 from .cterm import CTerm
 from .kast import KInner, KRuleLike, Subst
-from .kastManip import buildRule, mlAnd, simplifyBool, unsafeMlPredToBool
+from .kastManip import buildRule, ml_pred_to_bool, mlAnd, simplifyBool
 from .ktool import KPrint
 from .utils import compare_short_hashes, shorten_hashes
 
@@ -265,7 +265,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Edge', 'KCFG.Cover']]):
             graph.node(name=node.id, label=label, **attrs)
 
         for edge in self.edges():
-            display_condition = simplifyBool(unsafeMlPredToBool(edge.condition))
+            display_condition = simplifyBool(ml_pred_to_bool(edge.condition))
             depth = edge.depth
             label = '\nandBool'.join(kprint.pretty_print(display_condition).split(' andBool'))
             label = f'{label}\n{depth} steps'

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -142,13 +142,14 @@ def _get_rule_log(debug_log_file: Path) -> List[List[Tuple[str, bool, int]]]:
 
     # rule_loc, is_success, ellapsed_time_since_start
     def _get_rule_line(_line: str) -> Optional[Tuple[str, bool, int]]:
-        time = int(_line.split('[')[1].split(']')[0])
-        if _line.find('(DebugTransition): after  apply axioms: '):
-            rule_name = ':'.join(_line.split(':')[-4:]).strip()
-            return (rule_name, True, time)
-        elif _line.find('(DebugAttemptedRewriteRules): '):
-            rule_name = ':'.join(_line.split(':')[-4:]).strip()
-            return (rule_name, False, time)
+        if _line.startswith('kore-exec: ['):
+            time = int(_line.split('[')[1].split(']')[0])
+            if _line.find('(DebugTransition): after  apply axioms: '):
+                rule_name = ':'.join(_line.split(':')[-4:]).strip()
+                return (rule_name, True, time)
+            elif _line.find('(DebugAttemptedRewriteRules): '):
+                rule_name = ':'.join(_line.split(':')[-4:]).strip()
+                return (rule_name, False, time)
         return None
 
     log_lines: List[Tuple[str, bool, int]] = []

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -75,7 +75,7 @@ def _kprove(spec_file: str, *args: str) -> CompletedProcess:
 
 class KProve(KPrint):
 
-    def __init__(self, kompiled_directory, main_file_name, use_directory=None):
+    def __init__(self, kompiled_directory, main_file_name=None, use_directory=None):
         super(KProve, self).__init__(kompiled_directory)
         self.directory = Path(self.kompiled_directory).parent
         self.use_directory = (self.directory / 'kprove') if use_directory is None else Path(use_directory)

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -89,7 +89,7 @@ class KProve(KPrint):
         with open(self.kompiled_directory / 'mainModule.txt', 'r') as mm:
             self.main_module = mm.read()
 
-    def prove(self, spec_file, spec_module_name, args=[], haskell_args=[], haskell_log_entries=[], log_axioms_file=None, allow_zero_step=False, dry_run=False, rule_profile=False):
+    def prove(self, spec_file, spec_module_name=None, args=[], haskell_args=[], haskell_log_entries=[], log_axioms_file=None, allow_zero_step=False, dry_run=False, rule_profile=False):
         log_file = spec_file.with_suffix('.debug-log') if log_axioms_file is None else log_axioms_file
         if log_file.exists():
             log_file.unlink()
@@ -97,7 +97,8 @@ class KProve(KPrint):
         haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(haskell_log_entries)]
         command = [c for c in self.prover]
         command += [str(spec_file)]
-        command += ['--definition', str(self.kompiled_directory), '-I', str(self.directory), '--spec-module', spec_module_name, '--output', 'json']
+        command += ['--definition', str(self.kompiled_directory), '-I', str(self.directory), '--output', 'json']
+        command += ['--spec-module', spec_module_name] if spec_module_name is not None else []
         command += [c for c in self.prover_args]
         command += args
 
@@ -122,7 +123,7 @@ class KProve(KPrint):
 
     def prove_claim(self, claim, claim_id, lemmas=[], args=[], haskell_args=[], log_axioms_file=None, allow_zero_step=False):
         self._write_claim_definition(claim, claim_id, lemmas=lemmas)
-        return self.prove(self.use_directory / (claim_id.lower() + '-spec.k'), claim_id.upper() + '-SPEC', args=args, haskell_args=haskell_args, log_axioms_file=log_axioms_file, allow_zero_step=allow_zero_step)
+        return self.prove(self.use_directory / (claim_id.lower() + '-spec.k'), spec_module_name=(claim_id.upper() + '-SPEC'), args=args, haskell_args=haskell_args, log_axioms_file=log_axioms_file, allow_zero_step=allow_zero_step)
 
     def _write_claim_definition(self, claim, claim_id, lemmas=[], rule=False):
         tmpClaim = self.use_directory / (claim_id.lower() if rule else (claim_id.lower() + '-spec'))

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -88,11 +88,12 @@ class KProve(KPrint):
         with open(self.kompiled_directory / 'mainModule.txt', 'r') as mm:
             self.main_module = mm.read()
 
-    def prove(self, spec_file, spec_module_name, args=[], haskell_args=[], log_axioms_file=None, allow_zero_step=False, dry_run=False):
+    def prove(self, spec_file, spec_module_name, args=[], haskell_args=[], haskell_log_entries=[], log_axioms_file=None, allow_zero_step=False, dry_run=False):
         log_file = spec_file.with_suffix('.debug-log') if log_axioms_file is None else log_axioms_file
         if log_file.exists():
             log_file.unlink()
-        haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', 'DebugTransition']
+        haskell_log_entries = set(['DebugTransition', 'DebugAttemptedRewriteRules'] + haskell_log_entries)
+        haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(haskell_log_entries)]
         command = [c for c in self.prover]
         command += [str(spec_file)]
         command += ['--definition', str(self.kompiled_directory), '-I', str(self.directory), '--spec-module', spec_module_name, '--output', 'json']

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -80,6 +80,7 @@ class KProve(KPrint):
         self.directory = Path(self.kompiled_directory).parent
         self.use_directory = (self.directory / 'kprove') if use_directory is None else Path(use_directory)
         self.use_directory.mkdir(parents=True, exist_ok=True)
+        # TODO: we should not have to supply main_file_name, it should be read
         self.main_file_name = main_file_name
         self.prover = ['kprove']
         self.prover_args = []

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -138,7 +138,7 @@ class KProve(KPrint):
 
 def _get_rule_log(debug_log_file: Path) -> List[List[Tuple[str, bool, int]]]:
 
-    # rule_loc, is_success, rule_time
+    # rule_loc, is_success, ellapsed_time_since_start
     def _get_rule_line(_line: str) -> Optional[Tuple[str, bool, int]]:
         time = int(_line.split('[')[1].split(']')[0])
         if _line.find('(DebugTransition): after  apply axioms: '):
@@ -155,16 +155,20 @@ def _get_rule_log(debug_log_file: Path) -> List[List[Tuple[str, bool, int]]]:
             if processed_line := _get_rule_line(line):
                 log_lines.append(processed_line)
 
+    # rule_loc, is_success, time_delta
     axioms: List[List[Tuple[str, bool, int]]] = [[]]
     just_applied = True
+    prev_time = 0
     for rule_name, is_application, rule_time in log_lines:
+        rtime = rule_time - prev_time
+        prev_time = rule_time
         if not is_application:
             if just_applied:
                 axioms.append([])
             just_applied = False
         else:
             just_applied = True
-        axioms[-1].append((rule_name, is_application, rule_time))
+        axioms[-1].append((rule_name, is_application, rtime))
 
     if len(axioms[-1]) == 0:
         axioms.pop(-1)

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -142,9 +142,31 @@ class KProve(KPrint):
 
             return final_state
 
-    def prove_claim(self, claim, claim_id, lemmas=[], args=[], haskell_args=[], log_axioms_file=None, allow_zero_step=False):
+    def prove_claim(
+        self,
+        claim,
+        claim_id,
+        lemmas=[],
+        args=[],
+        haskell_args=[],
+        haskell_log_entries=[],
+        log_axioms_file=None,
+        allow_zero_step=False,
+        dry_run=False,
+        rule_profile=False,
+    ):
         self._write_claim_definition(claim, claim_id, lemmas=lemmas)
-        return self.prove(self.use_directory / (claim_id.lower() + '-spec.k'), spec_module_name=(claim_id.upper() + '-SPEC'), args=args, haskell_args=haskell_args, log_axioms_file=log_axioms_file, allow_zero_step=allow_zero_step)
+        return self.prove(
+            self.use_directory / (claim_id.lower() + '-spec.k'),
+            spec_module_name=(claim_id.upper() + '-SPEC'),
+            args=args,
+            haskell_args=haskell_args,
+            haskell_log_entries=haskell_log_entries,
+            log_axioms_file=log_axioms_file,
+            allow_zero_step=allow_zero_step,
+            dry_run=dry_run,
+            rule_profile=rule_profile,
+        )
 
     def _write_claim_definition(self, claim, claim_id, lemmas=[], rule=False):
         tmpClaim = self.use_directory / (claim_id.lower() if rule else (claim_id.lower() + '-spec'))

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -112,6 +112,7 @@ class KProve(KPrint):
         command += [str(spec_file)]
         command += ['--definition', str(self.kompiled_directory), '-I', str(self.directory), '--output', 'json']
         command += ['--spec-module', spec_module_name] if spec_module_name is not None else []
+        command += ['--dry-run'] if dry_run else []
         command += [c for c in self.prover_args]
         command += args
 

--- a/pyk/src/pyk/prelude.py
+++ b/pyk/src/pyk/prelude.py
@@ -1,14 +1,22 @@
 from typing import Iterable, Union
 
-from .kast import BOOL, BOTTOM, INT, STRING, TOP, TRUE, KApply, KInner, KToken
+from .kast import (
+    BOOL,
+    BOTTOM,
+    INT,
+    STRING,
+    TOP,
+    TRUE,
+    KApply,
+    KInner,
+    KLabel,
+    KToken,
+)
 
 
-def buildAssoc(unit: KInner, join: str, ls: Iterable[KInner]) -> KInner:
-    """Build an associative binary operator term given the join and unit ops.
-
-    -   Input: unit, join, and list of elements to join.
-    -   Output: cons-list style construction of the joined term.
-    """
+def buildAssoc(unit: KInner, join: Union[str, KLabel], ls: Iterable[KInner]) -> KInner:
+    if type(join) is str:
+        join = KLabel(join)
     ls = list(filter(lambda l: l != unit, ls))
     if len(ls) == 0:
         return unit

--- a/pyk/src/pyk/prelude.py
+++ b/pyk/src/pyk/prelude.py
@@ -14,7 +14,7 @@ from .kast import (
 )
 
 
-def buildAssoc(unit: KInner, join: Union[str, KLabel], ls: Iterable[KInner]) -> KInner:
+def build_assoc(unit: KInner, join: Union[str, KLabel], ls: Iterable[KInner]) -> KInner:
     if type(join) is str:
         join = KLabel(join)
     ls = list(filter(lambda l: l != unit, ls))
@@ -23,8 +23,8 @@ def buildAssoc(unit: KInner, join: Union[str, KLabel], ls: Iterable[KInner]) -> 
     if len(ls) == 1:
         return ls[0]
     if ls[0] == unit:
-        return buildAssoc(unit, join, ls[1:])
-    return KApply(join, [ls[0], buildAssoc(unit, join, ls[1:])])
+        return build_assoc(unit, join, ls[1:])
+    return KApply(join, [ls[0], build_assoc(unit, join, ls[1:])])
 
 
 def buildCons(unit, cons, ls):
@@ -85,11 +85,11 @@ def mlBottom():
 
 
 def mlAnd(cs):
-    return buildAssoc(mlTop(), '#And', cs)
+    return build_assoc(mlTop(), '#And', cs)
 
 
 def mlOr(cs):
-    return buildAssoc(mlBottom(), '#Or', cs)
+    return build_assoc(mlBottom(), '#Or', cs)
 
 
 def mlImplies(an, co):

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -64,6 +64,7 @@ class MlPredToBoolTest(TestCase):
             (KApply('#Top'), TRUE),
             (mlTop(), TRUE),
             (KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
+            (KApply(KLabel('#Equals'), [TRUE, f(a)]), f(a)),
         )
 
         for i, (before, expected) in enumerate(test_data):

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -12,7 +12,7 @@ from ..kast import (
     ktokenDots,
 )
 from ..kastManip import minimize_term, ml_pred_to_bool, push_down_rewrites
-from ..prelude import intToken, mlTop
+from ..prelude import intToken, mlEqualsTrue, mlTop
 
 a, b, c = (KApply(label) for label in ['a', 'b', 'c'])
 f, g, k = (partial(KApply.of, label) for label in ['f', 'g', '<k>'])
@@ -68,6 +68,7 @@ class MlPredToBoolTest(TestCase):
             (False, KApply(KLabel('#Equals', [KSort('Int'), KSort('GeneratedTopCell')]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
             (False, KApply(KLabel('#Not', [KSort('GeneratedTopCell')]), [mlTop()]), KApply('notBool_', [TRUE])),
             (True, KApply(KLabel('#Equals'), [f(a), f(x)]), KApply('_==K_', [f(a), f(x)])),
+            (False, KApply(KLabel('#And', [KSort('GeneratedTopCell')]), [mlEqualsTrue(TRUE), mlEqualsTrue(TRUE)]), KApply('_andBool_', [TRUE, TRUE]))
         )
 
         for i, (unsafe, before, expected) in enumerate(test_data):

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -1,8 +1,9 @@
+import sys
 from functools import partial
 from unittest import TestCase
 
-from ..kast import KApply, KRewrite, KSequence, ktokenDots
-from ..kastManip import minimize_term, push_down_rewrites
+from ..kast import TRUE, KApply, KLabel, KRewrite, KSequence, KSort, ktokenDots
+from ..kastManip import minimize_term, ml_pred_to_bool, push_down_rewrites
 
 a, b, c = (KApply(label) for label in ['a', 'b', 'c'])
 f, g, k = (partial(KApply.of, label) for label in ['f', 'g', '<k>'])
@@ -38,6 +39,24 @@ class MinimizeTermTest(TestCase):
             with self.subTest(i=i):
                 # When
                 actual = minimize_term(before, abstract_labels=abstract_labels)
+
+                # Then
+                self.assertEqual(actual, expected)
+
+
+class MlPredToBoolTest(TestCase):
+
+    def test_ml_pred_to_bool(self):
+        # Given
+        test_data = (
+            (KApply(KLabel('#Equals', [KSort('Bool'), KSort('GeneratedTopCell')]), [TRUE, f(a)]), f(a)),
+        )
+        sys.stderr.write(str(test_data))
+
+        for i, (before, expected) in enumerate(test_data):
+            with self.subTest(i=i):
+                # When
+                actual = ml_pred_to_bool(before)
 
                 # Then
                 self.assertEqual(actual, expected)

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -1,4 +1,3 @@
-import sys
 from functools import partial
 from unittest import TestCase
 

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -66,6 +66,7 @@ class MlPredToBoolTest(TestCase):
             (KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
             (KApply(KLabel('#Equals'), [TRUE, f(a)]), f(a)),
             (KApply(KLabel('#Equals', [KSort('Int'), KSort('GeneratedTopCell')]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
+            (KApply(KLabel('#Not', [KSort('GeneratedTopCell')]), [mlTop()]), KApply('notBool_', [TRUE])),
         )
 
         for i, (before, expected) in enumerate(test_data):

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -12,7 +12,7 @@ from ..kast import (
     ktokenDots,
 )
 from ..kastManip import minimize_term, ml_pred_to_bool, push_down_rewrites
-from ..prelude import mlTop
+from ..prelude import intToken, mlTop
 
 a, b, c = (KApply(label) for label in ['a', 'b', 'c'])
 f, g, k = (partial(KApply.of, label) for label in ['f', 'g', '<k>'])
@@ -65,6 +65,7 @@ class MlPredToBoolTest(TestCase):
             (mlTop(), TRUE),
             (KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
             (KApply(KLabel('#Equals'), [TRUE, f(a)]), f(a)),
+            (KApply(KLabel('#Equals', [KSort('Int'), KSort('GeneratedTopCell')]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
         )
 
         for i, (before, expected) in enumerate(test_data):

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from ..kast import TRUE, KApply, KLabel, KRewrite, KSequence, KSort, ktokenDots
 from ..kastManip import minimize_term, ml_pred_to_bool, push_down_rewrites
+from ..prelude import mlTop
 
 a, b, c = (KApply(label) for label in ['a', 'b', 'c'])
 f, g, k = (partial(KApply.of, label) for label in ['f', 'g', '<k>'])
@@ -50,8 +51,10 @@ class MlPredToBoolTest(TestCase):
         # Given
         test_data = (
             (KApply(KLabel('#Equals', [KSort('Bool'), KSort('GeneratedTopCell')]), [TRUE, f(a)]), f(a)),
+            (KApply(KLabel('#Top', [KSort('Bool')])), TRUE),
+            (KApply('#Top'), TRUE),
+            (mlTop(), TRUE),
         )
-        sys.stderr.write(str(test_data))
 
         for i, (before, expected) in enumerate(test_data):
             with self.subTest(i=i):

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -59,20 +59,21 @@ class MlPredToBoolTest(TestCase):
     def test_ml_pred_to_bool(self):
         # Given
         test_data = (
-            (KApply(KLabel('#Equals', [KSort('Bool'), KSort('GeneratedTopCell')]), [TRUE, f(a)]), f(a)),
-            (KApply(KLabel('#Top', [KSort('Bool')])), TRUE),
-            (KApply('#Top'), TRUE),
-            (mlTop(), TRUE),
-            (KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
-            (KApply(KLabel('#Equals'), [TRUE, f(a)]), f(a)),
-            (KApply(KLabel('#Equals', [KSort('Int'), KSort('GeneratedTopCell')]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
-            (KApply(KLabel('#Not', [KSort('GeneratedTopCell')]), [mlTop()]), KApply('notBool_', [TRUE])),
+            (False, KApply(KLabel('#Equals', [KSort('Bool'), KSort('GeneratedTopCell')]), [TRUE, f(a)]), f(a)),
+            (False, KApply(KLabel('#Top', [KSort('Bool')])), TRUE),
+            (False, KApply('#Top'), TRUE),
+            (False, mlTop(), TRUE),
+            (False, KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
+            (False, KApply(KLabel('#Equals'), [TRUE, f(a)]), f(a)),
+            (False, KApply(KLabel('#Equals', [KSort('Int'), KSort('GeneratedTopCell')]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
+            (False, KApply(KLabel('#Not', [KSort('GeneratedTopCell')]), [mlTop()]), KApply('notBool_', [TRUE])),
+            (True, KApply(KLabel('#Equals'), [f(a), f(x)]), KApply('_==K_', [f(a), f(x)])),
         )
 
-        for i, (before, expected) in enumerate(test_data):
+        for i, (unsafe, before, expected) in enumerate(test_data):
             with self.subTest(i=i):
                 # When
-                actual = ml_pred_to_bool(before)
+                actual = ml_pred_to_bool(before, unsafe=unsafe)
 
                 # Then
                 self.assertEqual(actual, expected)

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -1,12 +1,22 @@
 from functools import partial
 from unittest import TestCase
 
-from ..kast import TRUE, KApply, KLabel, KRewrite, KSequence, KSort, ktokenDots
+from ..kast import (
+    TRUE,
+    KApply,
+    KLabel,
+    KRewrite,
+    KSequence,
+    KSort,
+    KVariable,
+    ktokenDots,
+)
 from ..kastManip import minimize_term, ml_pred_to_bool, push_down_rewrites
 from ..prelude import mlTop
 
 a, b, c = (KApply(label) for label in ['a', 'b', 'c'])
 f, g, k = (partial(KApply.of, label) for label in ['f', 'g', '<k>'])
+x = KVariable('X')
 
 
 class PushDownRewritesTest(TestCase):
@@ -53,6 +63,7 @@ class MlPredToBoolTest(TestCase):
             (KApply(KLabel('#Top', [KSort('Bool')])), TRUE),
             (KApply('#Top'), TRUE),
             (mlTop(), TRUE),
+            (KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
         )
 
         for i, (before, expected) in enumerate(test_data):


### PR DESCRIPTION
This PR:

- Adds enough functionality to the python `KProve` class that KEVM can use it directly instead of bash script.
- Adds rule profiling to the `KProve` class in pyk, so that `kevm ...` can easily call it to generate rule profiles.
- Renames `unsafeMlPredToBool` to `ml_pred_to_bool` and makes it safe by default (can get unsafe behavior as needed with `unsafe=True`). Refactors and simplifies this function to handle allowable cases directly, and fail horribly if something unsafe is done. Adds several tests of cases that came up when trying the summarizer with this branch.
- Renames `boolToMlPred` to `bool_to_ml_pred`.
- Renames `buildAssoc` to `build_assoc`, and makes it handle the `KLabel/str` more gracefully.
- Remove many unused functions from `kastManip.py` (checked here, KEVM, and ERC20 repo): `whereMatchingBottomUp`, `getOccurances`, `count_rhs_vars`, `drop_var_prefixes`, `drop_ques`, `drop_unds`, `structurallyFrameKCell`, `applyCellSubst`, `hasExistentials`, `onCells`, and `abstractCell`. `structurallyFrameKCell` had a test for it, but the use it had downstream has since been removed. `abstractCell` has been moved downstream, because I don't like it and don't want to encourage it.
- Specializes all uses of `build_assoc` that can be to `mlAnd` or `mlOr`, and adds needed sorts.
- Renames `propagateUpConstraints => propagate_up_constraints`

These changes make it possible to:

- Use `pyk` for `kevm kompile ...` and `kevm prove ...` across the haskell backend test-suite: https://github.com/runtimeverification/evm-semantics/pull/1258
- Move all the logic of `ktoken summary-init ...` into `pyk` instead of bash (PR to come, work is local).