### PR TITLE
Call `lldb` instead of `gdb` in `krun --debugger` on macOS

### DIFF
--- a/k-distribution/k-tutorial/1_basic/19_debugging/README.md
+++ b/k-distribution/k-tutorial/1_basic/19_debugging/README.md
@@ -69,6 +69,8 @@ command listed in this output message and add the corresponding
 Please note that the path will be different on your machine than the one
 listed above. 
 
+> *Note* The `krun --debugger` command will launch the `lldb` debugger on macOS instead of `gdb`. See https://lldb.llvm.org/use/map.html for a mapping between `gdb` and `lldb` commands. 
+
 ## Basic commands
 
 The most basic commands you can execute in the K GDB session are to run your

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -31,6 +31,12 @@ dryRun=false
 expandMacros=true
 filterSubst=
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  DBG_CMD="lldb -- "
+else
+  DBG_CMD="gdb --args "
+fi
+
 # setup temp files
 now="$(date +"%Y-%m-%d-%H-%M-%S")"
 tempDir="$(mktemp -d .krun-${now}-XXXXXXXXXX)"
@@ -356,7 +362,7 @@ do
       ;;
 
       --debugger)
-      cmdprefix="gdb --args "
+      cmdprefix="$DBG_CMD"
       ;;
 
       --statistics)


### PR DESCRIPTION
This replicates the functionality of `krun-legacy` which calls `lldb` on macOS instead of `gdb`