### PR TITLE
More ways to pass in definitions/specs

### DIFF
--- a/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
@@ -37,7 +37,11 @@ public class OuterParsingOptions implements Serializable {
             if (mainParameter == null) {
                 throw KEMException.criticalError("You have to provide exactly one main file in order to do outer parsing.");
             }
-            mainDefinitionFile = files.resolveWorkingDirectory(mainParameter);
+            if (mainParameter.equals("-")) {
+                mainDefinitionFile = new File("/dev/stdin");
+            } else {
+                mainDefinitionFile = files.resolveWorkingDirectory(mainParameter);
+            }
         }
         return mainDefinitionFile;
     }


### PR DESCRIPTION
fixes: #2429 

So far this allows you to pipe in a K definition/spec by using `-` as the filename (caveat: You must supply `--main-module` or `--spec-module` when doing this).