### PR TITLE
Error Capturing left of Pipe commands during image creation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:bionic
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV TZ=American/Chicago
 


### PR DESCRIPTION
Pipe commands can fail left of a | and still report success if the right most command in a pipe returns success. 

Intent is to capture failures and fail the build to avoid images building with bad layers. Testing downstream images was tested as follows: 

"Dockerfile.1":
```Dockerfile
FROM ubuntu:latest 
# SHELL ["/bin/bash", "-o", "pipefail", "-c"]
RUN apt-get update
RUN DEBIAN_FRONTEND=noninteractive apt-get install --yes curl
```

Build first Image w/ : 
`docker build -t base:latest -f ./Dockerfile.1 .`

Using a secondary Dockerfile as a "downstream" image build test 
"Dockerfile.2": 

```Dockerfile
FROM base:latest
RUN curl -sL https://deb.nodesourceaaaa.com/setup_14.x | bash -
```
Try and build: `docker build -t multistage:latest -f ./Dockerfile.2 . `
Expected result is a failed build and no image is created. However the build is successful as 'bash -' results in success 

Uncomment 'SHELL' in Dockerfile.1 and rebuild then rebuild Dockerfile.2. This results as follows: 
```bash
Sending build context to Docker daemon  18.94kB
Step 1/2 : FROM test:latest
 ---> 9ba911b4fea4
Step 2/2 : RUN curl -sL https://deb.nodesourceaaaa.com/setup_14.x | bash -
 ---> Running in 9c63d8488e51
The command '/bin/bash -o pipefail -c curl -sL https://deb.nodesourceaaaa.com/setup_14.x | bash -' returned a non-zero code: 6
```
Provide a good URL `curl -sL https://deb.nodesource.com/setup_14.x` in Dockerfile.2 and the build is successful as expected. 