### PR TITLE
Fixing a change causing failure to merge master and release in automation 

### DIFF
--- a/nix/k.nix
+++ b/nix/k.nix
@@ -4,7 +4,7 @@
 
 let
   unwrapped = mavenix.buildMaven {
-    name = "k-${version}";
+    name = "k-5.3.0";
     infoFile = ./mavenix.lock;
     inherit src;
 


### PR DESCRIPTION
### Background:    
Fixing pipeline failure, further info can be seen in [Jenkins build failure](https://ci.runtimeverification.com/jenkins/job/K/job/master/362/)   

TLDR from logs:   

There is an issue in merging master on to release as line 7 of nix/k.nix is modified on each release update by the patch version.sh script.  From what I can tell master needs to provide just the Major/Minor version number i.e. 5.3.0 and the  version.sh script updates the following files with the patch version:    
```bash
    sed --in-place 's/^K_VERSION=.*$/K_VERSION='${version}'/'                                                         install-k
    sed --in-place 's/^    name = "k-.*";$/    name = "k-'${version}'";/'                                             nix/k.nix
    sed --in-place 's/^pkgver=.*$/pkgver='${version}'/'                                                               package/arch/PKGBUILD
    sed --in-place 's/^kframework (.*) unstable; urgency=medium$/kframework ('${version}') unstable; urgency=medium/' package/debian/changelog
    sed --in-place 's/^K_VERSION=.*$/K_VERSION='${version}'/'                                                         src/main/scripts/test-in-container-debian

```
This may also be fixable by manually resolving the merge conflict on release.   

### Testing Merge
Tested using this branch as the latest "master" commit and ran through the Jenkinsfile steps to confirm a successful merge same as is done [here](https://github.com/runtimeverification/k/blob/master/Jenkinsfile#L508)   

Results of a test merge on my local are as follows: 
```bash
$ git branch
  hotfix/Dockerfile-update
  hotfix/nix-release-packaging
  master
* release
$ git merge --no-edit hotfix/nox-release-packaging 
merge: hotfix/nox-release-packaging - not something we can merge
$ git merge --no-edit hotfix/nix-release-packaging 
Auto-merging nix/k.nix
Merge made by the 'ort' strategy.
 default.nix         |  52 ++++++++++----
 flake.lock          | 634 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 flake.nix           | 111 +++++++++++++++++++++++++++++
 nix/k.nix           |  89 +++++++++++-------------
 nix/shell.maven.nix |  12 ++--
 nix/sources.nix     | 227 +++++++++++++++++++++++++++++++++--------------------------
 shell.nix           |  18 ++---
 test.nix            |  70 ++++++++++---------
 8 files changed, 1004 insertions(+), 209 deletions(-)
 create mode 100644 flake.lock
 create mode 100644 flake.nix
```
And looks good. Should avoid a failure to publish the release
No other changes from the previous master commit should have been removed. 
@radumereuta  @goodlyrottenapple  can you please confirm no unintended effects of this change regress your intended changes from #2644 
@ehildenb  Can you please confirm my logic on the release process. 