### PR TITLE
Check existence of `use_directory` in `KProve`

### DIFF
--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -87,6 +87,7 @@ class KProve(KPrint):
             self.use_directory = self._temp_dir.name
         else:
             self.use_directory = Path(use_directory)
+            check_dir_path(self.use_directory)
         # TODO: we should not have to supply main_file_name, it should be read
         self.main_file_name = main_file_name
         self.prover = ['kprove']


### PR DESCRIPTION
As of https://github.com/runtimeverification/k/pull/2649 the `KProve` constructor argument `use_directory`, if provided, should point to an existing directory. This PR adds a precondition check.