### PR TITLE
Better error message for missing klabel

### DIFF
--- a/k-distribution/tests/regression-new/checkWarns/missingKlabel.k
+++ b/k-distribution/tests/regression-new/checkWarns/missingKlabel.k
@@ -1,0 +1,12 @@
+module MISSINGKLABEL-SYNTAX
+endmodule
+
+module MISSINGKLABEL
+  imports MISSINGKLABEL-SYNTAX
+
+  syntax MyMap ::= MyMap MyMap
+      [ left, function, hook(MAP.concat), klabel(_MyMap_), symbol, assoc, comm
+      , unit(.MyMap), element(_M|->_), index(0), format(%1%n%2), unused
+      ]
+
+endmodule

--- a/k-distribution/tests/regression-new/checkWarns/missingKlabel.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/missingKlabel.k.out
@@ -1,0 +1,1 @@
+[Error] Compiler: Expected to find exactly one production for KLabel: .MyMap found: 0

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -1619,8 +1619,8 @@ public class ModuleToKORE {
         if (klabel.name().equals(KLabels.INJ))
             return instantiatePolySorts ? INJ_PROD.substitute(term.klabel().params()) : INJ_PROD;
         Option<scala.collection.Set<Production>> prods = module.productionsFor().get(klabel.head());
-        assert(prods.nonEmpty());
-        assert(prods.get().size() == 1);
+        if (!(prods.nonEmpty() && prods.get().size() == 1))
+            throw KEMException.compilerError("Expected to find exactly one production for KLabel: " + klabel + " found: " + prods.getOrElse(Collections::Set).size());
         return instantiatePolySorts ? prods.get().head().substitute(term.klabel().params()) : prods.get().head();
     }
 


### PR DESCRIPTION
Fixes #2668
```
$ kompile test.k --no-exc-wrap
[Error] Compiler: Expected to find exactly one production for KLabel: _M|->_ found 0
```