### PR TITLE
Support converting Ceil and Exists conditions to Bool unsafely

### DIFF
--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -106,11 +106,11 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
                 if _kast.label.name == '#Equals':
                     return KApply('_==K_', _kast.args)
                 if _kast.label.name == '#Ceil':
-                    ceil_var = abstractTermSafely(_kast, baseName='Ceil')
+                    ceil_var = abstract_term_safely(_kast, base_name='Ceil')
                     _LOGGER.warning(f'Converting #Ceil condition to variable {ceil_var.name}: {_kast}')
                     return ceil_var
                 if _kast.label.name == '#Exists':
-                    exists_var = abstractTermSafely(_kast, baseName='Exists')
+                    exists_var = abstract_term_safely(_kast, base_name='Exists')
                     _LOGGER.warning(f'Converting #Exists condition to variable {exists_var.name}: {_kast}')
                     return exists_var
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
@@ -617,9 +617,9 @@ def buildRule(ruleId, initConstrainedTerm, finalConstrainedTerm, claim=False, pr
     return (minimizeRule(rule, keepVars=newKeepVars), vremapSubst)
 
 
-def abstractTermSafely(kast, baseName='V'):
+def abstract_term_safely(kast, base_name='V'):
     vname = hash_str(kast)[0:8]
-    return KVariable(baseName + '_' + vname)
+    return KVariable(base_name + '_' + vname)
 
 
 def antiUnify(state1, state2):
@@ -628,7 +628,7 @@ def antiUnify(state1, state2):
 
     def _rewritesToAbstractions(_kast):
         if type(_kast) is KRewrite:
-            return abstractTermSafely(_kast)
+            return abstract_term_safely(_kast)
         return _kast
 
     minimizedRewrite = push_down_rewrites(KRewrite(state1, state2))

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -617,7 +617,7 @@ def buildRule(ruleId, initConstrainedTerm, finalConstrainedTerm, claim=False, pr
     return (minimizeRule(rule, keepVars=newKeepVars), vremapSubst)
 
 
-def abstract_term_safely(kast, base_name='V'):
+def abstract_term_safely(kast: KInner, base_name: str = 'V') -> KVariable:
     vname = hash_str(kast)[0:8]
     return KVariable(base_name + '_' + vname)
 

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -109,6 +109,10 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
                     ceil_var = abstractTermSafely(_kast, baseName='Ceil')
                     _LOGGER.warning(f'Converting #Ceil condition to variable {ceil_var.name}: {_kast}')
                     return ceil_var
+                if _kast.label.name == '#Exists':
+                    exists_var = abstractTermSafely(_kast, baseName='Exists')
+                    _LOGGER.warning(f'Converting #Exists condition to variable {exists_var.name}: {_kast}')
+                    return exists_var
         raise ValueError(f'Could not convert ML predicate to sort Bool: {_kast}')
 
     return _ml_constraint_to_bool(kast)

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -68,7 +68,8 @@ class MlPredToBoolTest(TestCase):
             (True, KApply(KLabel('#Equals'), [f(a), f(x)]), KApply('_==K_', [f(a), f(x)])),
             (False, KApply(KLabel('#And', [Sorts.GENERATED_TOP_CELL]), [mlEqualsTrue(TRUE), mlEqualsTrue(TRUE)]), KApply('_andBool_', [TRUE, TRUE])),
             (True, KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))]), KVariable('Ceil_d06736ac')),
-            (True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))])]), KApply('notBool_', [KVariable('Ceil_d06736ac')]))
+            (True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))])]), KApply('notBool_', [KVariable('Ceil_d06736ac')])),
+            (True, KApply(KLabel('#Exists', [Sorts.INT, Sorts.BOOL]), [KVariable('X'), KApply('_==Int_', [KVariable('X'), KVariable('Y')])]), KVariable('Exists_8676e20c')),
         )
 
         for i, (unsafe, before, expected) in enumerate(test_data):

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -11,7 +11,7 @@ from ..kast import (
     ktokenDots,
 )
 from ..kastManip import minimize_term, ml_pred_to_bool, push_down_rewrites
-from ..prelude import intToken, mlEqualsTrue, mlTop
+from ..prelude import Sorts, intToken, mlEqualsTrue, mlTop
 from .utils import a, b, c, f, k
 
 x = KVariable('X')
@@ -57,16 +57,18 @@ class MlPredToBoolTest(TestCase):
     def test_ml_pred_to_bool(self):
         # Given
         test_data = (
-            (False, KApply(KLabel('#Equals', [KSort('Bool'), KSort('GeneratedTopCell')]), [TRUE, f(a)]), f(a)),
-            (False, KApply(KLabel('#Top', [KSort('Bool')])), TRUE),
+            (False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.GENERATED_TOP_CELL]), [TRUE, f(a)]), f(a)),
+            (False, KApply(KLabel('#Top', [Sorts.BOOL])), TRUE),
             (False, KApply('#Top'), TRUE),
             (False, mlTop(), TRUE),
             (False, KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
             (False, KApply(KLabel('#Equals'), [TRUE, f(a)]), f(a)),
-            (False, KApply(KLabel('#Equals', [KSort('Int'), KSort('GeneratedTopCell')]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
-            (False, KApply(KLabel('#Not', [KSort('GeneratedTopCell')]), [mlTop()]), KApply('notBool_', [TRUE])),
+            (False, KApply(KLabel('#Equals', [KSort('Int'), Sorts.GENERATED_TOP_CELL]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
+            (False, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [mlTop()]), KApply('notBool_', [TRUE])),
             (True, KApply(KLabel('#Equals'), [f(a), f(x)]), KApply('_==K_', [f(a), f(x)])),
-            (False, KApply(KLabel('#And', [KSort('GeneratedTopCell')]), [mlEqualsTrue(TRUE), mlEqualsTrue(TRUE)]), KApply('_andBool_', [TRUE, TRUE]))
+            (False, KApply(KLabel('#And', [Sorts.GENERATED_TOP_CELL]), [mlEqualsTrue(TRUE), mlEqualsTrue(TRUE)]), KApply('_andBool_', [TRUE, TRUE])),
+            (True, KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))]), KVariable('Ceil_d06736ac')),
+            (True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))])]), KApply('notBool_', [KVariable('Ceil_d06736ac')]))
         )
 
         for i, (unsafe, before, expected) in enumerate(test_data):


### PR DESCRIPTION
If the user passes `unsafe=True`, we now support converting `Ceil` conditions to `Bool`, and `#Exists` conditions.

I'm pretty sure the transformation is actually safe, but seeing as how this has only been a problem in the summarizer we can mark it as unsafe for now.

These cases were discovered when @jberthold was trying the summarizer on a new proof, and the conditions given back by the prover contained `#Ceil` and `#Exists` conditions. This will make it easier to track down what part of the specification needed to change.