### PR TITLE
pyk getters for KOuter classes, updates to unparsing

### DIFF
--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1235,7 +1235,9 @@ class KFlatModule(KOuter, WithKAtt):
 
     @property
     def functions(self) -> List[KProduction]:
-        return [prod for prod in self.syntax_productions if 'function' in prod.att.atts or 'functional' in prod.att.atts and not (prod.klabel and KFlatModule._is_non_free_constructor(prod.klabel.name))]
+        _functions = [prod for prod in self.syntax_productions if 'function' in prod.att.atts or 'functional' in prod.att.atts]
+        _functions = [f for f in _functions if not (f.klabel and KFlatModule._is_non_free_constructor(f.klabel.name))]
+        return _functions
 
     @property
     def constructors(self) -> List[KProduction]:

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1224,6 +1224,10 @@ class KFlatModule(KOuter, WithKAtt):
         return [sentence for sentence in self.sentences if type(sentence) is KProduction]
 
     @property
+    def syntax_productions(self) -> List[KProduction]:
+        return [prod for prod in self.productions if prod.klabel]
+
+    @property
     def rules(self) -> List[KRule]:
         return [sentence for sentence in self.sentences if type(sentence) is KRule]
 
@@ -1353,6 +1357,14 @@ class KDefinition(KOuter, WithKAtt):
 
     def let_att(self, att: KAtt) -> 'KDefinition':
         return self.let(att=att)
+
+    @property
+    def productions(self) -> List[KProduction]:
+        return [prod for module in self.modules for prod in module.productions]
+
+    @property
+    def syntax_productions(self) -> List[KProduction]:
+        return [prod for module in self.modules for prod in module.syntax_productions]
 
 
 # TODO make method of KInner

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1230,12 +1230,12 @@ class KFlatModule(KOuter, WithKAtt):
         return [prod for prod in self.productions if prod.klabel]
 
     @property
-    def constructors(self) -> List[KProduction]:
-        return [prod for prod in self.syntax_productions if 'constructor' in prod.att or (prod.klabel and prod.klabel.name in NON_FREE_CONSTRUCTORS)]
-
-    @property
     def functions(self) -> List[KProduction]:
         return [prod for prod in self.syntax_productions if 'function' in prod.att or 'functional' and ((not prod.klabel) or prod.klabel.name not in NON_FREE_CONSTRUCTORS)]
+
+    @property
+    def constructors(self) -> List[KProduction]:
+        return [prod for prod in self.syntax_productions if prod not in self.functions]
 
     @property
     def rules(self) -> List[KRule]:
@@ -1377,12 +1377,12 @@ class KDefinition(KOuter, WithKAtt):
         return [prod for module in self.modules for prod in module.syntax_productions]
 
     @property
-    def constructors(self) -> List[KProduction]:
-        return [prod for module in self.modules for prod in module.constructors]
-
-    @property
     def functions(self) -> List[KProduction]:
         return [prod for module in self.modules for prod in module.functions]
+
+    @property
+    def constructors(self) -> List[KProduction]:
+        return [prod for module in self.modules for prod in module.constructors]
 
 
 # TODO make method of KInner

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1230,7 +1230,7 @@ class KFlatModule(KOuter, WithKAtt):
     @staticmethod
     def _is_non_free_constructor(label: str) -> bool:
         is_cell_map_constructor = label.endswith('CellMapItem') or label.endswith('CellMap_')
-        is_builtin_data_constructor = label in ['_Set_', '_List_', '_Map_', 'SetItem', 'ListItem', '_|->_']
+        is_builtin_data_constructor = label in {'_Set_', '_List_', '_Map_', 'SetItem', 'ListItem', '_|->_'}
         return is_cell_map_constructor or is_builtin_data_constructor
 
     @property

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1227,16 +1227,16 @@ class KFlatModule(KOuter, WithKAtt):
     def syntax_productions(self) -> List[KProduction]:
         return [prod for prod in self.productions if prod.klabel]
 
-    @staticmethod
-    def _is_non_free_constructor(label: str) -> bool:
-        is_cell_map_constructor = label.endswith('CellMapItem') or label.endswith('CellMap_')
-        is_builtin_data_constructor = label in ['_Set_', '_List_', '_Map_', 'SetItem', 'ListItem', '_|->_']
-        return is_cell_map_constructor or is_builtin_data_constructor
-
     @property
     def functions(self) -> List[KProduction]:
+
+        def _is_non_free_constructor(label: str) -> bool:
+            is_cell_map_constructor = label.endswith('CellMapItem') or label.endswith('CellMap_')
+            is_builtin_data_constructor = label in ['_Set_', '_List_', '_Map_', 'SetItem', 'ListItem', '_|->_']
+            return is_cell_map_constructor or is_builtin_data_constructor
+
         _functions = [prod for prod in self.syntax_productions if 'function' in prod.att.atts or 'functional' in prod.att.atts]
-        _functions = [f for f in _functions if not (f.klabel and KFlatModule._is_non_free_constructor(f.klabel.name))]
+        _functions = [f for f in _functions if not (f.klabel and _is_non_free_constructor(f.klabel.name))]
         return _functions
 
     @property

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -30,6 +30,8 @@ T = TypeVar('T', bound='KAst')
 W = TypeVar('W', bound='WithKAtt')
 KI = TypeVar('KI', bound='KInner')
 
+NON_FREE_CONSTRUCTORS: Final = ['_Set_', '_List_', '_Map_', 'SetItem', 'ListItem', '_|->_']
+
 
 class KAst(ABC):
 
@@ -1228,6 +1230,14 @@ class KFlatModule(KOuter, WithKAtt):
         return [prod for prod in self.productions if prod.klabel]
 
     @property
+    def constructors(self) -> List[KProduction]:
+        return [prod for prod in self.syntax_productions if 'constructor' in prod.att or (prod.klabel and prod.klabel.name in NON_FREE_CONSTRUCTORS)]
+
+    @property
+    def functions(self) -> List[KProduction]:
+        return [prod for prod in self.syntax_productions if 'function' in prod.att or 'functional' and ((not prod.klabel) or prod.klabel.name not in NON_FREE_CONSTRUCTORS)]
+
+    @property
     def rules(self) -> List[KRule]:
         return [sentence for sentence in self.sentences if type(sentence) is KRule]
 
@@ -1365,6 +1375,14 @@ class KDefinition(KOuter, WithKAtt):
     @property
     def syntax_productions(self) -> List[KProduction]:
         return [prod for module in self.modules for prod in module.syntax_productions]
+
+    @property
+    def constructors(self) -> List[KProduction]:
+        return [prod for module in self.modules for prod in module.constructors]
+
+    @property
+    def functions(self) -> List[KProduction]:
+        return [prod for module in self.modules for prod in module.functions]
 
 
 # TODO make method of KInner

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -66,10 +66,7 @@ def unparser_for_production(prod):
             elif type(item) is KNonTerminal and index < len(args):
                 result.append(args[index])
                 index += 1
-        unparsed = ' '.join(result)
-        if type(prod.items[0]) is KNonTerminal or type(prod.items[-1]) is KNonTerminal:
-            unparsed = '( ' + unparsed + ' )'
-        return unparsed
+        return ' '.join(result)
 
     return _unparser
 

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -1,6 +1,5 @@
 import sys
 from pathlib import Path
-from typing import Optional
 
 from ..kast import (
     TRUE,
@@ -83,17 +82,12 @@ def build_symbol_table(definition, opinionated=False):
 
     symbol_table = {}
     for module in definition.modules:
-        for prod in module.productions:
-            label: Optional[str] = None
-
-            if prod.klabel:
-                label = prod.klabel.name
-            elif 'symbol' in prod.att and 'klabel' in prod.att:
+        for prod in module.syntax_productions:
+            label = prod.klabel.name
+            if 'symbol' in prod.att and 'klabel' in prod.att:
                 label = prod.att['klabel']
-
-            if label:
-                unparser = unparser_for_production(prod)
-                symbol_table[label] = unparser
+            unparser = unparser_for_production(prod)
+            symbol_table[label] = unparser
 
     if opinionated:
         symbol_table['#And'] = lambda c1, c2: c1 + '\n#And ' + c2

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -66,7 +66,10 @@ def unparser_for_production(prod):
             elif type(item) is KNonTerminal and index < len(args):
                 result.append(args[index])
                 index += 1
-        return ' '.join(result)
+        unparsed = ' '.join(result)
+        if type(prod.items[0]) is KNonTerminal or type(prod.items[-1]) is KNonTerminal:
+            unparsed = '( ' + unparsed + ' )'
+        return unparsed
 
     return _unparser
 


### PR DESCRIPTION
This adds several methods to the KAST outer classes `KFlatModule` and `KDefinition`:

- `syntax_productions`: return productions that have a klabel.
- `functions`: return things marked as function, but _not_ non-free-constructors (@dwightguth this distinction becomes important in a routine in pyk I've written to remove function symbols from the LHS of rules, here we want things marked in this PR as "NON_FREE_CONSTRUCTORS" to remain on the LHS of rules so you can do normal pattern matching on them).
- `constructors`: return things that are not functions.
- The unparser only builds symbols in the symbol table for `syntax_productions`, not all `productions`.