### PR TITLE
Tests for #Ceil(Map MapItem) rule generation

### DIFF
--- a/k-distribution/tests/regression-new/ceil-map-generated/Makefile
+++ b/k-distribution/tests/regression-new/ceil-map-generated/Makefile
@@ -1,0 +1,11 @@
+DEF=ceil-map
+EXT=test
+TESTDIR=.
+KOMPILE_BACKEND=haskell
+KPROVE_FLAGS=--warnings none
+export KORE_EXEC_OPTS=--log-level error
+
+include ../../../include/kframework/ktest.mak
+
+KPROVE_OR_LEGACY=$(KPROVE)
+CONSIDER_PROVER_ERRORS=2>&1

--- a/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-cellMap-spec.k
+++ b/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-cellMap-spec.k
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 K Team. All Rights Reserved.
+
+requires "ceil-map.k"
+
+module CEIL-MAP-CELLMAP-SPEC
+    imports CEIL-MAP
+
+    claim <k> testCell(_K1, _A1, _B1, _K2, _A2, _B2) => . </k>
+          <cellMap> _CELLMAP => ?_ </cellMap>
+
+endmodule

--- a/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-cellMap-spec.k.out
+++ b/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-cellMap-spec.k.out
@@ -1,0 +1,50 @@
+  #Not ( {
+    partialInt ( _K1 )
+  #Equals
+    partialInt ( _K2 )
+  } )
+#And
+  <generatedTop>
+    <k>
+      done ( . ) ~> .
+    </k>
+    <cellMap>
+      <cellElem>
+        <key>
+          partialInt ( _K1 )
+        </key>
+        <cellA>
+          partialInt ( _A1 )
+        </cellA>
+        <cellB>
+          partialInt ( _B1 )
+        </cellB>
+      </cellElem> <cellElem>
+        <key>
+          partialInt ( _K2 )
+        </key>
+        <cellA>
+          partialInt ( _A2 )
+        </cellA>
+        <cellB>
+          partialInt ( _B2 )
+        </cellB>
+      </cellElem> _CELLMAP
+    </cellMap>
+  </generatedTop>
+#And
+  {
+    false
+  #Equals
+    <key>
+      partialInt ( _K1 )
+    </key> in_keys ( _CELLMAP )
+  }
+#And
+  {
+    false
+  #Equals
+    <key>
+      partialInt ( _K2 )
+    </key> in_keys ( _CELLMAP )
+  }

--- a/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-regularMap-spec.k
+++ b/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-regularMap-spec.k
@@ -1,0 +1,11 @@
+// Copyright (c) 2022 K Team. All Rights Reserved.
+
+requires "ceil-map.k"
+
+module CEIL-MAP-REGULARMAP-SPEC
+    imports CEIL-MAP
+
+    claim <k> testRegular(_S, _K1, _V1, _K2, _V2) => . </k>
+          <cellMap> _CELLMAP </cellMap>
+
+endmodule

--- a/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-regularMap-spec.k.out
+++ b/k-distribution/tests/regression-new/ceil-map-generated/ceil-map-regularMap-spec.k.out
@@ -1,0 +1,34 @@
+  #Ceil ( partialInt ( _K1 ) )
+#And
+  #Ceil ( partialInt ( _V1 ) )
+#And
+  #Ceil ( partialInt ( _V2 ) )
+#And
+  #Not ( {
+    partialInt ( _K1 )
+  #Equals
+    partialInt ( _K2 )
+  } )
+#And
+  <generatedTop>
+    <k>
+      done ( partialInt ( _K1 ) |-> partialInt ( _V1 )
+      partialInt ( _K2 ) |-> partialInt ( _V2 )
+      partialMap ( _S ) ~> . ) ~> .
+    </k>
+    <cellMap>
+      _CELLMAP
+    </cellMap>
+  </generatedTop>
+#And
+  {
+    false
+  #Equals
+    partialInt ( _K1 ) in_keys ( partialMap ( _S ) )
+  }
+#And
+  {
+    false
+  #Equals
+    partialInt ( _K2 ) in_keys ( partialMap ( _S ) )
+  }

--- a/k-distribution/tests/regression-new/ceil-map-generated/ceil-map.k
+++ b/k-distribution/tests/regression-new/ceil-map-generated/ceil-map.k
@@ -1,0 +1,47 @@
+// Copyright (c) 2022 K Team. All Rights Reserved.
+
+module CEIL-MAP-SYNTAX
+    imports MAP
+    imports INT
+
+    syntax Test ::= testRegular ( Map , Int , Int , Int , Int ) | testCell ( Int , Int , Int , Int , Int , Int ) | done ( K )
+
+    syntax Map ::= partialMap ( Map ) [function]
+    syntax Int ::= partialInt ( Int ) [function]
+
+endmodule
+
+module CEIL-MAP
+    imports CEIL-MAP-SYNTAX
+
+    configuration <k> $PGM:Test </k>
+                  <cellMap>
+                    <cellElem multiplicity="*" type="Map">
+                      <key>   0 </key>
+                      <cellA> 0 </cellA>
+                      <cellB> 0 </cellB>
+                    </cellElem>
+                  </cellMap>
+
+    rule <k> testRegular(MAP, K1, V1, K2, V2) => done( partialMap(MAP) (partialInt(K1) |-> partialInt(V1)) (partialInt(K2) |-> partialInt(V2)) ) </k>
+
+    rule <k> testCell(K1, A1, B1, K2, A2, B2) => done(.) </k>
+         <cellMap>
+          ( REST => <cellElem>
+                        <key>   partialInt(K1) </key>
+                        <cellA> partialInt(A1) </cellA>
+                        <cellB> partialInt(B1) </cellB>
+                    </cellElem>
+                    <cellElem>
+                        <key>   partialInt(K2) </key>
+                        <cellA> partialInt(A2) </cellA>
+                        <cellB> partialInt(B2) </cellB>
+                    </cellElem>
+                    REST )
+         </cellMap>
+
+    //to avoid warnings that function has no rules
+    rule partialMap(.Map) => .Map
+    rule partialInt(0) => 0
+
+endmodule


### PR DESCRIPTION
Out files are what the current results are, not necessarily correct. I adapted it from similar test for `#Ceil(Set)` just to compare with what's going on here.

There are 2 tests here: 

- for `#Ceil(Map MapItem)` where Map is the builtin map
- for `#Ceil(CellMap CellMapItem)` where "CellMap" is generated for a collection cell of type map.

I'm not sure the results are correct. For the 1st test, I'd expect a couple more `#Ceil` expressions: `#Ceil ( partialInt ( _K2 ) )`, `#Ceil ( partialMap ( _S ) )`. For the 2nd test no `#Ceil(partialInt) / #Ceil(partialSet) ` is generated at all.

Please review/correct/use this test if it makes sense.