### PR TITLE
Pyk: Additional args for kompile, KProve has kompile named constructor.

### DIFF
--- a/pyk/src/pyk/ktool/kompile.py
+++ b/pyk/src/pyk/ktool/kompile.py
@@ -28,7 +28,7 @@ def kompile(
     hook_namespaces: Iterable[str] = (),
     emit_json=False,
     concrete_rules: Iterable[str] = (),
-    additional_args: Iterable[str] = ()
+    additional_args: Iterable[str] = (),
 ) -> Path:
     check_file_path(main_file)
 

--- a/pyk/src/pyk/ktool/kompile.py
+++ b/pyk/src/pyk/ktool/kompile.py
@@ -19,17 +19,32 @@ class KompileBackend(Enum):
 def kompile(
     main_file: Path,
     *,
+    main_module: Optional[str] = None,
+    syntax_module: Optional[str] = None,
     backend: Optional[KompileBackend],
     output_dir: Optional[Path] = None,
     include_dirs: Iterable[Path] = (),
+    md_selector: Optional[str] = None,
+    hook_namespaces: Iterable[str] = (),
     emit_json=False,
+    concrete_rules: Iterable[str] = (),
 ) -> Path:
     check_file_path(main_file)
 
     for include_dir in include_dirs:
         check_dir_path(include_dir)
 
-    args = _build_arg_list(backend=backend, output_dir=output_dir, include_dirs=include_dirs, emit_json=emit_json)
+    args = _build_arg_list(
+        main_module=main_module,
+        syntax_module=syntax_module,
+        backend=backend,
+        output_dir=output_dir,
+        include_dirs=include_dirs,
+        md_selector=md_selector,
+        hook_namespaces=hook_namespaces,
+        emit_json=emit_json,
+        concrete_rules=concrete_rules
+    )
 
     try:
         _kompile(str(main_file), *args)
@@ -43,12 +58,23 @@ def kompile(
 
 def _build_arg_list(
     *,
+    main_module: Optional[str],
+    syntax_module: Optional[str],
     backend: Optional[KompileBackend],
     output_dir: Optional[Path],
     include_dirs: Iterable[Path],
-    emit_json: bool,
+    md_selector: Optional[str],
+    hook_namespaces: Iterable[str],
+    emit_json,
+    concrete_rules: Iterable[str],
 ) -> List[str]:
     args = []
+
+    if main_module:
+        args.extend(['--main-module', main_module])
+
+    if syntax_module:
+        args.extend(['--syntax-module', syntax_module])
 
     if backend:
         args += ['--backend', backend.value]
@@ -59,8 +85,17 @@ def _build_arg_list(
     for include_dir in include_dirs:
         args += ['-I', str(include_dir)]
 
+    if md_selector:
+        args.extend(['--md-selector', md_selector])
+
+    if hook_namespaces:
+        args.extend(['--hook-namespaces', ' '.join(hook_namespaces)])
+
     if emit_json:
         args.append('--emit-json')
+
+    if concrete_rules:
+        args.extend(['--concrete-rules', ','.join(concrete_rules)])
 
     return args
 

--- a/pyk/src/pyk/ktool/kompile.py
+++ b/pyk/src/pyk/ktool/kompile.py
@@ -28,6 +28,7 @@ def kompile(
     hook_namespaces: Iterable[str] = (),
     emit_json=False,
     concrete_rules: Iterable[str] = (),
+    additional_args: Iterable[str] = ()
 ) -> Path:
     check_file_path(main_file)
 
@@ -43,7 +44,8 @@ def kompile(
         md_selector=md_selector,
         hook_namespaces=hook_namespaces,
         emit_json=emit_json,
-        concrete_rules=concrete_rules
+        concrete_rules=concrete_rules,
+        additional_args=additional_args
     )
 
     try:
@@ -67,6 +69,7 @@ def _build_arg_list(
     hook_namespaces: Iterable[str],
     emit_json,
     concrete_rules: Iterable[str],
+    additional_args: Iterable[str]
 ) -> List[str]:
     args = []
 
@@ -96,6 +99,8 @@ def _build_arg_list(
 
     if concrete_rules:
         args.extend(['--concrete-rules', ','.join(concrete_rules)])
+
+    args.extend(additional_args)
 
     return args
 

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -17,7 +17,6 @@ from ..cli_utils import (
 from ..kast import KAst, KDefinition, KFlatModule, KImport, KRequire
 from ..prelude import mlTop
 from ..utils import unique
-from .kompile import kompile
 from .kprint import KPrint
 
 _LOGGER: Final = logging.getLogger(__name__)
@@ -98,10 +97,6 @@ class KProve(KPrint):
             self.backend = ba.read()
         with open(self.kompiled_directory / 'mainModule.txt', 'r') as mm:
             self.main_module = mm.read()
-
-    @staticmethod
-    def kompile(main_file: Path, *args, **kwargs) -> 'KProve':
-        return KProve(kompile(main_file, *args, **kwargs))
 
     def prove(
         self,

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -17,6 +17,7 @@ from ..cli_utils import (
 from ..kast import KAst, KDefinition, KFlatModule, KImport, KRequire
 from ..prelude import mlTop
 from ..utils import unique
+from .kompile import kompile
 from .kprint import KPrint
 
 _LOGGER: Final = logging.getLogger(__name__)
@@ -97,6 +98,10 @@ class KProve(KPrint):
             self.backend = ba.read()
         with open(self.kompiled_directory / 'mainModule.txt', 'r') as mm:
             self.main_module = mm.read()
+
+    @staticmethod
+    def kompile(main_file: Path, *args, **kwargs) -> 'KProve':
+        return KProve(kompile(main_file, *args, **kwargs))
 
     def prove(
         self,

--- a/pyk/src/pyk/tests/test_kompile.py
+++ b/pyk/src/pyk/tests/test_kompile.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+from unittest import TestCase
+
+from ..ktool.kompile import KompileBackend, _build_arg_list
+
+
+class BuildArgsTest(TestCase):
+    def test_all_args(self):
+        actual = _build_arg_list(
+            main_module='MAIN-MODULE',
+            syntax_module='SYNTAX-MODULE',
+            backend=KompileBackend.HASKELL,
+            output_dir=Path('path/to/kompiled'),
+            include_dirs=['/', '/include/lib'],
+            md_selector='k & ! nobytes & ! node',
+            hook_namespaces=['JSON', 'KRYPTO', 'BLOCKCHAIN'],
+            emit_json=True,
+            concrete_rules=['foo', 'bar']
+        )
+        expected = [
+            '--main-module', 'MAIN-MODULE',
+            '--syntax-module', 'SYNTAX-MODULE',
+            '--backend', 'haskell',
+            '--output-definition', 'path/to/kompiled',
+            '-I', '/',
+            '-I', '/include/lib',
+            '--md-selector', 'k & ! nobytes & ! node',
+            '--hook-namespaces', 'JSON KRYPTO BLOCKCHAIN',
+            '--emit-json',
+            '--concrete-rules', 'foo,bar',
+        ]
+        self.assertEqual(actual, expected)

--- a/pyk/src/pyk/tests/test_kompile.py
+++ b/pyk/src/pyk/tests/test_kompile.py
@@ -15,7 +15,8 @@ class BuildArgsTest(TestCase):
             md_selector='k & ! nobytes & ! node',
             hook_namespaces=['JSON', 'KRYPTO', 'BLOCKCHAIN'],
             emit_json=True,
-            concrete_rules=['foo', 'bar']
+            concrete_rules=['foo', 'bar'],
+            additional_args=['--new-fangled-option', 'buzz']
         )
         expected = [
             '--main-module', 'MAIN-MODULE',
@@ -28,5 +29,6 @@ class BuildArgsTest(TestCase):
             '--hook-namespaces', 'JSON KRYPTO BLOCKCHAIN',
             '--emit-json',
             '--concrete-rules', 'foo,bar',
+            '--new-fangled-option', 'buzz'
         ]
         self.assertEqual(actual, expected)


### PR DESCRIPTION
Besides the args needed for KEVM, I've allowed the `kompile` to take additional unstructured args. This is so we don't get blocked on adding new args to this function if we need an argument we don't explicitly support.