### PR TITLE
Update docker agent to focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:focal
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ENV TZ=American/Chicago


### PR DESCRIPTION
The CI build was breaking because the latest version of Calibre (which we use to build the tutorial from markdown) requires a newer version of `libc` than is provided in Ubuntu Bionic.

This PR upgrades the Jenkins agent from bionic to focal.