### PR TITLE
Fix macos version error in release page

### DIFF
--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -6,7 +6,7 @@ We currently strive to provide packages for the following platforms:
 -   Ubuntu Focal Fossa (20.04) and Jammy Jellyfish (22.04)
 -   Debian Bullseye
 -   Arch Linux
--   MacOS X Mojave/Homewbrew
+-   macOS Catalina (10.15), Big Sur (11) and Monterey (12) via Homebrew
 -   Docker Images
 
 Pre-installation Notes


### PR DESCRIPTION
This updates the list of supported macOS versions in release pages.

Fixes #2656 