### PR TITLE
CODEOWNERS: remove USER_MANUAL from codeowner restrictions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 /k-distribution/include/kframework/builtin/* @dwightguth
-/Jenkinsfile @kframework/admin
-/.github/workflows/* @kframework/admin
+/Jenkinsfile @runtimeverification/admin
+/.github/workflows/* @runtimeverification/admin

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,3 @@
 /k-distribution/include/kframework/builtin/* @dwightguth
-/USER_MANUAL.md @dwightguth
 /Jenkinsfile @kframework/admin
 /.github/workflows/* @kframework/admin


### PR DESCRIPTION
This means that people reviewing USER_MANUAL file need to pay extra special attention @radumereuta 