### PR TITLE
Add back error for function simplification rules

### DIFF
--- a/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k
+++ b/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k
@@ -1,0 +1,17 @@
+requires "test.k"
+
+
+module VERIFICATION
+  import TEST
+
+  rule <k> (X +Int Y) +Int Z => Z +Int (X +Int Y) </k> [simplification, symbolic(X), concrete(Y, Z)]
+  rule notAFunction => 1 [simplification]
+endmodule
+
+module A2-SPEC
+  import VERIFICATION
+
+  claim [s1]:
+    <k> run(5) => .K </k> <counter> n => 0 </counter>
+
+endmodule

--- a/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k.out
@@ -1,9 +1,9 @@
-[Error] Compiler: Simplification rules need to be function/functional/mlOp like.
+[Error] Compiler: Simplification rules expect function/functional/mlOp symbols at the top of the left hand side term.
 	Source(a2-spec.k)
 	Location(7,8,7,55)
 	7 |	  rule <k> (X +Int Y) +Int Z => Z +Int (X +Int Y) </k> [simplification, symbolic(X), concrete(Y, Z)]
 	  .	       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-[Error] Compiler: Simplification rules need to be function/functional/mlOp like.
+[Error] Compiler: Simplification rules expect function/functional/mlOp symbols at the top of the left hand side term.
 	Source(a2-spec.k)
 	Location(8,8,8,25)
 	8 |	  rule notAFunction => 1 [simplification]

--- a/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k.out
+++ b/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a2-spec.k.out
@@ -1,0 +1,11 @@
+[Error] Compiler: Simplification rules need to be function/functional/mlOp like.
+	Source(a2-spec.k)
+	Location(7,8,7,55)
+	7 |	  rule <k> (X +Int Y) +Int Z => Z +Int (X +Int Y) </k> [simplification, symbolic(X), concrete(Y, Z)]
+	  .	       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Simplification rules need to be function/functional/mlOp like.
+	Source(a2-spec.k)
+	Location(8,8,8,25)
+	8 |	  rule notAFunction => 1 [simplification]
+	  .	       ^~~~~~~~~~~~~~~~~
+[Error] Compiler: Had 2 structural errors.

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -449,10 +449,7 @@ public class Kompile {
         ModuleTransformer mt = ModuleTransformer.fromSentenceTransformer((m, s) -> {
             if (s instanceof Rule && (s.att().contains(Att.SIMPLIFICATION()))) {
                 KLabel kl = m.matchKLabel((Rule) s);
-                scala.collection.Set<Production> prods = m.productionsFor().get(kl).getOrElse(() -> {
-                    throw KEMException.criticalError("Could not find productions for label " + kl.name(), s);
-                });
-                Att atts = prods.iterator().next().att();
+                Att atts = m.attributesFor().get(kl).getOrElse(Att::empty);
                 if (!(atts.contains(Att.FUNCTION()) || atts.contains(Att.FUNCTIONAL()) || atts.contains("mlOp")))
                     errors.add(KEMException.compilerError("Simplification rules expect function/functional/mlOp symbols at the top of the left hand side term.", s));
             }

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -454,7 +454,7 @@ public class Kompile {
                 });
                 Att atts = prods.iterator().next().att();
                 if (!(atts.contains(Att.FUNCTION()) || atts.contains(Att.FUNCTIONAL()) || atts.contains("mlOp")))
-                    errors.add(KEMException.compilerError("Simplification rules need to be function/functional/mlOp like.", s));
+                    errors.add(KEMException.compilerError("Simplification rules expect function/functional/mlOp symbols at the top of the left hand side term.", s));
             }
             if (m.name().equals(mainDefModule.name()) || mainDefModule.importedModuleNames().contains(m.name()))
                 return s;


### PR DESCRIPTION
Fixes: #2750
This was removed [here](https://github.com/runtimeverification/k/pull/2711/files#diff-487106080746c9047c18b3addae0c79a7a377a2e1c517ac087bfd17eecf38b7eL455)
But after a discussion with @ana-pantilie we think it should still be checked.