### PR TITLE
Include pyk in Focal package

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,7 +124,11 @@ pipeline {
           options { skipDefaultCheckout() }
           steps {
             unstash 'focal'
-            sh 'src/main/scripts/test-in-container-debian'
+            sh '''
+              src/main/scripts/test-in-container-debian
+              pyk --help
+              python3 -m pyk --help
+            '''
           }
           post {
             always {

--- a/package/debian/Dockerfile
+++ b/package/debian/Dockerfile
@@ -41,8 +41,12 @@ RUN    apt-get update            \
         parallel                 \
         pkg-config               \
         python3                  \
+        python3-all              \
         python3-graphviz         \
         python3-pip              \
+        python3-setuptools       \
+        python-all               \
+        python-setuptools        \
         zlib1g-dev
 
 RUN pip3 install virtualenv

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: clang-12 , cmake , debhelper (>=9) , flex , libboost-test-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , zlib1g-dev
+Build-Depends: clang-12 , cmake , debhelper (>=9) , dh-python , flex , libboost-test-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , python-all , python-setuptools , python3-all , python3-setuptools , zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/k
 
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-12 , default-jre-headless , flex , gcc , libffi-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , pkg-config , llvm-12
+Depends: bison , clang-12 , default-jre-headless , flex , gcc , libffi-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , llvm-12 , pkg-config , python3-graphviz
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: clang-12 , cmake , debhelper (>=9) , dh-python , flex , libboost-test-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , python-all , python-setuptools , python3-all , python3-setuptools , zlib1g-dev
+Build-Depends: clang-12 , cmake , debhelper (>=9) , flex , libboost-test-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , python-all , python-setuptools , python3-all , python3-setuptools , zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/k
 

--- a/package/debian/rules
+++ b/package/debian/rules
@@ -28,7 +28,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	package/package
-	@mkdir -p $(DESTDIR)$(PREFIX)/lib/python3/dist-packages
+	@mkdir -p $(DESTDIR)$(PREFIX)/lib/$(PYTHON_DEB_VERSION)/dist-packages
 	ln --symbolic --relative $(DESTDIR)$(PREFIX)/lib/$(PYTHON_VERSION)/site-packages/pyk $(DESTDIR)$(PREFIX)/lib/$(PYTHON_DEB_VERSION)/dist-packages/pyk
 
 override_dh_strip:

--- a/package/debian/rules
+++ b/package/debian/rules
@@ -13,15 +13,23 @@ export DEB_BUILD_MAINT_OPTIONS=hardening=-stackprotector
 # package maintainers to append LDFLAGS
 #export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
 
+DESTDIR=$(shell pwd)/debian/kframework
+PREFIX=/usr
+PYTHON_VERSION=python3.8
+PYTHON_DEB_VERSION=python3
+export DESTDIR
+export PREFIX
 
 %:
 	dh $@ 
 
 override_dh_auto_build:
-	mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=/usr -Dllvm.backend.destdir=$(shell pwd)/debian/kframework
+	mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=$(PREFIX) -Dllvm.backend.destdir=$(DESTDIR)
 
 override_dh_auto_install:
-	DESTDIR=$(shell pwd)/debian/kframework PREFIX=/usr package/package
+	package/package
+	@mkdir -p $(DESTDIR)$(PREFIX)/lib/python3/dist-packages
+	ln --symbolic --relative $(DESTDIR)$(PREFIX)/lib/$(PYTHON_VERSION)/site-packages/pyk $(DESTDIR)$(PREFIX)/lib/$(PYTHON_DEB_VERSION)/dist-packages/pyk
 
 override_dh_strip:
 	dh_strip -Xliballoc.a -Xlibarithmetic.a -XlibAST.a -Xlibutil.a -XlibParser.a -Xlibcollect.a -Xlibcollections.a -Xlibjson.a -Xlibstrings.a -Xlibmeta.a -Xlibio.a

--- a/package/docker/Dockerfile.ubuntu-focal
+++ b/package/docker/Dockerfile.ubuntu-focal
@@ -3,13 +3,18 @@ FROM ubuntu:focal
 ENV TZ=America/Chicago
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN    apt-get update                   \
-    && apt-get upgrade --yes            \
-    && apt-get install --yes            \
-                        build-essential \
-                        git             \
-                        python          \
-                        python3-pip
+RUN    apt-get update                      \
+    && apt-get upgrade --yes               \
+    && apt-get install --yes               \
+                        build-essential    \
+                        dh-python          \
+                        git                \
+                        python             \
+                        python3-all        \
+                        python3-pip        \
+                        python3-setuptools \
+                        python-all         \
+                        python-setuptools
 
 RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
     && cd z3                                                         \

--- a/package/package
+++ b/package/package
@@ -8,3 +8,4 @@ cp -R k-distribution/target/release/k/include/* $DESTDIR$PREFIX/include
 cp -R k-distribution/target/release/k/lib/* $DESTDIR$PREFIX/lib
 cp -R k-distribution/target/release/k/share/* $DESTDIR$PREFIX/share
 ( cd llvm-backend/target/build && make install )
+( cd pyk && make install DESTDIR=$DESTDIR PREFIX=$PREFIX )

--- a/pyk/Makefile
+++ b/pyk/Makefile
@@ -47,9 +47,7 @@ $(VENV_PROD_DIR): $(VENV_PROD)
 	@echo $(ACTIVATE_PROD)
 
 install:
-	   virtualenv -p python3.8 $(VENV_PROD_DIR) \
-	&& $(ACTIVATE_PROD)                         \
-	&& pip install . --root=$(DESTDIR) --prefix=$(PREFIX)
+	pip3 install . --root=$(DESTDIR) --prefix=$(PREFIX) --system
 
 
 # Tests

--- a/pyk/Makefile
+++ b/pyk/Makefile
@@ -4,7 +4,7 @@ K_BIN  := $(K_ROOT)/k-distribution/target/release/k/bin
 export PATH := $(K_BIN):$(PATH)
 
 
-.PHONY: default all clean                                          \
+.PHONY: default all clean install                                  \
         $(VENV_DEV_DIR) $(VENV_PROD_DIR)                           \
         test test-unit test-integration test-pyk                   \
         check-code-style isort check-isort check-flake8 check-mypy
@@ -45,6 +45,11 @@ $(VENV_PROD):
 
 $(VENV_PROD_DIR): $(VENV_PROD)
 	@echo $(ACTIVATE_PROD)
+
+install:
+	   virtualenv -p python3.8 $(VENV_PROD_DIR) \
+	&& $(ACTIVATE_PROD)                         \
+	&& pip install . --root=$(DESTDIR) --prefix=$(PREFIX)
 
 
 # Tests

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -21,7 +21,7 @@ from .prelude import Sorts, mlAnd, mlOr, mlTop
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'
 
 
-def main(extraMain=None):
+def main():
     # KAST terms can end up nested quite deeply, because of the various assoc operators (eg. _Map_, _Set_, ...).
     # Most pyk operations are defined recursively, meaning you get a callstack the same depth as the term.
     # This change makes it so that in most cases, by default, pyk doesn't run out of stack space.
@@ -86,8 +86,8 @@ def main(extraMain=None):
             args['output'].write('\nUnparsed:\n')
             args['output'].write(prettyPrintKast(rule, symbol_table))
 
-    elif extraMain is not None:
-        extraMain(args, kompiled_dir)
+    else:
+        raise ValueError(f'Unknown command: {args["command"]}')
 
 
 def create_argument_parser():


### PR DESCRIPTION
This includes the pyk library in the Focal package. I do not think this is the most widely accepted way to package python dependencies, but I have verified that the package installs and uninstalls cleanly, and added tests on CI that python is picking it up correctly. So this should at least enable downstream to start using pyk like a proper package, and then we can clean up the packaging process later.

This only enables it for Ubuntu Focal for the moment, just so we can begin testing this with downstream repos KEVM and ksummarize.

Part of: https://github.com/runtimeverification/k/issues/2627