### PR TITLE
Upstreaming pyk functionality

### DIFF
--- a/pyk/Makefile
+++ b/pyk/Makefile
@@ -55,10 +55,10 @@ install:
 test: test-unit test-integration test-pyk
 
 test-unit: $(VENV_DEV)
-	$(ACTIVATE_DEV) && python3 -m unittest discover -vt src pyk.tests
+	$(ACTIVATE_DEV) && python3 -m unittest discover --verbose --top src pyk.tests
 
 test-integration: $(VENV_DEV)
-	$(ACTIVATE_DEV) && python3 -m unittest discover -vt src pyk.integration_tests
+	$(ACTIVATE_DEV) && python3 -m unittest discover --verbose --top src pyk.integration_tests
 
 test-pyk: $(VENV_PROD)
 	$(ACTIVATE_PROD) && $(MAKE) -C pyk-tests

--- a/pyk/src/pyk/integration_tests/test_defn.py
+++ b/pyk/src/pyk/integration_tests/test_defn.py
@@ -2,6 +2,7 @@ from ..kast import (
     KApply,
     KClaim,
     KRewrite,
+    KSort,
     KToken,
     KVariable,
     assocWithUnit,
@@ -9,6 +10,7 @@ from ..kast import (
 )
 from ..kastManip import push_down_rewrites
 from ..ktool import KompileBackend
+from ..prelude import Sorts
 from .kprove_test import KProveTest
 
 
@@ -73,3 +75,37 @@ class DefnTest(KProveTest):
         # Then
         self.assertEqual(minimized_claim_rewrite_expected, minimized_claim_rewrite_actual)
         self.assertTop(result)
+
+    def test_empty_config(self):
+        # Given
+        empty_config_generated_top = self.kprove.definition.empty_config(Sorts.GENERATED_TOP_CELL)
+        empty_config_t = self.kprove.definition.empty_config(KSort('TCell'))
+
+        empty_config_generated_top_printed = '\n'.join([ '<generatedTop>'               # noqa
+                                                       , '  <T>'                        # noqa
+                                                       , '    <k>'                      # noqa
+                                                       , '      K_CELL'                 # noqa
+                                                       , '    </k>'                     # noqa
+                                                       , '    <state>'                  # noqa
+                                                       , '      STATE_CELL'             # noqa
+                                                       , '    </state>'                 # noqa
+                                                       , '  </T>'                       # noqa
+                                                       , '  <generatedCounter>'         # noqa
+                                                       , '    GENERATEDCOUNTER_CELL'    # noqa
+                                                       , '  </generatedCounter>'        # noqa
+                                                       , '</generatedTop>'              # noqa
+                                                       ])                               # noqa
+
+        empty_config_t_printed = '\n'.join([ '<T>'                # noqa
+                                           , '  <k>'              # noqa
+                                           , '    K_CELL'         # noqa
+                                           , '  </k>'             # noqa
+                                           , '  <state>'          # noqa
+                                           , '    STATE_CELL'     # noqa
+                                           , '  </state>'         # noqa
+                                           , '</T>'               # noqa
+                                           ])                     # noqa
+
+        # Then
+        self.assertEqual(empty_config_generated_top_printed, self.kprove.pretty_print(empty_config_generated_top))
+        self.assertEqual(empty_config_t_printed, self.kprove.pretty_print(empty_config_t))

--- a/pyk/src/pyk/integration_tests/test_defn.py
+++ b/pyk/src/pyk/integration_tests/test_defn.py
@@ -7,9 +7,8 @@ from ..kast import (
     assocWithUnit,
     constLabel,
 )
-from ..kastManip import push_down_rewrites, simplifyBool
+from ..kastManip import push_down_rewrites
 from ..ktool import KompileBackend
-from ..prelude import boolToken, intToken
 from .kprove_test import KProveTest
 
 
@@ -74,16 +73,3 @@ class DefnTest(KProveTest):
         # Then
         self.assertEqual(minimized_claim_rewrite_expected, minimized_claim_rewrite_actual)
         self.assertTop(result)
-
-    def test_bool_simplify(self):
-        # Given
-        bool_test_1 = KApply('_andBool_', [boolToken(False), boolToken(True)])
-        bool_test_2 = KApply('_andBool_', [KApply('_==Int_', [intToken(3), intToken(4)]), boolToken(True)])
-
-        # When
-        bool_test_1_simplified = simplifyBool(bool_test_1)
-        bool_test_2_simplified = simplifyBool(bool_test_2)
-
-        # Then
-        self.assertEqual(boolToken(False), bool_test_1_simplified)
-        self.assertEqual(KApply('_==Int_', [intToken(3), intToken(4)]), bool_test_2_simplified)

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1478,6 +1478,10 @@ class KDefinition(KOuter, WithKAtt):
         return self.let(att=att)
 
     @property
+    def module_names(self) -> List[str]:
+        return [_m.name for _m in self.modules]
+
+    @property
     def productions(self) -> List[KProduction]:
         return [prod for module in self.modules for prod in module.productions]
 

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -112,33 +112,33 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
     return _ml_constraint_to_bool(kast)
 
 
-def simplifyBool(k):
+def simplify_bool(k):
     if k is None:
         return None
-    simplifyRules = [ (KApply('_==K_', [KVariable('#LHS'), Bool.true]), KVariable('#LHS'))                                                                      # noqa
-                    , (KApply('_==K_', [Bool.true, KVariable('#RHS')]), KVariable('#RHS'))                                                                      # noqa
-                    , (KApply('_==K_', [KVariable('#LHS'), Bool.false]), Bool.notBool([KVariable('#LHS')]))                                                     # noqa
-                    , (KApply('_==K_', [Bool.false, KVariable('#RHS')]), Bool.notBool([KVariable('#RHS')]))                                                     # noqa
-                    , (Bool.notBool([Bool.false]), Bool.true)                                                                                                   # noqa
-                    , (Bool.notBool([Bool.true]), Bool.false)                                                                                                   # noqa
-                    , (Bool.notBool([KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')]))    # noqa
-                    , (Bool.notBool([KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')]))    # noqa
-                    , (Bool.notBool([KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')]))    # noqa
-                    , (Bool.notBool([KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')]))    # noqa
-                    , (Bool.andBool([Bool.true, KVariable('#REST')]), KVariable('#REST'))                                                                       # noqa
-                    , (Bool.andBool([KVariable('#REST'), Bool.true]), KVariable('#REST'))                                                                       # noqa
-                    , (Bool.andBool([Bool.false, KVariable('#REST')]), Bool.false)                                                                              # noqa
-                    , (Bool.andBool([KVariable('#REST'), Bool.false]), Bool.false)                                                                              # noqa
-                    , (Bool.orBool([Bool.false, KVariable('#REST')]), KVariable('#REST'))                                                                       # noqa
-                    , (Bool.orBool([KVariable('#REST'), Bool.false]), KVariable('#REST'))                                                                       # noqa
-                    , (Bool.orBool([Bool.true, KVariable('#REST')]), Bool.true)                                                                                 # noqa
-                    , (Bool.orBool([KVariable('#REST'), Bool.true]), Bool.true)                                                                                 # noqa
-                    ]                                                                                                                                           # noqa
-    newK = k
-    for rule in simplifyRules:
+    simplify_rules = [ (KApply('_==K_', [KVariable('#LHS'), Bool.true]), KVariable('#LHS'))                                                                     # noqa
+                     , (KApply('_==K_', [Bool.true, KVariable('#RHS')]), KVariable('#RHS'))                                                                     # noqa
+                     , (KApply('_==K_', [KVariable('#LHS'), Bool.false]), Bool.notBool([KVariable('#LHS')]))                                                    # noqa
+                     , (KApply('_==K_', [Bool.false, KVariable('#RHS')]), Bool.notBool([KVariable('#RHS')]))                                                    # noqa
+                     , (Bool.notBool([Bool.false]), Bool.true)                                                                                                  # noqa
+                     , (Bool.notBool([Bool.true]), Bool.false)                                                                                                  # noqa
+                     , (Bool.notBool([KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')]))   # noqa
+                     , (Bool.notBool([KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')]))   # noqa
+                     , (Bool.notBool([KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')]))   # noqa
+                     , (Bool.notBool([KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')]))   # noqa
+                     , (Bool.andBool([Bool.true, KVariable('#REST')]), KVariable('#REST'))                                                                      # noqa
+                     , (Bool.andBool([KVariable('#REST'), Bool.true]), KVariable('#REST'))                                                                      # noqa
+                     , (Bool.andBool([Bool.false, KVariable('#REST')]), Bool.false)                                                                             # noqa
+                     , (Bool.andBool([KVariable('#REST'), Bool.false]), Bool.false)                                                                             # noqa
+                     , (Bool.orBool([Bool.false, KVariable('#REST')]), KVariable('#REST'))                                                                      # noqa
+                     , (Bool.orBool([KVariable('#REST'), Bool.false]), KVariable('#REST'))                                                                      # noqa
+                     , (Bool.orBool([Bool.true, KVariable('#REST')]), Bool.true)                                                                                # noqa
+                     , (Bool.orBool([KVariable('#REST'), Bool.true]), Bool.true)                                                                                # noqa
+                     ]                                                                                                                                          # noqa
+    new_k = k
+    for rule in simplify_rules:
         rewrite = KRewrite(*rule)
-        newK = rewrite(newK)
-    return newK
+        new_k = rewrite(new_k)
+    return new_k
 
 
 def extract_lhs(term: KInner) -> KInner:
@@ -445,10 +445,10 @@ def minimizeRule(rule, keepVars=[]):
     ruleEnsures = rule.ensures
 
     ruleRequires = Bool.andBool(flattenLabel('_andBool_', ruleRequires))
-    ruleRequires = simplifyBool(ruleRequires)
+    ruleRequires = simplify_bool(ruleRequires)
 
     ruleEnsures = Bool.andBool(flattenLabel('_andBool_', ruleEnsures))
-    ruleEnsures = simplifyBool(ruleEnsures)
+    ruleEnsures = simplify_bool(ruleEnsures)
 
     constrainedVars = [] if keepVars is None else keepVars
     constrainedVars = constrainedVars + collectFreeVars(ruleRequires)
@@ -578,8 +578,8 @@ def build_rule(
     (final_config, final_constraint) = split_config_and_constraints(final_term)
 
     rule_body = push_down_rewrites(KRewrite(init_config, final_config))
-    rule_requires = simplifyBool(ml_pred_to_bool(init_constraint))
-    rule_ensures = simplifyBool(ml_pred_to_bool(final_constraint))
+    rule_requires = simplify_bool(ml_pred_to_bool(init_constraint))
+    rule_ensures = simplify_bool(ml_pred_to_bool(final_constraint))
     att_dict = {} if priority is None else {'priority': str(priority)}
     rule_att = KAtt(atts=att_dict)
 

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -15,15 +15,12 @@ from typing import (
 
 from .cterm import CTerm, split_config_and_constraints
 from .kast import (
-    FALSE,
-    TRUE,
     KApply,
     KAtt,
     KClaim,
     KDefinition,
     KFlatModule,
     KInner,
-    KLabel,
     KRewrite,
     KRule,
     KSequence,
@@ -38,10 +35,9 @@ from .kast import (
     top_down,
 )
 from .prelude import (
+    Bool,
     Labels,
     Sorts,
-    boolToken,
-    build_assoc,
     mlAnd,
     mlBottom,
     mlEquals,
@@ -50,7 +46,7 @@ from .prelude import (
     mlOr,
     mlTop,
 )
-from .utils import find_common_items, hash_str, unique
+from .utils import find_common_items, hash_str
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -82,22 +78,22 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
     def _ml_constraint_to_bool(_kast: KInner) -> KInner:
         if type(_kast) is KApply:
             if _kast.label.name == '#Top':
-                return TRUE
+                return Bool.true
             if _kast.label.name == '#Bottom':
-                return FALSE
-            if _kast.label.name == '#Not':
-                return KApply('notBool_', map(_ml_constraint_to_bool, _kast.args))
+                return Bool.false
+            if _kast.label.name == '#Not' and len(_kast.args) == 1:
+                return Bool.notBool(_ml_constraint_to_bool(_kast.args[0]))
             if _kast.label.name == '#And':
-                return KApply('_andBool_', map(_ml_constraint_to_bool, _kast.args))
+                return Bool.andBool(map(_ml_constraint_to_bool, _kast.args))
             if _kast.label.name == '#Or':
-                return KApply('_orBool_', map(_ml_constraint_to_bool, _kast.args))
-            if _kast.label.name == '#Implies':
-                return KApply('_impliesBool_', map(_ml_constraint_to_bool, _kast.args))
+                return Bool.orBool(map(_ml_constraint_to_bool, _kast.args))
+            if _kast.label.name == '#Implies' and len(_kast.args) == 2:
+                return Bool.impliesBool(_ml_constraint_to_bool(_kast.args[0]), _ml_constraint_to_bool(_kast.args[1]))
             if _kast.label.name == '#Equals':
-                if _kast.args[0] == TRUE:
+                if _kast.args[0] == Bool.true:
                     return _kast.args[1]
-                if _kast.args[0] == FALSE:
-                    return KApply(KLabel('notBool_'), [_kast.args[1]])
+                if _kast.args[0] == Bool.false:
+                    return Bool.notBool(_kast.args[1])
                 if type(_kast.args[0]) in [KVariable, KToken]:
                     return KApply('_==K_', _kast.args)
             if unsafe:
@@ -119,25 +115,25 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
 def simplifyBool(k):
     if k is None:
         return None
-    simplifyRules = [ (KApply('_==K_', [KVariable('#LHS'), TRUE]), KVariable('#LHS'))                                                                               # noqa
-                    , (KApply('_==K_', [TRUE, KVariable('#RHS')]), KVariable('#RHS'))                                                                               # noqa
-                    , (KApply('_==K_', [KVariable('#LHS'), FALSE]), KApply('notBool_', [KVariable('#LHS')]))                                                        # noqa
-                    , (KApply('_==K_', [FALSE, KVariable('#RHS')]), KApply('notBool_', [KVariable('#RHS')]))                                                        # noqa
-                    , (KApply('notBool_', [FALSE]), TRUE)                                                                                                           # noqa
-                    , (KApply('notBool_', [TRUE]), FALSE)                                                                                                           # noqa
-                    , (KApply('notBool_', [KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')]))  # noqa
-                    , (KApply('notBool_', [KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')]))  # noqa
-                    , (KApply('notBool_', [KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')]))  # noqa
-                    , (KApply('notBool_', [KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')]))  # noqa
-                    , (KApply('_andBool_', [TRUE, KVariable('#REST')]), KVariable('#REST'))                                                                         # noqa
-                    , (KApply('_andBool_', [KVariable('#REST'), TRUE]), KVariable('#REST'))                                                                         # noqa
-                    , (KApply('_andBool_', [FALSE, KVariable('#REST')]), FALSE)                                                                                     # noqa
-                    , (KApply('_andBool_', [KVariable('#REST'), FALSE]), FALSE)                                                                                     # noqa
-                    , (KApply('_orBool_', [FALSE, KVariable('#REST')]), KVariable('#REST'))                                                                         # noqa
-                    , (KApply('_orBool_', [KVariable('#REST'), FALSE]), KVariable('#REST'))                                                                         # noqa
-                    , (KApply('_orBool_', [TRUE, KVariable('#REST')]), TRUE)                                                                                        # noqa
-                    , (KApply('_orBool_', [KVariable('#REST'), TRUE]), TRUE)                                                                                        # noqa
-                    ]                                                                                                                                               # noqa
+    simplifyRules = [ (KApply('_==K_', [KVariable('#LHS'), Bool.true]), KVariable('#LHS'))                                                                      # noqa
+                    , (KApply('_==K_', [Bool.true, KVariable('#RHS')]), KVariable('#RHS'))                                                                      # noqa
+                    , (KApply('_==K_', [KVariable('#LHS'), Bool.false]), Bool.notBool([KVariable('#LHS')]))                                                     # noqa
+                    , (KApply('_==K_', [Bool.false, KVariable('#RHS')]), Bool.notBool([KVariable('#RHS')]))                                                     # noqa
+                    , (Bool.notBool([Bool.false]), Bool.true)                                                                                                   # noqa
+                    , (Bool.notBool([Bool.true]), Bool.false)                                                                                                   # noqa
+                    , (Bool.notBool([KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')]))    # noqa
+                    , (Bool.notBool([KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')]))    # noqa
+                    , (Bool.notBool([KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')]))    # noqa
+                    , (Bool.notBool([KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')]))    # noqa
+                    , (Bool.andBool([Bool.true, KVariable('#REST')]), KVariable('#REST'))                                                                       # noqa
+                    , (Bool.andBool([KVariable('#REST'), Bool.true]), KVariable('#REST'))                                                                       # noqa
+                    , (Bool.andBool([Bool.false, KVariable('#REST')]), Bool.false)                                                                              # noqa
+                    , (Bool.andBool([KVariable('#REST'), Bool.false]), Bool.false)                                                                              # noqa
+                    , (Bool.orBool([Bool.false, KVariable('#REST')]), KVariable('#REST'))                                                                       # noqa
+                    , (Bool.orBool([KVariable('#REST'), Bool.false]), KVariable('#REST'))                                                                       # noqa
+                    , (Bool.orBool([Bool.true, KVariable('#REST')]), Bool.true)                                                                                 # noqa
+                    , (Bool.orBool([KVariable('#REST'), Bool.true]), Bool.true)                                                                                 # noqa
+                    ]                                                                                                                                           # noqa
     newK = k
     for rule in simplifyRules:
         rewrite = KRewrite(*rule)
@@ -170,7 +166,7 @@ def extract_subst(term: KInner) -> Tuple[Subst, KInner]:
                 if subst is not None:
                     return subst
 
-                if conjunct.args[0] == boolToken(True) and type(conjunct.args[1]) is KApply and conjunct.args[1].label.name in {'_==K_', '_==Int_'}:
+                if conjunct.args[0] == Bool.true and type(conjunct.args[1]) is KApply and conjunct.args[1].label.name in {'_==K_', '_==Int_'}:
                     subst = _subst_for_terms(conjunct.args[1].args[0], conjunct.args[1].args[1])
 
                     if subst is not None:
@@ -448,10 +444,10 @@ def minimizeRule(rule, keepVars=[]):
     ruleRequires = rule.requires
     ruleEnsures = rule.ensures
 
-    ruleRequires = build_assoc(TRUE, '_andBool_', unique(flattenLabel('_andBool_', ruleRequires)))
+    ruleRequires = Bool.andBool(flattenLabel('_andBool_', ruleRequires))
     ruleRequires = simplifyBool(ruleRequires)
 
-    ruleEnsures = build_assoc(TRUE, '_andBool_', unique(flattenLabel('_andBool_', ruleEnsures)))
+    ruleEnsures = Bool.andBool(flattenLabel('_andBool_', ruleEnsures))
     ruleEnsures = simplifyBool(ruleEnsures)
 
     constrainedVars = [] if keepVars is None else keepVars

--- a/pyk/src/pyk/kcfg.py
+++ b/pyk/src/pyk/kcfg.py
@@ -22,8 +22,14 @@ from typing import (
 from graphviz import Digraph
 
 from .cterm import CTerm
-from .kast import KInner, KRuleLike, Subst
-from .kastManip import build_rule, ml_pred_to_bool, mlAnd, simplifyBool
+from .kast import KClaim, KInner, KRule, Subst
+from .kastManip import (
+    build_claim,
+    build_rule,
+    ml_pred_to_bool,
+    mlAnd,
+    simplifyBool,
+)
 from .ktool import KPrint
 from .utils import add_indent, compare_short_hashes, shorten_hash
 
@@ -67,10 +73,15 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Edge', 'KCFG.Cover']]):
         def to_dict(self) -> Dict[str, Any]:
             return {'source': self.source.id, 'target': self.target.id, 'condition': self.condition.to_dict(), 'depth': self.depth}
 
-        def to_rule(self, claim=False, priority=50) -> KRuleLike:
+        def to_rule(self, priority=50) -> KRule:
             sentence_id = f'BASIC-BLOCK-{self.source.id}-TO-{self.target.id}'
-            rule, _ = build_rule(sentence_id, self.source.cterm.add_constraint(self.condition), self.target.cterm, claim=claim, priority=priority)
+            rule, _ = build_rule(sentence_id, self.source.cterm.add_constraint(self.condition), self.target.cterm, priority=priority)
             return rule
+
+        def to_claim(self) -> KClaim:
+            sentence_id = f'BASIC-BLOCK-{self.source.id}-TO-{self.target.id}'
+            claim, _ = build_claim(sentence_id, self.source.cterm.add_constraint(self.condition), self.target.cterm)
+            return claim
 
         def pretty(self, kprint: KPrint) -> Iterable[str]:
             if self.depth == 0:

--- a/pyk/src/pyk/kcfg.py
+++ b/pyk/src/pyk/kcfg.py
@@ -28,7 +28,7 @@ from .kastManip import (
     build_rule,
     ml_pred_to_bool,
     mlAnd,
-    simplifyBool,
+    simplify_bool,
 )
 from .ktool import KPrint
 from .utils import add_indent, compare_short_hashes, shorten_hash
@@ -378,7 +378,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Edge', 'KCFG.Cover']]):
             graph.node(name=node.id, label=label, **attrs)
 
         for edge in self.edges():
-            display_condition = simplifyBool(ml_pred_to_bool(edge.condition))
+            display_condition = simplify_bool(ml_pred_to_bool(edge.condition))
             depth = edge.depth
             label = '\nandBool'.join(kprint.pretty_print(display_condition).split(' andBool'))
             label = f'{label}\n{depth} steps'

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from typing import Callable, Mapping
+from typing import Callable, Dict
 
 from ..kast import (
     TRUE,
@@ -37,7 +37,7 @@ from ..kast import (
 from ..prelude import Labels
 from ..utils import hash_str
 
-SymbolTable = Mapping[str, Callable]
+SymbolTable = Dict[str, Callable]
 
 
 class KPrint:

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -3,7 +3,6 @@ from pathlib import Path
 from typing import Callable, Dict
 
 from ..kast import (
-    TRUE,
     KApply,
     KAs,
     KAst,
@@ -34,7 +33,7 @@ from ..kast import (
     ktokenDots,
     readKastTerm,
 )
-from ..prelude import Labels
+from ..prelude import Bool, Labels
 from ..utils import hash_str
 
 SymbolTable = Dict[str, Callable]
@@ -191,10 +190,10 @@ def prettyPrintKast(kast: KAst, symbol_table: SymbolTable, debug=False):
             ruleStr = ruleStr + '[' + kast.att['label'] + ']:'
         ruleStr = ruleStr + ' ' + body
         attsStr = prettyPrintKast(kast.att, symbol_table, debug=debug)
-        if kast.requires != TRUE:
+        if kast.requires != Bool.true:
             requiresStr = 'requires ' + '\n  '.join(prettyPrintKastBool(kast.requires, symbol_table, debug=debug).split('\n'))
             ruleStr = ruleStr + '\n  ' + requiresStr
-        if kast.ensures != TRUE:
+        if kast.ensures != Bool.true:
             ensuresStr = 'ensures ' + '\n  '.join(prettyPrintKastBool(kast.ensures, symbol_table, debug=debug).split('\n'))
             ruleStr = ruleStr + '\n   ' + ensuresStr
         return ruleStr + '\n  ' + attsStr
@@ -203,7 +202,7 @@ def prettyPrintKast(kast: KAst, symbol_table: SymbolTable, debug=False):
         contextStr = 'context alias ' + body
         requiresStr = ''
         attsStr = prettyPrintKast(kast.att, symbol_table, debug=debug)
-        if kast.requires != TRUE:
+        if kast.requires != Bool.true:
             requiresStr = prettyPrintKast(kast.requires, symbol_table, debug=debug)
             requiresStr = 'requires ' + indent(requiresStr)
         return contextStr + '\n  ' + requiresStr + '\n  ' + attsStr

--- a/pyk/src/pyk/prelude.py
+++ b/pyk/src/pyk/prelude.py
@@ -1,6 +1,7 @@
 from typing import Final, Iterable, Optional, Union, final
 
-from .kast import TRUE, KApply, KInner, KLabel, KSort, KToken
+from .kast import FALSE, TRUE, KApply, KInner, KLabel, KSort, KToken
+from .utils import unique
 
 
 @final
@@ -22,6 +23,36 @@ class Labels:
 
     def __init__(self):
         raise ValueError('Class Labels should not be instantiated')
+
+
+@final
+class Bool:
+
+    true: Final = TRUE
+    false: Final = FALSE
+
+    def __init__(self):
+        raise ValueError('Class Bool should not be instantiated')
+
+    @staticmethod
+    def of(b: bool) -> KToken:
+        return Bool.true if b else Bool.false
+
+    @staticmethod
+    def andBool(items: Iterable[KInner]) -> KInner:
+        return build_assoc(Bool.true, KLabel('_andBool_'), unique(items))
+
+    @staticmethod
+    def orBool(items: Iterable[KInner]) -> KInner:
+        return build_assoc(Bool.false, KLabel('_orBool_'), unique(items))
+
+    @staticmethod
+    def notBool(item: KInner) -> KApply:
+        return KApply(KLabel('notBool_'), [item])
+
+    @staticmethod
+    def impliesBool(antecedent: KInner, consequent: KInner) -> KApply:
+        return KApply(KLabel('_impliesBool_'), [antecedent, consequent])
 
 
 def build_assoc(unit: KInner, label: Union[str, KLabel], terms: Iterable[KInner]) -> KInner:
@@ -50,16 +81,12 @@ def buildCons(unit, cons, ls):
 
 def token(x: Union[bool, int, str]) -> KToken:
     if type(x) is bool:
-        return boolToken(x)
+        return Bool.of(x)
     if type(x) is int:
         return intToken(x)
     if type(x) is str:
         return stringToken(x)
     assert False
-
-
-def boolToken(b: bool) -> KToken:
-    return KToken('true' if b else 'false', Sorts.BOOL)
 
 
 def intToken(i: int) -> KToken:
@@ -84,7 +111,7 @@ def mlEquals(term1: KInner, term2: KInner, sort1: Union[str, KSort] = Sorts.K, s
 
 
 def mlEqualsTrue(term: KInner) -> KApply:
-    return mlEquals(TRUE, term, Sorts.BOOL)
+    return mlEquals(Bool.true, term, Sorts.BOOL)
 
 
 def mlTop(sort: Union[str, KSort] = Sorts.K) -> KApply:

--- a/pyk/src/pyk/tests/test_kast.py
+++ b/pyk/src/pyk/tests/test_kast.py
@@ -1,7 +1,15 @@
 from typing import Final, List, Tuple
 from unittest import TestCase
 
-from ..kast import KApply, KInner, KLabel, KSequence, KVariable
+from ..kast import (
+    KApply,
+    KDefinition,
+    KFlatModule,
+    KInner,
+    KLabel,
+    KSequence,
+    KVariable,
+)
 from ..prelude import Sorts
 
 x, y, z = (KVariable(name) for name in ['x', 'y', 'z'])
@@ -165,3 +173,9 @@ class KSequenceTest(TestCase):
                 # Then
                 actual_message = context.exception.args[0]
                 self.assertEqual(actual_message, expected_message)
+
+
+class KDefinitionTest(TestCase):
+    def test(self):
+        defn = KDefinition('FOO', [KFlatModule('BAR', [], []), KFlatModule('FOO', [], [])])
+        self.assertCountEqual(defn.module_names, ['FOO', 'BAR'])

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -18,9 +18,10 @@ from ..kastManip import (
     ml_pred_to_bool,
     push_down_rewrites,
     remove_generated_cells,
+    simplifyBool,
     substitute,
 )
-from ..prelude import Sorts, intToken, mlEqualsTrue, mlTop
+from ..prelude import Sorts, boolToken, intToken, mlEqualsTrue, mlTop
 from .utils import a, b, c, f, k
 
 x = KVariable('X')
@@ -150,3 +151,19 @@ class CollapseDotsTest(TestCase):
 
         # Then
         self.assertEqual(config_actual, config_expected)
+
+
+class BooleanTest(TestCase):
+
+    def test_bool_simplify(self):
+        # Given
+        bool_test_1 = KApply('_andBool_', [boolToken(False), boolToken(True)])
+        bool_test_2 = KApply('_andBool_', [KApply('_==Int_', [intToken(3), intToken(4)]), boolToken(True)])
+
+        # When
+        bool_test_1_simplified = simplifyBool(bool_test_1)
+        bool_test_2_simplified = simplifyBool(bool_test_2)
+
+        # Then
+        self.assertEqual(boolToken(False), bool_test_1_simplified)
+        self.assertEqual(KApply('_==Int_', [intToken(3), intToken(4)]), bool_test_2_simplified)

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -17,7 +17,7 @@ from ..kastManip import (
     ml_pred_to_bool,
     push_down_rewrites,
     remove_generated_cells,
-    simplifyBool,
+    simplify_bool,
     substitute,
 )
 from ..prelude import Bool, Sorts, intToken, mlEqualsTrue, mlTop
@@ -160,8 +160,8 @@ class BooleanTest(TestCase):
         bool_test_2 = Bool.andBool([KApply('_==Int_', [intToken(3), intToken(4)]), Bool.true])
 
         # When
-        bool_test_1_simplified = simplifyBool(bool_test_1)
-        bool_test_2_simplified = simplifyBool(bool_test_2)
+        bool_test_1_simplified = simplify_bool(bool_test_1)
+        bool_test_2_simplified = simplify_bool(bool_test_2)
 
         # Then
         self.assertEqual(Bool.false, bool_test_1_simplified)

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -2,7 +2,6 @@ from unittest import TestCase
 
 from ..cterm import CTerm
 from ..kast import (
-    TRUE,
     KApply,
     KLabel,
     KRewrite,
@@ -21,7 +20,7 @@ from ..kastManip import (
     simplifyBool,
     substitute,
 )
-from ..prelude import Sorts, boolToken, intToken, mlEqualsTrue, mlTop
+from ..prelude import Bool, Sorts, intToken, mlEqualsTrue, mlTop
 from .utils import a, b, c, f, k
 
 x = KVariable('X')
@@ -98,18 +97,18 @@ class MlPredToBoolTest(TestCase):
     def test_ml_pred_to_bool(self):
         # Given
         test_data = (
-            (False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.GENERATED_TOP_CELL]), [TRUE, f(a)]), f(a)),
-            (False, KApply(KLabel('#Top', [Sorts.BOOL])), TRUE),
-            (False, KApply('#Top'), TRUE),
-            (False, mlTop(), TRUE),
+            (False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.GENERATED_TOP_CELL]), [Bool.true, f(a)]), f(a)),
+            (False, KApply(KLabel('#Top', [Sorts.BOOL])), Bool.true),
+            (False, KApply('#Top'), Bool.true),
+            (False, mlTop(), Bool.true),
             (False, KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
-            (False, KApply(KLabel('#Equals'), [TRUE, f(a)]), f(a)),
+            (False, KApply(KLabel('#Equals'), [Bool.true, f(a)]), f(a)),
             (False, KApply(KLabel('#Equals', [KSort('Int'), Sorts.GENERATED_TOP_CELL]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
-            (False, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [mlTop()]), KApply('notBool_', [TRUE])),
+            (False, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [mlTop()]), Bool.notBool(Bool.true)),
             (True, KApply(KLabel('#Equals'), [f(a), f(x)]), KApply('_==K_', [f(a), f(x)])),
-            (False, KApply(KLabel('#And', [Sorts.GENERATED_TOP_CELL]), [mlEqualsTrue(TRUE), mlEqualsTrue(TRUE)]), KApply('_andBool_', [TRUE, TRUE])),
+            (False, KApply(KLabel('#And', [Sorts.GENERATED_TOP_CELL]), [mlEqualsTrue(Bool.true), mlEqualsTrue(Bool.true)]), Bool.true),
             (True, KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))]), KVariable('Ceil_37f1b5e5')),
-            (True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))])]), KApply('notBool_', [KVariable('Ceil_37f1b5e5')])),
+            (True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))])]), Bool.notBool(KVariable('Ceil_37f1b5e5'))),
             (True, KApply(KLabel('#Exists', [Sorts.INT, Sorts.BOOL]), [KVariable('X'), KApply('_==Int_', [KVariable('X'), KVariable('Y')])]), KVariable('Exists_6acf2557')),
         )
 
@@ -157,13 +156,13 @@ class BooleanTest(TestCase):
 
     def test_bool_simplify(self):
         # Given
-        bool_test_1 = KApply('_andBool_', [boolToken(False), boolToken(True)])
-        bool_test_2 = KApply('_andBool_', [KApply('_==Int_', [intToken(3), intToken(4)]), boolToken(True)])
+        bool_test_1 = Bool.andBool([Bool.false, Bool.true])
+        bool_test_2 = Bool.andBool([KApply('_==Int_', [intToken(3), intToken(4)]), Bool.true])
 
         # When
         bool_test_1_simplified = simplifyBool(bool_test_1)
         bool_test_2_simplified = simplifyBool(bool_test_2)
 
         # Then
-        self.assertEqual(boolToken(False), bool_test_1_simplified)
+        self.assertEqual(Bool.false, bool_test_1_simplified)
         self.assertEqual(KApply('_==Int_', [intToken(3), intToken(4)]), bool_test_2_simplified)

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -154,7 +154,7 @@ class CollapseDotsTest(TestCase):
 
 class BooleanTest(TestCase):
 
-    def test_bool_simplify(self):
+    def test_simplify_bool(self):
         # Given
         bool_test_1 = Bool.andBool([Bool.false, Bool.true])
         bool_test_2 = Bool.andBool([KApply('_==Int_', [intToken(3), intToken(4)]), Bool.true])

--- a/pyk/src/pyk/tests/test_kcfg.py
+++ b/pyk/src/pyk/tests/test_kcfg.py
@@ -2,9 +2,9 @@ from typing import Any, Dict, List, Tuple
 from unittest import TestCase
 
 from ..cterm import CTerm
-from ..kast import TRUE, KApply, KInner, KVariable
+from ..kast import KApply, KInner, KVariable
 from ..kcfg import KCFG
-from ..prelude import mlEquals, token
+from ..prelude import Bool, mlEquals, token
 from ..utils import shorten_hash
 from .mock_kprint import MockKPrint
 
@@ -26,7 +26,7 @@ def node(i: int) -> KCFG.Node:
 
 
 def edge(i: int, j: int) -> KCFG.Edge:
-    return KCFG.Edge(node(i), node(j), TRUE, 1)
+    return KCFG.Edge(node(i), node(j), Bool.true, 1)
 
 
 def node_dicts(n: int) -> List[Dict[str, Any]]:
@@ -35,7 +35,7 @@ def node_dicts(n: int) -> List[Dict[str, Any]]:
 
 def edge_dicts(*edges: Tuple[int, int]) -> List[Dict[str, Any]]:
 
-    def _make_edge_dict(i, j, depth=1, condition=TRUE):
+    def _make_edge_dict(i, j, depth=1, condition=Bool.true):
         return {'source': nid(i), 'target': nid(j), 'condition': condition.to_dict(), 'depth': depth}
 
     return [_make_edge_dict(*edge) for edge in edges]
@@ -43,7 +43,7 @@ def edge_dicts(*edges: Tuple[int, int]) -> List[Dict[str, Any]]:
 
 def cover_dicts(*edges: Tuple[int, int]) -> List[Dict[str, Any]]:
     return [
-        {'source': nid(i), 'target': nid(j), 'condition': TRUE.to_dict(), 'depth': 1}
+        {'source': nid(i), 'target': nid(j), 'condition': Bool.true.to_dict(), 'depth': 1}
         for i, j in edges
     ]
 
@@ -171,7 +171,7 @@ class KCFGTestCase(TestCase):
         cfg = KCFG.from_dict(d)
 
         # When
-        new_edge = cfg.create_edge(nid(0), nid(0), TRUE, 1)
+        new_edge = cfg.create_edge(nid(0), nid(0), Bool.true, 1)
 
         # Then
         self.assertEqual(new_edge, edge(0, 0))
@@ -185,7 +185,7 @@ class KCFGTestCase(TestCase):
         cfg = KCFG.from_dict(d)
 
         # When
-        new_edge = cfg.create_edge(nid(0), nid(1), TRUE, 1)
+        new_edge = cfg.create_edge(nid(0), nid(1), Bool.true, 1)
 
         # Then
         self.assertEqual(new_edge, edge(0, 1))

--- a/pyk/src/pyk/tests/test_pretty_print_kast.py
+++ b/pyk/src/pyk/tests/test_pretty_print_kast.py
@@ -1,30 +1,22 @@
 from typing import Final, Tuple
 from unittest import TestCase
 
-from pyk.kast import (
-    TRUE,
-    KApply,
-    KAst,
-    KLabel,
-    KProduction,
-    KRule,
-    KSort,
-    KTerminal,
-)
+from pyk.kast import KApply, KAst, KLabel, KProduction, KRule, KSort, KTerminal
 from pyk.ktool.kprint import (
     SymbolTable,
     prettyPrintKast,
     unparser_for_production,
 )
+from pyk.prelude import Bool
 
 success_production = KProduction(KSort('EndStatusCode'), [KTerminal('EVMC_SUCCESS')], klabel=KLabel('EVMC_SUCCESS_NETWORK_EndStatusCode'))
 
 
 class PrettyPrintKastTest(TestCase):
     TEST_DATA: Final[Tuple[Tuple[KAst, str], ...]] = (
-        (KRule(TRUE), 'rule  true\n  '),
-        (KRule(TRUE, ensures=TRUE), 'rule  true\n  '),
-        (KRule(TRUE, ensures=KApply('_andBool_', [TRUE, TRUE])), 'rule  true\n   ensures ( true\n   andBool ( true\n           ))\n  '),
+        (KRule(Bool.true), 'rule  true\n  '),
+        (KRule(Bool.true, ensures=Bool.true), 'rule  true\n  '),
+        (KRule(Bool.true, ensures=KApply('_andBool_', [Bool.true, Bool.true])), 'rule  true\n   ensures ( true\n   andBool ( true\n           ))\n  '),
     )
 
     SYMBOL_TABLE: Final[SymbolTable] = {}

--- a/pyk/src/pyk/tests/test_subst.py
+++ b/pyk/src/pyk/tests/test_subst.py
@@ -1,11 +1,9 @@
 from typing import Dict, Final, Tuple
 from unittest import TestCase
 
-from pyk.kast import TRUE
-
 from ..kast import KApply, KInner, KLabel, KVariable, Subst
 from ..kastManip import extract_subst
-from ..prelude import mlAnd, mlEquals, mlEqualsTrue, mlTop, token
+from ..prelude import Bool, mlAnd, mlEquals, mlEqualsTrue, mlTop, token
 from .mock_kprint import MockKPrint
 from .utils import a, b, c, f, g, h, x, y, z
 
@@ -102,7 +100,7 @@ class SubstTest(TestCase):
 
     def test_pretty(self):
         self.assertListEqual(
-            list(Subst({'X': TRUE, 'Y': KApply('_andBool_', [TRUE, TRUE])}).pretty(MockKPrint())),
+            list(Subst({'X': Bool.true, 'Y': KApply('_andBool_', [Bool.true, Bool.true])}).pretty(MockKPrint())),
             ['X |-> true', 'Y |-> _andBool_ ( true , true )']
         )
 


### PR DESCRIPTION
Pulling issue from this list: https://github.com/runtimeverification/ksummarize/issues/82

- Move a test that doesn't actually need a kompiled definition from integration tests to unit tests.
- Adds methods `module_names`, `production_for_klabel`, `production_for_cell_sort`, and `empty_config` to `KDefinition`.
- The type `SymbolTable` is now an alias for `Dict` instead of `Mapping`, which makes it behave nicer when the symbol table needs to be patched.
- Factor out method `build_claim` and `KCFG.Edge.to_claim`, instead of passing a boolean into `build_rule`.
- Adds class `Bool` to the `pyk.prelude`, which has helpers for constructing common `Bool` patterns.
- Rename method `simplifyBool => simplify_bool`.