### PR TITLE
Fix java kore parser

### DIFF
--- a/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/2.kast
+++ b/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/2.kast
@@ -1,0 +1,1 @@
+inj { SortBool { }, SortKItem { } } ( Lblpred1 { } ( \dv { SortInt { } } ( "3" ) ) )

--- a/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/2.kast.out
+++ b/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/2.kast.out
@@ -1,0 +1,1 @@
+pred1(#token("3","Int"))

--- a/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/Makefile
+++ b/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/Makefile
@@ -4,6 +4,7 @@ TESTDIR=.
 KOMPILE_BACKEND=haskell
 KRUN_FLAGS=--output kore
 KOMPILE_FLAGS=--syntax-module TEST
+KAST_FLAGS=--input kore
 
 include ../../../include/kframework/ktest.mak
 # force krun instead of kx

--- a/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/test.k
+++ b/k-distribution/tests/regression-new/issue-1682-korePrettyPrint/test.k
@@ -3,4 +3,5 @@ module TEST
     syntax X ::= "a"
     configuration <k> $PGM:X </k>
     rule <k> a => ?_:Int </k>
+    syntax Bool ::= pred1 ( Int ) [function, functional, klabel(pred1), symbol, no-evaluators]
 endmodule

--- a/kore/src/main/scala/org/kframework/parser/kore/parser/TextToKore.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/parser/TextToKore.scala
@@ -615,7 +615,7 @@ class TextToKore(b: Builders = DefaultBuilders) {
   // Sort = SortVariable | Name { List{Sort, ",", ")"} }
   private def parseSort(parsingLevel: ParsingLevel = both): Sort = {
     val name = parseId(parsingLevel)
-    scanner.next() match {
+    scanner.nextWithSkippingWhitespaces() match {
       case '{' =>
         if (previousParsingLevel == meta) { // name is a meta-level id
           val metalevelSorts = Seq("#Char", "#CharList", "#String", "#Sort", "#SortList",


### PR DESCRIPTION
not being able to parse sort params after whitespace
Fixes: #2762 