### PR TITLE
Upstream `get_basic_block` from ksummarize repo

### DIFF
--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -8,7 +8,7 @@ from graphviz import Digraph
 
 from .coverage import getRuleById, stripCoverageLogger
 from .cterm import split_config_and_constraints
-from .kast import KAst, flattenLabel, readKastTerm
+from .kast import KAst, flatten_label, readKastTerm
 from .kastManip import (
     minimize_term,
     minimizeRule,
@@ -48,7 +48,7 @@ def main():
             if args['minimize']:
                 abstractLabels = [] if args['omit_labels'] is None else args['omit_labels'].split(',')
                 minimizedDisjuncts = []
-                for d in flattenLabel('#Or', term):
+                for d in flatten_label('#Or', term):
                     dMinimized = minimize_term(d, abstract_labels=abstractLabels)
                     dConfig, dConstraint = split_config_and_constraints(dMinimized)
                     if dConstraint != mlTop():

--- a/pyk/src/pyk/cterm.py
+++ b/pyk/src/pyk/cterm.py
@@ -3,13 +3,13 @@ from functools import cached_property
 from itertools import chain
 from typing import Iterable, Optional, Tuple
 
-from .kast import KApply, KInner, Subst, flattenLabel
+from .kast import KApply, KInner, Subst, flatten_label
 from .prelude import Sorts, mlAnd, mlImplies, mlTop
 from .utils import unique
 
 
 def split_config_and_constraints(kast: KInner) -> Tuple[KInner, KInner]:
-    conjuncts = flattenLabel('#And', kast)
+    conjuncts = flatten_label('#And', kast)
     term = None
     constraints = []
     for c in conjuncts:
@@ -31,7 +31,7 @@ class CTerm:
 
     def __init__(self, term: KInner) -> None:
         config, constraint = split_config_and_constraints(term)
-        constraints = CTerm._normalize_constraints(flattenLabel('#And', constraint))
+        constraints = CTerm._normalize_constraints(flatten_label('#And', constraint))
         object.__setattr__(self, 'config', config)
         object.__setattr__(self, 'constraints', constraints)
 

--- a/pyk/src/pyk/integration_tests/test_proofs.py
+++ b/pyk/src/pyk/integration_tests/test_proofs.py
@@ -58,17 +58,29 @@ class ImpProofTest(KProveTest):
 
     def test_get_basic_block(self):
         # Given
-        new_claim = KClaim(KToken('<k> s = 0 ; while ( n > 0 ) { s = s + n ; n = n - 1 ; } => . ... </k> <state> n |-> (N => 0) s |-> (_ => (N *Int (N +Int 1)) /Int 2) </state>', 'KCell'))
+        new_claim = KClaim(KToken('<k> $s = 0 ; while ( 0 <= $n ) { $s = $s + $n ; $n = $n + -1 ; } => . ... </k> <state> $n |-> (N => 0) $s |-> (_ => (N *Int (N +Int 1)) /Int 2) </state>', 'KCell'))
 
         # When
-        post_state = self.kprove.get_basic_block(new_claim, 'imp-spec')
+        post_depth_actual, post_branching_actual, post_state = self.kprove.get_claim_basic_block('imp-basic-block', new_claim)
         post_state_pretty_actual = self.kprove.pretty_print(post_state)
 
-        post_state_pretty_expected = '<generatedTop>\n' +                                                                                                            \
-                                     '  <T>\n' +                                                                                                                     \
-                                     '    <k> if ( N >Int 0 ) { s = s + n ; n = n - 1 ; while ( n > 0 ) { s = s + n ; n = n - 1 ; } } else { } ~> _DotVar0 </k>\n' + \
-                                     '    <state> n |-> N s |-> 0 </state>\n' +                                                                                      \
-                                     '  </T>\n' +                                                                                                                    \
-                                     '</generatedTop>\n'
+        post_depth_expected = 9
+        post_branching_expected = True
+        post_state_pretty_expected = '<generatedTop>\n' +                                                                                                                        \
+                                     '  <T>\n' +                                                                                                                                 \
+                                     '    <k>\n' + \
+                                     '      if ( 0 <=Int N ) { { $s = $s + $n ; $n = $n + -1 ; } while ( 0 <= $n ) { $s = $s + $n ; $n = $n + -1 ; } } else { }\n' + \
+                                     '      ~> _DotVar2\n' + \
+                                     '    </k>\n' + \
+                                     '    <state>\n' + \
+                                     '      $n |-> N $s |-> 0\n' + \
+                                     '    </state>\n' +                                                                                                \
+                                     '  </T>\n' +                                                                                                                                \
+                                     '  <generatedCounter>\n' + \
+                                     '    _DotVar3\n' + \
+                                     '  </generatedCounter>\n' + \
+                                     '</generatedTop>'
 
+        self.assertEqual(post_depth_actual, post_depth_expected)
+        self.assertEqual(post_branching_actual, post_branching_expected)
         self.assertEqual(post_state_pretty_actual, post_state_pretty_expected)

--- a/pyk/src/pyk/integration_tests/test_proofs.py
+++ b/pyk/src/pyk/integration_tests/test_proofs.py
@@ -66,20 +66,20 @@ class ImpProofTest(KProveTest):
 
         post_depth_expected = 9
         post_branching_expected = True
-        post_state_pretty_expected = '<generatedTop>\n' +                                                                                                            \
-                                     '  <T>\n' +                                                                                                                     \
-                                     '    <k>\n' +                                                                                                                   \
-                                     '      if ( 0 <=Int N ) { { $s = $s + $n ; $n = $n + -1 ; } while ( 0 <= $n ) { $s = $s + $n ; $n = $n + -1 ; } } else { }\n' + \
-                                     '      ~> _DotVar2\n' +                                                                                                         \
-                                     '    </k>\n' +                                                                                                                  \
-                                     '    <state>\n' +                                                                                                               \
-                                     '      $n |-> N $s |-> 0\n' +                                                                                                   \
-                                     '    </state>\n' +                                                                                                              \
-                                     '  </T>\n' +                                                                                                                    \
-                                     '  <generatedCounter>\n' +                                                                                                      \
-                                     '    _DotVar3\n' +                                                                                                              \
-                                     '  </generatedCounter>\n' +                                                                                                     \
-                                     '</generatedTop>'
+        post_state_pretty_expected = ('<generatedTop>\n'
+                                      '  <T>\n'
+                                      '    <k>\n'
+                                      '      if ( 0 <=Int N ) { { $s = $s + $n ; $n = $n + -1 ; } while ( 0 <= $n ) { $s = $s + $n ; $n = $n + -1 ; } } else { }\n'
+                                      '      ~> _DotVar2\n'
+                                      '    </k>\n'
+                                      '    <state>\n'
+                                      '      $n |-> N $s |-> 0\n'
+                                      '    </state>\n'
+                                      '  </T>\n'
+                                      '  <generatedCounter>\n'
+                                      '    _DotVar3\n'
+                                      '  </generatedCounter>\n'
+                                      '</generatedTop>')
 
         self.assertEqual(post_depth_actual, post_depth_expected)
         self.assertEqual(post_branching_actual, post_branching_expected)

--- a/pyk/src/pyk/integration_tests/test_proofs.py
+++ b/pyk/src/pyk/integration_tests/test_proofs.py
@@ -42,3 +42,33 @@ class SimpleProofTest(KProveTest):
         with open(rule_profile, 'r') as rp:
             lines = rp.read().split('\n')
             self.assertEqual(len(lines), 4)
+
+
+class ImpProofTest(KProveTest):
+    KOMPILE_MAIN_FILE = 'k-files/imp-verification.k'
+    KOMPILE_BACKEND = KompileBackend.HASKELL
+    KOMPILE_OUTPUT_DIR = 'definitions/imp'
+    KOMPILE_EMIT_JSON = True
+
+    KPROVE_USE_DIR = '.imp'
+
+    @staticmethod
+    def _update_symbol_table(symbol_table):
+        pass
+
+    def test_get_basic_block(self):
+        # Given
+        new_claim = KClaim(KToken('<k> s = 0 ; while ( n > 0 ) { s = s + n ; n = n - 1 ; } => . ... </k> <state> n |-> (N => 0) s |-> (_ => (N *Int (N +Int 1)) /Int 2) </state>', 'KCell'))
+
+        # When
+        post_state = self.kprove.get_basic_block(new_claim, 'imp-spec')
+        post_state_pretty_actual = self.kprove.pretty_print(post_state)
+
+        post_state_pretty_expected = '<generatedTop>\n' +                                                                                                            \
+                                     '  <T>\n' +                                                                                                                     \
+                                     '    <k> if ( N >Int 0 ) { s = s + n ; n = n - 1 ; while ( n > 0 ) { s = s + n ; n = n - 1 ; } } else { } ~> _DotVar0 </k>\n' + \
+                                     '    <state> n |-> N s |-> 0 </state>\n' +                                                                                      \
+                                     '  </T>\n' +                                                                                                                    \
+                                     '</generatedTop>\n'
+
+        self.assertEqual(post_state_pretty_actual, post_state_pretty_expected)

--- a/pyk/src/pyk/integration_tests/test_proofs.py
+++ b/pyk/src/pyk/integration_tests/test_proofs.py
@@ -66,19 +66,19 @@ class ImpProofTest(KProveTest):
 
         post_depth_expected = 9
         post_branching_expected = True
-        post_state_pretty_expected = '<generatedTop>\n' +                                                                                                                        \
-                                     '  <T>\n' +                                                                                                                                 \
-                                     '    <k>\n' + \
+        post_state_pretty_expected = '<generatedTop>\n' +                                                                                                            \
+                                     '  <T>\n' +                                                                                                                     \
+                                     '    <k>\n' +                                                                                                                   \
                                      '      if ( 0 <=Int N ) { { $s = $s + $n ; $n = $n + -1 ; } while ( 0 <= $n ) { $s = $s + $n ; $n = $n + -1 ; } } else { }\n' + \
-                                     '      ~> _DotVar2\n' + \
-                                     '    </k>\n' + \
-                                     '    <state>\n' + \
-                                     '      $n |-> N $s |-> 0\n' + \
-                                     '    </state>\n' +                                                                                                \
-                                     '  </T>\n' +                                                                                                                                \
-                                     '  <generatedCounter>\n' + \
-                                     '    _DotVar3\n' + \
-                                     '  </generatedCounter>\n' + \
+                                     '      ~> _DotVar2\n' +                                                                                                         \
+                                     '    </k>\n' +                                                                                                                  \
+                                     '    <state>\n' +                                                                                                               \
+                                     '      $n |-> N $s |-> 0\n' +                                                                                                   \
+                                     '    </state>\n' +                                                                                                              \
+                                     '  </T>\n' +                                                                                                                    \
+                                     '  <generatedCounter>\n' +                                                                                                      \
+                                     '    _DotVar3\n' +                                                                                                              \
+                                     '  </generatedCounter>\n' +                                                                                                     \
                                      '</generatedTop>'
 
         self.assertEqual(post_depth_actual, post_depth_expected)

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1562,14 +1562,14 @@ def collect(callback: Callable[[KInner], None], kinner: KInner) -> None:
     bottom_up(f, kinner)
 
 
-def flattenLabel(label: str, kast: KInner) -> List[KInner]:
+def flatten_label(label: str, kast: KInner) -> List[KInner]:
     """Given a cons list, return a flat Python list of the elements.
 
     -   Input: Cons operation to flatten.
     -   Output: Items of cons list.
     """
     if type(kast) is KApply and kast.label.name == label:
-        items = [flattenLabel(label, arg) for arg in kast.args]
+        items = [flatten_label(label, arg) for arg in kast.args]
         return [c for cs in items for c in cs]
     return [kast]
 

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -29,7 +29,7 @@ from ..kast import (
     KTerminal,
     KToken,
     KVariable,
-    flattenLabel,
+    flatten_label,
     ktokenDots,
     readKastTerm,
 )
@@ -240,7 +240,7 @@ def prettyPrintKastBool(kast, symbol_table, debug=False):
         sys.stderr.write('\n')
         sys.stderr.flush()
     if type(kast) is KApply and kast.label.name in ['_andBool_', '_orBool_']:
-        clauses = [prettyPrintKastBool(c, symbol_table, debug=debug) for c in flattenLabel(kast.label.name, kast)]
+        clauses = [prettyPrintKastBool(c, symbol_table, debug=debug) for c in flatten_label(kast.label.name, kast)]
         head = kast.label.name.replace('_', ' ')
         if head == ' orBool ':
             head = '  orBool '

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -23,6 +23,7 @@ from ..kast import (
     KRequire,
     KRule,
     KSentence,
+    flatten_label,
 )
 from ..prelude import mlTop
 from ..utils import unique
@@ -216,10 +217,9 @@ class KProve(KPrint):
 
         claim_path, claim_module = self._write_claim_definition(claim, claim_id, lemmas=lemmas)
         log_axioms_file = claim_path.with_suffix('.debug.log')
-        next_states = self.prove(claim_path, spec_module_name=claim_module, args=(args + ['--depth', str(max_depth)]), haskell_args=(['--execute-to-branch'] + haskell_args), log_axioms_file=log_axioms_file)
-        if len(next_states) != 1:
-            raise AssertionError(f'get_basic_block execeted 1 state from Haskell backend, got: {next_states}')
-        next_state = next_states[0]
+        next_state = self.prove(claim_path, spec_module_name=claim_module, args=(args + ['--depth', str(max_depth)]), haskell_args=(['--execute-to-branch'] + haskell_args), log_axioms_file=log_axioms_file)
+        if len(flatten_label('#And', next_state)) != 1:
+            raise AssertionError(f'get_basic_block execeted 1 state from Haskell backend, got: {next_state}')
         with open(log_axioms_file) as lf:
             log_file = lf.readlines()
         depth = -1

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -198,17 +198,17 @@ class KProve(KPrint):
             rule_profile=rule_profile,
         )
 
-    def _write_claim_definition(self, claim, claim_id, lemmas=[], rule=False):
-        tmpClaim = self.use_directory / (claim_id.lower() if rule else (claim_id.lower() + '-spec'))
-        tmpModuleName = claim_id.upper() if rule else (claim_id.upper() + '-SPEC')
-        tmpClaim = tmpClaim.with_suffix('.k')
-        with open(tmpClaim, 'w') as tc:
-            claimModule = KFlatModule(tmpModuleName, lemmas + [claim], imports=[KImport(self.main_module, True)])
-            claimDefinition = KDefinition(tmpModuleName, [claimModule], requires=[KRequire(self.main_file_name)])
+    def _write_claim_definition(self, claim: KClaim, claim_id: str, lemmas: List[KRule] = []):
+        tmp_claim = self.use_directory / (claim_id.lower() + '-spec')
+        tmp_module_name = claim_id.upper() if rule else (claim_id.upper() + '-SPEC')
+        tmp_claim = tmp_claim.with_suffix('.k')
+        with open(tmp_claim, 'w') as tc:
+            claim_module = KFlatModule(tmp_module_name, lemmas + [claim], imports=[KImport(self.main_module, True)])
+            claim_definition = KDefinition(tmp_module_name, [claim_module], requires=[KRequire(self.main_file_name)])
             tc.write(gen_file_timestamp() + '\n')
-            tc.write(self.pretty_print(claimDefinition) + '\n\n')
+            tc.write(self.pretty_print(claim_definition) + '\n\n')
             tc.flush()
-        _LOGGER.debug(f'Wrote claim file: {tmpClaim}.')
+        _LOGGER.debug(f'Wrote claim file: {tmp_claim}.')
 
 
 def _get_rule_profile(debug_log: List[List[Tuple[str, bool, int]]]) -> Mapping[str, Tuple[float, int, float, float, int, float, float]]:


### PR DESCRIPTION
This adds function `KProve.get_claim_basic_block`.

- Method `flattenLabel` is renamed to `_flatten_label`.
- Method `KProve._write_claim_definition` is updated with variable naming scheme, and changed to return both the Path that it wrote the definition to and the main module name.
- First a test is added in the IMP language of getting a basic block of a proof.
- Method `KProve.get_claim_basic_block` is implemented and exercised by the test.

This PR takes the implementation wholesale from ksummarize repo, with the intention of eventually simplifying it via JSON RPC.