### PR TITLE
pyk.kastManip: fix bug in simplify_bool

### DIFF
--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -117,14 +117,14 @@ def simplify_bool(k):
         return None
     simplify_rules = [ (KApply('_==K_', [KVariable('#LHS'), Bool.true]), KVariable('#LHS'))                                                                     # noqa
                      , (KApply('_==K_', [Bool.true, KVariable('#RHS')]), KVariable('#RHS'))                                                                     # noqa
-                     , (KApply('_==K_', [KVariable('#LHS'), Bool.false]), Bool.notBool([KVariable('#LHS')]))                                                    # noqa
-                     , (KApply('_==K_', [Bool.false, KVariable('#RHS')]), Bool.notBool([KVariable('#RHS')]))                                                    # noqa
-                     , (Bool.notBool([Bool.false]), Bool.true)                                                                                                  # noqa
-                     , (Bool.notBool([Bool.true]), Bool.false)                                                                                                  # noqa
-                     , (Bool.notBool([KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')]))   # noqa
-                     , (Bool.notBool([KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')]))   # noqa
-                     , (Bool.notBool([KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')])]), KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')]))   # noqa
-                     , (Bool.notBool([KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')])]), KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')]))   # noqa
+                     , (KApply('_==K_', [KVariable('#LHS'), Bool.false]), Bool.notBool(KVariable('#LHS')))                                                      # noqa
+                     , (KApply('_==K_', [Bool.false, KVariable('#RHS')]), Bool.notBool(KVariable('#RHS')))                                                      # noqa
+                     , (Bool.notBool(Bool.false), Bool.true)                                                                                                    # noqa
+                     , (Bool.notBool(Bool.true), Bool.false)                                                                                                    # noqa
+                     , (Bool.notBool(KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')])), KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')]))     # noqa
+                     , (Bool.notBool(KApply('_=/=K_'   , [KVariable('#V1'), KVariable('#V2')])), KApply('_==K_'    , [KVariable('#V1'), KVariable('#V2')]))     # noqa
+                     , (Bool.notBool(KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')])), KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')]))     # noqa
+                     , (Bool.notBool(KApply('_=/=Int_' , [KVariable('#V1'), KVariable('#V2')])), KApply('_==Int_'  , [KVariable('#V1'), KVariable('#V2')]))     # noqa
                      , (Bool.andBool([Bool.true, KVariable('#REST')]), KVariable('#REST'))                                                                      # noqa
                      , (Bool.andBool([KVariable('#REST'), Bool.true]), KVariable('#REST'))                                                                      # noqa
                      , (Bool.andBool([Bool.false, KVariable('#REST')]), Bool.false)                                                                             # noqa

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -158,6 +158,7 @@ class SimplifyBoolTest(TestCase):
         bool_tests = (
             ('trivial-false', Bool.andBool([Bool.false, Bool.true]), Bool.false),
             ('and-true', Bool.andBool([KApply('_==Int_', [intToken(3), intToken(4)]), Bool.true]), KApply('_==Int_', [intToken(3), intToken(4)])),
+            ('not-false', Bool.notBool(Bool.false), Bool.true),
         )
 
         for test_name, bool_in, bool_out in bool_tests:

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -152,17 +152,14 @@ class CollapseDotsTest(TestCase):
         self.assertEqual(config_actual, config_expected)
 
 
-class BooleanTest(TestCase):
+class SimplifyBoolTest(TestCase):
 
     def test_simplify_bool(self):
-        # Given
-        bool_test_1 = Bool.andBool([Bool.false, Bool.true])
-        bool_test_2 = Bool.andBool([KApply('_==Int_', [intToken(3), intToken(4)]), Bool.true])
+        bool_tests = (
+            ('trivial-false', Bool.andBool([Bool.false, Bool.true]), Bool.false),
+            ('and-true', Bool.andBool([KApply('_==Int_', [intToken(3), intToken(4)]), Bool.true]), KApply('_==Int_', [intToken(3), intToken(4)])),
+        )
 
-        # When
-        bool_test_1_simplified = simplify_bool(bool_test_1)
-        bool_test_2_simplified = simplify_bool(bool_test_2)
-
-        # Then
-        self.assertEqual(Bool.false, bool_test_1_simplified)
-        self.assertEqual(KApply('_==Int_', [intToken(3), intToken(4)]), bool_test_2_simplified)
+        for test_name, bool_in, bool_out in bool_tests:
+            bool_out_actual = simplify_bool(bool_in)
+            self.assertEqual(bool_out_actual, bool_out)


### PR DESCRIPTION
There are several places where `Bool.notBool` is fed a list of arguments instead of a singleton. These are all fixed.