### PR TITLE
pyk: updates to cli_utils, better process management

### DIFF
--- a/pyk/Makefile
+++ b/pyk/Makefile
@@ -70,7 +70,7 @@ test-unit: venv-dev
 test-integration: venv-dev
 	$(ACTIVATE_DEV) && python3 -m unittest discover --verbose --top src pyk.integration_tests $(PYK_TEST_ARGS)
 
-test-pyk: $(VENV_PROD)
+test-pyk: venv-prod
 	$(ACTIVATE_PROD) && $(MAKE) -C pyk-tests
 	rm -rf $(VENV_PROD_DIR) build src/pyk.egg-info
 

--- a/pyk/Makefile
+++ b/pyk/Makefile
@@ -5,7 +5,7 @@ export PATH := $(K_BIN):$(PATH)
 
 
 .PHONY: default all clean install                                  \
-        $(VENV_DEV_DIR) $(VENV_PROD_DIR)                           \
+        venv venv-dev venv-clean                                   \
         test test-unit test-integration test-pyk                   \
         check-code-style isort check-isort check-flake8 check-mypy
 
@@ -13,17 +13,17 @@ default: check-code-style test-unit
 
 all: check-code-style test
 
-clean:
-	rm -rf $(VENV_DEV_DIR) $(VENV_PROD_DIR) definitions build src/pyk.egg-info .myp_cache
+clean: venv-clean
+	rm -rf definitions build src/pyk.egg-info .myp_cache
 	find -type d -name __pycache__ -prune -exec rm -rf {} \;
 	$(MAKE) -C pyk-tests clean
 
 
 # Virtualenv
 
-VENV_DEV_DIR := venv-dev
+VENV_DEV_DIR := build
 VENV_DEV     := $(VENV_DEV_DIR)/pyvenv.cfg
-ACTIVATE_DEV := . $(VENV_DEV_DIR)/bin/activate
+ACTIVATE_DEV := . $(CURDIR)/$(VENV_DEV_DIR)/bin/activate
 
 $(VENV_DEV):
 	   virtualenv -p python3.8 $(VENV_DEV_DIR) \
@@ -36,7 +36,7 @@ $(VENV_DEV_DIR): $(VENV_DEV)
 
 VENV_PROD_DIR := venv-prod
 VENV_PROD     := $(VENV_PROD_DIR)/pyvenv.cfg
-ACTIVATE_PROD := . $(VENV_PROD_DIR)/bin/activate
+ACTIVATE_PROD := . $(CURDIR)/$(VENV_PROD_DIR)/bin/activate
 
 $(VENV_PROD):
 	   virtualenv -p python3.8 $(VENV_PROD_DIR) \
@@ -45,6 +45,14 @@ $(VENV_PROD):
 
 $(VENV_PROD_DIR): $(VENV_PROD)
 	@echo $(ACTIVATE_PROD)
+
+venv: $(VENV_PROD_DIR)
+
+venv-dev: $(VENV_DEV_DIR)
+
+venv-clean:
+	rm -rf $(VENV_PROD_DIR)
+	rm -rf $(VENV_DEV_DIR)
 
 install:
 	pip3 install . --root=$(DESTDIR) --prefix=$(PREFIX)
@@ -56,10 +64,10 @@ PYK_TEST_ARGS :=
 
 test: test-unit test-integration test-pyk
 
-test-unit: $(VENV_DEV)
+test-unit: venv-dev
 	$(ACTIVATE_DEV) && python3 -m unittest discover --verbose --top src pyk.tests $(PYK_TEST_ARGS)
 
-test-integration: $(VENV_DEV)
+test-integration: venv-dev
 	$(ACTIVATE_DEV) && python3 -m unittest discover --verbose --top src pyk.integration_tests $(PYK_TEST_ARGS)
 
 test-pyk: $(VENV_PROD)
@@ -71,15 +79,15 @@ test-pyk: $(VENV_PROD)
 
 check-code-style: check-isort check-flake8 check-mypy
 
-isort: $(VENV_DEV)
+isort: venv-dev
 	$(ACTIVATE_DEV) && isort src
 
-check-isort: $(VENV_DEV)
+check-isort: venv-dev
 	$(ACTIVATE_DEV) && isort --check src
 
-check-flake8: $(VENV_DEV)
+check-flake8: venv-dev
 	$(ACTIVATE_DEV) && flake8 src
 
-check-mypy: $(VENV_DEV)
+check-mypy: venv-dev
 	$(ACTIVATE_DEV) && mypy src
 

--- a/pyk/Makefile
+++ b/pyk/Makefile
@@ -26,8 +26,8 @@ VENV_DEV     := $(VENV_DEV_DIR)/pyvenv.cfg
 ACTIVATE_DEV := . $(CURDIR)/$(VENV_DEV_DIR)/bin/activate
 
 $(VENV_DEV):
-	   virtualenv -p python3.8 $(VENV_DEV_DIR) \
-	&& $(ACTIVATE_DEV)                         \
+	   virtualenv -p python3 $(VENV_DEV_DIR) \
+	&& $(ACTIVATE_DEV)                       \
 	&& pip install -r requirements/dev.txt
 
 $(VENV_DEV_DIR): $(VENV_DEV)
@@ -39,8 +39,8 @@ VENV_PROD     := $(VENV_PROD_DIR)/pyvenv.cfg
 ACTIVATE_PROD := . $(CURDIR)/$(VENV_PROD_DIR)/bin/activate
 
 $(VENV_PROD):
-	   virtualenv -p python3.8 $(VENV_PROD_DIR) \
-	&& $(ACTIVATE_PROD)                         \
+	   virtualenv -p python3 $(VENV_PROD_DIR) \
+	&& $(ACTIVATE_PROD)                       \
 	&& pip install .
 
 $(VENV_PROD_DIR): $(VENV_PROD)

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -102,7 +102,7 @@ def create_argument_parser():
 
     logging_args = argparse.ArgumentParser(add_help=False)
     logging_args.add_argument('-v', '--verbose', action='count', help='Verbosity level, repeat for more verbosity (up to two times).')
-    logging_args.add_argument('--profile', type=bool, default=False, action='store_true', help='Enable coarse-grained process profiling.')
+    logging_args.add_argument('--profile', dest='profile', default=False, action='store_true', help='Enable coarse-grained process profiling.')
 
     definition_args = argparse.ArgumentParser(add_help=False)
     definition_args.add_argument('definition', type=str, help='Kompiled directory for definition.')
@@ -112,7 +112,7 @@ def create_argument_parser():
 
     print_args = pyk_args_command.add_parser('print', help='Pretty print a term.', parents=[logging_args, definition_args])
     print_args.add_argument('term', type=argparse.FileType('r'), help='Input term (in JSON).')
-    print_args.add_argument('--minimize', default=True, action='store_true', help='Minimize the JSON configuration before printing.')
+    print_args.add_argument('--minimize', dest='minimize', default=True, action='store_true', help='Minimize the JSON configuration before printing.')
     print_args.add_argument('--no-minimize', dest='minimize', action='store_false', help='Do not minimize the JSON configuration before printing.')
     print_args.add_argument('--omit-labels', default='', nargs='?', help='List of labels to omit from output.')
     print_args.add_argument('--output-file', type=argparse.FileType('w'), default='-')

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -41,7 +41,7 @@ def main():
         logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT)
 
     if args['command'] == 'print':
-        printer = KPrint(kompiled_dir, profile=args.profile)
+        printer = KPrint(kompiled_dir, profile=args['profile'])
         _LOGGER.info(f'Reading Kast from file: {args["term"].name}')
         term = KAst.from_json(args['term'].read())
         if type(term) is dict and 'term' in term:
@@ -65,13 +65,13 @@ def main():
             _LOGGER.info(f'Wrote file: {args["output_file"].name}')
 
     elif args['command'] == 'prove':
-        kprover = KProve(kompiled_dir, args['main-file'], profile=args.profile)
+        kprover = KProve(kompiled_dir, args['main-file'], profile=args['profile'])
         finalState = kprover.prove(Path(args['spec-file']), spec_module_name=args['spec-module'], args=args['kArgs'])
         args['output_file'].write(finalState.to_json())
         _LOGGER.info(f'Wrote file: {args["output_file"].name}')
 
     elif args['command'] == 'graph-imports':
-        kprinter = KPrint(kompiled_dir, profile=args.profile)
+        kprinter = KPrint(kompiled_dir, profile=args['profile'])
         kDefn = kprinter.definition
         importGraph = Digraph()
         graphFile = kompiled_dir / 'import-graph'

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -41,7 +41,7 @@ def main():
         logging.basicConfig(level=logging.DEBUG, format=_LOG_FORMAT)
 
     if args['command'] == 'print':
-        printer = KPrint(kompiled_dir)
+        printer = KPrint(kompiled_dir, profile=args.profile)
         _LOGGER.info(f'Reading Kast from file: {args["term"].name}')
         term = KAst.from_json(args['term'].read())
         if type(term) is dict and 'term' in term:
@@ -65,13 +65,13 @@ def main():
             _LOGGER.info(f'Wrote file: {args["output_file"].name}')
 
     elif args['command'] == 'prove':
-        kprover = KProve(kompiled_dir, args['main-file'])
+        kprover = KProve(kompiled_dir, args['main-file'], profile=args.profile)
         finalState = kprover.prove(Path(args['spec-file']), spec_module_name=args['spec-module'], args=args['kArgs'])
         args['output_file'].write(finalState.to_json())
         _LOGGER.info(f'Wrote file: {args["output_file"].name}')
 
     elif args['command'] == 'graph-imports':
-        kprinter = KPrint(kompiled_dir)
+        kprinter = KPrint(kompiled_dir, profile=args.profile)
         kDefn = kprinter.definition
         importGraph = Digraph()
         graphFile = kompiled_dir / 'import-graph'
@@ -102,6 +102,7 @@ def create_argument_parser():
 
     logging_args = argparse.ArgumentParser(add_help=False)
     logging_args.add_argument('-v', '--verbose', action='count', help='Verbosity level, repeat for more verbosity (up to two times).')
+    logging_args.add_argument('--profile', type=bool, default=False, action='store_true', help='Enable coarse-grained process profiling.')
 
     definition_args = argparse.ArgumentParser(add_help=False)
     definition_args.add_argument('definition', type=str, help='Kompiled directory for definition.')

--- a/pyk/src/pyk/cli_utils.py
+++ b/pyk/src/pyk/cli_utils.py
@@ -39,6 +39,7 @@ def file_path(s: str) -> Path:
 def run_process(
     args: Union[str, Sequence[str]],
     *,
+    check: bool = True,
     suppress_stderr: bool = False,
     input: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
@@ -55,7 +56,7 @@ def run_process(
     logger.info(f'Running: {command}')
     try:
         stderr = subprocess.PIPE if suppress_stderr else None
-        res = subprocess.run(args, input=input, env=env, stdout=subprocess.PIPE, stderr=stderr, check=True, text=True)
+        res = subprocess.run(args, input=input, env=env, stdout=subprocess.PIPE, stderr=stderr, check=check, text=True)
     except CalledProcessError as err:
         logger.info(f'Completed with status {err.returncode}: {command}')
         raise

--- a/pyk/src/pyk/cli_utils.py
+++ b/pyk/src/pyk/cli_utils.py
@@ -1,6 +1,7 @@
 import logging
 import subprocess
 import sys
+import time
 from datetime import datetime
 from logging import Logger
 from pathlib import Path
@@ -40,6 +41,7 @@ def run_process(
     args: Union[str, Sequence[str]],
     *,
     check: bool = True,
+    profile: bool = False,
     suppress_stderr: bool = False,
     input: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
@@ -56,10 +58,17 @@ def run_process(
     logger.info(f'Running: {command}')
     try:
         stderr = subprocess.PIPE if suppress_stderr else None
+        if profile:
+            start_time = time.time()
         res = subprocess.run(args, input=input, env=env, stdout=subprocess.PIPE, stderr=stderr, check=check, text=True)
     except CalledProcessError as err:
         logger.info(f'Completed with status {err.returncode}: {command}')
         raise
+
+    if profile:
+        stop_time = time.time()
+        delta_time = stop_time - start_time
+        logger.info(f'Timing [{delta_time:.3f}]: {command}')
 
     logger.info(f'Completed: {command}')
     return res

--- a/pyk/src/pyk/cli_utils.py
+++ b/pyk/src/pyk/cli_utils.py
@@ -38,6 +38,7 @@ def run_process(
     args: Union[str, Sequence[str]],
     logger: Logger,
     *,
+    suppress_stderr: bool = False,
     log_level: int = logging.DEBUG,
     input: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
@@ -49,7 +50,8 @@ def run_process(
 
     logger.log(log_level, f'Running: {command}')
     try:
-        res = subprocess.run(args, input=input, env=env, capture_output=True, check=True, text=True)
+        stderr = subprocess.PIPE if suppress_stderr else None
+        res = subprocess.run(args, input=input, env=env, stdout=subprocess.PIPE, stderr=stderr, check=True, text=True)
     except CalledProcessError as err:
         logger.log(log_level, f'Completed with status {err.returncode}: {command}')
         raise

--- a/pyk/src/pyk/cli_utils.py
+++ b/pyk/src/pyk/cli_utils.py
@@ -5,7 +5,9 @@ from datetime import datetime
 from logging import Logger
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
-from typing import Mapping, Optional, Sequence, Union
+from typing import Final, Mapping, Optional, Sequence, Union
+
+_LOGGER: Final = logging.getLogger(__name__)
 
 
 def check_dir_path(path: Path) -> None:
@@ -36,27 +38,29 @@ def file_path(s: str) -> Path:
 
 def run_process(
     args: Union[str, Sequence[str]],
-    logger: Logger,
     *,
     suppress_stderr: bool = False,
-    log_level: int = logging.DEBUG,
     input: Optional[str] = None,
     env: Optional[Mapping[str, str]] = None,
+    logger: Optional[Logger] = None,
 ) -> CompletedProcess:
     if type(args) is str:
         command = args
     else:
         command = ' '.join(args)
 
-    logger.log(log_level, f'Running: {command}')
+    if not logger:
+        logger = _LOGGER
+
+    logger.info(f'Running: {command}')
     try:
         stderr = subprocess.PIPE if suppress_stderr else None
         res = subprocess.run(args, input=input, env=env, stdout=subprocess.PIPE, stderr=stderr, check=True, text=True)
     except CalledProcessError as err:
-        logger.log(log_level, f'Completed with status {err.returncode}: {command}')
+        logger.info(f'Completed with status {err.returncode}: {command}')
         raise
 
-    logger.log(log_level, f'Completed: {command}')
+    logger.info(f'Completed: {command}')
     return res
 
 

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -225,11 +225,16 @@ class Subst(Mapping[str, KInner]):
         return (key + ' |-> ' + kprint.pretty_print(value) for key, value in self.items())
 
     @property
-    def to_ml_pred(self) -> KInner:
-        ml_term: KInner = TRUE
+    def ml_pred(self) -> KInner:
+        items = []
         for k in self:
             if KVariable(k) != self[k]:
-                ml_term = KApply('#And', [ml_term, KApply('#Equals', [KVariable(k), self[k]])])
+                items.append(KApply('#Equals', [KVariable(k), self[k]]))
+        if len(items) == 0:
+            return KApply('#Top')
+        ml_term = items[0]
+        for _i in items[1:]:
+            ml_term = KApply('#And', [ml_term, _i])
         return ml_term
 
 

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -224,6 +224,14 @@ class Subst(Mapping[str, KInner]):
     def pretty(self, kprint) -> Iterable[str]:
         return (key + ' |-> ' + kprint.pretty_print(value) for key, value in self.items())
 
+    @property
+    def to_ml_pred(self) -> KInner:
+        ml_term: KInner = TRUE
+        for k in self:
+            if KVariable(k) != self[k]:
+                ml_term = KApply('#And', [ml_term, KApply('#Equals', [KVariable(k), self[k]])])
+        return ml_term
+
 
 @final
 @dataclass(frozen=True)

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -40,7 +40,6 @@ from .prelude import (
     Sorts,
     mlAnd,
     mlBottom,
-    mlEquals,
     mlEqualsTrue,
     mlImplies,
     mlOr,
@@ -635,8 +634,8 @@ def antiUnifyWithConstraints(constrainedTerm1, constrainedTerm2, implications=Fa
     constraints = [c for c in constraints1 if c in constraints2]
     constraint1 = mlAnd([c for c in constraints1 if c not in constraints])
     constraint2 = mlAnd([c for c in constraints2 if c not in constraints])
-    implication1 = mlImplies(constraint1, substToMlPred(subst1))
-    implication2 = mlImplies(constraint2, substToMlPred(subst2))
+    implication1 = mlImplies(constraint1, subst1.to_ml_pred)
+    implication2 = mlImplies(constraint2, subst2.to_ml_pred)
 
     if implications:
         constraints.append(implication1)
@@ -709,14 +708,6 @@ def matchWithConstraint(constrainedTerm1, constrainedTerm2):
     if subst is not None and constraintSubsume(substitute(constraint1, subst), constraint2):
         return subst
     return None
-
-
-def substToMlPred(subst):
-    mlTerms = []
-    for k in subst:
-        if KVariable(k) != subst[k]:
-            mlTerms.append(mlEquals(KVariable(k), subst[k]))
-    return mlAnd(mlTerms)
 
 
 def undoAliases(definition, kast):

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -68,7 +68,7 @@ def substitute(pattern: KInner, subst: Mapping[str, KInner]) -> KInner:
     return subst(pattern)
 
 
-def bool_to_ml_pred(kast: KInner) -> KInner:
+def bool_ml_pred(kast: KInner) -> KInner:
     return mlAnd([mlEqualsTrue(cond) for cond in flatten_label('_andBool_', kast)])
 
 
@@ -634,8 +634,8 @@ def antiUnifyWithConstraints(constrainedTerm1, constrainedTerm2, implications=Fa
     constraints = [c for c in constraints1 if c in constraints2]
     constraint1 = mlAnd([c for c in constraints1 if c not in constraints])
     constraint2 = mlAnd([c for c in constraints2 if c not in constraints])
-    implication1 = mlImplies(constraint1, subst1.to_ml_pred)
-    implication2 = mlImplies(constraint2, subst2.to_ml_pred)
+    implication1 = mlImplies(constraint1, subst1.ml_pred)
+    implication2 = mlImplies(constraint2, subst2.ml_pred)
 
     if implications:
         constraints.append(implication1)

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -550,7 +550,7 @@ def build_rule(
     final_cterm: CTerm,
     priority: Optional[int] = None,
     keep_vars: Optional[List[str]] = None
-) -> Tuple[KRule, Dict[str, KVariable]]:
+) -> Tuple[KRule, Subst]:
 
     init_config, *init_constraints = init_cterm
     final_config, *final_constraints = final_cterm
@@ -588,7 +588,7 @@ def build_rule(
     new_keep_vars = None
     if keep_vars is not None:
         new_keep_vars = [v_subst[v].name for v in keep_vars]
-    return (minimizeRule(rule, keepVars=new_keep_vars), vremap_subst)
+    return (minimizeRule(rule, keepVars=new_keep_vars), Subst(vremap_subst))
 
 
 def build_claim(
@@ -596,7 +596,7 @@ def build_claim(
     init_cterm: CTerm,
     final_cterm: CTerm,
     keep_vars: Optional[List[str]] = None
-) -> Tuple[KClaim, Dict[str, KVariable]]:
+) -> Tuple[KClaim, Subst]:
     rule, var_map = build_rule(claim_id, init_cterm, final_cterm, keep_vars=keep_vars)
     claim = KClaim(rule.body, requires=rule.requires, ensures=rule.ensures, att=rule.att)
     return claim, var_map

--- a/pyk/src/pyk/ktool/kompile.py
+++ b/pyk/src/pyk/ktool/kompile.py
@@ -20,6 +20,7 @@ class KompileBackend(Enum):
 def kompile(
     main_file: Path,
     *,
+    check: bool = True,
     main_module: Optional[str] = None,
     syntax_module: Optional[str] = None,
     backend: Optional[KompileBackend],
@@ -52,7 +53,7 @@ def kompile(
     )
 
     try:
-        _kompile(str(main_file), *args)
+        _kompile(str(main_file), check=check, *args)
     except CalledProcessError as err:
         raise RuntimeError(f'Command kompile exited with code {err.returncode} for: {main_file}', err.stdout, err.stderr) from err
 
@@ -112,9 +113,9 @@ def _build_arg_list(
     return _args
 
 
-def _kompile(main_file: str, *args: str) -> CompletedProcess:
+def _kompile(main_file: str, *args: str, check: bool = True) -> CompletedProcess:
     run_args = ['kompile', main_file] + list(args)
-    return run_process(run_args, logger=_LOGGER)
+    return run_process(run_args, check=check, logger=_LOGGER)
 
 
 def _kompiled_dir(main_file: Path, output_dir: Optional[Path] = None) -> Path:

--- a/pyk/src/pyk/ktool/kompile.py
+++ b/pyk/src/pyk/ktool/kompile.py
@@ -114,7 +114,7 @@ def _build_arg_list(
 
 def _kompile(main_file: str, *args: str) -> CompletedProcess:
     run_args = ['kompile', main_file] + list(args)
-    return run_process(run_args, _LOGGER)
+    return run_process(run_args, logger=_LOGGER)
 
 
 def _kompiled_dir(main_file: Path, output_dir: Optional[Path] = None) -> Path:

--- a/pyk/src/pyk/ktool/kompile.py
+++ b/pyk/src/pyk/ktool/kompile.py
@@ -21,6 +21,7 @@ def kompile(
     main_file: Path,
     *,
     check: bool = True,
+    profile: bool = False,
     main_module: Optional[str] = None,
     syntax_module: Optional[str] = None,
     backend: Optional[KompileBackend],
@@ -53,7 +54,7 @@ def kompile(
     )
 
     try:
-        _kompile(str(main_file), check=check, *args)
+        _kompile(str(main_file), check=check, profile=profile, *args)
     except CalledProcessError as err:
         raise RuntimeError(f'Command kompile exited with code {err.returncode} for: {main_file}', err.stdout, err.stderr) from err
 
@@ -113,9 +114,9 @@ def _build_arg_list(
     return _args
 
 
-def _kompile(main_file: str, *args: str, check: bool = True) -> CompletedProcess:
+def _kompile(main_file: str, *args: str, check: bool = True, profile: bool = False) -> CompletedProcess:
     run_args = ['kompile', main_file] + list(args)
-    return run_process(run_args, check=check, logger=_LOGGER)
+    return run_process(run_args, logger=_LOGGER, check=check, profile=profile)
 
 
 def _kompiled_dir(main_file: Path, output_dir: Optional[Path] = None) -> Path:

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -51,6 +51,7 @@ SymbolTable = Dict[str, Callable]
 def _kast(
     definition: Path,
     expression: str,
+    check: bool = True,
     input: str = 'program',
     output: str = 'json',
     sort: KSort = Sorts.K,
@@ -61,7 +62,7 @@ def _kast(
     kast_command += ['--sort', sort.name]
     kast_command += ['--expression', expression]
     command_env = os.environ.copy()
-    proc_result = run_process(kast_command, env=command_env, logger=_LOGGER)
+    proc_result = run_process(kast_command, env=command_env, logger=_LOGGER, check=check)
     if proc_result.returncode != 0:
         raise RuntimeError(f'Calling kast failed: {kast_command}')
     return proc_result.stdout

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -61,7 +61,7 @@ def _kast(
     kast_command += ['--sort', sort.name]
     kast_command += ['--expression', expression]
     command_env = os.environ.copy()
-    proc_result = run_process(kast_command, _LOGGER, env=command_env)
+    proc_result = run_process(kast_command, env=command_env, logger=_LOGGER)
     if proc_result.returncode != 0:
         raise RuntimeError(f'Calling kast failed: {kast_command}')
     return proc_result.stdout

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -35,6 +35,7 @@ def kprove(
     spec_file: Path,
     *,
     check: bool = True,
+    profile: bool = False,
     kompiled_dir: Optional[Path] = None,
     include_dirs: Iterable[Path] = (),
     emit_json_spec: Optional[Path] = None,
@@ -53,7 +54,7 @@ def kprove(
     )
 
     try:
-        _kprove(str(spec_file), *args, check=check)
+        _kprove(str(spec_file), *args, check=check, profile=profile)
     except CalledProcessError as err:
         raise RuntimeError(f'Command kprove exited with code {err.returncode} for: {spec_file}', err.stdout, err.stderr) from err
 
@@ -82,9 +83,9 @@ def _build_arg_list(
     return args
 
 
-def _kprove(spec_file: str, *args: str, check: bool = True) -> CompletedProcess:
+def _kprove(spec_file: str, *args: str, check: bool = True, profile: bool = False) -> CompletedProcess:
     run_args = ['kprove', spec_file] + list(args)
-    return run_process(run_args, logger=_LOGGER, check=check)
+    return run_process(run_args, logger=_LOGGER, check=check, profile=profile)
 
 
 class KProve(KPrint):
@@ -95,8 +96,8 @@ class KProve(KPrint):
     backend: str
     main_module: str
 
-    def __init__(self, definition_dir: Path, main_file: Optional[Path] = None, use_directory: Optional[Path] = None):
-        super(KProve, self).__init__(definition_dir, use_directory=use_directory)
+    def __init__(self, definition_dir: Path, main_file: Optional[Path] = None, use_directory: Optional[Path] = None, profile: bool = False):
+        super(KProve, self).__init__(definition_dir, use_directory=use_directory, profile=profile)
         # TODO: we should not have to supply main_file, it should be read
         # TODO: setting use_directory manually should set temp files to not be deleted and a log message
         self.main_file = main_file
@@ -139,7 +140,7 @@ class KProve(KPrint):
         command_env = os.environ.copy()
         command_env['KORE_EXEC_OPTS'] = kore_exec_opts
 
-        proc_result = run_process(command, logger=_LOGGER, env=command_env, check=False)
+        proc_result = run_process(command, logger=_LOGGER, env=command_env, check=False, profile=self._profile)
 
         if not dry_run:
 

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -83,7 +83,7 @@ def _build_arg_list(
 
 def _kprove(spec_file: str, *args: str) -> CompletedProcess:
     run_args = ['kprove', spec_file] + list(args)
-    return run_process(run_args, _LOGGER)
+    return run_process(run_args, logger=_LOGGER)
 
 
 class KProve(KPrint):
@@ -140,7 +140,7 @@ class KProve(KPrint):
 
         proc_output: str
         try:
-            proc_output = run_process(command, _LOGGER, env=command_env).stdout
+            proc_output = run_process(command, logger=_LOGGER, env=command_env).stdout
         except CalledProcessError as err:
             if err.returncode != 1:
                 raise RuntimeError(f'Command kprove exited with code {err.returncode} for: {spec_file}', err.stdout, err.stderr)

--- a/pyk/src/pyk/ktool/krun.py
+++ b/pyk/src/pyk/ktool/krun.py
@@ -27,7 +27,7 @@ def _krun(
         args += ['--depth', str(depth)]
 
     try:
-        return run_process(krun_command + args, _LOGGER)
+        return run_process(krun_command + args, logger=_LOGGER)
     except CalledProcessError as err:
         raise RuntimeError(f'Command krun exited with code {err.returncode} for: {input_file}', err.stdout, err.stderr) from err
 

--- a/pyk/src/pyk/ktool/krun.py
+++ b/pyk/src/pyk/ktool/krun.py
@@ -17,6 +17,7 @@ def _krun(
     definition_dir: Path,
     input_file: Path,
     check: bool = True,
+    profile: bool = True,
     output: str = 'json',
     depth: Optional[int] = None,
     args: List[str] = [],
@@ -29,7 +30,7 @@ def _krun(
         args += ['--depth', str(depth)]
 
     try:
-        return run_process(krun_command + args, logger=_LOGGER, check=check)
+        return run_process(krun_command + args, logger=_LOGGER, check=check, profile=profile)
     except CalledProcessError as err:
         raise RuntimeError(f'Command krun exited with code {err.returncode} for: {input_file}', err.stdout, err.stderr) from err
 
@@ -39,8 +40,8 @@ class KRun(KPrint):
     backend: str
     main_module: str
 
-    def __init__(self, definition_dir: Path, use_directory: Optional[Path] = None) -> None:
-        super(KRun, self).__init__(definition_dir, use_directory=use_directory)
+    def __init__(self, definition_dir: Path, use_directory: Optional[Path] = None, profile: bool = False) -> None:
+        super(KRun, self).__init__(definition_dir, use_directory=use_directory, profile=profile)
         with open(self.definition_dir / 'backend.txt', 'r') as ba:
             self.backend = ba.read()
         with open(self.definition_dir / 'mainModule.txt', 'r') as mm:
@@ -50,7 +51,7 @@ class KRun(KPrint):
         with NamedTemporaryFile('w', dir=self.use_directory, delete=False) as ntf:
             ntf.write(self.pretty_print(init_PGM))
             ntf.flush()
-            result = _krun(self.definition_dir, Path(ntf.name), depth=depth, args=['--output', 'json'])
+            result = _krun(self.definition_dir, Path(ntf.name), depth=depth, args=['--output', 'json'], profile=self._profile)
             if result.returncode != 0:
                 raise RuntimeError('Non-zero exit-code from krun.')
             result_kast = KAst.from_dict(json.loads(result.stdout)['term'])

--- a/pyk/src/pyk/ktool/krun.py
+++ b/pyk/src/pyk/ktool/krun.py
@@ -16,18 +16,20 @@ _LOGGER: Final = logging.getLogger(__name__)
 def _krun(
     definition_dir: Path,
     input_file: Path,
+    check: bool = True,
+    output: str = 'json',
     depth: Optional[int] = None,
     args: List[str] = [],
 ) -> CompletedProcess:
     check_file_path(input_file)
 
-    krun_command = ['krun', '--definition', str(definition_dir), str(input_file)]
+    krun_command = ['krun', '--definition', str(definition_dir), str(input_file), '--output', output]
 
     if depth and depth >= 0:
         args += ['--depth', str(depth)]
 
     try:
-        return run_process(krun_command + args, logger=_LOGGER)
+        return run_process(krun_command + args, logger=_LOGGER, check=check)
     except CalledProcessError as err:
         raise RuntimeError(f'Command krun exited with code {err.returncode} for: {input_file}', err.stdout, err.stderr) from err
 

--- a/pyk/src/pyk/tests/test_subst.py
+++ b/pyk/src/pyk/tests/test_subst.py
@@ -3,7 +3,15 @@ from unittest import TestCase
 
 from ..kast import KApply, KInner, KLabel, KVariable, Subst
 from ..kastManip import extract_subst
-from ..prelude import Bool, mlAnd, mlEquals, mlEqualsTrue, mlTop, token
+from ..prelude import (
+    Bool,
+    intToken,
+    mlAnd,
+    mlEquals,
+    mlEqualsTrue,
+    mlTop,
+    token,
+)
 from .mock_kprint import MockKPrint
 from .utils import a, b, c, f, g, h, x, y, z
 
@@ -103,6 +111,16 @@ class SubstTest(TestCase):
             list(Subst({'X': Bool.true, 'Y': KApply('_andBool_', [Bool.true, Bool.true])}).pretty(MockKPrint())),
             ['X |-> true', 'Y |-> _andBool_ ( true , true )']
         )
+
+    def test_ml_pred(self):
+        subst_pred_pairs = (
+            ('empty', Subst({}), KApply('#Top')),
+            ('singleton', Subst({'X': Bool.true}), KApply('#Equals', [KVariable('X'), Bool.true])),
+            ('double', Subst({'X': Bool.true, 'Y': intToken(4)}), KApply('#And', [KApply('#Equals', [KVariable('X'), Bool.true]), KApply('#Equals', [KVariable('Y'), intToken(4)])])),
+        )
+        for name, subst, pred in subst_pred_pairs:
+            with self.subTest(name):
+                self.assertEqual(subst.ml_pred, pred)
 
 
 class ExtractSubstTest(TestCase):


### PR DESCRIPTION
This PR makes several improvements to `run_process` and associated functions:

- `stderr` is defaulted to being printed on `run_process`, but can be turned off with option `suppress_stderr`.
- Default to `check` being turned on for `run_process`, but allow it to be turned off (needed for kprove, for example).
- `build_rule/build_claim` return a `Subst` instead of a `Dict`.
- Add `Subst.ml_pred` property and removes `kastManip.substToMlPred`, adds test of `Subst.ml_pred`.
- Rename `python3.8` in `Makefile` to `python3`.
- Add standard named targets `venv`, `venv-dev`, and `venv-clean` to the `pyk/Makefile` for consistent development across our repos.