### PR TITLE
pyk/kprove: Remove rule profiling entirely

### DIFF
--- a/pyk/src/pyk/integration_tests/test_kprove.py
+++ b/pyk/src/pyk/integration_tests/test_kprove.py
@@ -29,20 +29,6 @@ class SimpleProofTest(KProveTest):
         self.assertNotTop(result1)
         self.assertTop(result2)
 
-    def test_prove_claim_rule_profile(self):
-        # Given
-        new_lemma = KRule(KToken('pred1(3) => true', Sorts.BOOL), requires=KToken('pred1(4)', Sorts.BOOL), att=KAtt(atts={'simplification': ''}))
-        new_claim = KClaim(KToken('<k> foo => bar ... </k> <state> 3 |-> 3 </state>', 'TCellFragment'), requires=KToken('pred1(4)', Sorts.BOOL))
-        rule_profile = self.KPROVE_USE_DIR + '/rule-profile'
-
-        # When
-        _ = self.kprove.prove_claim(new_claim, 'claim-with-lemma', lemmas=[new_lemma], rule_profile=rule_profile)
-
-        # Then
-        with open(rule_profile, 'r') as rp:
-            lines = rp.read().split('\n')
-            self.assertEqual(len(lines), 4)
-
 
 class ImpProofTest(KProveTest):
     KOMPILE_MAIN_FILE = 'k-files/imp-verification.k'

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -1,10 +1,9 @@
-import csv
 import json
 import logging
 import os
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
-from typing import Dict, Final, Iterable, List, Mapping, Optional, Tuple
+from typing import Final, Iterable, List, Optional, Tuple
 
 from ..cli_utils import (
     check_dir_path,
@@ -116,13 +115,11 @@ class KProve(KPrint):
         log_axioms_file=None,
         allow_zero_step=False,
         dry_run=False,
-        rule_profile=None,
     ):
         log_file = spec_file.with_suffix('.debug-log') if log_axioms_file is None else log_axioms_file
         if log_file.exists():
             log_file.unlink()
         haskell_log_entries += ['DebugTransition']
-        haskell_log_entries += ['DebugAttemptedRewriteRules'] if rule_profile else []
         haskell_log_entries = unique(haskell_log_entries)
         haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(haskell_log_entries)]
         command = [c for c in self.prover]
@@ -147,39 +144,10 @@ class KProve(KPrint):
             proc_output = err.stdout
 
         if not dry_run:
-
             debug_log = _get_rule_log(log_file)
-
             final_state = KAst.from_dict(json.loads(proc_output)['term'])
             if final_state == mlTop() and len(debug_log) == 0 and not allow_zero_step:
                 raise ValueError(f'Proof took zero steps, likely the LHS is invalid: {spec_file}')
-
-            if rule_profile:
-                rule_data = _get_rule_profile(debug_log)
-                table_lines = []
-                total_success_time = 0.0
-                total_failure_time = 0.0
-                total_success_n = 0.0
-                total_failure_n = 0.0
-                for rule_name in rule_data:
-                    table_line = [rule_name, *rule_data[rule_name]]
-                    table_lines.append(table_line)
-                    total_success_time += table_line[1]
-                    total_failure_time += table_line[4]
-                    total_success_n += table_line[2]
-                    total_failure_n += table_line[5]
-                avg_success_time = total_success_time / total_success_n if total_success_n > 0 else 0.0
-                avg_failure_time = total_failure_time / total_failure_n if total_failure_n > 0 else 0.0
-                total_time = total_success_time + total_failure_time
-                productivity = total_success_time / total_time if total_time > 0.0 else 0.0
-                table_lines.append(['TOTAL', total_success_time, total_success_n, avg_success_time, total_failure_time, total_failure_n, avg_failure_time, productivity])
-                table_lines = sorted(table_lines, key=lambda x: x[1] + x[4])
-                with open(rule_profile, 'w') as rp_file:
-                    writer = csv.writer(rp_file)
-                    writer.writerow(('Rule', 'Total Success Time', '# Successes', 'Avg. Success Time', 'Total Failure Time', '# Failures', 'Avg. Failure Time', 'Productivity'))
-                    writer.writerows(table_lines)
-                    _LOGGER.info(f'Wrote rule profile: {rule_profile}')
-
             return final_state
 
     def prove_claim(
@@ -193,7 +161,6 @@ class KProve(KPrint):
         log_axioms_file=None,
         allow_zero_step=False,
         dry_run=False,
-        rule_profile=False,
     ):
         claim_path, claim_module_name = self._write_claim_definition(claim, claim_id, lemmas=lemmas)
         return self.prove(
@@ -205,7 +172,6 @@ class KProve(KPrint):
             log_axioms_file=log_axioms_file,
             allow_zero_step=allow_zero_step,
             dry_run=dry_run,
-            rule_profile=rule_profile,
         )
 
     def get_claim_basic_block(self, claim_id: str, claim: KClaim, lemmas: List[KRule] = [], args: List[str] = [], haskell_args: List[str] = [], max_depth: int = 1000) -> Tuple[int, bool, KInner]:
@@ -262,34 +228,6 @@ class KProve(KPrint):
             tc.flush()
         _LOGGER.info(f'Wrote claim file: {tmp_claim}.')
         return tmp_claim, tmp_module_name
-
-
-def _get_rule_profile(debug_log: List[List[Tuple[str, bool, int]]]) -> Mapping[str, Tuple[float, int, float, float, int, float, float]]:
-
-    def _get_single_rule_profile(_rule_log: List[Tuple[float, bool]]) -> Tuple[float, int, float, float, int, float, float]:
-        success_time = 0.0
-        failure_time = 0.0
-        success_n = 0
-        failure_n = 0
-        for time, success in _rule_log:
-            if success:
-                success_time += time
-                success_n += 1
-            else:
-                failure_time += time
-                failure_n += 1
-        success_avg = success_time / success_n if success_n > 0 else 0.0
-        failure_avg = failure_time / failure_n if failure_n > 0 else 0.0
-        productivity = success_time / (success_time + failure_time)
-        return (success_time, success_n, success_avg, failure_time, failure_n, failure_avg, productivity)
-
-    rule_data: Dict[str, List[Tuple[float, bool]]] = {}
-    for rule_name, apply_success, apply_time in [rl for rls in debug_log for rl in rls]:
-        if rule_name not in rule_data:
-            rule_data[rule_name] = []
-        rule_data[rule_name].append((apply_time, apply_success))
-
-    return {rule_name: _get_single_rule_profile(rule_data[rule_name]) for rule_name in rule_data}
 
 
 def _get_rule_log(debug_log_file: Path) -> List[List[Tuple[str, bool, int]]]:


### PR DESCRIPTION
The rule profiling code is a big ugly beast that only was used to find out that KEVM is being very unproductive when applying rules. We should remove it, so we don't have to commit to supporting it.