### PR TITLE
[pyk] Upstream KProve.prove_cterm and KPrint.parse_token

### DIFF
--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -15,7 +15,8 @@ from .kastManip import (
     propagate_up_constraints,
     removeSourceMap,
 )
-from .ktool import KPrint, KProve, build_symbol_table, pretty_print_kast
+from .ktool import KPrint, KProve
+from .ktool.kprint import build_symbol_table, pretty_print_kast
 from .prelude import Sorts, mlAnd, mlOr, mlTop
 
 _LOG_FORMAT: Final = '%(levelname)s %(asctime)s %(name)s - %(message)s'

--- a/pyk/src/pyk/integration_tests/kprove_test.py
+++ b/pyk/src/pyk/integration_tests/kprove_test.py
@@ -7,9 +7,6 @@ from typing import Iterable
 
 from pyk.ktool import KProve
 
-from ..kast import KInner
-from ..ktool import KProve
-from ..prelude import mlTop
 from .kompiled_test import KompiledTest
 
 

--- a/pyk/src/pyk/integration_tests/kprove_test.py
+++ b/pyk/src/pyk/integration_tests/kprove_test.py
@@ -7,6 +7,9 @@ from typing import Iterable
 
 from pyk.ktool import KProve
 
+from ..kast import KInner
+from ..ktool import KProve
+from ..prelude import mlTop
 from .kompiled_test import KompiledTest
 
 

--- a/pyk/src/pyk/integration_tests/test_emit_json_spec.py
+++ b/pyk/src/pyk/integration_tests/test_emit_json_spec.py
@@ -3,7 +3,8 @@ from pathlib import Path
 
 from ..kast import EMPTY_ATT, KAst, KDefinition, KFlatModuleList, KRequire
 from ..kastManip import remove_generated_cells
-from ..ktool import KompileBackend, _kprove
+from ..ktool import KompileBackend
+from ..ktool.kprove import _kprove
 from .kprove_test import KProveTest
 
 

--- a/pyk/src/pyk/integration_tests/test_emit_json_spec.py
+++ b/pyk/src/pyk/integration_tests/test_emit_json_spec.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 from ..kast import EMPTY_ATT, KAst, KDefinition, KFlatModuleList, KRequire
 from ..kastManip import remove_generated_cells
-from ..ktool import KompileBackend, kprove
+from ..ktool import KompileBackend, _kprove
 from .kprove_test import KProveTest
 
 
@@ -25,7 +25,7 @@ class EmitJsonSpecTest(KProveTest):
 
         spec_file = Path(self.SPEC_FILE)
         emit_json_spec = Path(self.SPEC_JSON_FILE)
-        kprove(spec_file, kompiled_dir=self.KOMPILE_OUTPUT_DIR, emit_json_spec=emit_json_spec, dry_run=True)
+        _kprove(spec_file, kompiled_dir=self.KOMPILE_OUTPUT_DIR, emit_json_spec=emit_json_spec, dry_run=True)
 
         with open(self.SPEC_JSON_FILE, 'r') as spec_file:
             kfml: KFlatModuleList = KAst.from_dict(json.load(spec_file)['term'])

--- a/pyk/src/pyk/integration_tests/test_kore_to_kast.py
+++ b/pyk/src/pyk/integration_tests/test_kore_to_kast.py
@@ -1,7 +1,7 @@
 from ..kast import KApply
 from ..kore.syntax import DV, App, SortApp, String
 from ..ktool import KompileBackend
-from ..prelude import Labels, intToken
+from ..prelude import intToken
 from .kprove_test import KProveTest
 
 
@@ -20,7 +20,7 @@ class KoreToKastTest(KProveTest):
     def test_kast_to_kore(self):
         kore_kast_pairs = (
             ('issue:k/2762', App('inj', [SortApp('SortBool'), SortApp('SortKItem')], [App('Lblpred1', [], [DV(SortApp('SortInt'), String('3'))])]), KApply('pred1', [intToken(3)])),
-            ('cells-conversion', App("Lbl'-LT-'k'-GT-'", [], [App('EmptyK', [], [])]), KApply('<k>', [KApply(Labels.EMPTY_K)])),
+            # TODO: ('cells-conversion', App("Lbl'-LT-'k'-GT-'", [], [App('EmptyK', [], [])]), KApply('<k>', [KApply(Labels.EMPTY_K)])),
         )
         for (name, kore, kast) in kore_kast_pairs:
             with self.subTest(name):

--- a/pyk/src/pyk/integration_tests/test_kore_to_kast.py
+++ b/pyk/src/pyk/integration_tests/test_kore_to_kast.py
@@ -1,7 +1,7 @@
 from ..kast import KApply
 from ..kore.syntax import DV, App, SortApp, String
 from ..ktool import KompileBackend
-from ..prelude import intToken
+from ..prelude import Labels, intToken
 from .kprove_test import KProveTest
 
 
@@ -20,6 +20,7 @@ class KoreToKastTest(KProveTest):
     def test_kast_to_kore(self):
         kore_kast_pairs = (
             ('issue:k/2762', App('inj', [SortApp('SortBool'), SortApp('SortKItem')], [App('Lblpred1', [], [DV(SortApp('SortInt'), String('3'))])]), KApply('pred1', [intToken(3)])),
+            ('cells-conversion', App("Lbl'-LT-'k'-GT-'", [], [App('EmptyK', [], [])]), KApply('<k>', [KApply(Labels.EMPTY_K)])),
         )
         for (name, kore, kast) in kore_kast_pairs:
             with self.subTest(name):

--- a/pyk/src/pyk/integration_tests/test_kprint.py
+++ b/pyk/src/pyk/integration_tests/test_kprint.py
@@ -1,4 +1,4 @@
-from ..kast import KApply, KToken
+from ..kast import KApply, KToken, KVariable
 from ..ktool import KompileBackend
 from ..prelude import intToken
 from .kprove_test import KProveTest
@@ -21,6 +21,7 @@ class ImpParseTest(KProveTest):
             ('int-token', KToken('3', 'Int'), intToken(3)),
             ('id-token', KToken('abc', 'Id'), KToken('abc', 'Id')),
             ('add-aexp', KToken('3 + 4', 'AExp'), KApply('_+_', [intToken(3), intToken(4)])),
+            # TODO: ('add-int', KToken('3 +Int V', 'Int'), KApply('_+Int_', [intToken(3), KVariable('V')])),
             # TODO: ('k-cell', KToken('<k> . </k>', 'KCell'), KApply('<k>', [KApply(Labels.EMPTY_K)])),
         )
 

--- a/pyk/src/pyk/integration_tests/test_kprint.py
+++ b/pyk/src/pyk/integration_tests/test_kprint.py
@@ -1,0 +1,29 @@
+from ..kast import KApply, KToken
+from ..ktool import KompileBackend
+from ..prelude import intToken
+from .kprove_test import KProveTest
+
+
+class ImpParseTest(KProveTest):
+    KOMPILE_MAIN_FILE = 'k-files/imp.k'
+    KOMPILE_BACKEND = KompileBackend.HASKELL
+    KOMPILE_OUTPUT_DIR = 'definitions/imp'
+    KOMPILE_EMIT_JSON = True
+
+    KPROVE_USE_DIR = '.imp'
+
+    @staticmethod
+    def _update_symbol_table(symbol_table):
+        pass
+
+    def test_parse_token(self):
+        test_parses = (
+            ('int-token', KToken('3', 'Int'), intToken(3)),
+            ('id-token', KToken('abc', 'Id'), KToken('abc', 'Id')),
+            ('add-aexp', KToken('3 + 4', 'AExp'), KApply('_+_', [intToken(3), intToken(4)])),
+        )
+
+        for name, token, kast in test_parses:
+            with self.subTest(name):
+                actual_kast = self.kprove.parse_token(token)
+                self.assertEqual(actual_kast, kast)

--- a/pyk/src/pyk/integration_tests/test_kprint.py
+++ b/pyk/src/pyk/integration_tests/test_kprint.py
@@ -1,6 +1,6 @@
 from ..kast import KApply, KToken
 from ..ktool import KompileBackend
-from ..prelude import intToken
+from ..prelude import Labels, intToken
 from .kprove_test import KProveTest
 
 
@@ -21,6 +21,7 @@ class ImpParseTest(KProveTest):
             ('int-token', KToken('3', 'Int'), intToken(3)),
             ('id-token', KToken('abc', 'Id'), KToken('abc', 'Id')),
             ('add-aexp', KToken('3 + 4', 'AExp'), KApply('_+_', [intToken(3), intToken(4)])),
+            ('k-cell', KToken('<k> . </k>', 'KCell'), KApply('<k>', [KApply(Labels.EMPTY_K)])),
         )
 
         for name, token, kast in test_parses:

--- a/pyk/src/pyk/integration_tests/test_kprint.py
+++ b/pyk/src/pyk/integration_tests/test_kprint.py
@@ -1,4 +1,4 @@
-from ..kast import KApply, KToken, KVariable
+from ..kast import KApply, KToken
 from ..ktool import KompileBackend
 from ..prelude import intToken
 from .kprove_test import KProveTest

--- a/pyk/src/pyk/integration_tests/test_kprint.py
+++ b/pyk/src/pyk/integration_tests/test_kprint.py
@@ -1,6 +1,6 @@
 from ..kast import KApply, KToken
 from ..ktool import KompileBackend
-from ..prelude import Labels, intToken
+from ..prelude import intToken
 from .kprove_test import KProveTest
 
 
@@ -21,7 +21,7 @@ class ImpParseTest(KProveTest):
             ('int-token', KToken('3', 'Int'), intToken(3)),
             ('id-token', KToken('abc', 'Id'), KToken('abc', 'Id')),
             ('add-aexp', KToken('3 + 4', 'AExp'), KApply('_+_', [intToken(3), intToken(4)])),
-            ('k-cell', KToken('<k> . </k>', 'KCell'), KApply('<k>', [KApply(Labels.EMPTY_K)])),
+            # TODO: ('k-cell', KToken('<k> . </k>', 'KCell'), KApply('<k>', [KApply(Labels.EMPTY_K)])),
         )
 
         for name, token, kast in test_parses:

--- a/pyk/src/pyk/integration_tests/test_kprove.py
+++ b/pyk/src/pyk/integration_tests/test_kprove.py
@@ -94,7 +94,7 @@ class ImpProofTest(KProveTest):
 
         pre_state = '.Map'
         post_k = '.'
-        post_state = 'POST_STATE_MAP'
+        post_state = '?_POST_STATE_MAP'
 
         test_data = (
             ('simple-step', ['--depth', '1'], 'int $n , $s ; $n = 3 ;', [('.', '.Map')]),

--- a/pyk/src/pyk/integration_tests/test_kprove.py
+++ b/pyk/src/pyk/integration_tests/test_kprove.py
@@ -29,20 +29,6 @@ class SimpleProofTest(KProveTest):
         self.assertNotTop(result1)
         self.assertTop(result2)
 
-    def test_prove_claim_rule_profile(self):
-        # Given
-        new_lemma = KRule(KToken('pred1(3) => true', Sorts.BOOL), requires=KToken('pred1(4)', Sorts.BOOL), att=KAtt(atts={'simplification': ''}))
-        new_claim = KClaim(KToken('<k> foo => bar ... </k> <state> 3 |-> 3 </state>', 'TCellFragment'), requires=KToken('pred1(4)', Sorts.BOOL))
-        rule_profile = self.KPROVE_USE_DIR + '/rule-profile'
-
-        # When
-        _ = self.kprove.prove_claim(new_claim, 'claim-with-lemma', lemmas=[new_lemma], rule_profile=rule_profile)
-
-        # Then
-        with open(rule_profile, 'r') as rp:
-            lines = rp.read().split('\n')
-            self.assertEqual(len(lines), 4)
-
 
 class ImpProofTest(KProveTest):
     KOMPILE_MAIN_FILE = 'k-files/imp-verification.k'

--- a/pyk/src/pyk/ktool/__init__.py
+++ b/pyk/src/pyk/ktool/__init__.py
@@ -1,13 +1,4 @@
 from .kompile import KompileBackend, kompile
-from .kprint import (
-    KPrint,
-    _kast,
-    applied_label_str,
-    build_symbol_table,
-    indent,
-    paren,
-    pretty_print_kast,
-    unparser_for_production,
-)
-from .kprove import KProve, _kprove
-from .krun import KRun, _krun
+from .kprint import KPrint
+from .kprove import KProve
+from .krun import KRun

--- a/pyk/src/pyk/ktool/__init__.py
+++ b/pyk/src/pyk/ktool/__init__.py
@@ -9,5 +9,5 @@ from .kprint import (
     pretty_print_kast,
     unparser_for_production,
 )
-from .kprove import KProve, kprove
+from .kprove import KProve, _kprove
 from .krun import KRun, _krun

--- a/pyk/src/pyk/ktool/__init__.py
+++ b/pyk/src/pyk/ktool/__init__.py
@@ -9,5 +9,5 @@ from .kprint import (
     pretty_print_kast,
     unparser_for_production,
 )
-from .kprove import KProve, _kprove
+from .kprove import KProve, kprove
 from .krun import KRun, _krun

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -18,6 +18,7 @@ from ..kast import (
     KDefinition,
     KFlatModule,
     KImport,
+    KInner,
     KNonTerminal,
     KProduction,
     KRegexTerminal,
@@ -90,6 +91,12 @@ class KPrint:
         self.symbol_table = build_symbol_table(self.definition, opinionated=True)
         self.definition_hash = hash_str(self.definition)
         self._profile = profile
+
+    def parse_token(self, ktoken: KToken) -> KInner:
+        output = _kast(self.definition_dir, ktoken.token, sort=ktoken.sort)
+        kast_token = KAst.from_dict(json.loads(output)['term'])
+        assert isinstance(kast_token, KInner)
+        return kast_token
 
     def kore_to_kast(self, kore: Kore) -> KAst:
         output = _kast(self.definition_dir, kore.text, input='kore', output='json', profile=self._profile)

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -93,7 +93,7 @@ class KPrint:
         self._profile = profile
 
     def parse_token(self, ktoken: KToken) -> KInner:
-        output = _kast(self.definition_dir, ktoken.token, sort=ktoken.sort)
+        output = _kast(self.definition_dir, ktoken.token, sort=ktoken.sort, profile=self._profile)
         kast_token = KAst.from_dict(json.loads(output)['term'])
         assert isinstance(kast_token, KInner)
         return kast_token

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -206,6 +206,9 @@ class KProve(KPrint):
             rule_profile=rule_profile,
         )
 
+    # TODO: This should return the empty disjunction `[]` instead of `#Top`.
+    # The prover should never return #Bottom, so we can ignore that case.
+    # Once those are taken care of, we can change the return type to a CTerm
     def prove_cterm(
         self,
         claim_id: str,
@@ -221,7 +224,7 @@ class KProve(KPrint):
         next_state = self.prove_claim(claim, claim_id, lemmas=lemmas, args=args, haskell_args=haskell_args, log_axioms_file=log_axioms_file, allow_zero_step=allow_zero_step)
         next_states = [var_map(ns) for ns in flatten_label('#Or', next_state)]
         constraint_subst, _ = extract_subst(init_cterm.term)
-        next_states = [mlAnd([constraint_subst.unapply(ns), constraint_subst.to_ml_pred]) if ns not in [mlTop(), mlBottom()] else ns for ns in next_states]
+        next_states = [mlAnd([constraint_subst.unapply(ns), constraint_subst.ml_pred]) if ns not in [mlTop(), mlBottom()] else ns for ns in next_states]
         return next_states
 
     def get_claim_basic_block(self, claim_id: str, claim: KClaim, lemmas: List[KRule] = [], args: List[str] = [], haskell_args: List[str] = [], max_depth: int = 1000) -> Tuple[int, bool, KInner]:

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -108,23 +108,24 @@ class KProve(KPrint):
 
     def prove(
         self,
-        spec_file,
-        spec_module_name=None,
-        args=[],
-        haskell_args=[],
-        haskell_log_entries=[],
-        log_axioms_file=None,
-        allow_zero_step=False,
-        dry_run=False,
-        rule_profile=None,
+        spec_file: Path,
+        spec_module_name: Optional[str] = None,
+        args: Iterable[str] = (),
+        haskell_args: Iterable[str] = (),
+        haskell_log_entries: Iterable[str] = (),
+        log_axioms_file: Optional[Path] = None,
+        allow_zero_step: bool = False,
+        dry_run: bool = False,
+        rule_profile: Optional[Path] = None,
     ):
         log_file = spec_file.with_suffix('.debug-log') if log_axioms_file is None else log_axioms_file
         if log_file.exists():
             log_file.unlink()
-        haskell_log_entries += ['DebugTransition']
-        haskell_log_entries += ['DebugAttemptedRewriteRules'] if rule_profile else []
-        haskell_log_entries = unique(haskell_log_entries)
-        haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(haskell_log_entries)]
+        _haskell_log_entries = list(haskell_log_entries)
+        _haskell_log_entries += ['DebugTransition']
+        _haskell_log_entries += ['DebugAttemptedRewriteRules'] if rule_profile else []
+        _haskell_log_entries = list(unique(_haskell_log_entries))
+        _haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(_haskell_log_entries)]
         command = [c for c in self.prover]
         command += [str(spec_file)]
         command += ['--definition', str(self.definition_dir), '--output', 'json']
@@ -133,7 +134,7 @@ class KProve(KPrint):
         command += [c for c in self.prover_args]
         command += args
 
-        kore_exec_opts = ' '.join(haskell_args + haskell_log_args)
+        kore_exec_opts = ' '.join(list(haskell_args) + _haskell_log_args)
         _LOGGER.debug(f'export KORE_EXEC_OPTS="{kore_exec_opts}"')
         command_env = os.environ.copy()
         command_env['KORE_EXEC_OPTS'] = kore_exec_opts

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -33,7 +33,7 @@ from .kprint import KPrint
 _LOGGER: Final = logging.getLogger(__name__)
 
 
-def kprove(
+def _kprove(
     spec_file: Path,
     *,
     check: bool = True,
@@ -42,7 +42,7 @@ def kprove(
     include_dirs: Iterable[Path] = (),
     emit_json_spec: Optional[Path] = None,
     dry_run=False,
-) -> None:
+) -> CompletedProcess:
     check_file_path(spec_file)
 
     for include_dir in include_dirs:
@@ -56,7 +56,8 @@ def kprove(
     )
 
     try:
-        _kprove(str(spec_file), *args, check=check, profile=profile)
+        run_args = [str(_a) for _a in ['kprove', spec_file] + list(args)]
+        return run_process(run_args, logger=_LOGGER, check=check, profile=profile)
     except CalledProcessError as err:
         raise RuntimeError(f'Command kprove exited with code {err.returncode} for: {spec_file}', err.stdout, err.stderr) from err
 
@@ -83,11 +84,6 @@ def _build_arg_list(
         args.append('--dry-run')
 
     return args
-
-
-def _kprove(spec_file: str, *args: str, check: bool = True, profile: bool = False) -> CompletedProcess:
-    run_args = ['kprove', spec_file] + list(args)
-    return run_process(run_args, logger=_LOGGER, check=check, profile=profile)
 
 
 class KProve(KPrint):

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -33,51 +33,61 @@ from .kprint import KPrint
 _LOGGER: Final = logging.getLogger(__name__)
 
 
-def _kprove(
-    definition_dir: Path,
+def kprove(
     spec_file: Path,
     *,
     check: bool = True,
     profile: bool = False,
-    output: str = 'json',
-    main_module: Optional[str] = None,
-    spec_module: Optional[str] = None,
+    kompiled_dir: Optional[Path] = None,
     include_dirs: Iterable[Path] = (),
     emit_json_spec: Optional[Path] = None,
     dry_run=False,
-    args: List[str] = [],
-    kore_exec_args: List[str] = [],
-) -> CompletedProcess:
+) -> None:
     check_file_path(spec_file)
 
     for include_dir in include_dirs:
         check_dir_path(include_dir)
 
-    kprove_command = ['kprove', str(spec_file), '--definition', str(definition_dir), '--output', output]
-
-    if main_module is not None:
-        kprove_command += ['--main-module', main_module]
-
-    if spec_module is not None:
-        kprove_command += ['--spec-module', spec_module]
-
-    for include_dir in include_dirs:
-        kprove_command += ['-I', str(include_dir)]
-
-    if emit_json_spec:
-        kprove_command += ['--emit-json-spec', str(emit_json_spec)]
-
-    if dry_run:
-        kprove_command.append('--dry-run')
-
-    if kore_exec_args:
-        os.environ['KORE_EXEC_OPTS'] = ' '.join(kore_exec_args)
-        _LOGGER.info(f'export KORE_EXEC_OPTS="{kore_exec_args}"')
+    args = _build_arg_list(
+        kompiled_dir=kompiled_dir,
+        include_dirs=include_dirs,
+        dry_run=dry_run,
+        emit_json_spec=emit_json_spec,
+    )
 
     try:
-        return run_process(kprove_command + args, logger=_LOGGER, check=check, profile=profile)
+        _kprove(str(spec_file), *args, check=check, profile=profile)
     except CalledProcessError as err:
-        raise RuntimeError(f'Command kprove exited with code {err.returncode} for: {spec_file}', err.stdout, err.stderr)
+        raise RuntimeError(f'Command kprove exited with code {err.returncode} for: {spec_file}', err.stdout, err.stderr) from err
+
+
+def _build_arg_list(
+    *,
+    kompiled_dir: Optional[Path],
+    include_dirs: Iterable[Path],
+    emit_json_spec: Optional[Path],
+    dry_run: bool,
+) -> List[str]:
+    args = []
+
+    if kompiled_dir:
+        args += ['--definition', str(kompiled_dir)]
+
+    for include_dir in include_dirs:
+        args += ['-I', str(include_dir)]
+
+    if emit_json_spec:
+        args += ['--emit-json-spec', str(emit_json_spec)]
+
+    if dry_run:
+        args.append('--dry-run')
+
+    return args
+
+
+def _kprove(spec_file: str, *args: str, check: bool = True, profile: bool = False) -> CompletedProcess:
+    run_args = ['kprove', spec_file] + list(args)
+    return run_process(run_args, logger=_LOGGER, check=check, profile=profile)
 
 
 class KProve(KPrint):
@@ -93,6 +103,7 @@ class KProve(KPrint):
         # TODO: we should not have to supply main_file, it should be read
         # TODO: setting use_directory manually should set temp files to not be deleted and a log message
         self.main_file = main_file
+        self.prover = ['kprove']
         self.prover_args = []
         with open(self.definition_dir / 'backend.txt', 'r') as ba:
             self.backend = ba.read()
@@ -118,17 +129,20 @@ class KProve(KPrint):
         haskell_log_entries += ['DebugAttemptedRewriteRules'] if rule_profile else []
         haskell_log_entries = unique(haskell_log_entries)
         haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(haskell_log_entries)]
+        command = [c for c in self.prover]
+        command += [str(spec_file)]
+        command += ['--definition', str(self.definition_dir), '--output', 'json']
+        command += ['--spec-module', spec_module_name] if spec_module_name is not None else []
+        command += ['--dry-run'] if dry_run else []
+        command += [c for c in self.prover_args]
+        command += args
 
-        proc_result = _kprove(
-            self.definition_dir,
-            spec_file,
-            check=False,
-            profile=self._profile,
-            spec_module=spec_module_name,
-            dry_run=dry_run,
-            args=(args + self.prover_args),
-            kore_exec_args=(haskell_args + haskell_log_args),
-        )
+        kore_exec_opts = ' '.join(haskell_args + haskell_log_args)
+        _LOGGER.debug(f'export KORE_EXEC_OPTS="{kore_exec_opts}"')
+        command_env = os.environ.copy()
+        command_env['KORE_EXEC_OPTS'] = kore_exec_opts
+
+        proc_result = run_process(command, logger=_LOGGER, env=command_env, check=False, profile=self._profile)
 
         if not dry_run:
 

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -119,10 +119,10 @@ class KProve(KPrint):
         log_file = spec_file.with_suffix('.debug-log') if log_axioms_file is None else log_axioms_file
         if log_file.exists():
             log_file.unlink()
-        _haskell_log_entries = list(haskell_log_entries)
-        _haskell_log_entries += ['DebugTransition']
-        _haskell_log_entries = list(unique(_haskell_log_entries))
-        _haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(_haskell_log_entries)]
+        haskell_log_entries = list(haskell_log_entries)
+        haskell_log_entries += ['DebugTransition']
+        haskell_log_entries = list(unique(haskell_log_entries))
+        haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(haskell_log_entries)]
         command = [c for c in self.prover]
         command += [str(spec_file)]
         command += ['--definition', str(self.definition_dir), '--output', 'json']
@@ -131,7 +131,7 @@ class KProve(KPrint):
         command += [c for c in self.prover_args]
         command += args
 
-        kore_exec_opts = ' '.join(list(haskell_args) + _haskell_log_args)
+        kore_exec_opts = ' '.join(list(haskell_args) + haskell_log_args)
         _LOGGER.debug(f'export KORE_EXEC_OPTS="{kore_exec_opts}"')
         command_env = os.environ.copy()
         command_env['KORE_EXEC_OPTS'] = kore_exec_opts

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -1,10 +1,9 @@
-import csv
 import json
 import logging
 import os
 from pathlib import Path
 from subprocess import CalledProcessError, CompletedProcess
-from typing import Dict, Final, Iterable, List, Mapping, Optional, Tuple
+from typing import Final, Iterable, List, Optional, Tuple
 
 from ..cli_utils import (
     check_dir_path,
@@ -116,13 +115,11 @@ class KProve(KPrint):
         log_axioms_file=None,
         allow_zero_step=False,
         dry_run=False,
-        rule_profile=None,
     ):
         log_file = spec_file.with_suffix('.debug-log') if log_axioms_file is None else log_axioms_file
         if log_file.exists():
             log_file.unlink()
         haskell_log_entries += ['DebugTransition']
-        haskell_log_entries += ['DebugAttemptedRewriteRules'] if rule_profile else []
         haskell_log_entries = unique(haskell_log_entries)
         haskell_log_args = ['--log', str(log_file), '--log-format', 'oneline', '--log-entries', ','.join(haskell_log_entries)]
         command = [c for c in self.prover]
@@ -147,39 +144,10 @@ class KProve(KPrint):
             proc_output = err.stdout
 
         if not dry_run:
-
             debug_log = _get_rule_log(log_file)
-
             final_state = KAst.from_dict(json.loads(proc_output)['term'])
             if final_state == mlTop() and len(debug_log) == 0 and not allow_zero_step:
                 raise ValueError(f'Proof took zero steps, likely the LHS is invalid: {spec_file}')
-
-            if rule_profile:
-                rule_data = _get_rule_profile(debug_log)
-                table_lines = []
-                total_success_time = 0.0
-                total_failure_time = 0.0
-                total_success_n = 0.0
-                total_failure_n = 0.0
-                for rule_name in rule_data:
-                    table_line = [rule_name, *rule_data[rule_name]]
-                    table_lines.append(table_line)
-                    total_success_time += table_line[1]
-                    total_failure_time += table_line[4]
-                    total_success_n += table_line[2]
-                    total_failure_n += table_line[5]
-                avg_success_time = total_success_time / total_success_n if total_success_n > 0 else 0.0
-                avg_failure_time = total_failure_time / total_failure_n if total_failure_n > 0 else 0.0
-                total_time = total_success_time + total_failure_time
-                productivity = total_success_time / total_time if total_time > 0.0 else 0.0
-                table_lines.append(['TOTAL', total_success_time, total_success_n, avg_success_time, total_failure_time, total_failure_n, avg_failure_time, productivity])
-                table_lines = sorted(table_lines, key=lambda x: x[1] + x[4])
-                with open(rule_profile, 'w') as rp_file:
-                    writer = csv.writer(rp_file)
-                    writer.writerow(('Rule', 'Total Success Time', '# Successes', 'Avg. Success Time', 'Total Failure Time', '# Failures', 'Avg. Failure Time', 'Productivity'))
-                    writer.writerows(table_lines)
-                    _LOGGER.info(f'Wrote rule profile: {rule_profile}')
-
             return final_state
 
     def prove_claim(
@@ -193,7 +161,6 @@ class KProve(KPrint):
         log_axioms_file=None,
         allow_zero_step=False,
         dry_run=False,
-        rule_profile=False,
     ):
         claim_path, claim_module_name = self._write_claim_definition(claim, claim_id, lemmas=lemmas)
         return self.prove(
@@ -205,7 +172,6 @@ class KProve(KPrint):
             log_axioms_file=log_axioms_file,
             allow_zero_step=allow_zero_step,
             dry_run=dry_run,
-            rule_profile=rule_profile,
         )
 
     def get_claim_basic_block(self, claim_id: str, claim: KClaim, lemmas: List[KRule] = [], args: List[str] = [], haskell_args: List[str] = [], max_depth: int = 1000) -> Tuple[int, bool, KInner]:
@@ -262,34 +228,6 @@ class KProve(KPrint):
             tc.flush()
         _LOGGER.info(f'Wrote claim file: {tmp_claim}.')
         return tmp_claim, tmp_module_name
-
-
-def _get_rule_profile(debug_log: List[List[Tuple[str, bool, int]]]) -> Mapping[str, Tuple[float, int, float, float, int, float, float]]:
-
-    def _get_single_rule_profile(_rule_log: List[Tuple[float, bool]]) -> Tuple[float, int, float, float, int, float, float]:
-        success_time = 0.0
-        failure_time = 0.0
-        success_n = 0
-        failure_n = 0
-        for time, success in _rule_log:
-            if success:
-                success_time += time
-                success_n += 1
-            else:
-                failure_time += time
-                failure_n += 1
-        success_avg = success_time / success_n if success_n > 0 else 0.0
-        failure_avg = failure_time / failure_n if failure_n > 0 else 0.0
-        productivity = success_time / (success_time + failure_time)
-        return (success_time, success_n, success_avg, failure_time, failure_n, failure_avg, productivity)
-
-    rule_data: Dict[str, List[Tuple[float, bool]]] = {}
-    for rule_name, apply_success, apply_time in [rl for rls in debug_log for rl in rls]:
-        if rule_name not in rule_data:
-            rule_data[rule_name] = []
-        rule_data[rule_name].append((apply_time, apply_success))
-
-    return {rule_name: _get_single_rule_profile(rule_data[rule_name]) for rule_name in rule_data}
 
 
 def _get_rule_log(debug_log_file: Path) -> List[List[Tuple[str, bool, int]]]:


### PR DESCRIPTION
See https://github.com/runtimeverification/k/pull/2788. Somehow adding the types to `KProve.prove` triggers a typing error in that code, and it's not worth keeping that code anyway.

This brings in two new functionalities from downstream:

- `KProve.prove_cterm`, which invokes the prover given a pair of `CTerm` and source/target. Adds some tests.
- `KPrint.parse_token`, which invokes `_kast` to parse a given token. Currently only works on program grammar (not on rule grammar), which limits its applicability (something we need to ask the frontend for more support on).
- Adds some TODO currently failing tests for `parse_token` and `kast_to_kore`.
- Refactors `kprove.py` module a bit. Inlines `_kprove` into `kprove`, then renames the whole thing `_kprove` to be similar to the other ktool modules.
- Adds typing to `KProve.prove`, which triggers some typing error in the rule profiling code, which is not worth keeping anyway.

I tried to do this one as well, but failed: https://github.com/runtimeverification/pyk/issues/8. It can happen in a follow-up PR.