### PR TITLE
always make progress on each z3 query

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
@@ -841,6 +841,30 @@ public class TypeInferencer implements AutoCloseable {
     return new HashMap<>(model);
   }
 
+  void pushGreater() {
+    level++;
+    println("(push)");
+    java.util.Set<String> realVariables = new HashSet<>(variables);
+    realVariables.removeAll(parameters);
+    for (String var : realVariables) {
+      print("(assert (<=SortSyntax ");
+      printSort(model.get(var));
+      print(" |");
+      print(var);
+      println("|))");
+    }
+    print("(assert (or false ");
+    for (String var : realVariables) {
+      print("(distinct ");
+      printSort(model.get(var));
+      print(" |");
+      print(var);
+      print("|) ");
+    }
+    println("))");
+    status = null;
+  }
+
   void pushNotModel() {
     print("(assert (not (and true");
     java.util.Set<String> realVariables = new HashSet<>(variables);
@@ -850,7 +874,7 @@ public class TypeInferencer implements AutoCloseable {
       printSort(model.get(var));
       print(") ");
     }
-    print(")))");
+    println(")))");
     status = null;
   }
 


### PR DESCRIPTION
This PR makes a slight modification to the way we search for type inference solutions. Intead of computing a solution then looking for more solutions that are not less than that solution, then discarding non-maximal solutions, we instead compute a solution, look for solutions greater than it until we find one which is maximal, then look for solutions not less than the maximal solution. This slightly cuts down the search space we need to explore during type inference, which yields moderate improvements in performance when I measured, on the order of 5-30%.