### PR TITLE
[pyk] Code cleanups, faster initialization

### DIFF
--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -8,7 +8,7 @@ from graphviz import Digraph
 
 from .coverage import getRuleById, stripCoverageLogger
 from .cterm import split_config_and_constraints
-from .kast import KAst, flatten_label, readKastTerm
+from .kast import KAst, flatten_label, read_kast_definition
 from .kastManip import (
     minimize_term,
     minimizeRule,
@@ -85,7 +85,7 @@ def main():
         _LOGGER.info(f'Wrote file: {graphFile}')
 
     elif args['command'] == 'coverage':
-        json_definition = removeSourceMap(readKastTerm(kompiled_dir / 'compiled.json'))
+        json_definition = removeSourceMap(read_kast_definition(kompiled_dir / 'compiled.json'))
         symbol_table = build_symbol_table(json_definition)
         for rid in args['coverage-file']:
             rule = minimizeRule(stripCoverageLogger(getRuleById(json_definition, rid.strip())))

--- a/pyk/src/pyk/coverage.py
+++ b/pyk/src/pyk/coverage.py
@@ -1,4 +1,4 @@
-from .kast import KApply, KRewrite, KRule, KSequence, readKastTerm
+from .kast import KApply, KRewrite, KRule, KSequence, read_kast_definition
 
 
 def getRuleById(definition, rule_id):
@@ -108,7 +108,7 @@ def translateCoverageFromPaths(src_kompiled_dir, dst_kompiled_dir, src_rules_fil
     with open(dst_kompiled_dir + '/allRules.txt', 'r') as dst_all_rules_file:
         dst_all_rules = [line.strip() for line in dst_all_rules_file]
 
-    dst_definition = readKastTerm(dst_kompiled_dir + '/compiled.json')
+    dst_definition = read_kast_definition(dst_kompiled_dir + '/compiled.json')
 
     src_rules_list = []
     with open(src_rules_file, 'r') as src_rules:

--- a/pyk/src/pyk/cterm.py
+++ b/pyk/src/pyk/cterm.py
@@ -55,12 +55,12 @@ class CTerm:
         return chain([self.config], self.constraints)
 
     @cached_property
-    def term(self) -> KInner:
+    def kast(self) -> KInner:
         return mlAnd(self, Sorts.GENERATED_TOP_CELL)
 
     @property
     def hash(self) -> str:
-        return self.term.hash
+        return self.kast.hash
 
     def match(self, cterm: 'CTerm') -> Optional[Subst]:
         match_res = self.match_with_constraint(cterm)

--- a/pyk/src/pyk/integration_tests/kprove_test.py
+++ b/pyk/src/pyk/integration_tests/kprove_test.py
@@ -28,7 +28,7 @@ class KProveTest(KompiledTest, ABC):
 
         self.kprove = KProve(self.kompiled_dir, kprove_main_file, Path(self.KPROVE_USE_DIR))
         self.kprove.prover_args += list(chain.from_iterable(['-I', include_dir] for include_dir in kprove_include_dirs))
-        self._update_symbol_table(self.kprove.symbol_table)
+        self._update_symbol_table(self.kprove._symbol_table)
 
     def tearDown(self):
         shutil.rmtree(self.KPROVE_USE_DIR, ignore_errors=True)

--- a/pyk/src/pyk/integration_tests/kprove_test.py
+++ b/pyk/src/pyk/integration_tests/kprove_test.py
@@ -28,9 +28,7 @@ class KProveTest(KompiledTest, ABC):
 
         self.kprove = KProve(self.kompiled_dir, kprove_main_file, Path(self.KPROVE_USE_DIR))
         self.kprove.prover_args += list(chain.from_iterable(['-I', include_dir] for include_dir in kprove_include_dirs))
-        # force computation of the symbol_table before updating it
-        if self.kprove.symbol_table:
-            self._update_symbol_table(self.kprove._symbol_table)
+        self._update_symbol_table(self.kprove.symbol_table)
 
     def tearDown(self):
         shutil.rmtree(self.KPROVE_USE_DIR, ignore_errors=True)

--- a/pyk/src/pyk/integration_tests/kprove_test.py
+++ b/pyk/src/pyk/integration_tests/kprove_test.py
@@ -28,7 +28,9 @@ class KProveTest(KompiledTest, ABC):
 
         self.kprove = KProve(self.kompiled_dir, kprove_main_file, Path(self.KPROVE_USE_DIR))
         self.kprove.prover_args += list(chain.from_iterable(['-I', include_dir] for include_dir in kprove_include_dirs))
-        self._update_symbol_table(self.kprove._symbol_table)
+        # force computation of the symbol_table before updating it
+        if self.kprove.symbol_table:
+            self._update_symbol_table(self.kprove._symbol_table)
 
     def tearDown(self):
         shutil.rmtree(self.KPROVE_USE_DIR, ignore_errors=True)

--- a/pyk/src/pyk/integration_tests/test_parse_kast.py
+++ b/pyk/src/pyk/integration_tests/test_parse_kast.py
@@ -1,6 +1,6 @@
 from abc import ABC
 
-from ..kast import KAs, KDefinition, KSort, KSortSynonym, readKastTerm
+from ..kast import KAs, KSort, KSortSynonym, read_kast_definition
 from ..ktool import KompileBackend
 from .kompiled_test import KompiledTest
 
@@ -11,8 +11,7 @@ class ParseKAstTest(KompiledTest, ABC):
 
     def setUp(self):
         super().setUp()
-        self.definition = readKastTerm(self.COMPILED_JSON_PATH)
-        self.assertIsInstance(self.definition, KDefinition)
+        self.definition = read_kast_definition(self.COMPILED_JSON_PATH)
         modules = [module for module in self.definition if module.name == self.MODULE_NAME]
         self.assertEqual(len(modules), 1)
         self.module = modules[0]

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -1599,12 +1599,12 @@ def assocWithUnit(assocJoin, unit):
     return _assocWithUnit
 
 
-def readKastTerm(termPath: Path) -> KAst:
-    with open(termPath, 'r') as termFile:
-        return KAst.from_dict(json.loads(termFile.read())['term'])
+def read_kast(ifile: Path) -> KAst:
+    with open(ifile, 'r') as _f:
+        return KAst.from_dict(json.loads(_f.read())['term'])
 
 
 def read_kast_definition(ifile: Path) -> KDefinition:
-    _defn = readKastTerm(ifile)
+    _defn = read_kast(ifile)
     assert isinstance(_defn, KDefinition)
     return _defn

--- a/pyk/src/pyk/kast.py
+++ b/pyk/src/pyk/kast.py
@@ -4,6 +4,7 @@ from dataclasses import InitVar, dataclass, fields
 from enum import Enum
 from functools import cached_property, reduce
 from itertools import chain
+from pathlib import Path
 from typing import (
     Any,
     Callable,
@@ -1598,6 +1599,12 @@ def assocWithUnit(assocJoin, unit):
     return _assocWithUnit
 
 
-def readKastTerm(termPath):
+def readKastTerm(termPath: Path) -> KAst:
     with open(termPath, 'r') as termFile:
         return KAst.from_dict(json.loads(termFile.read())['term'])
+
+
+def read_kast_definition(ifile: Path) -> KDefinition:
+    _defn = readKastTerm(ifile)
+    assert isinstance(_defn, KDefinition)
+    return _defn

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -68,7 +68,7 @@ def substitute(pattern: KInner, subst: Mapping[str, KInner]) -> KInner:
     return subst(pattern)
 
 
-def bool_ml_pred(kast: KInner) -> KInner:
+def bool_to_ml_pred(kast: KInner) -> KInner:
     return mlAnd([mlEqualsTrue(cond) for cond in flatten_label('_andBool_', kast)])
 
 

--- a/pyk/src/pyk/kastManip.py
+++ b/pyk/src/pyk/kastManip.py
@@ -111,7 +111,7 @@ def ml_pred_to_bool(kast: KInner, unsafe: bool = False) -> KInner:
     return _ml_constraint_to_bool(kast)
 
 
-def simplify_bool(k):
+def simplify_bool(k: KInner) -> KInner:
     if k is None:
         return None
     simplify_rules = [ (KApply('_==K_', [KVariable('#LHS'), Bool.true]), KVariable('#LHS'))                                                                     # noqa

--- a/pyk/src/pyk/kcfg.py
+++ b/pyk/src/pyk/kcfg.py
@@ -48,7 +48,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Edge', 'KCFG.Cover']]):
             return self.cterm.hash
 
         def to_dict(self) -> Dict[str, Any]:
-            return {'id': self.id, 'term': self.cterm.term.to_dict()}
+            return {'id': self.id, 'term': self.cterm.kast.to_dict()}
 
     class EdgeLike(ABC):
         source: 'KCFG.Node'

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -74,10 +74,11 @@ class KPrint:
 
     definition_dir: Path
     use_directory: Path
-    _definition: Optional[KDefinition]
-    symbol_table: SymbolTable
-    definition_hash: str
     _profile: bool
+
+    _definition: Optional[KDefinition]
+    _definition_hash: Optional[str]
+    _symbol_table: Optional[SymbolTable]
 
     def __init__(self, definition_dir: Path, use_directory: Optional[Path] = None, profile: bool = False) -> None:
         self.definition_dir = Path(definition_dir)
@@ -87,8 +88,9 @@ class KPrint:
             td = TemporaryDirectory()
             self.use_directory = Path(td.name)
         check_dir_path(self.use_directory)
-        self.symbol_table = build_symbol_table(self.definition, opinionated=True)
-        self.definition_hash = hash_str(self.definition)
+        self._definition = None
+        self._definition_hash = None
+        self._symbol_table = None
         self._profile = profile
 
     @property
@@ -97,6 +99,20 @@ class KPrint:
             self._definition = readKastTerm(self.definition_dir / 'compiled.json')
             assert self._definition is not None
         return self._definition
+
+    @property
+    def definition_hash(self) -> str:
+        if not self._definition_hash:
+            self._definition_hash = hash_str(self.definition)
+            assert self._definition_hash is not None
+        return self._definition_hash
+
+    @property
+    def symbol_table(self) -> SymbolTable:
+        if not self._symbol_table:
+            self._symbol_table = build_symbol_table(self.definition, opinionated=True)
+            assert self._symbol_table is not None
+        return self._symbol_table
 
     def parse_token(self, ktoken: KToken) -> KInner:
         output = _kast(self.definition_dir, ktoken.token, sort=ktoken.sort, profile=self._profile)

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -42,7 +42,6 @@ from ..kast import (
 from ..kore.parser import KoreParser
 from ..kore.syntax import Kore
 from ..prelude import Bool, Labels, Sorts
-from ..utils import hash_str
 
 _LOGGER: Final = logging.getLogger(__name__)
 
@@ -77,7 +76,6 @@ class KPrint:
     _profile: bool
 
     _definition: Optional[KDefinition]
-    _definition_hash: Optional[str]
     _symbol_table: Optional[SymbolTable]
 
     def __init__(self, definition_dir: Path, use_directory: Optional[Path] = None, profile: bool = False) -> None:
@@ -101,9 +99,7 @@ class KPrint:
 
     @property
     def definition_hash(self) -> str:
-        if not self._definition_hash:
-            self._definition_hash = hash_str(self.definition)
-        return self._definition_hash
+        return self.definition.hash
 
     @property
     def symbol_table(self) -> SymbolTable:

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -87,7 +87,6 @@ class KPrint:
             self.use_directory = Path(td.name)
         check_dir_path(self.use_directory)
         self._definition = None
-        self._definition_hash = None
         self._symbol_table = None
         self._profile = profile
 

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -37,7 +37,7 @@ from ..kast import (
     KVariable,
     flatten_label,
     ktokenDots,
-    readKastTerm,
+    read_kast_definition,
 )
 from ..kore.parser import KoreParser
 from ..kore.syntax import Kore
@@ -96,22 +96,19 @@ class KPrint:
     @property
     def definition(self) -> KDefinition:
         if not self._definition:
-            self._definition = readKastTerm(self.definition_dir / 'compiled.json')
-            assert self._definition is not None
+            self._definition = read_kast_definition(self.definition_dir / 'compiled.json')
         return self._definition
 
     @property
     def definition_hash(self) -> str:
         if not self._definition_hash:
             self._definition_hash = hash_str(self.definition)
-            assert self._definition_hash is not None
         return self._definition_hash
 
     @property
     def symbol_table(self) -> SymbolTable:
         if not self._symbol_table:
             self._symbol_table = build_symbol_table(self.definition, opinionated=True)
-            assert self._symbol_table is not None
         return self._symbol_table
 
     def parse_token(self, ktoken: KToken) -> KInner:

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -74,7 +74,7 @@ class KPrint:
 
     definition_dir: Path
     use_directory: Path
-    definition: KDefinition
+    _definition: Optional[KDefinition]
     symbol_table: SymbolTable
     definition_hash: str
     _profile: bool
@@ -87,10 +87,16 @@ class KPrint:
             td = TemporaryDirectory()
             self.use_directory = Path(td.name)
         check_dir_path(self.use_directory)
-        self.definition = readKastTerm(self.definition_dir / 'compiled.json')
         self.symbol_table = build_symbol_table(self.definition, opinionated=True)
         self.definition_hash = hash_str(self.definition)
         self._profile = profile
+
+    @property
+    def definition(self) -> KDefinition:
+        if not self._definition:
+            self._definition = readKastTerm(self.definition_dir / 'compiled.json')
+            assert self._definition is not None
+        return self._definition
 
     def parse_token(self, ktoken: KToken) -> KInner:
         output = _kast(self.definition_dir, ktoken.token, sort=ktoken.sort, profile=self._profile)

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -181,10 +181,10 @@ class KProve(KPrint):
         log_axioms_file: Path = None,
         allow_zero_step: bool = False,
     ) -> List[KInner]:
-        claim, var_map = build_claim(claim_id, init_cterm, target_cterm, keep_vars=collectFreeVars(init_cterm.term))
+        claim, var_map = build_claim(claim_id, init_cterm, target_cterm, keep_vars=collectFreeVars(init_cterm.kast))
         next_state = self.prove_claim(claim, claim_id, lemmas=lemmas, args=args, haskell_args=haskell_args, log_axioms_file=log_axioms_file, allow_zero_step=allow_zero_step)
         next_states = [var_map(ns) for ns in flatten_label('#Or', next_state)]
-        constraint_subst, _ = extract_subst(init_cterm.term)
+        constraint_subst, _ = extract_subst(init_cterm.kast)
         next_states = [mlAnd([constraint_subst.unapply(ns), constraint_subst.ml_pred]) if ns not in [mlTop(), mlBottom()] else ns for ns in next_states]
         return next_states
 

--- a/pyk/src/pyk/tests/mock_kprint.py
+++ b/pyk/src/pyk/tests/mock_kprint.py
@@ -3,5 +3,5 @@ from ..ktool.kprint import KPrint
 
 class MockKPrint(KPrint):
     def __init__(self):
-        self.symbol_table = {}
+        self._symbol_table = {}
         return

--- a/pyk/src/pyk/tests/mock_kprint.py
+++ b/pyk/src/pyk/tests/mock_kprint.py
@@ -1,7 +1,9 @@
+from ..kast import KDefinition, KFlatModule
 from ..ktool.kprint import KPrint
 
 
 class MockKPrint(KPrint):
     def __init__(self):
+        self._definition = KDefinition('MOCK', [KFlatModule('MOCK', [])], [])
         self._symbol_table = {}
         return

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -103,32 +103,27 @@ class MinimizeTermTest(TestCase):
                 self.assertEqual(actual, expected)
 
 
-class MlPredToBoolTest(TestCase):
+class BoolMlPredConversionsTest(TestCase):
+    test_data = (
+        ('equals-true', False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.GENERATED_TOP_CELL]), [Bool.true, f(a)]), f(a)),
+        ('top-sort-bool', False, KApply(KLabel('#Top', [Sorts.BOOL])), Bool.true),
+        ('top-no-sort', False, KApply('#Top'), Bool.true),
+        ('top-no-sort', False, mlTop(), Bool.true),
+        ('equals-variabl', False, KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
+        ('equals-true-no-sort', False, KApply(KLabel('#Equals'), [Bool.true, f(a)]), f(a)),
+        ('equals-token', False, KApply(KLabel('#Equals', [KSort('Int'), Sorts.GENERATED_TOP_CELL]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
+        ('not-top', False, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [mlTop()]), Bool.notBool(Bool.true)),
+        ('equals-term', True, KApply(KLabel('#Equals'), [f(a), f(x)]), KApply('_==K_', [f(a), f(x)])),
+        ('simplify-and-true', False, KApply(KLabel('#And', [Sorts.GENERATED_TOP_CELL]), [mlEqualsTrue(Bool.true), mlEqualsTrue(Bool.true)]), Bool.true),
+        ('ceil-set-concat-no-sort', True, KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_'), [KVariable('_'), KVariable('_')])]), KVariable('Ceil_0f9c9997')),
+        ('ceil-set-concat-sort', True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_'), [KVariable('_'), KVariable('_')])])]), Bool.notBool(KVariable('Ceil_0f9c9997'))),
+        ('exists-equal-int', True, KApply(KLabel('#Exists', [Sorts.INT, Sorts.BOOL]), [KVariable('X'), KApply('_==Int_', [KVariable('X'), KVariable('Y')])]), KVariable('Exists_6acf2557')),
+    )
 
     def test_ml_pred_to_bool(self):
-        # Given
-        test_data = (
-            (False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.GENERATED_TOP_CELL]), [Bool.true, f(a)]), f(a)),
-            (False, KApply(KLabel('#Top', [Sorts.BOOL])), Bool.true),
-            (False, KApply('#Top'), Bool.true),
-            (False, mlTop(), Bool.true),
-            (False, KApply(KLabel('#Equals'), [x, f(a)]), KApply('_==K_', [x, f(a)])),
-            (False, KApply(KLabel('#Equals'), [Bool.true, f(a)]), f(a)),
-            (False, KApply(KLabel('#Equals', [KSort('Int'), Sorts.GENERATED_TOP_CELL]), [intToken(3), f(a)]), KApply('_==K_', [intToken(3), f(a)])),
-            (False, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [mlTop()]), Bool.notBool(Bool.true)),
-            (True, KApply(KLabel('#Equals'), [f(a), f(x)]), KApply('_==K_', [f(a), f(x)])),
-            (False, KApply(KLabel('#And', [Sorts.GENERATED_TOP_CELL]), [mlEqualsTrue(Bool.true), mlEqualsTrue(Bool.true)]), Bool.true),
-            (True, KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))]), KVariable('Ceil_37f1b5e5')),
-            (True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_', [KVariable('_'), KVariable('_')]))])]), Bool.notBool(KVariable('Ceil_37f1b5e5'))),
-            (True, KApply(KLabel('#Exists', [Sorts.INT, Sorts.BOOL]), [KVariable('X'), KApply('_==Int_', [KVariable('X'), KVariable('Y')])]), KVariable('Exists_6acf2557')),
-        )
-
-        for i, (unsafe, before, expected) in enumerate(test_data):
-            with self.subTest(i=i):
-                # When
+        for name, unsafe, before, expected in self.test_data:
+            with self.subTest(name):
                 actual = ml_pred_to_bool(before, unsafe=unsafe)
-
-                # Then
                 self.assertEqual(actual, expected)
 
 

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -165,7 +165,7 @@ class CollapseDotsTest(TestCase):
 
 class SimplifyBoolTest(TestCase):
 
-    def test_simplify_bool(self):
+    def test_simplify_bool(self) -> None:
         bool_tests = (
             ('trivial-false', Bool.andBool([Bool.false, Bool.true]), Bool.false),
             ('and-true', Bool.andBool([KApply('_==Int_', [intToken(3), intToken(4)]), Bool.true]), KApply('_==Int_', [intToken(3), intToken(4)])),

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -107,7 +107,8 @@ class MinimizeTermTest(TestCase):
 class BoolMlPredConversionsTest(TestCase):
 
     # TODO: We'd like for bool_to_ml_pred and ml_pred_to_bool to be somewhat invertible.
-    test_data_1 = (
+
+    test_data_ml_pred_to_bool = (
         ('equals-true', False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.GENERATED_TOP_CELL]), [Bool.true, f(a)]), f(a)),
         ('top-sort-bool', False, KApply(KLabel('#Top', [Sorts.BOOL])), Bool.true),
         ('top-no-sort', False, KApply('#Top'), Bool.true),
@@ -122,18 +123,19 @@ class BoolMlPredConversionsTest(TestCase):
         ('ceil-set-concat-sort', True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_'), [KVariable('_'), KVariable('_')])])]), Bool.notBool(KVariable('Ceil_0f9c9997'))),
         ('exists-equal-int', True, KApply(KLabel('#Exists', [Sorts.INT, Sorts.BOOL]), [KVariable('X'), KApply('_==Int_', [KVariable('X'), KVariable('Y')])]), KVariable('Exists_6acf2557')),
     )
-    test_data_2 = (
-        ('equals-true', False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.K]), [Bool.true, f(a)]), f(a)),
-    )
 
     def test_ml_pred_to_bool(self):
-        for name, unsafe, ml_pred, bool_expected in self.test_data_1:
+        for name, unsafe, ml_pred, bool_expected in self.test_data_ml_pred_to_bool:
             with self.subTest(name):
                 bool_actual = ml_pred_to_bool(ml_pred, unsafe=unsafe)
                 self.assertEqual(bool_actual, bool_expected)
 
+    test_data_bool_to_ml_pred = (
+        ('equals-true', False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.K]), [Bool.true, f(a)]), f(a)),
+    )
+
     def test_bool_to_ml_pred(self):
-        for name, unsafe, ml_pred_expected, bool_in in self.test_data_2:
+        for name, unsafe, ml_pred_expected, bool_in in self.test_data_bool_to_ml_pred:
             with self.subTest(name):
                 ml_pred_actual = bool_to_ml_pred(bool_in)
                 self.assertEqual(ml_pred_actual, ml_pred_expected)

--- a/pyk/src/pyk/tests/test_kastManip.py
+++ b/pyk/src/pyk/tests/test_kastManip.py
@@ -14,6 +14,7 @@ from ..kast import (
     ktokenDots,
 )
 from ..kastManip import (
+    bool_to_ml_pred,
     build_claim,
     build_rule,
     collapseDots,
@@ -104,7 +105,9 @@ class MinimizeTermTest(TestCase):
 
 
 class BoolMlPredConversionsTest(TestCase):
-    test_data = (
+
+    # TODO: We'd like for bool_to_ml_pred and ml_pred_to_bool to be somewhat invertible.
+    test_data_1 = (
         ('equals-true', False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.GENERATED_TOP_CELL]), [Bool.true, f(a)]), f(a)),
         ('top-sort-bool', False, KApply(KLabel('#Top', [Sorts.BOOL])), Bool.true),
         ('top-no-sort', False, KApply('#Top'), Bool.true),
@@ -119,12 +122,21 @@ class BoolMlPredConversionsTest(TestCase):
         ('ceil-set-concat-sort', True, KApply(KLabel('#Not', [Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('#Ceil', [KSort('Set'), Sorts.GENERATED_TOP_CELL]), [KApply(KLabel('_Set_'), [KVariable('_'), KVariable('_')])])]), Bool.notBool(KVariable('Ceil_0f9c9997'))),
         ('exists-equal-int', True, KApply(KLabel('#Exists', [Sorts.INT, Sorts.BOOL]), [KVariable('X'), KApply('_==Int_', [KVariable('X'), KVariable('Y')])]), KVariable('Exists_6acf2557')),
     )
+    test_data_2 = (
+        ('equals-true', False, KApply(KLabel('#Equals', [Sorts.BOOL, Sorts.K]), [Bool.true, f(a)]), f(a)),
+    )
 
     def test_ml_pred_to_bool(self):
-        for name, unsafe, before, expected in self.test_data:
+        for name, unsafe, ml_pred, bool_expected in self.test_data_1:
             with self.subTest(name):
-                actual = ml_pred_to_bool(before, unsafe=unsafe)
-                self.assertEqual(actual, expected)
+                bool_actual = ml_pred_to_bool(ml_pred, unsafe=unsafe)
+                self.assertEqual(bool_actual, bool_expected)
+
+    def test_bool_to_ml_pred(self):
+        for name, unsafe, ml_pred_expected, bool_in in self.test_data_2:
+            with self.subTest(name):
+                ml_pred_actual = bool_to_ml_pred(bool_in)
+                self.assertEqual(ml_pred_actual, ml_pred_expected)
 
 
 class RemoveGeneratedCellsTest(TestCase):


### PR DESCRIPTION
This PR introduces some accumulated cleanup changes, fixes a typo bug, and reduces KEVM initialization time:

- This one https://github.com/runtimeverification/k/pull/2786 accidentally renamed `bool_to_ml_pred` to be `bool_ml_pred`. That is fixed, and a test is added for `bool_to_ml_pred`.
- Types are added to `simplify_bool` method.
- `CTerm.term` is renamed `CTerm.kast`. Not 100% on this one, but eventually I want `CTerm.kore` as well, so I was thinking it made sense.
- `KPrint` only actually loads the definition from disk if it's used by the program, by changing `KPrint.definition`, `KPrint.definition_hash`, and `KPrint.symbol_table` into `@property` instead of direct fields. On KEVM, the overhead of running each conformance test with pyk is ~4s originally. With this change, it drops to ~2s (because to run the KEVM conformance tests the kevm pyk runner never actually needs to use the definition or unparser). The KEVM tests are normally running with the bash script in around ~0.05s.
- Renames `readKastTerm` to `read_kast`, and adds a new one `read_kast_definition` which is actually what is used throughout the rest of the codebase. Adds types to both `read_kast` and `read_kast_definition`.