### PR TITLE
Use new LLDB script to debug on mac

### DIFF
--- a/USER_MANUAL.md
+++ b/USER_MANUAL.md
@@ -2832,6 +2832,14 @@ on a particular program by passing the `--debugger` flag to krun, or by
 invoking the llvm backend interpreter directly. Below we provide a simple
 tutorial to explain some of the basic commands supported by the LLVM backend.
 
+### LLDB Support
+
+GDB is not well-supported on macOS, particularly on newer OS versions and Apple
+Silicon ARM hardware. Consequently, if the `--debugger` option is passed to krun
+on macOS, LLDB[^1] is launched instead of GDB. However, the K-specific debugger
+scripts that GDB uses have not been ported to LLDB yet, and so the instructions
+in the rest of this section will not work.
+
 ### The K Definition
 
 Here is a sample K definition we will use to demonstrate debugging
@@ -3238,3 +3246,6 @@ sed 's/hook(//' | sed 's/)//' | sort | uniq | grep -v org.kframework
 ```
 
 All of these hooks will also eventually need documentation.
+
+[^1]: More precisely, a lightly-customized debugger built using the LLDB Python
+  API.

--- a/k-distribution/k-tutorial/1_basic/19_debugging/README.md
+++ b/k-distribution/k-tutorial/1_basic/19_debugging/README.md
@@ -5,10 +5,10 @@ the K-language support provided in [GDB](https://www.gnu.org/software/gdb/).
 
 ## Caveats
 
-Debugging K definitions using GDB is currently only supported on Linux; it is
-unlikely that the instructions in this section will work properly on macOS.
-Support for debugging K using LLDB is a work in progress, and this chapter will
-be updated when doing so is possible.
+Debugging K definitions using GDB is currently only supported on Linux; the
+instructions in this section will not work properly on macOS. Support for
+debugging K using LLDB is a work in progress, and this chapter will be updated
+when doing so is possible.
 
 ## Getting started
 

--- a/k-distribution/k-tutorial/1_basic/19_debugging/README.md
+++ b/k-distribution/k-tutorial/1_basic/19_debugging/README.md
@@ -3,6 +3,13 @@
 The purpose of this lesson is to teach how to debug your K interpreter using
 the K-language support provided in [GDB](https://www.gnu.org/software/gdb/).
 
+## Caveats
+
+Debugging K definitions using GDB is currently only supported on Linux; it is
+unlikely that the instructions in this section will work properly on macOS.
+Support for debugging K using LLDB is a work in progress, and this chapter will
+be updated when doing so is possible.
+
 ## Getting started
 
 You will need GDB in order to complete this lesson. If you do not already

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -31,6 +31,12 @@ dryRun=false
 expandMacros=true
 filterSubst=
 
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  DBG_CMD="python3 $(dirname "$0")/../lib/lldb/klldb.py"
+else
+  DBG_CMD="gdb --args "
+fi
+
 # setup temp files
 now="$(date +"%Y-%m-%d-%H-%M-%S")"
 tempDir="$(mktemp -d .krun-${now}-XXXXXXXXXX)"
@@ -356,7 +362,7 @@ do
       ;;
 
       --debugger)
-      cmdprefix="gdb --args "
+      cmdprefix="$DBG_CMD"
       ;;
 
       --statistics)


### PR DESCRIPTION
This is the corresponding frontend PR for https://github.com/runtimeverification/llvm-backend/pull/546. It launches the new `klldb.py` script when `--debugger` is passed to `krun` on macOS.

It also makes some small updates to the tutorial and user manual sections that deal with GDB, to explain that it won't currently work on macOS / LLDB yet.

Supersedes https://github.com/runtimeverification/k/pull/2646