### PR TITLE
Print `llvm-kompile` invocation in verbose mode

### DIFF
--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -16,6 +16,7 @@ import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KException.ExceptionType;
 import org.kframework.utils.file.FileUtil;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.ArrayList;
@@ -118,7 +119,13 @@ public class LLVMBackend extends KoreBackend {
         if (kompileOptions.optimize3) args.add("-O2"); // clang -O3 does not make the llvm backend any faster
         args.addAll(options.ccopts);
         try {
-            Process p = pb.command(args).directory(files.resolveKompiled(".")).inheritIO().start();
+            File kompiledDir = files.resolveKompiled(".");
+
+            if (globalOptions.verbose) {
+                System.out.println("Executing in " + kompiledDir.getCanonicalPath() + ": " + String.join(" ", args));
+            }
+
+            Process p = pb.command(args).directory(kompiledDir).inheritIO().start();
             int exit = p.waitFor();
             if (exit != 0) {
                 throw KEMException.criticalError("llvm-kompile returned nonzero exit code: " + exit + "\nExamine output to see errors.");


### PR DESCRIPTION
Fixes #2791.

When `-v` / `--verbose` is passed to `kompile`, it will now print a message like:
```
Executing in /home/bruce/code/k/test-kompiled: llvm-kompile definition.kore dt main -o interpreter
```
when the LLVM backend is invoked.

@radumereuta All the files concerned here live in the kompiled directory, so we don't need to save anything to the temp dir.