### PR TITLE
Hotfix for `/usr/local` packaging on Jammy

### DIFF
--- a/package/debian/rules.jammy
+++ b/package/debian/rules.jammy
@@ -32,6 +32,7 @@ override_dh_auto_build:
 
 override_dh_auto_install:
 	package/package
+	mv $(DESTDIR)$(PREFIX)/local/lib/$(PYTHON_VERSION) $(DESTDIR)$(PREFIX)/lib/$(PYTHON_VERSION)
 	@mkdir -p $(DESTDIR)$(PREFIX)/lib/$(PYTHON_DEB_VERSION)/dist-packages
 	ln --symbolic --relative $(DESTDIR)$(PREFIX)/lib/$(PYTHON_VERSION)/site-packages/kllvm $(DESTDIR)$(PREFIX)/lib/$(PYTHON_DEB_VERSION)/dist-packages/kllvm
 


### PR DESCRIPTION
We've experienced this problem before; the solution is to move things out of `/usr/local' into `/usr`