### PR TITLE
Fix for bullseye packaging

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -220,6 +220,7 @@ pipeline {
                   sh '''
                     mv package/debian ./debian
                     mv debian/control.debian debian/control
+                    mv debian/rules.debian debian/rules
                     dpkg-buildpackage
                   '''
                 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -202,7 +202,7 @@ pipeline {
       when {
         anyOf {
           branch 'master'
-          branch 'bullseye-fix'
+          changeRequest()
         }
         beforeAgent true
       }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,7 +200,10 @@ pipeline {
     }
     stage('Build and Package on Debian Bullseye') {
       when {
-        branch 'master'
+        anyOf {
+          branch 'master'
+          branch 'bullseye-fix'
+        }
         beforeAgent true
       }
       stages {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,10 +200,7 @@ pipeline {
     }
     stage('Build and Package on Debian Bullseye') {
       when {
-        anyOf {
-          branch 'master'
-          changeRequest()
-        }
+        branch 'master'
         beforeAgent true
       }
       stages {

--- a/package/debian/rules.debian
+++ b/package/debian/rules.debian
@@ -1,0 +1,41 @@
+#!/usr/bin/make -f
+# See debhelper(7) (uncomment to enable)
+# output every command that modifies files on the build system.
+#export DH_VERBOSE = 1
+
+
+# see FEATURE AREAS in dpkg-buildflags(1)
+export DEB_BUILD_MAINT_OPTIONS=hardening=-stackprotector
+
+# see ENVIRONMENT in dpkg-buildflags(1)
+# package maintainers to append CFLAGS
+#export DEB_CFLAGS_MAINT_APPEND  = -Wall -pedantic
+# package maintainers to append LDFLAGS
+#export DEB_LDFLAGS_MAINT_APPEND = -Wl,--as-needed
+
+DESTDIR=$(shell pwd)/debian/kframework
+PREFIX=/usr
+PYTHON_VERSION=python3.9
+PYTHON_DEB_VERSION=python3
+export DESTDIR
+export PREFIX
+
+%:
+	dh $@
+
+override_dh_auto_build:
+	mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=$(PREFIX) -Dllvm.backend.destdir=$(DESTDIR)
+
+override_dh_auto_install:
+	package/package
+	@mkdir -p $(DESTDIR)$(PREFIX)/lib/$(PYTHON_DEB_VERSION)/dist-packages
+	ln --symbolic --relative $(DESTDIR)$(PREFIX)/lib/$(PYTHON_VERSION)/site-packages/kllvm $(DESTDIR)$(PREFIX)/lib/$(PYTHON_DEB_VERSION)/dist-packages/kllvm
+
+override_dh_strip:
+	dh_strip -Xliballoc.a -Xlibarithmetic.a -XlibAST.a -Xlibutil.a -XlibParser.a -Xlibcollect.a -Xlibcollections.a -Xlibjson.a -Xlibstrings.a -Xlibmeta.a -Xlibio.a
+
+# dh_make generated override targets
+# This is example for Cmake (See https://bugs.debian.org/641051 )
+#override_dh_auto_configure:
+#	dh_auto_configure -- #	-DCMAKE_LIBRARY_PATH=$(DEB_HOST_MULTIARCH)
+


### PR DESCRIPTION
This should fix the current Bullseye packaging failure; the problem is that the Python 3 version used by Debian Bullseye and Ubuntu Focal is different. This causes the `kllvm` module not to be installed in the correct place, and the test that exercises it to fail.