### PR TITLE
Remove docker master commit from install instructions

### DIFF
--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -140,8 +140,6 @@ Docker images with K pre-installed are available at the
 
 Each release at `COMMIT_ID` has an image associated with it at
 `runtimeverificationinc/kframework-k:ubuntu-focal-COMMIT_ID`.
-The latest `master` build Docker image can be accessed with `COMMIT_ID` set to
-`master`.
 
 To run the image directly:
 


### PR DESCRIPTION
We no longer tag these images and the docs are out of date.

Fixes #2782