### PR TITLE
tests: remove haskell backend info from test output

### DIFF
--- a/k-distribution/tests/regression-new/kprove-error-status/Makefile
+++ b/k-distribution/tests/regression-new/kprove-error-status/Makefile
@@ -6,4 +6,4 @@ KOMPILE_BACKEND=haskell
 include ../../../include/kframework/ktest.mak
 
 KPROVE_OR_LEGACY=$(KPROVE)
-CONSIDER_PROVER_ERRORS=2>&1 | sed 's/\(kore-exec: \)\[[0-9]\+\]/\1/g'
+CONSIDER_PROVER_ERRORS=2>&1 | sed 's/\(kore-exec: \)\[[0-9]\+\]/\1/g' | sed 's/\(error, called at\) .*\.hs:[0-9]\+:[0-9]\+ in .*/\1/g'

--- a/k-distribution/tests/regression-new/kprove-error-status/crash-spec.k.out
+++ b/k-distribution/tests/regression-new/kprove-error-status/crash-spec.k.out
@@ -10,6 +10,6 @@ kore-exec:  Error (ErrorException):
     and include the text of this message.
     Workaround: Give rules for Lblcrash'LParUndsRParUnds'VERIF-SYNTAX'Unds'Pgm'Unds'Int{}
     CallStack (from HasCallStack):
-      error, called at src/Kore/Rewrite/Function/Evaluator.hs:274:6 in kore-0.60.0.0-C6NIGnCldg2CHYuzj5V8fi:Kore.Rewrite.Function.Evaluator
+      error, called at
 Created bug report: kore-exec.tar.gz
 [Error] Critical: Haskell Backend execution failed with code 1 and produced no output.


### PR DESCRIPTION
Previous change that added these files resulted in retaining output generated from haskell backend such as file line numbers and hashes. Remove their output to improve the stability of this test.