### PR TITLE
Update short version ubuntu instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,15 +59,15 @@ must first be installed.
 
 ## The Short Version
 
-On Ubuntu Linux:
+On Ubuntu Linux 20.04 (Focal) or 22.04 (Jammy):
 
 ```shell
 git submodule update --init --recursive
-sudo apt-get install build-essential m4 openjdk-11-jdk libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 cmake gcc clang-10 lld-10 llvm-10-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
+sudo apt-get install build-essential m4 openjdk-11-jdk libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 python3-dev cmake gcc clang-12 lld-12 llvm-12-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 
-Note: we require version 10 or greater for clang, lld, and llvm-tools.
+Note: we require a version between 10 and 14 for clang, lld, and llvm-tools.
 
 On Arch Linux:
 


### PR DESCRIPTION
This is a tiny PR to address the installation instructions being out of date for Ubuntu Jammy. Tested locally on both Focal and Jammy; no issues.

Fixes #2880 