### PR TITLE
Automatically change base branch to develop on PRs

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -1,0 +1,39 @@
+name: 'Bump version and make master job'
+on:
+  push:
+    branches:
+      - 'develop'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  version-bump:
+    name: 'Version Bump'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
+          # fetch-depth 0 means deep clone the repo
+          fetch-depth: 0
+      - name: 'Update Version'
+        run: |
+          set -x
+          git config user.name devops
+          git config user.email devops@runtimeverification.com
+          git checkout -B master origin/master
+          old_develop="$(git merge-base origin/develop origin/master)"
+          new_develop="$(git rev-parse origin/develop)"
+          if git diff --exit-code ${old_develop} ${new_develop} -- package/version; then
+            git merge --no-edit origin/develop
+            ./package/version.sh bump
+          else
+            git merge --no-edit --strategy-option=theirs origin/develop
+          fi
+          ./package/version.sh sub
+          if git add --update && git commit --no-edit --allow-empty --message "Set Version: $(cat package/version)"; then
+            git push origin master
+          fi

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -19,12 +19,14 @@ jobs:
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
           # fetch-depth 0 means deep clone the repo
           fetch-depth: 0
-      - name: 'Update Version'
+      - name: 'Change base'
+        env:
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
         run: |
           set -x
           pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
           curl -X PATCH                                                             \
             -H "Accept: application/vnd.github+json"                                \
-            -H "Authorization: Bearer <YOUR-TOKEN>"                                 \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}"                              \
             https://api.github.com/repos/runtimeverification/k/pulls/${pull_number} \
             -d '{"base":"develop"}'

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -1,0 +1,30 @@
+name: 'Test PR'
+on:
+  pull_request:
+    branches:
+      - 'master'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+
+  change-base:
+    name: 'Change base to develop branch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
+          # fetch-depth 0 means deep clone the repo
+          fetch-depth: 0
+      - name: 'Update Version'
+        run: |
+          set -x
+          pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
+          curl -X PATCH                                                             \
+            -H "Accept: application/vnd.github+json"                                \
+            -H "Authorization: Bearer <YOUR-TOKEN>"                                 \
+            https://api.github.com/repos/runtimeverification/k/pulls/${pull_number} \
+            -d '{"base":"develop"}'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -24,7 +24,6 @@ jobs:
           set -x
           git config user.name devops
           git config user.email devops@runtimeverification.com
-          ./package/version.sh bump $(git show origin/${GITHUB_BASE_REF}:package/version)
           ./package/version.sh sub
           if git add --update && git commit --message "Set Version: $(cat package/version)"; then
             git push origin HEAD:${GITHUB_HEAD_REF}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -2,7 +2,7 @@ name: 'Test PR'
 on:
   pull_request:
     branches:
-      - 'master'
+      - 'develop'
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/package/version.sh
+++ b/package/version.sh
@@ -8,19 +8,13 @@ fatal() { echo "[FATAL] $@" ; exit 1 ; }
 version_file="package/version"
 
 version_bump() {
-    local version release_commit version_major version_minor version_patch new_version current_version current_version_major current_version_minor current_version_patch
-    version="$1" ; shift
-    version_major="$(echo ${version} | cut --delimiter '.' --field 1)"
-    version_minor="$(echo ${version} | cut --delimiter '.' --field 2)"
-    version_patch="$(echo ${version} | cut --delimiter '.' --field 3)"
-    current_version="$(cat ${version_file})"
-    current_version_major="$(echo ${current_version} | cut --delimiter '.' --field 1)"
-    current_version_minor="$(echo ${current_version} | cut --delimiter '.' --field 2)"
-    current_version_patch="$(echo ${current_version} | cut --delimiter '.' --field 3)"
+    local version release_commit version_major version_minor version_patch new_version
+    version="$(cat ${version_file})"
+    version_major="$(echo ${current_version} | cut --delimiter '.' --field 1)"
+    version_minor="$(echo ${current_version} | cut --delimiter '.' --field 2)"
+    version_patch="$(echo ${current_version} | cut --delimiter '.' --field 3)"
     new_version="${version}"
-    if [[ "${version_major}" == "${current_version_major}" ]] && [[ "${version_minor}" == "${current_version_minor}" ]]; then
-        new_version="${version_major}.${version_minor}.$((version_patch + 1))"
-    fi
+    new_version="${version_major}.${version_minor}.$((version_patch + 1))"
     echo "${new_version}" > "${version_file}"
     notif "Version: ${new_version}"
 }


### PR DESCRIPTION
This PR changes:

- On PRs opened into `master` branch, automatically changes the merge-base to `develop` branch.
- Runs normal CI checks on PRs to `develop` branch.
- Normal CI version bumper is changed to not bump versions, but just to sub them (to make sure version identifiers are consistent throughout the repo).
- On updates to `develop` branch, merges thoes changes into `master` and bumps the version number (if it's not manually changed by the `develop` branch in the meantime).

This mirrors almost exactly the logic we had before for the `master` and `release` branch, only now we are having the correct version identifier be on the `master` branch (default to clone), and automatically adjusting PRs to go into `develop` branch instead.

After merging this, the `master` status checks need to be updated to look like the `release` status checks.