### PR TITLE
Fix version bump for master job

### DIFF
--- a/package/version.sh
+++ b/package/version.sh
@@ -10,9 +10,9 @@ version_file="package/version"
 version_bump() {
     local version release_commit version_major version_minor version_patch new_version
     version="$(cat ${version_file})"
-    version_major="$(echo ${current_version} | cut --delimiter '.' --field 1)"
-    version_minor="$(echo ${current_version} | cut --delimiter '.' --field 2)"
-    version_patch="$(echo ${current_version} | cut --delimiter '.' --field 3)"
+    version_major="$(echo ${version} | cut --delimiter '.' --field 1)"
+    version_minor="$(echo ${version} | cut --delimiter '.' --field 2)"
+    version_patch="$(echo ${version} | cut --delimiter '.' --field 3)"
     new_version="${version}"
     new_version="${version_major}.${version_minor}.$((version_patch + 1))"
     echo "${new_version}" > "${version_file}"


### PR DESCRIPTION
A variable is named incorrectly in the `package/version.sh`, which was causing the master job to fail: https://github.com/runtimeverification/k/actions/workflows/develop.yml