### PR TITLE
Hotfix for release job

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -14,8 +14,10 @@ jobs:
             os: ubuntu-latest
           - runner: macos-12
             os: macos-12
-          - runner: MacM1
-            os: self-macos-12
+          # Disabled as a hotfix until this PR is merged:
+          # https://github.com/runtimeverification/k/pull/2924
+          # - runner: MacM1
+          #   os: self-macos-12
     runs-on: ${{ matrix.runner }}
     steps:
       - name: 'Check out code'
@@ -54,4 +56,3 @@ jobs:
           kup=$(nix build .#kup --json | jq -r '.[].outputs | to_entries[].value')
           drv=$(nix-store --query --deriver ${kup})
           nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
-            


### PR DESCRIPTION
The current workflow file for master pushes tries to run on the M1 mac; this is known to be broken wrt. Nix and is fixed in a different PR: https://github.com/runtimeverification/k/pull/2924

This PR is a hotfix for the issue that we can revert when the above PR is merged.