### PR TITLE
master-push workflow fix

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -14,8 +14,10 @@ jobs:
             os: ubuntu-latest
           - runner: macos-12
             os: macos-12
-          - runner: MacM1
-            os: self-macos-12
+          # Disabled as a hotfix until this PR is merged:
+          # https://github.com/runtimeverification/k/pull/2924
+          # - runner: MacM1
+          #   os: self-macos-12
     runs-on: ${{ matrix.runner }}
     steps:
       - name: 'Check out code'
@@ -51,6 +53,8 @@ jobs:
             
       - name: 'Build and cache kup'
         run: |
+          export GC_DONT_GC=1
+          export CACHIX_AUTH_TOKEN=${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}
           kup=$(nix build .#kup --json | jq -r '.[].outputs | to_entries[].value')
           drv=$(nix-store --query --deriver ${kup})
           nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework

--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -14,10 +14,8 @@ jobs:
             os: ubuntu-latest
           - runner: macos-12
             os: macos-12
-          # Disabled as a hotfix until this PR is merged:
-          # https://github.com/runtimeverification/k/pull/2924
-          # - runner: MacM1
-          #   os: self-macos-12
+          - runner: MacM1
+            os: self-macos-12
     runs-on: ${{ matrix.runner }}
     steps:
       - name: 'Check out code'


### PR DESCRIPTION
it seems that steps in the CI do not share exported bash variables. this should fix the failing kup step 