### PR TITLE
Release nix on M1 mac

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -14,10 +14,8 @@ jobs:
             os: ubuntu-latest
           - runner: macos-12
             os: macos-12
-          # Disabled as a hotfix until this PR is merged:
-          # https://github.com/runtimeverification/k/pull/2924
-          # - runner: MacM1
-          #   os: self-macos-12
+          - runner: MacM1
+            os: self-macos-12
     runs-on: ${{ matrix.runner }}
     steps:
       - name: 'Check out code'


### PR DESCRIPTION
This was hotfixed in https://github.com/runtimeverification/k/pull/2937, but can be reinstated now that CI runs on the M1 machine as well (https://github.com/runtimeverification/k/pull/2924).