### PR TITLE
Fix JQ error on M1 release CI

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -41,16 +41,37 @@ jobs:
           signingKey: '${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}'
 
       - name: 'Build and cache K Framework'
-        run: |
-          export GC_DONT_GC=1
-          export CACHIX_AUTH_TOKEN=${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}
-          nix shell nixpkgs#jq
-          k=$(nix build .#k --json | jq -r '.[].outputs | to_entries[].value')
-          drv=$(nix-store --query --deriver ${k})
-          nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
+        uses: workflow/nix-shell-action@v3
+        env:
+          GC_DONT_GC: 1
+          CACHIX_AUTH_TOKEN: '${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}'
+        with:
+          packages: jq
+          script: |
+            k=$(nix build .#k --json | jq -r '.[].outputs | to_entries[].value')
+            drv=$(nix-store --query --deriver ${k})
+            nix-store --query --requisites --include-outputs ${drv} # | cachix push k-framework
+
+      - name: 'Build and cache kup'
+        uses: workflow/nix-shell-action@v3
+        env:
+          GC_DONT_GC: 1
+          CACHIX_AUTH_TOKEN: '${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}'
+        with:
+          packages: jq
+          script: |
+            k=$(nix build .#k --json | jq -r '.[].outputs | to_entries[].value')
+            drv=$(nix-store --query --deriver ${k})
+            nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
             
       - name: 'Build and cache kup'
-        run: |
-          kup=$(nix build .#kup --json | jq -r '.[].outputs | to_entries[].value')
-          drv=$(nix-store --query --deriver ${kup})
-          nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework
+        uses: workflow/nix-shell-action@v3
+        env:
+          GC_DONT_GC: 1
+          CACHIX_AUTH_TOKEN: '${{ secrets.RV_DEVOPS_CACHIX_TOKEN }}'
+        with:
+          packages: jq
+          script: |
+            kup=$(nix build .#kup --json | jq -r '.[].outputs | to_entries[].value')
+            drv=$(nix-store --query --deriver ${kup})
+            nix-store --query --requisites --include-outputs ${drv} | cachix push k-framework


### PR DESCRIPTION
Some combination of `nix shell`, Github actions, and a subshell invocation was breaking when run in CI. This PR uses the official nix shell action to avoid this problem.

I've tested these changes by removing the branch predicate from the workflow, and having it back out before pushing to cachix. The problem with `jq` is not present in this fixed version.