### PR TITLE
Add token to authenticate github API requests

### DIFF
--- a/.github/workflows/master-push.yml
+++ b/.github/workflows/master-push.yml
@@ -30,6 +30,7 @@ jobs:
         uses: cachix/install-nix-action@v15
         with:
           extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
         uses: cachix/install-nix-action@v14.1
         with:
           install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload release.nix
         uses: ttuegel/upload-release.nix@v1.0

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -43,6 +43,8 @@ jobs:
         uses: cachix/install-nix-action@v14.1
         with:
           install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Install Cachix'
         uses: cachix/cachix-action@v10


### PR DESCRIPTION
We were seeing Github API rate limiting errors for the master nix release job; this PR adds our github secret token to the environment per the instructions [here](https://github.com/marketplace/actions/nix-shell) so that our requests will be authenticated.