### PR TITLE
Move macro attribute from rules to syntax

### DIFF
--- a/k-distribution/pl-tutorial/1_k/1_lambda/lesson_7/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/1_lambda/lesson_7/lambda.k
@@ -21,16 +21,16 @@ module LAMBDA-SYNTAX
 
   syntax Exp ::= "if" Exp "then" Exp "else" Exp  [strict(1)]
 
-  syntax Exp ::= "let" KVar "=" Exp "in" Exp
-  rule let X = E in E':Exp => (lambda X . E') E                        [macro]
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp [macro]
   syntax KVar ::= "$x" [token] | "$y" [token]
   rule letrec F:KVar X:KVar = E in E'
     => let F =
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
-       in E'                                                           [macro]
+       in E'
 endmodule
 
 module LAMBDA

--- a/k-distribution/pl-tutorial/1_k/1_lambda/lesson_8/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/1_lambda/lesson_8/lambda.k
@@ -21,12 +21,12 @@ module LAMBDA-SYNTAX
 
   syntax Exp ::= "if" Exp "then" Exp "else" Exp  [strict(1)]
 
-  syntax Exp ::= "let" KVar "=" Exp "in" Exp
-  rule let X = E in E':Exp => (lambda X . E') E                        [macro]
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
-               | "mu" KVar "." Exp      [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:KVar X = E in E' => let F = mu F . lambda X . E in E'    [macro]
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp [macro]
+               | "mu" KVar "." Exp                   [binder, latex(\mu{#1}.{#2})]
+  rule letrec F:KVar X = E in E' => let F = mu F . lambda X . E in E'
 endmodule
 
 module LAMBDA

--- a/k-distribution/pl-tutorial/1_k/1_lambda/lesson_9/lambda.md
+++ b/k-distribution/pl-tutorial/1_k/1_lambda/lesson_9/lambda.md
@@ -124,8 +124,8 @@ really necessary, but it makes the definition of letrec easier to understand
 and faster to execute.
 
 ```k
-  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
-               | "mu" KVar "." Exp                  [macro, binder, latex(\mu{#1}.{#2})]
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp [macro]
+               | "mu" KVar "." Exp                   [binder, latex(\mu{#1}.{#2})]
   rule letrec F:KVar X:KVar = E in E' => let F = mu F . lambda X . E in E'
 endmodule
 ```

--- a/k-distribution/pl-tutorial/1_k/1_lambda/lesson_9/lambda.md
+++ b/k-distribution/pl-tutorial/1_k/1_lambda/lesson_9/lambda.md
@@ -114,8 +114,8 @@ Note that the `if` construct is strict only in its first argument.
 The let binder is a derived construct, because it can be defined using λ.
 
 ```k
-  syntax Exp ::= "let" KVar "=" Exp "in" Exp
-  rule let X = E in E':Exp => (lambda X . E') E                         [macro]
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 ```
 
 ### Letrec Binder
@@ -125,8 +125,8 @@ and faster to execute.
 
 ```k
   syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
-               | "mu" KVar "." Exp                  [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:KVar X:KVar = E in E' => let F = mu F . lambda X . E in E' [macro]
+               | "mu" KVar "." Exp                  [macro, binder, latex(\mu{#1}.{#2})]
+  rule letrec F:KVar X:KVar = E in E' => let F = mu F . lambda X . E in E'
 endmodule
 ```
 

--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_1/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_1/lambda.k
@@ -21,12 +21,12 @@ module LAMBDA-SYNTAX
 
   syntax Exp ::= "if" Exp "then" Exp "else" Exp  [strict(1)]
 
-  syntax Exp ::= "let" KVar "=" Exp "in" Exp
-  rule let X = E in E':Exp => (lambda X . E') E                        [macro]
+  syntax Exp ::= "let" KVar "=" Exp "in" Exp [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp
-               | "mu" KVar "." Exp                 [binder, latex(\mu{#1}.{#2})]
-  rule letrec F:KVar X = E in E' => let F = mu F . lambda X . E in E'    [macro]
+  syntax Exp ::= "letrec" KVar KVar "=" Exp "in" Exp  [macro]
+               | "mu" KVar "." Exp                    [binder, latex(\mu{#1}.{#2})]
+  rule letrec F:KVar X = E in E' => let F = mu F . lambda X . E in E'
 
   syntax Exp ::= "callcc" Exp  [strict]
   syntax Val ::= cc(K)

--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_3/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_3/lambda.k
@@ -43,14 +43,14 @@ module LAMBDA
   rule if true  then E else _ => E
   rule if false then _ else E => E
 
-  syntax Exp ::= "let" Id "=" Exp "in" Exp
-  rule let X = E in E':Exp => (lambda X . E') E                        [macro]
+  syntax Exp ::= "let" Id "=" Exp "in" Exp [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
+  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp [macro]
   syntax Id ::= "$x" [token] | "$y" [token]
   rule letrec F:Id X:Id = E in E'
     => let F =
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
-       in E'                                                           [macro]
+       in E'
 endmodule

--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_4/README.md
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_4/README.md
@@ -69,7 +69,7 @@ possible?  The problem is now the non-deterministic evaluation strategy of
 the function application construct.  Indeed, recall that the semantics of
 the let-in construct is defined by desugaring to lambda application:
 
-    rule let X = E in E' => (lambda X . E') E     [macro]
+    rule let X = E in E' => (lambda X . E') E
 
 With this, the program above eventually reduces to
 

--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_4/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_4/lambda.k
@@ -43,16 +43,16 @@ module LAMBDA
   rule if true  then E else _ => E
   rule if false then _ else E => E
 
-  syntax Exp ::= "let" Id "=" Exp "in" Exp
-  rule let X = E in E':Exp => (lambda X . E') E                        [macro]
+  syntax Exp ::= "let" Id "=" Exp "in" Exp [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
+  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp [macro]
   syntax Id ::= "$x" [token] | "$y" [token]
   rule letrec F:Id X:Id = E in E'
     => let F =
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
          (lambda $x . ((lambda F . lambda X . E) (lambda $y . ($x $x $y))))
-       in E'                                                           [macro]
+       in E'
 
   syntax Exp ::= "callcc" Exp  [strict]
   syntax Val ::= cc(K)

--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_5/README.md
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_5/README.md
@@ -28,9 +28,9 @@ Let us next add one more closure-like semantic computational item, for `mu`.
 But before that, let us reuse the semantics of `letrec` in terms of `mu` that
 was defined in Lesson 8 of Part 1 of the tutorial on LAMBDA:
 
-    syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
-                 | "mu" Id "." Exp      [latex(\mu{#1}.{#2})]
-    rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'    [macro]
+    syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp [macro]
+                 | "mu" Id "." Exp                 [latex(\mu{#1}.{#2})]
+    rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'
 
 We removed the `binder` annotation of `mu`, because it is not necessary
 anymore (since we do not work with substitutions anymore).

--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_5/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_5/lambda.k
@@ -44,12 +44,12 @@ module LAMBDA
   rule if true  then E else _ => E
   rule if false then _ else E => E
 
-  syntax Exp ::= "let" Id "=" Exp "in" Exp
-  rule let X = E in E':Exp => (lambda X . E') E                        [macro]
+  syntax Exp ::= "let" Id "=" Exp "in" Exp [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 
-  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp
-               | "mu" Id "." Exp      [latex(\mu{#1}.{#2})]
-  rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'    [macro]
+  syntax Exp ::= "letrec" Id Id "=" Exp "in" Exp  [macro]
+               | "mu" Id "." Exp                  [latex(\mu{#1}.{#2})]
+  rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'
 
   syntax Exp ::= muclosure(Map,Exp)
   rule <k> mu X . E => muclosure(Rho[X <- !N], E) ...</k>

--- a/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_6/lambda.md
+++ b/k-distribution/pl-tutorial/1_k/3_lambda++/lesson_6/lambda.md
@@ -50,8 +50,8 @@ We move all the LAMBDA++ syntax here.
                > Exp "<=" Exp         [strict]
 // Other functional constructs
   syntax Exp ::= "if" Exp "then" Exp "else" Exp  [strict(1)] // Conditional
-               | "let" Id "=" Exp "in" Exp                   // Let binder
-               | "letrec" Id Id "=" Exp "in" Exp             // Letrec
+               | "let" Id "=" Exp "in" Exp [macro]           // Let binder
+               | "letrec" Id Id "=" Exp "in" Exp [macro]     // Letrec
                | "mu" Id "." Exp      [latex(\mu{#1}.{#2})]  // Mu
                | "callcc" Exp  [strict]                      // Callcc
 ```
@@ -160,14 +160,14 @@ division rule.
 ### Let Binder
 
 ```k
-  rule let X = E in E':Exp => (lambda X . E') E                         [macro]
+  rule let X = E in E':Exp => (lambda X . E') E
 ```
 
 ### Letrec Binder
 We define `letrec` in term of `mu`, whose semantics is below.
 
 ```k
-  rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'     [macro]
+  rule letrec F:Id X = E in E' => let F = mu F . lambda X . E in E'
 ```
 
 ### Mu

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_1.9/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_1.9/lambda.k
@@ -40,12 +40,12 @@ module LAMBDA
   syntax Exp ::= "if" Exp "then" Exp "else" Exp
   rule if bool then T:Type else T => T         [anywhere]
 
-  syntax Exp ::= "let" KVar ":" Type "=" Exp "in" Exp
-  rule let X : T = E in E' => (lambda X : T . E') E                   [macro]
+  syntax Exp ::= "let" KVar ":" Type "=" Exp "in" Exp [macro]
+  rule let X : T = E in E' => (lambda X : T . E') E
 
-  syntax Exp ::= "letrec" KVar ":" Type KVar ":" Type "=" Exp "in" Exp
-               | "mu" KVar ":" Type "." Exp      [binder]
+  syntax Exp ::= "letrec" KVar ":" Type KVar ":" Type "=" Exp "in" Exp  [macro]
+               | "mu" KVar ":" Type "." Exp                             [binder]
   rule letrec F : T1  X : T2 = E in E'
-    => let F : T1 = mu F : T1 . lambda X : T2 . E in E'               [macro]
+    => let F : T1 = mu F : T1 . lambda X : T2 . E in E'
   rule mu X : T . E => (T -> T) (E[T/X])         [anywhere]
 endmodule

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_2/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_2/lambda.k
@@ -40,12 +40,12 @@ module LAMBDA
   syntax Exp ::= "if" Exp "then" Exp "else" Exp                       [strict]
   rule if bool then T:Type else T => T
 
-  syntax Exp ::= "let" KVar ":" Type "=" Exp "in" Exp
-  rule let X : T = E in E' => (lambda X : T . E') E                   [macro]
+  syntax Exp ::= "let" KVar ":" Type "=" Exp "in" Exp [macro]
+  rule let X : T = E in E' => (lambda X : T . E') E
 
-  syntax Exp ::= "letrec" KVar ":" Type KVar ":" Type "=" Exp "in" Exp
+  syntax Exp ::= "letrec" KVar ":" Type KVar ":" Type "=" Exp "in" Exp  [macro]
                | "mu" KVar ":" Type "." Exp                             [binder]
   rule letrec F : T1  X : T2 = E in E'
-    => let F : T1 = mu F : T1 . lambda X : T2 . E in E'               [macro]
+    => let F : T1 = mu F : T1 . lambda X : T2 . E in E'
   rule mu X : T . E => (T -> T) (E[T/X])
 endmodule

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_3/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_3/lambda.k
@@ -43,13 +43,13 @@ module LAMBDA
   syntax Exp ::= "if" Exp "then" Exp "else" Exp                       [strict]
   rule if bool then T:Type else T => T
 
-  syntax Exp ::= "let" Id ":" Type "=" Exp "in" Exp
-  rule let X : T = E in E' => (lambda X : T . E') E                   [macro]
+  syntax Exp ::= "let" Id ":" Type "=" Exp "in" Exp [macro]
+  rule let X : T = E in E' => (lambda X : T . E') E
 
-  syntax Exp ::= "letrec" Id ":" Type Id ":" Type "=" Exp "in" Exp
+  syntax Exp ::= "letrec" Id ":" Type Id ":" Type "=" Exp "in" Exp [macro]
                | "mu" Id ":" Type "." Exp
   rule letrec F : T1  X : T2 = E in E'
-    => let F : T1 = mu F : T1 . lambda X : T2 . E in E'               [macro]
+    => let F : T1 = mu F : T1 . lambda X : T2 . E in E'
   rule <k> mu X : T . E => (T -> T) E ~> Rho ...</k>
        <tenv> Rho => Rho[X <- T] </tenv>
 

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_4/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_4/lambda.k
@@ -15,8 +15,8 @@ module LAMBDA
                > Exp "<=" Exp                     [strict]
                > "lambda" KVar "." Exp              [binder]
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" KVar "=" Exp "in" Exp        [binder]
-               | "letrec" KVar KVar "=" Exp "in" Exp  [binder]
+               | "let" KVar "=" Exp "in" Exp        [macro, binder]
+               | "letrec" KVar KVar "=" Exp "in" Exp  [macro, binder]
                | "mu" KVar "." Exp                  [binder]
 
   syntax Type ::= "int" | "bool"
@@ -40,8 +40,8 @@ module LAMBDA
 
   rule T1:Type T2:Type => T1 = (T2 -> ?T:Type) ~> ?T
   rule if T:Type then T1:Type else T2:Type => T = bool ~> T1 = T2 ~> T1
-  rule let X = E in E' => (lambda X . E') E                             [macro]
-  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
+  rule let X = E in E' => (lambda X . E') E
+  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'
   rule mu X . E => (?T:Type -> ?T) (E[?T/X])
 
   syntax KItem ::= Type "=" Type

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_5/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_5/lambda.k
@@ -12,8 +12,8 @@ module LAMBDA
                > Exp "<=" Exp                     [strict]
                > "lambda" Id "." Exp
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" Id "=" Exp "in" Exp
-               | "letrec" Id Id "=" Exp "in" Exp
+               | "let" Id "=" Exp "in" Exp        [macro]
+               | "letrec" Id Id "=" Exp "in" Exp  [macro]
                | "mu" Id "." Exp
 
   syntax Type ::= "int" | "bool"
@@ -39,8 +39,8 @@ module LAMBDA
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
   rule T1:Type T2:Type => T1 = (T2 -> ?T:Type) ~> ?T
   rule if T:Type then T1:Type else T2:Type => T = bool ~> T1 = T2 ~> T1
-  rule let X = E in E' => (lambda X . E') E                             [macro]
-  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
+  rule let X = E in E' => (lambda X . E') E
+  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'
   rule <k> mu X:Id . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_6/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_6/lambda.k
@@ -12,8 +12,8 @@ module LAMBDA
                > Exp "<=" Exp
                > "lambda" Id "." Exp
                | "if" Exp "then" Exp "else" Exp
-               | "let" Id "=" Exp "in" Exp
-               | "letrec" Id Id "=" Exp "in" Exp
+               | "let" Id "=" Exp "in" Exp        [macro]
+               | "letrec" Id Id "=" Exp "in" Exp  [macro]
                | "mu" Id "." Exp
 
   syntax Type ::= "int" | "bool"
@@ -59,8 +59,8 @@ module LAMBDA
              <task> <k> E1 = ?T </k> <tenv> Rho </tenv> </task>
              <task> <k> E2 = ?T </k> <tenv> Rho </tenv> </task>)
 
-  rule let X = E in E' => (lambda X . E') E                             [macro]
-  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
+  rule let X = E in E' => (lambda X . E') E
+  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'
   rule <k> mu X . E => ?T:Type ...</k>  <tenv> TEnv </tenv>
        (.Bag => <task> <k> E = ?T </k> <tenv> TEnv[X <- ?T] </tenv> </task>)
 

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_7/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_7/lambda.k
@@ -15,8 +15,8 @@ module LAMBDA
                > Exp "<=" Exp                     [strict]
                > "lambda" KVar "." Exp              [binder]
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" KVar "=" Exp "in" Exp        [binder]
-               | "letrec" KVar KVar "=" Exp "in" Exp  [binder]
+               | "let" KVar "=" Exp "in" Exp        [macro, binder]
+               | "letrec" KVar KVar "=" Exp "in" Exp  [macro, binder]
                | "mu" KVar "." Exp                  [binder]
 
   syntax Type ::= "int" | "bool"
@@ -40,8 +40,8 @@ module LAMBDA
 
   rule T1:Type T2:Type => T1 = (T2 -> ?T:Type) ~> ?T
   rule if T:Type then T1:Type else T2:Type => T = bool ~> T1 = T2 ~> T1
-  rule let X = E in E' => E'[E/X]                                       [macro]
-  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
+  rule let X = E in E' => E'[E/X]
+  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'
   rule mu X . E => (?T:Type -> ?T) (E[?T/X])
 
   syntax KItem ::= Type "=" Type

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_8/README.md
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_8/README.md
@@ -9,18 +9,18 @@ characters. In terms of the K framework, you will learn how to have
 both environments and substitution in the same definition.
 
 Like in the previous lesson, all we have to do is to take the LAMBDA
-type inferencer in Lesson 5 and only change the macro
+type inferencer in Lesson 5 and only change the rule
 
-    rule let X = E in E' => (lambda X . E') E  [macro]
+    rule let X = E in E' => (lambda X . E') E
 
 as follows:
 
-    rule let X = E in E' => E'[E/X]  [macro]
+    rule let X = E in E' => E'[E/X]
 
 The reasons why this works have already been explained in the previous
 lesson, so we do not repeat them here.
 
-Since our new let macro uses substitution, we have to require the
+Since our new let rule uses substitution, we have to require the
 substitution module at the top and also import SUBSTITUTION in the
 current module, besides the already existing UNIFICATION.
 

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_8/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_8/lambda.k
@@ -15,8 +15,8 @@ module LAMBDA
                > Exp "<=" Exp                     [strict]
                > "lambda" KVar "." Exp              [binder]
                | "if" Exp "then" Exp "else" Exp   [strict]
-               | "let" KVar "=" Exp "in" Exp
-               | "letrec" KVar KVar "=" Exp "in" Exp
+               | "let" KVar "=" Exp "in" Exp          [macro]
+               | "letrec" KVar KVar "=" Exp "in" Exp  [macro]
                | "mu" KVar "." Exp                  [binder]
 
   syntax Type ::= "int" | "bool"
@@ -43,8 +43,8 @@ module LAMBDA
 
   rule T1:Type T2:Type => T1 = (T2 -> ?T:Type) ~> ?T
   rule if T:Type then T1:Type else T2:Type => T = bool ~> T1 = T2 ~> T1
-  rule let X = E in E' => E'[E/X]                                       [macro]
-  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
+  rule let X = E in E' => E'[E/X]
+  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'
   rule <k> mu X:KVar . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_9.5/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_9.5/lambda.k
@@ -16,7 +16,7 @@ module LAMBDA-SYNTAX
                > "lambda" KVar "." Exp
                | "if" Exp "then" Exp "else" Exp   [strict]
                | "let" KVar "=" Exp "in" Exp        [strict(2)]
-               | "letrec" KVar KVar "=" Exp "in" Exp
+               | "letrec" KVar KVar "=" Exp "in" Exp [macro]
                | "mu" KVar "." Exp
 endmodule
 
@@ -60,7 +60,7 @@ module LAMBDA
   rule <k> X:KVar => #renameMetaKVariables(T, Tvs) ...</k>
        <tenv>... X |-> (forall Tvs) T ...</tenv>
 
-  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
+  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'
   rule <k> mu X:KVar . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_9/README.md
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_9/README.md
@@ -21,7 +21,7 @@ the above possible.
 
 The main idea is to replace the rule
 
-    rule let X = E in E' => E'[E/X]  [macro]
+    rule let X = E in E' => E'[E/X]
 
 which creates potentially many copies of `E` within `E'` with a rule
 which types `E` once and then reuses that type in each place where `X`
@@ -137,9 +137,9 @@ of a type schema will always be a set of fresh types. We also declare
 this construct to be a `binder`, so that we can make use of the generic
 free variable function provided by the K tool.
 
-We now replace the old macro of `let`
+We now replace the old rule for `let`
 
-    rule let X = E in E' => E'[E/X]  [macro]
+    rule let X = E in E' => E'[E/X]
 
 with the following rule:
 

--- a/k-distribution/pl-tutorial/1_k/5_types/lesson_9/lambda.k
+++ b/k-distribution/pl-tutorial/1_k/5_types/lesson_9/lambda.k
@@ -16,7 +16,7 @@ module LAMBDA
                > "lambda" Id "." Exp
                | "if" Exp "then" Exp "else" Exp   [strict]
                | "let" Id "=" Exp "in" Exp        [strict(2)]
-               | "letrec" Id Id "=" Exp "in" Exp
+               | "letrec" Id Id "=" Exp "in" Exp  [macro]
                | "mu" Id "." Exp
 
   syntax Type ::= "int" | "bool"
@@ -53,7 +53,7 @@ module LAMBDA
   rule <k> X:Id => #renameMetaKVariables(T, Tvs) ...</k>
        <tenv>... X |-> (forall Tvs) T ...</tenv>
 
-  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'        [macro]
+  rule letrec F X = E in E' => let F = mu F . lambda X . E in E'
   rule <k> mu X:Id . E:Exp => (?T:Type -> ?T) E ~> setTenv(TEnv) ...</k>
        <tenv> TEnv => TEnv[X <- ?T] </tenv>
 

--- a/k-distribution/tests/regression-new/checks/checkMacroRecord.k
+++ b/k-distribution/tests/regression-new/checks/checkMacroRecord.k
@@ -5,8 +5,8 @@ module CHECKMACRORECORD
 
     configuration <k> $PGM:Int </k>
 
-    syntax Int ::= f ( a: Int, b: Int )
+    syntax Int ::= f ( a: Int, b: Int ) [macro]
  // -----------------------------------
-    rule f(X, Y) => X +Int Y [macro]
+    rule f(X, Y) => X +Int Y
 
 endmodule

--- a/k-distribution/tests/regression-new/checks/macroWithFunction.k
+++ b/k-distribution/tests/regression-new/checks/macroWithFunction.k
@@ -8,13 +8,13 @@ module MACROWITHFUNCTION
  // ---------------------------------------------------------------------
 
     syntax Wad = FInt
-    syntax Wad ::= wad ( Int )
+    syntax Wad ::= wad ( Int ) [macro]
  // --------------------------
-    rule wad(I) => FInt(I *Int WAD, WAD) [macro]
+    rule wad(I) => FInt(I *Int WAD, WAD)
 
-    syntax Int ::= "WAD"
+    syntax Int ::= "WAD" [macro]
  // --------------------
-    rule WAD => 1000000000000000000 [macro]
+    rule WAD => 1000000000000000000
 
     syntax Pgm ::= "go" FInt | Pgm ";" Pgm [left]
  // ---------------------------------------------

--- a/k-distribution/tests/regression-new/checks/macroWithFunction.k.out
+++ b/k-distribution/tests/regression-new/checks/macroWithFunction.k.out
@@ -1,7 +1,7 @@
 [Error] Compiler: Illegal function symbol _*Int_ on LHS of rule. Consider adding `simplification` attribute to the rule if this is intended.
 	Source(macroWithFunction.k)
 	Location(13,25,13,35)
-	13 |	    rule wad(I) => FInt(I *Int WAD, WAD) [macro]
+	13 |	    rule wad(I) => FInt(I *Int WAD, WAD)
 	   .	                        ^~~~~~~~~~
 [Error] Compiler: Had 1 structural errors after macro expansion.
   while executing phase "expand macros" on sentence at

--- a/k-distribution/tests/regression-new/checks/tokenCheck.k
+++ b/k-distribution/tests/regression-new/checks/tokenCheck.k
@@ -13,7 +13,7 @@ module TOKENCHECK
   syntax Y ::= Z
   syntax Z ::= "b" [token]
 
-  syntax Int ::= "foo"
-  rule foo => 3 [macro]
+  syntax Int ::= "foo" [macro]
+  rule foo => 3
 
 endmodule


### PR DESCRIPTION
This PR is a mechanical transformation of the regression test suite and `1_k` part of the PL tutorial; it moves the `[macro]` attribute from rules to productions and updates test outputs where appropriate.

It does not address the `2_languages` part of the tutorial; the code there needs to be revisited and modernised in more detail than would make sense in this PR.

Fixes #2882 