### PR TITLE
Add preserves-definedness attribute for semantic rules

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -132,7 +132,7 @@ public class KoreBackend extends AbstractBackend {
         Function1<Definition, Definition> markExtraConcreteRules = d -> DefinitionTransformer.fromSentenceTransformer((m, s) ->
                 s instanceof Rule && kompileOptions.extraConcreteRuleLabels.contains(s.att().getOption(Att.LABEL()).getOrElse(() -> null)) ?
                         Rule.apply(((Rule) s).body(), ((Rule) s).requires(), ((Rule) s).ensures(), s.att().add(Att.CONCRETE())) : s, "mark extra concrete rules").apply(d);
-        DefinitionTransformer markPreservesDefinednessDT = DefinitionTransformer.fromSentenceTransformer(KoreBackend::markPreservesDefinedness, "markPreservesDefinednessDT");
+        Function1<Definition, Definition> markPreservesDefinednessDT = d -> DefinitionTransformer.fromSentenceTransformer((m, s) -> new MarkPreserveDefinedness(d).resolve(m, s), "markPreservesDefinednessDT").apply(d);
 
         return def -> resolveComm
                 .andThen(resolveIO)
@@ -222,47 +222,6 @@ public class KoreBackend extends AbstractBackend {
             Att atts = m.attributesFor().get(kl).getOrElse(Att::empty);
             if (!(atts.contains(Att.FUNCTION()) || atts.contains(Att.FUNCTIONAL()) || atts.contains("mlOp")))
                 throw  KEMException.compilerError("Simplification rules expect function/functional/mlOp symbols at the top of the left hand side term.", s);
-        }
-        return s;
-    }
-
-    public static Sentence markPreservesDefinedness(Module m, Sentence s) {
-        // temporary code to test out the efficacy of selective application of @Ceil checks
-        // https://github.com/runtimeverification/k/issues/2943#issuecomment-1265519499
-        if (!(s instanceof Rule)) return s;
-        Rule r = (Rule) s;
-        if (s.att().contains(Att.SIMPLIFICATION()) || s.att().contains(Att.ANYWHERE())) return s;
-        KLabel kl = m.matchKLabel((Rule) s);
-        Att atts = m.attributesFor().get(kl).getOrElse(Att::empty);
-        if (atts.contains(Att.FUNCTION()) || atts.contains(Att.FUNCTIONAL()) || atts.contains("mlOp"))
-            return s;
-        
-        Set<KEMException> errors = new HashSet<>();
-        new RewriteAwareVisitor(true, errors) {
-            @Override
-            public void apply(KApply k) {
-                if (!errors.isEmpty())
-                    return;
-                Att attributes = m.attributesFor().apply(k.klabel());
-                if (isRHS()) {
-                    if (attributes.contains(Att.FUNCTION()) && !attributes.contains(Att.FUNCTIONAL())) // only total functions
-                        errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
-                    else if (attributes.contains(Att.ASSOC()) || attributes.contains(Att.IDEM())) // only constructors
-                        errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
-                }
-                super.apply(k);
-            }
-
-            @Override
-            public void apply(KVariable k) {
-                if (k.name().startsWith("@")) // no set variables
-                    errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
-            }
-        }.apply(r.body());
-
-        if (errors.isEmpty()) {
-            //System.out.println("preserves-definedness: " + r.source().orElse(Source.apply("gen")).source() + ":" + r.location().orElse(Location.apply(0,0,0,0)).startLine());
-            return Rule.apply(r.body(), r.requires(), r.ensures(), r.att().add("preserves-definedness"));
         }
         return s;
     }

--- a/kernel/src/main/java/org/kframework/compile/MarkPreserveDefinedness.java
+++ b/kernel/src/main/java/org/kframework/compile/MarkPreserveDefinedness.java
@@ -1,0 +1,113 @@
+// Copyright (c) 2019 K Team. All Rights Reserved.
+package org.kframework.compile;
+
+import org.kframework.attributes.Att;
+import org.kframework.definition.Definition;
+import org.kframework.definition.Module;
+import org.kframework.definition.Rule;
+import org.kframework.definition.Sentence;
+import org.kframework.kore.KApply;
+import org.kframework.kore.KLabel;
+import org.kframework.kore.KVariable;
+import org.kframework.utils.errorsystem.KEMException;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class MarkPreserveDefinedness {
+
+    private final Module mainModule;
+
+    public MarkPreserveDefinedness(Definition d) {
+        mainModule = d.mainModule();
+    }
+
+
+    public Sentence resolve(Module m, Sentence s) {
+        // temporary code to test out the efficacy of selective application of @Ceil checks
+        // https://github.com/runtimeverification/k/issues/2943#issuecomment-1265519499
+        if (!(s instanceof Rule)) return s;
+        Rule r = (Rule) s;
+        if (r.att().contains(Att.SIMPLIFICATION()) || r.att().contains(Att.ANYWHERE())) return r;
+        KLabel kl = m.matchKLabel(r);
+        Att atts = m.attributesFor().get(kl).getOrElse(Att::empty);
+        if (atts.contains(Att.FUNCTION()) || atts.contains(Att.FUNCTIONAL()) || atts.contains("mlOp"))
+            return r;
+
+        Set<KEMException> errors = new HashSet<>();
+        new RewriteAwareVisitor(true, errors) {
+            @Override
+            public void apply(KApply k) {
+                if (!errors.isEmpty())
+                    return;
+                Att attributes;
+                // special case for when rules are defined in the syntax module, but they don't yet have knowledge of the configuration
+                if (m.attributesFor().contains(k.klabel()))
+                    attributes = m.attributesFor().apply(k.klabel());
+                else
+                    attributes = mainModule.attributesFor().apply(k.klabel());
+                if (isRHS()) {
+                    if (attributes.contains(Att.FUNCTION()) && !attributes.contains(Att.FUNCTIONAL())) // only total functions
+                        errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
+                    else if (attributes.contains(Att.ASSOC()) || attributes.contains(Att.IDEM())) // only constructors
+                        errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
+                }
+                super.apply(k);
+            }
+
+            @Override
+            public void apply(KVariable k) {
+                if (k.name().startsWith("@")) // no set variables
+                    errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
+            }
+        }.apply(r.body());
+
+        if (errors.isEmpty()) {
+            //System.out.println("preserves-definedness: " + r.source().orElse(Source.apply("gen")).source() + ":" + r.location().orElse(Location.apply(0,0,0,0)).startLine());
+            return Rule.apply(r.body(), r.requires(), r.ensures(), r.att().add("preserves-definedness"));
+        }
+        return s;    }
+
+    public static Sentence markPreservesDefinedness(Module m, Sentence s) {
+        // temporary code to test out the efficacy of selective application of @Ceil checks
+        // https://github.com/runtimeverification/k/issues/2943#issuecomment-1265519499
+        if (!(s instanceof Rule)) return s;
+        Rule r = (Rule) s;
+        if (s.att().contains(Att.SIMPLIFICATION()) || s.att().contains(Att.ANYWHERE())) return s;
+        KLabel kl = m.matchKLabel((Rule) s);
+        Att atts = m.attributesFor().get(kl).getOrElse(Att::empty);
+        if (atts.contains(Att.FUNCTION()) || atts.contains(Att.FUNCTIONAL()) || atts.contains("mlOp"))
+            return s;
+
+        Set<KEMException> errors = new HashSet<>();
+        new RewriteAwareVisitor(true, errors) {
+            @Override
+            public void apply(KApply k) {
+                if (!errors.isEmpty())
+                    return;
+                if (!k.klabel().name().equals("<generatedTop>")) { // special case for when rules are defined in the syntax module, but they don't yet have knowledge of the configuration
+                    Att attributes = m.attributesFor().apply(k.klabel());
+                    if (isRHS()) {
+                        if (attributes.contains(Att.FUNCTION()) && !attributes.contains(Att.FUNCTIONAL())) // only total functions
+                            errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
+                        else if (attributes.contains(Att.ASSOC()) || attributes.contains(Att.IDEM())) // only constructors
+                            errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
+                    }
+                }
+                super.apply(k);
+            }
+
+            @Override
+            public void apply(KVariable k) {
+                if (k.name().startsWith("@")) // no set variables
+                    errors.add(KEMException.compilerError("Not an actual error. Used as a marker for markPreservesDefinedness.", r));
+            }
+        }.apply(r.body());
+
+        if (errors.isEmpty()) {
+            //System.out.println("preserves-definedness: " + r.source().orElse(Source.apply("gen")).source() + ":" + r.location().orElse(Location.apply(0,0,0,0)).startLine());
+            return Rule.apply(r.body(), r.requires(), r.ensures(), r.att().add("preserves-definedness"));
+        }
+        return s;
+    }
+}

--- a/kernel/src/main/java/org/kframework/compile/RewriteAwareVisitor.java
+++ b/kernel/src/main/java/org/kframework/compile/RewriteAwareVisitor.java
@@ -18,7 +18,7 @@ import java.util.Set;
  */
 public class RewriteAwareVisitor extends VisitK {
 
-    private final Set<KEMException> errors;
+    protected final Set<KEMException> errors;
     public RewriteAwareVisitor(boolean isBody, Set<KEMException> errors) {
         this.errors = errors;
         if (isBody) {


### PR DESCRIPTION
First item of runtimeverification/haskell-backend#3373
Needs more testing.
Waiting on the haskell-backend to provide a way to check if these changes are correct.