### PR TITLE
Rework update deps

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -150,6 +150,7 @@ jobs:
         uses: cachix/install-nix-action@v15
         with:
           extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
@@ -199,6 +200,8 @@ jobs:
         uses: cachix/install-nix-action@v14.1
         with:
           install_url: "https://releases.nixos.org/nix/nix-2.3.16/install"
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
 
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -40,9 +40,7 @@ jobs:
 
       - name: Update Nix flake inputs from submodules
         run: |
-          if ! GC_DONT_GC=1 nix run .#check-submodules ; then
-            GC_DONT_GC=1 nix run .#update-from-submodules
-            git add 'flake.lock'
-            git commit -m 'Sync flake inputs to submodules'
+          GC_DONT_GC=1 nix run .#update-from-submodules
+          if git add 'flake.lock' && git commit -m 'Sync flake inputs to submodules'; then
             git push
           fi

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -21,6 +21,7 @@ jobs:
           git config --global user.email github-actions@github.com
       - uses: actions/checkout@v3
         with:
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
           submodules: recursive
 
       - name: 'Install Nix'

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,18 +17,11 @@ jobs:
     steps:
       - id: config
         run: |
-          ref=${{ github.ref }}
-          if [ "${{ github.event_name }}" == 'pull_request' ]; then
-            ref="${{ github.event.pull_request.head.sha }}"
-          fi
-          ref="${ref#refs/heads/}"
-          echo "::set-output name=ref::$ref"
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
       - name: Check out code
         uses: actions/checkout@v2.3.4
         with:
-          ref: ${{ steps.config.outputs.ref }}
           submodules: recursive
 
       - name: 'Install Nix'

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -27,6 +27,7 @@ jobs:
         uses: cachix/install-nix-action@v15
         with:
           extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://cache.iog.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -17,8 +17,8 @@ jobs:
     steps:
       - name: 'Check out code, set up Git'
         run: |
-          git config --global user.name github-actions
-          git config --global user.email github-actions@github.com
+          git config --global user.name rv-jenkins
+          git config --global user.email devops@runtimeverification.com
       - uses: actions/checkout@v3
         with:
           token: ${{ secrets.JENKINS_GITHUB_PAT }}

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -15,12 +15,11 @@ jobs:
     name: 'Nix flake submodule sync'
     runs-on: ubuntu-latest
     steps:
-      - id: config
+      - name: 'Check out code, set up Git'
         run: |
           git config --global user.name github-actions
           git config --global user.email github-actions@github.com
-      - name: Check out code
-        uses: actions/checkout@v2.3.4
+      - uses: actions/checkout@v3
         with:
           submodules: recursive
 


### PR DESCRIPTION
This PR does a few cleanups:

- Makes sure that all "Install Nix" steps are authenticated, to avoid rate limits.
- Makes sure that we use `JENKINS_GITHUB_PAT` for the clone on nix-flake sync step,   so that it retriggers workflows on push.
- Simplifies the logic of `git add/commit/push` in the flake submodule sync.