### PR TITLE
Fix stale versions with `mvn package`

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -219,7 +219,7 @@
         <executions>
           <execution>
             <id>get-git-revision</id>
-            <phase>package</phase>
+            <phase>compile</phase>
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>
@@ -240,6 +240,7 @@
         <artifactId>maven-jar-plugin</artifactId>
         <version>2.5</version>
         <configuration>
+          <forceCreation> true </forceCreation>
           <archive>
             <manifestEntries>
               <Implementation-Revision>${buildNumber}</Implementation-Revision>

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -219,7 +219,7 @@
         <executions>
           <execution>
             <id>get-git-revision</id>
-            <phase>compile</phase>
+            <phase>package</phase>
             <configuration>
               <exportAntProperties>true</exportAntProperties>
               <target>


### PR DESCRIPTION
Fixes #2914 - the problem here is that the Jar file containing the version information isn't remade unless something changes in the `kernel/` tree. To fix the problem we just force it to be remade on every packaging phase, even if Maven thinks it doesn't need to be.