### PR TITLE
Speculative fix for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,6 +64,7 @@ jobs:
           docker exec -t k-package-docker-test-jammy bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
+          dockert stop -t 0 k-package-docker-test-jammy
 
   ubuntu-focal:
     name: 'K Ubuntu Focal Package'
@@ -99,6 +100,7 @@ jobs:
           docker exec -t k-package-docker-test-focal bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-focal bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
+          dockert stop -t 0 k-package-docker-test-focal
 
   macos-build:
     name: 'Build MacOS Package'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,11 @@ jobs:
           docker exec -t k-package-docker-test-jammy bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-          dockert stop -t 0 k-package-docker-test-jammy
+      - name: 'Clean up Docker Container'
+        if: always()
+        run: |
+          docker stop -t 0 k-package-docker-test-jammy || true
+          docker rm -f k-package-docker-test-jammy || true 
 
   ubuntu-focal:
     name: 'K Ubuntu Focal Package'
@@ -100,7 +104,11 @@ jobs:
           docker exec -t k-package-docker-test-focal bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-focal bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-          dockert stop -t 0 k-package-docker-test-focal
+      - name: 'Clean up Docker Container'
+        if: always()
+        run: |
+          docker stop -t 0 k-package-docker-test-focal || true
+          docker rm -f k-package-docker-test-focal || true 
 
   macos-build:
     name: 'Build MacOS Package'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         with:
           asset_content_type: 'application/gzip'
           asset_name: 'K Framework Ubuntu Jammy (22.04) Deb'
-          asset_path: kframework_ubuntu_jammy.deb
+          asset_path: kframework_amd64_jammy.deb
           upload_url: ${{ github.event.release.upload_url }}
       - name: 'Test and Push up Docker Image'
         shell: bash {0}
@@ -81,7 +81,7 @@ jobs:
         with:
           asset_content_type: 'application/gzip'
           asset_name: 'K Framework Ubuntu Focal (20.04) Deb'
-          asset_path: kframework_ubuntu_focal.deb
+          asset_path: kframework_amd64_focal.deb
           upload_url: ${{ github.event.release.upload_url }}
       - name: 'Test and Push up Docker Image'
         shell: bash {0}


### PR DESCRIPTION
Potential fix for #2983 by renaming the path that the release job expects to find the built `.deb` files at.