### PR TITLE
Add -v to packaged version string

### DIFF
--- a/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
+++ b/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
@@ -85,7 +85,7 @@ public class JarInfo {
             // the release version if we're not (e.g. from a release tarball).
             String version = mf.getMainAttributes().getValue("Implementation-Git-Describe");
             if (version.isEmpty()) {
-                version = FileUtils.readFileToString(new File(kBase + "/lib/version")).trim();
+                version = "v" + FileUtils.readFileToString(new File(kBase + "/lib/version")).trim();
             }
 
             System.out.println("K version:    " + version);


### PR DESCRIPTION
This fixes the second complaint in #2915 (namely, that the packaged version string reported by the K tools doesn't have `v` in front of it).