### PR TITLE
Have with-docker step run CI script directly

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -22,25 +22,12 @@ runs:
       subdir: k-${{ inputs.distro }}/
       distro: ${{ inputs.distro }}
       llvm: ${{ inputs.llvm }}
-  - name: 'Build Package: ${{ inputs.distro }}'
-    shell: bash {0}
-    env:
-      DISTRO: ${{ inputs.distro }}
-    run: |
-      set -euxo pipefail
-      docker exec -t k-package-build-${DISTRO} /bin/bash -c 'mv package/debian debian'
-      docker exec -t k-package-build-${DISTRO} /bin/bash -c 'mv debian/compat.jammy debian/compat'
-      docker exec -t k-package-build-${DISTRO} /bin/bash -c 'mv debian/control.jammy debian/control'
-      docker exec -t k-package-build-${DISTRO} /bin/bash -c 'mv debian/rules.jammy debian/rules'
-      docker exec -t k-package-build-${DISTRO} /bin/bash -c 'dpkg-buildpackage'
-  - name: 'Tear down Docker'
-    shell: bash {0}
-    env:
-      DISTRO: ${{ inputs.distro }}
-    if: always()
-    run: |
-      docker stop --time=0 k-package-build-${DISTRO}
-      docker container rm --force k-package-build-${DISTRO} || true
+      script: |
+        mv package/debian debian
+        mv debian/compat.jammy debian/compat
+        mv debian/control.jammy debian/control
+        mv debian/rules.jammy debian/rules
+        dpkg-buildpackage
   - name: 'Set up Docker Test Image: ${{ inputs.distro }}'
     shell: bash {0}
     env:

--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -23,6 +23,7 @@ runs:
       distro: ${{ inputs.distro }}
       llvm: ${{ inputs.llvm }}
       script: |
+        |
         mv package/debian debian
         mv debian/compat.jammy debian/compat
         mv debian/control.jammy debian/control

--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -23,7 +23,6 @@ runs:
       distro: ${{ inputs.distro }}
       llvm: ${{ inputs.llvm }}
       script: |
-        |
         mv package/debian debian
         mv debian/compat.jammy debian/compat
         mv debian/control.jammy debian/control

--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -27,7 +27,7 @@ runs:
       SUBDIR: ${{ inputs.subdir }}
       BASE_IMAGE: ${{ inputs.distro }}
       LLVM_VERSION: ${{ inputs.llvm }}
-      SCRIPT: ${{ inputs.script }}
+      SCRIPT: "${{ inputs.script }}"
     run: |
       set -euxo pipefail
 

--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -58,8 +58,8 @@ runs:
           -v "/etc/group:/etc/group:ro"      \
           runtimeverification/${TAG_NAME}
 
-      while read line; do
+      echo ${SCRIPT} | while read line; do
           docker exec --tag ${TAG_NAME} /bin/bash -c "${line}"
-      done <(cat ${SCRIPT})
+      done
 
       docker stop --time=0 ${TAG_NAME}

--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -14,6 +14,9 @@ inputs:
   llvm:
     description: 'LLVM version to use.'
     required: true
+  script:
+    description: 'Commands to run in Docker container.'
+    required: true
 runs:
   using: 'composite'
   steps:
@@ -24,6 +27,7 @@ runs:
       SUBDIR: ${{ inputs.subdir }}
       BASE_IMAGE: ${{ inputs.distro }}
       LLVM_VERSION: ${{ inputs.llvm }}
+      SCRIPT: ${{ inputs.script }}
     run: |
       set -euxo pipefail
 
@@ -53,3 +57,9 @@ runs:
           -v "/etc/passwd:/etc/passwd:ro"    \
           -v "/etc/group:/etc/group:ro"      \
           runtimeverification/${TAG_NAME}
+
+      while read line; do
+          docker exec --tag ${TAG_NAME} /bin/bash -c "${line}"
+      done
+
+      docker stop --time=0 ${TAG_NAME}

--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -60,6 +60,6 @@ runs:
 
       while read line; do
           docker exec --tag ${TAG_NAME} /bin/bash -c "${line}"
-      done
+      done <(cat ${SCRIPT})
 
       docker stop --time=0 ${TAG_NAME}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -81,14 +81,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           submodules: recursive
-      - name: 'Set up Docker'
-        uses: ./.github/actions/with-docker
-        with:
-          tag: k-ci
-          distro: jammy
-          llvm: 14
-      - name: 'Build and Test K'
-        run: docker exec -t k-ci /bin/bash -c 'mvn verify --batch-mode -U'
       - name: 'Check out k-exercises'
         uses: actions/checkout@v3
         with:
@@ -96,16 +88,17 @@ jobs:
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
           submodules: recursive
           path: k-exercises
-      - name: 'Tutorial Integration Tests'
-        run: |
-          docker exec -t k-ci /bin/bash -c 'k-distribution/target/release/k/bin/spawn-kserver kserver.log'
-          docker exec -t k-ci /bin/bash -c 'cd k-exercises/tutorial && make -j`nproc` --output-sync'
-          docker exec -t k-ci /bin/bash -c 'cd k-distribution/k-tutorial/1_basic && ./test_kompile.sh'
-      - name: 'Tear down Docker'
-        if: always()
-        run: |
-          docker stop --time=0 k-ci
-          docker container rm --force k-ci || true
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-docker
+        with:
+          tag: k-ci
+          distro: jammy
+          llvm: 14
+          script: |
+            mvn verify --batch-mode -U
+            k-distribution/target/release/k/bin/spawn-kserver kserver.log
+            cd k-exercises/tutorial && make -j`nproc` --output-sync && cd -
+            cd k-distribution/k-tutorial/1_basic && ./test_kompile.sh && cd -
 
   test-package-ubuntu-jammy:
     name: 'K Ubuntu Jammy Package'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -95,6 +95,7 @@ jobs:
           distro: jammy
           llvm: 14
           script: |
+            |
             mvn verify --batch-mode -U
             k-distribution/target/release/k/bin/spawn-kserver kserver.log
             cd k-exercises/tutorial && make -j`nproc` --output-sync && cd -

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -95,7 +95,6 @@ jobs:
           distro: jammy
           llvm: 14
           script: |
-            |
             mvn verify --batch-mode -U
             k-distribution/target/release/k/bin/spawn-kserver kserver.log
             cd k-exercises/tutorial && make -j`nproc` --output-sync && cd -

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -88,7 +88,7 @@ jobs:
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
           submodules: recursive
           path: k-exercises
-      - name: 'Set up Docker'
+      - name: 'Run K Tests'
         uses: ./.github/actions/with-docker
         with:
           tag: k-ci


### PR DESCRIPTION
This avoids the user having to do the docker setup/teardown themselves by passing the CI script directly into the `with-docker` step.