### PR TITLE
Automatically import BOOL when strictness is applied

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -1623,7 +1623,7 @@ Evaluation Strategy
 ### `strict` and `seqstrict` attributes
 
 The strictness attributes allow defining evaluation strategies without having
-to explicitely make rules which implement them. This is done by injecting
+to explicitly make rules which implement them. This is done by injecting
 *heating* and *cooling* rules for the subterms. For this to work, you need to
 define what a *result* is for K, by extending the  `KResult` sort.
 
@@ -1663,7 +1663,9 @@ variable, but it has special meaning in the context of sentences with the
 `heat` or `cool` attribute. In heating or cooling rules, the variable named
 `HOLE` is considered to be the term being heated or cooled and the compiler
 will generate `isKResult(HOLE)` and `notBool isKResult(HOLE)` side conditions
-appropriately to ensure that the backend does not loop infinitely.
+appropriately to ensure that the backend does not loop infinitely. The module
+`BOOL` will also be automatically and privately included for semantic
+purposes. The syntax for parsing programs will not be affected.
 
 In order for this functionality to work, you need to define the `KResult` sort.
 For instance, we tell K that a term is fully evaluated once it becomes an `Int`

--- a/k-distribution/tests/regression-new/checks/checkStrictBOOLInclusion.k
+++ b/k-distribution/tests/regression-new/checks/checkStrictBOOLInclusion.k
@@ -1,0 +1,17 @@
+module CHECKSTRICTBOOLINCLUSION-SYNTAX
+// https://github.com/runtimeverification/k/issues/2564
+// imports BOOL
+    syntax MyBool ::= "mytrue" | "myfalse"
+    syntax BExp ::= MyBool | BExp "myand" BExp [strict]
+
+    syntax KResult ::= MyBool
+
+endmodule
+
+module CHECKSTRICTBOOLINCLUSION
+    imports CHECKSTRICTBOOLINCLUSION-SYNTAX
+
+    rule mytrue  myand B2 => B2
+    rule myfalse myand _  => myfalse
+
+endmodule

--- a/kernel/src/main/java/org/kframework/compile/ResolveStrict.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveStrict.java
@@ -3,14 +3,10 @@ package org.kframework.compile;
 
 import org.kframework.attributes.Att;
 import org.kframework.builtin.BooleanUtils;
+import org.kframework.builtin.Hooks;
 import org.kframework.builtin.Sorts;
-import org.kframework.definition.Context;
-import org.kframework.definition.ContextAlias;
-import org.kframework.definition.Definition;
+import org.kframework.definition.*;
 import org.kframework.definition.Module;
-import org.kframework.definition.Production;
-import org.kframework.definition.Rule;
-import org.kframework.definition.Sentence;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
@@ -240,6 +236,10 @@ public class ResolveStrict {
                 .filter(s -> s instanceof Production)
                 .map(s -> (Production) s)
                 .filter(p -> p.att().contains("strict") || p.att().contains("seqstrict")).collect(Collectors.toSet()));
-        return Module(input.name(), input.imports(), (scala.collection.Set<Sentence>) stream(input.localSentences()).filter(s -> !(s instanceof ContextAlias)).collect(Collections.toSet()).$bar(immutable(contextsToAdd)), input.att());
+        scala.collection.Set<Import> imports = input.imports();
+        // strictness makes use _andBool_ found in the BOOL module. Make sure it's imported
+        if (!contextsToAdd.isEmpty() && !input.importedModuleNames().contains(Hooks.BOOL))
+            imports = (scala.collection.Set<Import>) Set(Import.apply(d.getModule(Hooks.BOOL).get(), false)).$bar(imports);
+        return Module(input.name(), imports, (scala.collection.Set<Sentence>) stream(input.localSentences()).filter(s -> !(s instanceof ContextAlias)).collect(Collections.toSet()).$bar(immutable(contextsToAdd)), input.att());
     }
 }


### PR DESCRIPTION
Fixes: #2564
This is done for the compiled definition so we don't taint program parsing.