### PR TITLE
Revert "Anywhere is not supported by the haskell backend (#2998)"

### DIFF
--- a/k-distribution/tests/regression-new/checkWarns/checkHaskellAnywhere.k
+++ b/k-distribution/tests/regression-new/checkWarns/checkHaskellAnywhere.k
@@ -1,8 +1,0 @@
-module CHECKHASKELLANYWHERE-SYNTAX
-endmodule
-
-module CHECKHASKELLANYWHERE
-  imports CHECKHASKELLANYWHERE-SYNTAX
-  imports INT
-  rule 1 => 2 [anywhere]
-endmodule

--- a/k-distribution/tests/regression-new/checkWarns/checkHaskellAnywhere.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/checkHaskellAnywhere.k.out
@@ -1,6 +1,0 @@
-[Error] Compiler: anywhere is not supported by the haskell backend.
-	Source(checkHaskellAnywhere.k)
-	Location(7,8,7,14)
-	7 |	  rule 1 => 2 [anywhere]
-	  .	       ^~~~~~
-[Error] Compiler: Had 1 structural errors.

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -459,7 +459,6 @@ public class Kompile {
     }
 
     public void structuralChecks(scala.collection.Set<Module> modules, Module mainModule, Option<Module> kModule, Set<String> excludedModuleTags) {
-        checkAnywhereRules(modules);
         boolean isSymbolic = excludedModuleTags.contains(Att.CONCRETE());
         boolean isKast = excludedModuleTags.contains(Att.KORE());
         CheckRHSVariables checkRHSVariables = new CheckRHSVariables(errors, !isSymbolic, kompileOptions.backend);
@@ -522,15 +521,6 @@ public class Kompile {
             kem.addAllKException(errors.stream().map(e -> e.exception).collect(Collectors.toList()));
             throw KEMException.compilerError("Had " + errors.size() + " structural errors.");
         }
-    }
-
-    private void checkAnywhereRules(scala.collection.Set<Module> modules) {
-        if (kompileOptions.backend.equals(Backends.HASKELL))
-            errors.addAll(stream(modules).flatMap(m -> stream(m.localSentences()).flatMap(s -> {
-                if (s instanceof Rule && s.att().contains(Att.ANYWHERE()))
-                    return Stream.of(KEMException.compilerError(Att.ANYWHERE() + " is not supported by the " + Backends.HASKELL + " backend.", s));
-                return Stream.empty();
-            })).collect(Collectors.toSet()));
     }
 
     public static Definition addSemanticsModule(Definition d) {


### PR DESCRIPTION
The C semantics is currently unable to update to the latest K version because of an issue with this PR; we have several `anywhere` rules that throw false-positive errors because of how we split our semantics into translation / execution phases.

I think the best thing here is for the original change to be reinstated with a flag to disable this check for users who want to self-certify they'll never write an `anywhere` rule that gets reached by the Haskell backend. For now it would be good to revert this change so that we can fix our CI.