### PR TITLE
Fix sort decl not being correctly calculated

### DIFF
--- a/k-distribution/tests/regression-new/checks/checkSortDeclIssue3038.k
+++ b/k-distribution/tests/regression-new/checks/checkSortDeclIssue3038.k
@@ -1,0 +1,18 @@
+module CHECKSORTDECLISSUE3038-SYNTAX
+  imports STRING
+
+  syntax Token ::= "token" [token]
+
+  syntax Token ::= String2Token( String ) [function, total, hook(STRING.string2token)]
+
+  syntax Nested ::= nested( Token )
+
+endmodule
+
+module CHECKSORTDECLISSUE3038
+  imports CHECKSORTDECLISSUE3038-SYNTAX
+
+  //syntax Token
+  syntax Nested ::= "NESTED_ALIAS" [alias]
+  rule NESTED_ALIAS => nested( String2Token("token") )
+endmodule

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -292,7 +292,7 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
   lazy val sortSynonymMap: Map[Sort, Sort] = sortSynonyms.map(s => (s.newSort, s.oldSort)).toMap
 
   lazy val sortDeclarationsFor: Map[SortHead, Set[SyntaxSort]] =
-    sortDeclarations
+    (sortDeclarations ++ allSorts.map(s => SyntaxSort(Seq(), s, Att.empty)))
       .groupBy(_.sort.head)
 
   @transient lazy val sortAttributesFor: Map[SortHead, Att] = sortDeclarationsFor mapValues {mergeAttributes(_)}


### PR DESCRIPTION
Fixes: #3038 
Because `Module.sortAttributesFor()` was only looking for `SyntaxSort` it would ignore sorts defined through productions and it would crash when queried.
This makes it so it will always contain the sort but with an empty list of attributes.