### PR TITLE
Forbid `[anywhere, symbolic]`

### DIFF
--- a/k-distribution/tests/regression-new/checks/anywhereSymbolic.k
+++ b/k-distribution/tests/regression-new/checks/anywhereSymbolic.k
@@ -1,0 +1,7 @@
+module ANYWHERESYMBOLIC
+
+  syntax Foo  ::= a() | b()
+
+  rule a() => b() [anywhere, symbolic]
+
+endmodule

--- a/k-distribution/tests/regression-new/checks/anywhereSymbolic.k.out
+++ b/k-distribution/tests/regression-new/checks/anywhereSymbolic.k.out
@@ -1,0 +1,6 @@
+[Error] Compiler: anywhere attribute is not supported on symbolic rules.
+	Source(anywhereSymbolic.k)
+	Location(5,8,5,18)
+	5 |	  rule a() => b() [anywhere, symbolic]
+	  .	       ^~~~~~~~~~
+[Error] Compiler: Had 1 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -185,5 +185,8 @@ public class CheckAtt {
         if(att.contains(Att.ANYWHERE()) && att.contains(Att.SIMPLIFICATION())) {
           errors.add(KEMException.compilerError("anywhere attribute is not supported on simplification rules.", loc));
         }
+        if(att.contains(Att.ANYWHERE()) && att.contains(Att.SYMBOLIC())) {
+            errors.add(KEMException.compilerError("anywhere attribute is not supported on symbolic rules.", loc));
+        }
     }
 }


### PR DESCRIPTION
The Haskell backend doesn't support anywhere rules, so we should forbid the attribute on `symbolic` rules as we already do for `simplification` rules: https://github.com/runtimeverification/k/pull/2711

Doing so prevents the LLVM backend from crashing with an uninformative error message in certain contexts.

Fixes https://github.com/runtimeverification/llvm-backend/issues/329