### PR TITLE
Implement python bindings option in `kompile`

### DIFF
--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -98,7 +98,7 @@ public class LLVMBackend extends KoreBackend {
                 llvmType = options.llvmKompileType;
                 break;
             default:
-                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|library|static|python]");
+                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|static|python]");
         }
 
         String llvmOutput = "interpreter";

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -94,11 +94,12 @@ public class LLVMBackend extends KoreBackend {
             case "main":
             case "search":
             case "static":
+            case "library":
             case "python":
                 llvmType = options.llvmKompileType;
                 break;
             default:
-                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|static|python]");
+                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|library|static|python]");
         }
 
         String llvmOutput = "interpreter";

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -86,22 +86,30 @@ public class LLVMBackend extends KoreBackend {
         if (options.enableSearch && options.llvmKompileOutput != null) {
             throw KEMException.criticalError("Can't use --llvm-kompile-output with --enable-search.");
         }
+        if (options.llvmKompileType.equals("python") && options.llvmKompileOutput != null) {
+            throw KEMException.criticalError("Can't use --llvm-kompile-output with --llvm-kompile-type python");
+        }
         String llvmType;
         switch (options.llvmKompileType) {
             case "main":
             case "search":
-            case "library":
             case "static":
+            case "python":
                 llvmType = options.llvmKompileType;
                 break;
             default:
-                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|library|static]");
+                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|library|static|python]");
         }
 
         String llvmOutput = "interpreter";
         if (options.llvmKompileOutput != null) {
             llvmOutput = options.llvmKompileOutput;
         }
+
+        if (options.llvmKompileType.equals("python")) {
+            llvmOutput = null;
+        }
+
         llvmKompile(llvmType, llvmOutput);
 
         if (options.enableSearch) {
@@ -121,8 +129,13 @@ public class LLVMBackend extends KoreBackend {
         // Arguments after this point are passed on to Clang.
         args.add("--");
 
-        args.add("-o");
-        args.add(executable);
+        // For Python bindings, we explicitly leave this unset so that python3-config
+        // can decide the proper filename.
+        if (executable != null) {
+            args.add("-o");
+            args.add(executable);
+        }
+
         if (kompileOptions.optimize1) args.add("-O1");
         if (kompileOptions.optimize2) args.add("-O2");
         if (kompileOptions.optimize3) args.add("-O2"); // clang -O3 does not make the llvm backend any faster

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
@@ -37,7 +37,7 @@ public class LLVMKompileOptions {
     @Parameter(names="--enable-search", description="By default, to reduce compilation time, `krun --search` is disabled on the LLVM backend. Pass this flag to enable it.")
     public boolean enableSearch;
 
-    @Parameter(names="--llvm-kompile-type", description="Specifies the llvm backend's output type. Valid choices are main (build an interpreter), search (same as main, but the interpreter does search instead of single-path execution), library (same as main, but a main method isn't linked in. The user is expected to link their own), and static (same as library, but no '-l' flags are passed during linking. Used for making a partially linked object file).")
+    @Parameter(names="--llvm-kompile-type", description="Specifies the llvm backend's output type. Valid choices are main (build an interpreter), search (same as main, but the interpreter does search instead of single-path execution), static (same as library, but no '-l' flags are passed during linking. Used for making a partially linked object file) and python (build a Python bindings module for this definition)")
     public String llvmKompileType = "main";
 
     @Parameter(names="--llvm-kompile-output", description="Name of the output binary from the llvm backend.")

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
@@ -37,7 +37,7 @@ public class LLVMKompileOptions {
     @Parameter(names="--enable-search", description="By default, to reduce compilation time, `krun --search` is disabled on the LLVM backend. Pass this flag to enable it.")
     public boolean enableSearch;
 
-    @Parameter(names="--llvm-kompile-type", description="Specifies the llvm backend's output type. Valid choices are main (build an interpreter), search (same as main, but the interpreter does search instead of single-path execution), static (same as library, but no '-l' flags are passed during linking. Used for making a partially linked object file) and python (build a Python bindings module for this definition)")
+    @Parameter(names="--llvm-kompile-type", description="Specifies the llvm backend's output type. Valid choices are main (build an interpreter), library (build an interpreter, but don't link a main function), search (same as main, but the interpreter does search instead of single-path execution), static (same as library, but no '-l' flags are passed during linking. Used for making a partially linked object file) and python (build a Python bindings module for this definition)")
     public String llvmKompileType = "main";
 
     @Parameter(names="--llvm-kompile-output", description="Name of the output binary from the llvm backend.")


### PR DESCRIPTION
Fixes #3056

This PR allows for Python bindings to be directly generated by `kompile`, rather than via `llvm-kompile`.