### PR TITLE
Print build logs when building Nix flakes

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -161,13 +161,13 @@ jobs:
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
       - name: 'Build K Framework'
-        run: GC_DONT_GC=1 nix build .
+        run: GC_DONT_GC=1 nix build --print-build-logs .
 
       # These tests take a really long time to run on other platforms, so we
       # skip them unless we're on the M1 runner.
       - name: 'Test K'
         if: ${{ matrix.os == 'self-macos-12' }}
-        run: GC_DONT_GC=1 nix build .#test
+        run: GC_DONT_GC=1 nix build --print-build-logs .#test
 
   test-nix:
     name: 'Nix'


### PR DESCRIPTION
This stops the logs from being tailed to their last 10 lines, making issues in CI easier to debug.