### PR TITLE
Pass through C build type option to llvm-kompile

### DIFF
--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -96,10 +96,11 @@ public class LLVMBackend extends KoreBackend {
             case "static":
             case "library":
             case "python":
+            case "c":
                 llvmType = options.llvmKompileType;
                 break;
             default:
-                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|library|static|python]");
+                throw KEMException.criticalError("Non-valid argument for --llvm-kompile-type: " + options.llvmKompileType + ". Expected [main|search|library|static|python|c]");
         }
 
         String llvmOutput = "interpreter";


### PR DESCRIPTION
This just allows the kompile wrapper to pass through 'c' as an option, as it already does for the python bindings.