### PR TITLE
Bring back focal dockerhub images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,26 @@ jobs:
           asset_name: 'K Framework Ubuntu Focal (20.04) Deb'
           asset_path: kframework_amd64_ubuntu_focal.deb
           upload_url: ${{ github.event.release.upload_url }}
+      - name: 'Build, Test, and Push Dockerhub Image'
+        shell: bash {0}
+        env:
+          DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
+          DOCKERHUB_REPO: runtimeverificationinc/kframework-k
+        run: |
+          set -euxo pipefail
+          version=$(cat package/version)
+          version_tag=ubuntu-focal-${version}
+          docker login --username rvdockerhub --password ${DOCKERHUB_PASSWORD}
+          docker image build . --file package/docker/Dockerfile.ubuntu-focal --tag ${DOCKERHUB_REPO}:${version_tag}
+          docker run --name k-package-docker-test-focal-${GITHUB_SHA} --rm -it --detach ${DOCKERHUB_REPO}:${version_tag}
+          docker exec -t k-package-docker-test-focal-${GITHUB_SHA} bash -c 'cd ~ && echo "module TEST imports BOOL endmodule" > test.k'
+          docker exec -t k-package-docker-test-focal-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
+          docker exec -t k-package-docker-test-focal-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
+          docker image push ${DOCKERHUB_REPO}:${version_tag}
+      - name: 'Clean up Docker Container'
+        if: always()
+        run: |
+          docker stop --time=0 k-package-docker-test-focal-${GITHUB_SHA}
 
   debian-bullseye:
     name: 'K Debian Bullseye Package'

--- a/package/docker/Dockerfile.ubuntu-focal
+++ b/package/docker/Dockerfile.ubuntu-focal
@@ -1,0 +1,28 @@
+FROM ubuntu:focal
+
+ENV TZ=America/Chicago
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN    apt-get update                   \
+    && apt-get upgrade --yes            \
+    && apt-get install --yes            \
+                        build-essential \
+                        git             \
+                        python3         \
+                        python3-pip
+
+RUN    git clone 'https://github.com/z3prover/z3' --branch=z3-4.8.15 \
+    && cd z3                                                         \
+    && python3 scripts/mk_make.py                                    \
+    && cd build                                                      \
+    && make -j8                                                      \
+    && make install                                                  \
+    && cd ../..                                                      \
+    && rm -rf z3
+
+COPY kframework_amd64_ubuntu_focal.deb /kframework_amd64_ubuntu_focal.deb
+RUN    apt-get update                                                                   \
+    && apt-get upgrade --yes                                                            \
+    && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_focal.deb
+
+RUN rm -rf /kframework_amd64_ubuntu_focal.deb


### PR DESCRIPTION
Several projects are still using Focal dockerhub images, so this brings them back.