### PR TITLE
Add FMT as a dependency

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -37,6 +37,7 @@ RUN    apt-get update              \
         libboost-test-dev          \
         libbz2-dev                 \
         libffi-dev                 \
+        libfmt-dev                 \
         libgdbm-dev                \
         libgmp-dev                 \
         libjemalloc-dev            \

--- a/flake.nix
+++ b/flake.nix
@@ -146,7 +146,7 @@
                 (nix-gitignore.gitignoreSourcePure [ ./.gitignore ]
                   ./k-distribution);
               preferLocalBuild = true;
-              buildInputs = [ gmp mpfr k ];
+              buildInputs = [ fmt gmp mpfr k ];
               postPatch = ''
                 patchShebangs tests/regression-new/*
                 substituteInPlace tests/regression-new/append/kparse-twice \

--- a/package/debian/Dockerfile
+++ b/package/debian/Dockerfile
@@ -24,6 +24,7 @@ RUN    apt-get update            \
         libgmp-dev               \
         libjemalloc-dev          \
         libffi-dev               \
+        libfmt-dev               \
         libmpfr-dev              \
         libncurses5-dev          \
         libnss3-dev              \

--- a/package/debian/control.bullseye
+++ b/package/debian/control.bullseye
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: clang-11 , cmake , debhelper (>=9) , flex , libboost-test-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , zlib1g-dev
+Build-Depends: clang-11 , cmake , debhelper (>=9) , flex , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/k
 
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-11 , default-jre-headless , flex , gcc , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , llvm-11
+Depends: bison , clang-11 , default-jre-headless , flex , gcc , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , llvm-11
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: clang-12 , cmake , debhelper (>=9) , flex , libboost-test-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , python3 , python3-dev , python3-distutils , python3-pip , zlib1g-dev
+Build-Depends: clang-12 , cmake , debhelper (>=9) , flex , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , python3 , python3-dev , python3-distutils , python3-pip , zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/k
 
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-12 , default-jre-headless , flex , gcc , libffi-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , llvm-12 , pkg-config
+Depends: bison , clang-12 , default-jre-headless , flex , gcc , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , llvm-12 , pkg-config
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.jammy
+++ b/package/debian/control.jammy
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: clang-14 , cmake , debhelper (>=10) , flex , libboost-test-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , pkg-config , python3 , python3-dev , python3-distutils , python3-pip , zlib1g-dev
+Build-Depends: clang-14 , cmake , debhelper (>=10) , flex , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , pkg-config , python3 , python3-dev , python3-distutils , python3-pip , zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/k
 
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-14 , default-jre-headless , flex , gcc , libffi-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
+Depends: bison , clang-14 , default-jre-headless , flex , gcc , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter


### PR DESCRIPTION
This addresses an issue with the LLVM backend update as a result of a change that adds a dependency on `fmt`: https://github.com/runtimeverification/llvm-backend/pull/603. It adds fmt to the various packaging dockerfiles and nix derivations that build K.

I've tested these changes by pulling this PR into the submodule update job, and they allow it to go through.