### PR TITLE
Lsp

### DIFF
--- a/k-distribution/src/main/scripts/bin/klsp
+++ b/k-distribution/src/main/scripts/bin/klsp
@@ -1,0 +1,2 @@
+#!/usr/bin/env sh
+"$(dirname "$0")/../lib/kframework/k" -klsp "$@"

--- a/k-distribution/tests/regression-new/checks/missingBar.k.out
+++ b/k-distribution/tests/regression-new/checks/missingBar.k.out
@@ -1,6 +1,6 @@
 [Error] Outer Parser: Encountered <LOWER_ID>.
 Was expecting one of: ["rule", "context", "configuration", "claim", "syntax", "endmodule", "[", ">", "|"]
 	Source(missingBar.k)
-	Location(4,18,4,20)
+	Location(4,18,4,21)
 	4 |	                 bar ()
-	  .	                 ^~
+	  .	                 ^~~

--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -15,6 +15,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.eclipse.lsp4j</groupId>
+      <artifactId>org.eclipse.lsp4j</artifactId>
+      <version>0.19.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.runtimeverification.k</groupId>
       <artifactId>kore</artifactId>
       <version>${project.version}</version>

--- a/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
+++ b/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
@@ -1,0 +1,101 @@
+package org.kframework.lsp;
+
+
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.CompletionOptions;
+import org.eclipse.lsp4j.CompletionRegistrationOptions;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageClientAware;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Language Server implementation for Ballerina.
+ */
+public class KLanguageServer implements LanguageServer, LanguageClientAware {
+
+    private TextDocumentService textDocumentService;
+    private WorkspaceService workspaceService;
+    private ClientCapabilities clientCapabilities;
+    LanguageClient languageClient;
+    private int shutdown = 1;
+
+    public KLanguageServer() {
+        this.textDocumentService = new KTextDocumentService(this);
+        this.workspaceService = new KWorkspaceService(this);
+    }
+
+    @Override
+    public CompletableFuture<InitializeResult> initialize(InitializeParams initializeParams) {
+        final InitializeResult response = new InitializeResult(new ServerCapabilities());
+        //Set the document synchronization capabilities to full.
+        response.getCapabilities().setTextDocumentSync(TextDocumentSyncKind.Full);
+        this.clientCapabilities = initializeParams.getCapabilities();
+
+        /* Check if dynamic registration of completion capability is allowed by the client. If so we don't register the capability.
+           Else, we register the completion capability.
+         */
+        if (!isDynamicCompletionRegistration()) {
+            response.getCapabilities().setCompletionProvider(new CompletionOptions());
+        }
+        return CompletableFuture.supplyAsync(() -> response);
+    }
+
+    @Override
+    public void initialized(InitializedParams params) {
+        //Check if dynamic completion support is allowed, if so register.
+        if (isDynamicCompletionRegistration()) {
+            CompletionRegistrationOptions completionRegistrationOptions = new CompletionRegistrationOptions();
+            Registration completionRegistration = new Registration(UUID.randomUUID().toString(),
+                    "textDocument/completion", completionRegistrationOptions);
+            languageClient.registerCapability(new RegistrationParams(List.of(completionRegistration)));
+        }
+    }
+
+    @Override
+    public CompletableFuture<Object> shutdown() {
+        shutdown = 0;
+        return CompletableFuture.supplyAsync(Object::new);
+    }
+
+    @Override
+    public void exit() {
+        System.exit(shutdown);
+    }
+
+    @Override
+    public TextDocumentService getTextDocumentService() {
+        return this.textDocumentService;
+    }
+
+    @Override
+    public WorkspaceService getWorkspaceService() {
+        return this.workspaceService;
+    }
+
+    @Override
+    public void connect(LanguageClient languageClient) {
+        this.languageClient = languageClient;
+        LSClientLogger.getInstance().initialize(this.languageClient);
+    }
+
+    private boolean isDynamicCompletionRegistration() {
+        TextDocumentClientCapabilities textDocumentCapabilities =
+                clientCapabilities.getTextDocument();
+        return textDocumentCapabilities != null && textDocumentCapabilities.getCompletion() != null
+                && Boolean.FALSE.equals(textDocumentCapabilities.getCompletion().getDynamicRegistration());
+    }
+}

--- a/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
+++ b/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
@@ -18,6 +18,7 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -27,14 +28,18 @@ import java.util.concurrent.CompletableFuture;
  */
 public class KLanguageServer implements LanguageServer, LanguageClientAware {
 
-    private TextDocumentService textDocumentService;
-    private WorkspaceService workspaceService;
+    private final TextDocumentService textDocumentService;
+    private final WorkspaceService workspaceService;
     private ClientCapabilities clientCapabilities;
     LanguageClient languageClient;
     private int shutdown = 1;
 
     public KLanguageServer() {
-        this.textDocumentService = new KTextDocumentService(this);
+        try {
+            this.textDocumentService = new KTextDocumentService(this);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
         this.workspaceService = new KWorkspaceService(this);
     }
 

--- a/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
+++ b/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
@@ -1,17 +1,7 @@
 package org.kframework.lsp;
 
 
-import org.eclipse.lsp4j.ClientCapabilities;
-import org.eclipse.lsp4j.CompletionOptions;
-import org.eclipse.lsp4j.CompletionRegistrationOptions;
-import org.eclipse.lsp4j.InitializeParams;
-import org.eclipse.lsp4j.InitializeResult;
-import org.eclipse.lsp4j.InitializedParams;
-import org.eclipse.lsp4j.Registration;
-import org.eclipse.lsp4j.RegistrationParams;
-import org.eclipse.lsp4j.ServerCapabilities;
-import org.eclipse.lsp4j.TextDocumentClientCapabilities;
-import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
@@ -56,6 +46,10 @@ public class KLanguageServer implements LanguageServer, LanguageClientAware {
         if (!isDynamicCompletionRegistration()) {
             response.getCapabilities().setCompletionProvider(new CompletionOptions());
         }
+        // TODO: check if client supports this capability
+        //if (!lsClientCapabilities.getInitializationOptions().isEnableLightWeightMode()) {
+            response.getCapabilities().setDiagnosticProvider(new DiagnosticRegistrationOptions(false, false));
+        //}
         return CompletableFuture.supplyAsync(() -> response);
     }
 

--- a/kernel/src/main/java/org/kframework/lsp/KLanguageServerLauncher.java
+++ b/kernel/src/main/java/org/kframework/lsp/KLanguageServerLauncher.java
@@ -1,0 +1,36 @@
+package org.kframework.lsp;
+
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+/**
+ * Standard IO Launcher for K Language Server.
+ */
+public class KLanguageServerLauncher {
+
+    public static void main(String[] args) throws InterruptedException, ExecutionException {
+        startServer(System.in, System.out);
+    }
+
+    /**
+     * Starts the language server given the input and output streams to read and write messages.
+     *
+     * @param in  input stream.
+     * @param out output stream.
+     * @throws InterruptedException
+     * @throws ExecutionException
+     */
+    public static void startServer(InputStream in, OutputStream out) throws InterruptedException, ExecutionException {
+        KLanguageServer server = new KLanguageServer();
+        Launcher<LanguageClient> launcher = Launcher.createLauncher(server, LanguageClient.class, in, out);
+        LanguageClient client = launcher.getRemoteProxy();
+        server.connect(client);
+        Future<?> startListening = launcher.startListening();
+        startListening.get();
+    }
+}

--- a/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
@@ -3,9 +3,19 @@ package org.kframework.lsp;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
+import org.kframework.attributes.Source;
+import org.kframework.kil.DefinitionItem;
+import org.kframework.parser.outer.Outer;
+import org.kframework.utils.StringUtil;
+import org.kframework.utils.file.FileUtil;
 
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 
 /**
@@ -16,6 +26,8 @@ public class KTextDocumentService implements TextDocumentService {
     private KLanguageServer languageServer;
     private LSClientLogger clientLogger;
 
+    private Map<String, List<DefinitionItem>> elems = new HashMap<>();
+
     public KTextDocumentService(KLanguageServer languageServer) {
         this.languageServer = languageServer;
         this.clientLogger = LSClientLogger.getInstance();
@@ -25,6 +37,7 @@ public class KTextDocumentService implements TextDocumentService {
     public void didOpen(DidOpenTextDocumentParams didOpenTextDocumentParams) {
         this.clientLogger.logMessage("Operation '" + "text/didOpen" +
                 "' {fileUri: '" + didOpenTextDocumentParams.getTextDocument().getUri() + "'} opened");
+        outerParse(didOpenTextDocumentParams.getTextDocument().getUri());
     }
 
     @Override
@@ -43,6 +56,7 @@ public class KTextDocumentService implements TextDocumentService {
     public void didSave(DidSaveTextDocumentParams didSaveTextDocumentParams) {
         this.clientLogger.logMessage("Operation '" + "text/didSave" +
                 "' {fileUri: '" + didSaveTextDocumentParams.getTextDocument().getUri() + "'} Saved");
+        outerParse(didSaveTextDocumentParams.getTextDocument().getUri());
     }
 
     @Override
@@ -56,5 +70,25 @@ public class KTextDocumentService implements TextDocumentService {
             completionItem.setKind(CompletionItemKind.Snippet);
             return Either.forLeft(Arrays.asList(completionItem));
         });
+        /*return CompletableFuture.supplyAsync(() -> {
+            this.clientLogger.logMessage("Operation '" + "text/completion");
+            CompletionItem completionItem = new CompletionItem();
+            completionItem.setLabel("Test completion item");
+            completionItem.setInsertText("Test");
+            completionItem.setDetail("Snippet");
+            completionItem.setKind(CompletionItemKind.Snippet);
+            return Either.forLeft(Arrays.asList(completionItem));
+        });*/
+    }
+
+    private void outerParse(String uri) {
+        List<DefinitionItem> di = null;
+        try {
+            di = Outer.parse(Source.apply(uri),FileUtil.load(new File(new URI(uri))),null);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+        elems.put(uri, di);
+        this.clientLogger.logMessage("Operation '" + "outerParse" + " #di: " + di.size());
     }
 }

--- a/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
@@ -175,10 +175,11 @@ public class KTextDocumentService implements TextDocumentService {
 
     // for quick testing
     public static void main(String[] args) throws InterruptedException, ExecutionException, URISyntaxException {
-        String uri = "file:///home/radu/work/test/test.k";
+        String uri = args[0];
+        ExtractFencedKCodeFromMarkdown mdExtractor = new ExtractFencedKCodeFromMarkdown(null, "k");
         List<DefinitionItem> dis = Outer.parse(Source.apply(uri), FileUtil.load(new File(new URI(uri))), null);
-        List<DefinitionItem> doma = Outer.parse(Source.apply(domains.toString()), FileUtil.load(new File(domains)), null);
-        List<DefinitionItem> kst = Outer.parse(Source.apply(kast.toString()), FileUtil.load(new File(kast)), null);
+        List<DefinitionItem> doma = Outer.parse(Source.apply(domains.toString()), mdExtractor.extract(FileUtil.load(new File(domains)), Source.apply(uri)), null);
+        List<DefinitionItem> kst = Outer.parse(Source.apply(kast.toString()), mdExtractor.extract(FileUtil.load(new File(kast)), Source.apply(uri)), null);
         List<CompletionItem> x = getCompletionItems(dis);
         System.out.println(x.size());
     }

--- a/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
@@ -109,6 +109,8 @@ public class KTextDocumentService implements TextDocumentService {
 
     private static List<CompletionItem> getCompletionItems(List<DefinitionItem> dis) {
         List<CompletionItem> lci = new ArrayList<>();
+        // Traverse all the modules and all the syntax declarations to find the Terminals in productions
+        // For each Terminal that follows the <ptrn> above, create a CompletionItem with some documentation
         dis.stream().filter(i -> i instanceof Module)
                 .map(m -> ((Module) m))
                 .forEach(m -> m.getItems().stream()

--- a/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
@@ -3,12 +3,11 @@ package org.kframework.lsp;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.TextDocumentService;
+import org.jetbrains.annotations.NotNull;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
-import org.kframework.kil.DefinitionItem;
+import org.kframework.kil.*;
 import org.kframework.kil.Module;
-import org.kframework.kil.Syntax;
-import org.kframework.kil.Terminal;
 import org.kframework.kompile.Kompile;
 import org.kframework.kore.Sort;
 import org.kframework.parser.outer.ExtractFencedKCodeFromMarkdown;
@@ -124,22 +123,28 @@ public class KTextDocumentService implements TextDocumentService {
                                                 .map(t -> (Terminal) t)
                                                 .forEach(t -> {
                                                     if (ptrn.matcher(t.getTerminal()).matches()) {
-                                                        CompletionItem completionItem = new CompletionItem();
-                                                        completionItem.setLabel(t.getTerminal());
-                                                        completionItem.setInsertText(t.getTerminal());
-                                                        completionItem.setDetail("module " + m.getName());
-                                                        String doc = "syntax ";
-                                                        doc += !s.getParams().isEmpty() ?
-                                                                "{" + s.getParams().stream().map(Sort::toString).collect(Collectors.joining(", ")) + "} " : "";
-                                                        doc += s.getDeclaredSort() + " ::= ";
-                                                        doc += p.toString();
-                                                        completionItem.setDocumentation(doc);
-                                                        completionItem.setKind(CompletionItemKind.Snippet);
+                                                        CompletionItem completionItem = buildCompletionItem(m, s, p, t);
                                                         lci.add(completionItem);
                                                     }
                                                 }))))));
 
         return lci;
+    }
+
+    @NotNull
+    private static CompletionItem buildCompletionItem(Module m, Syntax s, Production p, Terminal t) {
+        CompletionItem completionItem = new CompletionItem();
+        completionItem.setLabel(t.getTerminal());
+        completionItem.setInsertText(t.getTerminal());
+        completionItem.setDetail("module " + m.getName());
+        String doc = "syntax ";
+        doc += !s.getParams().isEmpty() ?
+                "{" + s.getParams().stream().map(Sort::toString).collect(Collectors.joining(", ")) + "} " : "";
+        doc += s.getDeclaredSort() + " ::= ";
+        doc += p.toString();
+        completionItem.setDocumentation(doc);
+        completionItem.setKind(CompletionItemKind.Snippet);
+        return completionItem;
     }
 
     private List<Diagnostic> outerParse(String uri) {

--- a/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
@@ -111,6 +111,7 @@ public class KTextDocumentService implements TextDocumentService {
         List<CompletionItem> lci = new ArrayList<>();
         // Traverse all the modules and all the syntax declarations to find the Terminals in productions
         // For each Terminal that follows the <ptrn> above, create a CompletionItem with some documentation
+        // Tree structure: Definition -> Module -> Syntax -> PriorityBlock -> Production -> Terminal
         dis.stream().filter(i -> i instanceof Module)
                 .map(m -> ((Module) m))
                 .forEach(m -> m.getItems().stream()

--- a/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
@@ -152,6 +152,7 @@ public class KTextDocumentService implements TextDocumentService {
             throw new RuntimeException(e);
         } catch (KEMException e) {
             Location loc = e.exception.getLocation();
+            if (loc == null) loc = new Location(1, 1, 1, 2);
             Range range = new Range(new Position(loc.startLine() - 1, loc.startColumn() - 1),
                     new Position(loc.endLine() - 1, loc.endColumn() - 1));
             Diagnostic d = new Diagnostic(range, e.exception.getMessage(), DiagnosticSeverity.Error, "Outer Parser");

--- a/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KTextDocumentService.java
@@ -1,0 +1,60 @@
+package org.kframework.lsp;
+
+import org.eclipse.lsp4j.*;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.services.TextDocumentService;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * TextDocumentService implementation for K.
+ */
+public class KTextDocumentService implements TextDocumentService {
+
+    private KLanguageServer languageServer;
+    private LSClientLogger clientLogger;
+
+    public KTextDocumentService(KLanguageServer languageServer) {
+        this.languageServer = languageServer;
+        this.clientLogger = LSClientLogger.getInstance();
+    }
+
+    @Override
+    public void didOpen(DidOpenTextDocumentParams didOpenTextDocumentParams) {
+        this.clientLogger.logMessage("Operation '" + "text/didOpen" +
+                "' {fileUri: '" + didOpenTextDocumentParams.getTextDocument().getUri() + "'} opened");
+    }
+
+    @Override
+    public void didChange(DidChangeTextDocumentParams didChangeTextDocumentParams) {
+        this.clientLogger.logMessage("Operation '" + "text/didChange" +
+                "' {fileUri: '" + didChangeTextDocumentParams.getTextDocument().getUri() + "'} Changed");
+    }
+
+    @Override
+    public void didClose(DidCloseTextDocumentParams didCloseTextDocumentParams) {
+        this.clientLogger.logMessage("Operation '" + "text/didClose" +
+                "' {fileUri: '" + didCloseTextDocumentParams.getTextDocument().getUri() + "'} Closed");
+    }
+
+    @Override
+    public void didSave(DidSaveTextDocumentParams didSaveTextDocumentParams) {
+        this.clientLogger.logMessage("Operation '" + "text/didSave" +
+                "' {fileUri: '" + didSaveTextDocumentParams.getTextDocument().getUri() + "'} Saved");
+    }
+
+    @Override
+    public CompletableFuture<Either<List<CompletionItem>, CompletionList>> completion(CompletionParams position) {
+        return CompletableFuture.supplyAsync(() -> {
+            this.clientLogger.logMessage("Operation '" + "text/completion");
+            CompletionItem completionItem = new CompletionItem();
+            completionItem.setLabel("Test completion item");
+            completionItem.setInsertText("Test");
+            completionItem.setDetail("Snippet");
+            completionItem.setKind(CompletionItemKind.Snippet);
+            return Either.forLeft(Arrays.asList(completionItem));
+        });
+    }
+}

--- a/kernel/src/main/java/org/kframework/lsp/KWorkspaceService.java
+++ b/kernel/src/main/java/org/kframework/lsp/KWorkspaceService.java
@@ -1,0 +1,35 @@
+package org.kframework.lsp;
+
+import org.eclipse.lsp4j.DidChangeConfigurationParams;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.RenameFilesParams;
+import org.eclipse.lsp4j.services.WorkspaceService;
+
+/**
+ * WorkspaceService implementation for K.
+ */
+public class KWorkspaceService implements WorkspaceService {
+
+    private KLanguageServer languageServer;
+    LSClientLogger clientLogger;
+
+    public KWorkspaceService(KLanguageServer languageServer) {
+        this.languageServer = languageServer;
+        this.clientLogger = LSClientLogger.getInstance();
+    }
+
+    @Override
+    public void didChangeConfiguration(DidChangeConfigurationParams didChangeConfigurationParams) {
+        this.clientLogger.logMessage("Operation 'workspace/didChangeConfiguration' Ack");
+    }
+
+    @Override
+    public void didChangeWatchedFiles(DidChangeWatchedFilesParams didChangeWatchedFilesParams) {
+        this.clientLogger.logMessage("Operation 'workspace/didChangeWatchedFiles' Ack");
+    }
+
+    @Override
+    public void didRenameFiles(RenameFilesParams params) {
+        this.clientLogger.logMessage("Operation 'workspace/didRenameFiles' Ack");
+    }
+}

--- a/kernel/src/main/java/org/kframework/lsp/LSClientLogger.java
+++ b/kernel/src/main/java/org/kframework/lsp/LSClientLogger.java
@@ -1,0 +1,39 @@
+package org.kframework.lsp;
+
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.services.LanguageClient;
+
+/**
+ * Use this class to send log messages to the client.
+ */
+public class LSClientLogger {
+
+    private static LSClientLogger INSTANCE;
+    private LanguageClient client;
+    private boolean isInitialized;
+
+    private LSClientLogger() {
+    }
+
+    public void initialize(LanguageClient languageClient) {
+        if (!Boolean.TRUE.equals(isInitialized)) {
+            this.client = languageClient;
+        }
+        isInitialized = true;
+    }
+
+    public static LSClientLogger getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new LSClientLogger();
+        }
+        return INSTANCE;
+    }
+
+    public void logMessage(String message) {
+        if (!isInitialized) {
+            return;
+        }
+        client.logMessage(new MessageParams(MessageType.Info, message));
+    }
+}

--- a/kernel/src/main/java/org/kframework/main/Main.java
+++ b/kernel/src/main/java/org/kframework/main/Main.java
@@ -37,6 +37,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.concurrent.ExecutionException;
 
 public class Main {
 
@@ -149,6 +150,13 @@ public class Main {
         List<Module> modules = new ArrayList<>();
 
             switch (tool) {
+                case "-klsp":
+                    try {
+                        org.kframework.lsp.KLanguageServerLauncher.startServer(System.in, System.out);
+                    } catch (InterruptedException | ExecutionException e) {
+                        throw new RuntimeException(e);
+                    }
+                    break;
                 case "-kserver":
                     modules.addAll(KServerFrontEnd.getModules());
                     break;

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -228,7 +228,7 @@ public class Outer {
                   return sb.toString();
                 }
               }).collect(Collectors.toList()).toString(), e, source,
-            new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn), false);
+            new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn + 1), false);
     } catch (TokenMgrException e) {
       // TODO: report location
       throw KEMException.outerParserError(e.getMessage(), e, source, null);

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -230,8 +230,18 @@ public class Outer {
               }).collect(Collectors.toList()).toString(), e, source,
             new Location(e.currentToken.next.beginLine, e.currentToken.next.beginColumn, e.currentToken.next.endLine, e.currentToken.next.endColumn + 1), false);
     } catch (TokenMgrException e) {
-      // TODO: report location
-      throw KEMException.outerParserError(e.getMessage(), e, source, null);
+      // extract the location info from the error message
+      Pattern p = Pattern.compile("\\d+");
+      Matcher m = p.matcher(e.getMessage());
+      Location loc = null;
+      if (m.find()) {
+        int line = Integer.parseInt(m.group());
+        if (m.find()) {
+            int col = Integer.parseInt(m.group());
+            loc = new Location(line, col, line, col + 1);
+        }
+      }
+      throw KEMException.outerParserError(e.getMessage(), e, source, loc);
     }
   }
 

--- a/nix/mavenix.lock
+++ b/nix/mavenix.lock
@@ -1274,6 +1274,18 @@
       "sha1": "8d93cdf4d84d7e1de736df607945c6df0730a10f"
     },
     {
+      "path": "com/google/code/gson/gson-parent/2.9.1/gson-parent-2.9.1.pom",
+      "sha1": "066fdfacdd5cac19a21e4cd2fc94ac8587f3a2a5"
+    },
+    {
+      "path": "com/google/code/gson/gson/2.9.1/gson-2.9.1.jar",
+      "sha1": "02cc2131b98ebfb04e2b2c7dfb84431f4045096b"
+    },
+    {
+      "path": "com/google/code/gson/gson/2.9.1/gson-2.9.1.pom",
+      "sha1": "f0cf3edcef8dcb74d27cb427544a309eb718d772"
+    },
+    {
       "path": "com/google/code/maven-scm-provider-svnjava/maven-scm-provider-svnjava/1.13/maven-scm-provider-svnjava-1.13.jar",
       "sha1": "f87ba6a4da7ba58626cb521652d7834a0fc4fdcc"
     },
@@ -1342,6 +1354,10 @@
       "sha1": "967743c6cda3e5267084455bca3c7ab08df3f453"
     },
     {
+      "path": "com/google/guava/guava-parent/30.1-jre/guava-parent-30.1-jre.pom",
+      "sha1": "b732bbf7c4ceb14dfd6af514a8b8b71dd952e53b"
+    },
+    {
       "path": "com/google/guava/guava/16.0.1/guava-16.0.1.pom",
       "sha1": "52f16cd93f1ee1f0d1e1e55f46fa21c35f829f85"
     },
@@ -1360,6 +1376,10 @@
     {
       "path": "com/google/guava/guava/30.0-jre/guava-30.0-jre.pom",
       "sha1": "d7239fe628e6e3fbb6734acbc07195435fdac305"
+    },
+    {
+      "path": "com/google/guava/guava/30.1-jre/guava-30.1-jre.pom",
+      "sha1": "4056c9385578a442117d1a68118def38087164da"
     },
     {
       "path": "com/google/guava/listenablefuture/9999.0-empty-to-avoid-conflict-with-guava/listenablefuture-9999.0-empty-to-avoid-conflict-with-guava.jar",
@@ -6846,6 +6866,58 @@
       "sha1": "17d9344459471ef3d2792e7452ead549809eccc5"
     },
     {
+      "path": "org/eclipse/lsp4j/org.eclipse.lsp4j.generator/0.19.0/org.eclipse.lsp4j.generator-0.19.0.jar",
+      "sha1": "7d3d3deea4e8062a3ea76f08e4eacbad0b0813cf"
+    },
+    {
+      "path": "org/eclipse/lsp4j/org.eclipse.lsp4j.generator/0.19.0/org.eclipse.lsp4j.generator-0.19.0.pom",
+      "sha1": "b91d9579771da9ab24d85d405d0820ab4e92608d"
+    },
+    {
+      "path": "org/eclipse/lsp4j/org.eclipse.lsp4j.jsonrpc/0.19.0/org.eclipse.lsp4j.jsonrpc-0.19.0.jar",
+      "sha1": "4096302e8fc7c55e85bb2825261320bdfc015f30"
+    },
+    {
+      "path": "org/eclipse/lsp4j/org.eclipse.lsp4j.jsonrpc/0.19.0/org.eclipse.lsp4j.jsonrpc-0.19.0.pom",
+      "sha1": "94f89861c682040a6cfde9a5de7f35f554ec7b04"
+    },
+    {
+      "path": "org/eclipse/lsp4j/org.eclipse.lsp4j/0.19.0/org.eclipse.lsp4j-0.19.0.jar",
+      "sha1": "aa73e1c6873c85369cd72d89a94e1493ce5e610a"
+    },
+    {
+      "path": "org/eclipse/lsp4j/org.eclipse.lsp4j/0.19.0/org.eclipse.lsp4j-0.19.0.pom",
+      "sha1": "4794e5b2ff8e4a168130d1528ceab28b01ee99ba"
+    },
+    {
+      "path": "org/eclipse/xtend/org.eclipse.xtend.lib.macro/2.28.0/org.eclipse.xtend.lib.macro-2.28.0.jar",
+      "sha1": "b7201908e9108ed1babd784b53208c7c22d2fe11"
+    },
+    {
+      "path": "org/eclipse/xtend/org.eclipse.xtend.lib.macro/2.28.0/org.eclipse.xtend.lib.macro-2.28.0.pom",
+      "sha1": "f196181d0c97b5d81723baaf90d4b6a391369200"
+    },
+    {
+      "path": "org/eclipse/xtend/org.eclipse.xtend.lib/2.28.0/org.eclipse.xtend.lib-2.28.0.jar",
+      "sha1": "b2119c6c7f87783cdf3b422c1901db03fe5fe2d3"
+    },
+    {
+      "path": "org/eclipse/xtend/org.eclipse.xtend.lib/2.28.0/org.eclipse.xtend.lib-2.28.0.pom",
+      "sha1": "50acae6035fd5112a089ee894f14b13357b5d6f7"
+    },
+    {
+      "path": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.28.0/org.eclipse.xtext.xbase.lib-2.28.0.jar",
+      "sha1": "44245e49dc576cf0b912e423af52bd52f104061a"
+    },
+    {
+      "path": "org/eclipse/xtext/org.eclipse.xtext.xbase.lib/2.28.0/org.eclipse.xtext.xbase.lib-2.28.0.pom",
+      "sha1": "bed15d716d0f6aef9b93434f0ad31ef2199bce91"
+    },
+    {
+      "path": "org/eclipse/xtext/xtext-dev-bom/2.28.0/xtext-dev-bom-2.28.0.pom",
+      "sha1": "4e468148c830041ebe9389f3b183febf6508b0d7"
+    },
+    {
       "path": "org/fusesource/fusesource-pom/1.11/fusesource-pom-1.11.pom",
       "sha1": "f5547b0657be718d1ec0d2816cbcd5c398d6fccb"
     },
@@ -7702,12 +7774,12 @@
       "sha1": "83c041bde1965b281cf4e6b31ab11bcf4b68a649"
     },
     {
-      "path": "org/yaml/snakeyaml/1.31/snakeyaml-1.31.jar",
-      "sha1": "cf26b7b05fef01e7bec00cb88ab4feeeba743e12"
+      "path": "org/yaml/snakeyaml/1.32/snakeyaml-1.32.jar",
+      "sha1": "e80612549feb5c9191c498de628c1aa80693cf0b"
     },
     {
-      "path": "org/yaml/snakeyaml/1.31/snakeyaml-1.31.pom",
-      "sha1": "d930834f6b4d9d226021db6c1d7908165c6dd6cd"
+      "path": "org/yaml/snakeyaml/1.32/snakeyaml-1.32.pom",
+      "sha1": "d51efbe04924b1b5c38ae59f4003acd040d5f436"
     },
     {
       "path": "oro/oro/2.0.8/oro-2.0.8.jar",
@@ -7808,6 +7880,10 @@
   ],
   "groupId": "com.runtimeverification.k",
   "metas": [
+    {
+      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>com.google.code.gson</groupId>\n  <artifactId>gson</artifactId>\n  <versioning>\n    <latest>2.10.1</latest>\n    <release>2.10.1</release>\n    <versions>\n      <version>1.1</version>\n      <version>1.4</version>\n      <version>1.5</version>\n      <version>1.6</version>\n      <version>1.7</version>\n      <version>1.7.1</version>\n      <version>1.7.2</version>\n      <version>2.0</version>\n      <version>2.1</version>\n      <version>2.2</version>\n      <version>2.2.1</version>\n      <version>2.2.2</version>\n      <version>2.2.3</version>\n      <version>2.2.4</version>\n      <version>2.3</version>\n      <version>2.3.1</version>\n      <version>2.4</version>\n      <version>2.5</version>\n      <version>2.6</version>\n      <version>2.6.1</version>\n      <version>2.6.2</version>\n      <version>2.7</version>\n      <version>2.8.0</version>\n      <version>2.8.1</version>\n      <version>2.8.2</version>\n      <version>2.8.3</version>\n      <version>2.8.4</version>\n      <version>2.8.5</version>\n      <version>2.8.6</version>\n      <version>2.8.7</version>\n      <version>2.8.8</version>\n      <version>2.8.9</version>\n      <version>2.9.0</version>\n      <version>2.9.1</version>\n      <version>2.10</version>\n      <version>2.10.1</version>\n    </versions>\n    <lastUpdated>20230106154835</lastUpdated>\n  </versioning>\n</metadata>",
+      "path": "com/google/code/gson/gson"
+    },
     {
       "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>org.kframework.dependencies</groupId>\n  <artifactId>nailgun-all</artifactId>\n  <version>0.9.2-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20180116.225224</timestamp>\n      <buildNumber>2</buildNumber>\n    </snapshot>\n    <lastUpdated>20180116225224</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>0.9.2-20180116.225224-2</value>\n        <updated>20180116225224</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
       "path": "org/kframework/dependencies/nailgun-all/0.9.2-SNAPSHOT"


### PR DESCRIPTION
Part of #3070

Adds LSP support for:
- code completion for the current file and domains.md and kast.md (doesn't recurse into required files yet)
- highlights error messages directly in the editor for outer parsing (one second delay)

This can be tested with VSCode with this branch: https://github.com/runtimeverification/k-editor-support/tree/kLanguageClient/k-vscode

General idea:
1. a language client (tested with VSCode) will have to call the script `klsp`
2. `klsp` starts the server in a similar way we do for kompile. Meaning we have direct access to all the parsing and kompile steps infrastructure.
3. the client sends requests for code completion or diagnostics, and the server responds in the appropriate manner.

To set things up, I followed this tutorial: https://medium.com/ballerina-techblog/practical-guide-for-the-language-server-protocol-3091a122b750

For now, I only implemented the minimum necessary for code completion and diagnostics for outer parsing errors.
More features can be added easily: workspace diagnostics and code completion that follows recursive inclusions.
