### PR TITLE
add maude backend to KompileOptions

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -99,7 +99,7 @@ public class KompileOptions implements Serializable {
     public List<String> extraConcreteRuleLabels = Collections.emptyList();
 
     public boolean isKore() {
-        return backend.equals("kore") || backend.equals("haskell") || backend.equals("llvm");
+        return backend.equals("kore") || backend.equals("haskell") || backend.equals("llvm") || backend.equals("maude");
     }
 
     @ParametersDelegate


### PR DESCRIPTION
Without this, the Maude backend will crash if multiple productions with different arities have the same klabel attribute.