### PR TITLE
Depend on libboost-dev for bindings build

### DIFF
--- a/package/debian/Dockerfile
+++ b/package/debian/Dockerfile
@@ -19,6 +19,7 @@ RUN    apt-get update            \
         flex                     \
         gcc                      \
         git                      \
+        libboost-dev             \
         libboost-test-dev        \
         libgdbm-dev              \
         libgmp-dev               \

--- a/package/debian/control.bullseye
+++ b/package/debian/control.bullseye
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-11 , default-jre-headless , flex , gcc , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , llvm-11
+Depends: bison , clang-11 , default-jre-headless , flex , gcc , libboost-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , llvm-11
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-12 , default-jre-headless , flex , gcc , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , llvm-12 , pkg-config
+Depends: bison , clang-12 , default-jre-headless , flex , gcc , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , llvm-12 , pkg-config
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.jammy
+++ b/package/debian/control.jammy
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-14 , default-jre-headless , flex , gcc , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
+Depends: bison , clang-14 , default-jre-headless , flex , gcc , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter


### PR DESCRIPTION
This addresses an issue where `libboost-dev` is not propagated into the debian packages, and so breaks Pyk's use of the new LLVM bindings.