### PR TITLE
Add proper error message

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -24,6 +24,7 @@ import org.kframework.kore.KVariable;
 import org.kframework.kore.Sort;
 import org.kframework.parser.outer.Outer;
 import org.kframework.utils.errorsystem.KEMException;
+import scala.Option;
 import scala.Tuple2;
 
 import java.util.ArrayList;
@@ -437,11 +438,12 @@ public class AddSortInjections {
         if (term.klabel() instanceof KVariable) {
           throw KEMException.internalError("KORE does not yet support KLabel variables.", term);
         }
-        scala.collection.Set<Production> prods = mod.productionsFor().apply(((KApply) term).klabel().head());
-        if (prods.size() == 0) {
-          throw KEMException.compilerError("Could not find production for KApply with label " + term.klabel(), term);
+        Option<scala.collection.Set<Production>> prods = mod.productionsFor().get(term.klabel().head());
+        if (prods.isEmpty()) {
+          throw KEMException.compilerError("Could not find productions for KApply with label "
+                  + term.klabel() + " in module " + mod.name(), term);
         }
-        return prods.head();
+        return prods.get().head();
     }
 
     private static Sort lub(Collection<Sort> entries, Sort expectedSort, HasLocation loc, Module mod) {


### PR DESCRIPTION
AddSortInjections  would fail with a stack trace if it failed to find a label in the main module.

The message now reads:
```
[Error] Compiler: Could not find productions for KApply with label _=__TEST-SYNTAX_Stuff_LValue_RValue in module TEST
	Source(/home/radu/work/test/./2.test)
	Location(1,1,1,6)
	1 |	a = b
	  .	^~~~~
```

The change is pretty simple. I don't think it warrants a test. But if you think it's worth it, I can also add a test.