### PR TITLE
Add line numbers to the debugging tutorial

### DIFF
--- a/k-distribution/k-tutorial/1_basic/19_debugging/README.md
+++ b/k-distribution/k-tutorial/1_basic/19_debugging/README.md
@@ -172,7 +172,7 @@ line of code containing the function or rule.
 
 For example, consider the following K definition (`lesson-19-b.k`):
 
-```k
+```{.k .numberLines .line-anchors startFrom="1"}
 module LESSON-19-B
   imports BOOL
 
@@ -257,7 +257,7 @@ Sometimes it is inconvenient to set the breakpoint based on a line number.
 It is also possible to set a breakpoint based on the rule label of a particular
 rule. Consider the following definition (`lesson-19-c.k`):
 
-```k
+```{.k .numberLines .line-anchors startFrom="1"}
 module LESSON-19-C
   imports INT
   imports BOOL


### PR DESCRIPTION
Since https://github.com/runtimeverification/k/issues/3169 has been implemented, I'm adding line numbers to the debugging tutorial.

