### PR TITLE
Tut fix typofix addedlink

### DIFF
--- a/k-distribution/k-tutorial/1_basic/03_parsing/README.md
+++ b/k-distribution/k-tutorial/1_basic/03_parsing/README.md
@@ -5,7 +5,7 @@ copyright: Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 # Lesson 1.3: BNF Syntax and Parser Generation
 
 The purpose of this lesson is to explain the full syntax and semantics of
-**productions** in K as well as how productions and other syntactic 
+**productions** in K as well as how productions and other syntactic
 **sentences** can be used to define grammars for use parsing both rules as well
 as programs.
 
@@ -269,7 +269,7 @@ only would it be cumbersome and tedious, you would also then have to deal with
 an AST generated for the literal which is not convenient to work with.
 
 Instead of doing this, K allows you to define **token** productions, where
-a production consists of a regular expression followed by the `token`
+a production consists of a [regular expression](https://en.wikipedia.org/wiki/Regular_expression) followed by the `token`
 attribute, and the resulting AST consists of a typed string containing the
 value recognized by the regular expression.
 
@@ -367,7 +367,7 @@ such, if your grammar is not LR(1), it may not parse exactly the same as if
 you were to use the just-in-time parser, because Bison will automatically pick
 one of the possible branches whenever it encounters a shift-reduce or
 reduce-reduce conflict. In this case, you can either modify your grammar to be
-LR(1), or you can enable use of Bison's GLR support by instead passing 
+LR(1), or you can enable use of Bison's GLR support by instead passing
 `--gen-glr-bison-parser` to `kompile`. Note that if your grammar is ambiguous,
 the ahead-of-time parser will not provide you with particularly readable error
 messages at this time.
@@ -387,7 +387,7 @@ yourself that both produce the same result, but that the latter is faster.
 subtraction, multiplication, division, and unary negation. Integers should be
 in decimal form and lexically without a sign, whereas negative numbers can be
 represented via unary negation. Ensure that you are able to parse some basic
-arithmetic expressions using a generated ahead-of-time parser. Do not worry 
+arithmetic expressions using a generated ahead-of-time parser. Do not worry
 about disambiguating the grammar or about writing rules to implement the
 operations in this definition.
 

--- a/k-distribution/k-tutorial/1_basic/19_debugging/README.md
+++ b/k-distribution/k-tutorial/1_basic/19_debugging/README.md
@@ -159,7 +159,7 @@ As we can see, ten rewrite steps were taken.
 
 The next important step in debugging an application in GDB is to be able to
 set breakpoints. Generally speaking, there are three types of breakpoints we
-are interested in in a K semantics: Setting a breakpoint when a particular
+are interested in a K semantics: Setting a breakpoint when a particular
 function is called, setting a breakpoint when a particular rule is applied,
 and setting a breakpoint when a side condition of a rule is evaluated.
 


### PR DESCRIPTION
Tutorial edits addressing [Comment on Issue #2033](https://github.com/runtimeverification/k/issues/2033#issuecomment-1421047332) adding a link to Wiki Reg Ex in Lesson 1.3. And typo fixed in lesson 19 from [Comment on Issue #2033](https://github.com/runtimeverification/k/issues/2033#issuecomment-1419975375).