### PR TITLE
Fix loc info for gen config cells

### DIFF
--- a/k-distribution/tests/regression-new/cell-bag-sort-llvm/test.k.out
+++ b/k-distribution/tests/regression-new/cell-bag-sort-llvm/test.k.out
@@ -1,9 +1,17 @@
 [Error] Compiler: Cell bags are only supported on the Java backend. If you want this feature, comment on https://github.com/runtimeverification/k/issues/1419 . As a workaround, you can add the attribute type="Set" and add a unique identifier to each element in the set.
 	Source(test.k)
-	Location(18,17,32,21)
-	   .	                v~~~~~~~~~~~~~~~~~
-	18 |	  configuration <T color="yellow">
+	Location(22,21,24,32)
+	   .	                    v~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	22 |	                    <function multiplicity = "*">
+	23 |	                      <fId> 0:Int </fId>
+	24 |	                    </function>
+	   .	                    ~~~~~~~~~~^
+[Error] Compiler: Cell bags are only supported on the Java backend. If you want this feature, comment on https://github.com/runtimeverification/k/issues/1419 . As a workaround, you can add the attribute type="Set" and add a unique identifier to each element in the set.
+	Source(test.k)
+	Location(27,21,30,32)
+	   .	                    v~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	27 |	                    <contract multiplicity = "*">
 	   |		...
-	32 |	                </T>
-	   .	                ~~~^
-[Error] Compiler: Had 1 structural errors.
+	30 |	                    </contract>
+	   .	                    ~~~~~~~~~~^
+[Error] Compiler: Had 2 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -4,6 +4,7 @@ package org.kframework.compile;
 import com.google.common.collect.Lists;
 import org.kframework.Collections;
 import org.kframework.attributes.Att;
+import org.kframework.attributes.Location;
 import org.kframework.builtin.BooleanUtils;
 import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Sorts;
@@ -96,11 +97,14 @@ public class GenerateSentencesFromConfigDecl {
                                 boolean isStream = cellProperties.getOption("stream").isDefined();
 
                                 K cellContents = kapp.klist().items().get(2);
+                                Att att = cfgAtt;
+                                if (kapp.att().contains(Location.class))
+                                    att = cfgAtt.add(Location.class, kapp.att().get(Location.class));
                                 Tuple4<Set<Sentence>, List<Sort>, K, Boolean> childResult = genInternal(
-                                        cellContents, null, cfgAtt, m, kore);
+                                        cellContents, null, att, m, kore);
 
                                 boolean isLeafCell = childResult._4();
-                                Tuple4<Set<Sentence>, Sort, K, Boolean> myResult = computeSentencesOfWellFormedCell(isLeafCell, isStream, kore, multiplicity, cfgAtt, m, cellName, cellProperties,
+                                Tuple4<Set<Sentence>, Sort, K, Boolean> myResult = computeSentencesOfWellFormedCell(isLeafCell, isStream, kore, multiplicity, att, m, cellName, cellProperties,
                                         childResult._2(), childResult._3(), ensures, hasConfigOrRegularVariable(cellContents, m));
                                 return Tuple4.apply((Set<Sentence>)childResult._1().$bar(myResult._1()), Lists.newArrayList(myResult._2()), myResult._3(), false);
                             }


### PR DESCRIPTION
Make it so generated productions from the configuration cells, have the exact location of the cell they are coming from instead of the entire configuration.

This made it look weird in the IDE.