### PR TITLE
Update kool to use llvm backend and fix warnings

### DIFF
--- a/k-distribution/pl-tutorial/2_languages/2_kool/1_untyped/kool-untyped.md
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/1_untyped/kool-untyped.md
@@ -240,8 +240,8 @@ Old desugaring rules, from SIMPLE
 ```k
   rule if (E) S => if (E) S else {}
   rule for(Start Cond; Step) {S} => {Start while (Cond) {S Step;}}
-  rule var E1::Exp, E2::Exp, Es::Exps; => var E1; var E2, Es;       [macro-rec]
-  rule var X::Id = E; => var X; X = E;                              [macro]
+  rule var E1::Exp, E2::Exp, Es::Exps; => var E1; var E2, Es;       [anywhere]
+  rule var X::Id = E; => var X; X = E;                              [anywhere]
 ```
 New desugaring rule
 ```k

--- a/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/1_dynamic/kool-typed-dynamic.md
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/1_dynamic/kool-typed-dynamic.md
@@ -126,9 +126,9 @@ untyped KOOL.
   syntax Stmt ::= Block
                 | Exp ";"                               [strict]
                 | "if" "(" Exp ")" Block "else" Block   [avoid, strict(1)]
-                | "if" "(" Exp ")" Block
+                | "if" "(" Exp ")" Block                [macro]
                 | "while" "(" Exp ")" Block
-                | "for" "(" Stmt Exp ";" Exp ")" Block
+                | "for" "(" Stmt Exp ";" Exp ")" Block  [macro]
                 | "print" "(" Exps ")" ";"              [strict]
                 | "return" Exp ";"                      [strict]
                 | "return" ";"
@@ -145,10 +145,10 @@ untyped KOOL.
 ## Desugaring macros
 
 ```k
-  rule if (E) S => if (E) S else {}                                     [macro]
-  rule for(Start Cond; Step) {S::Stmt} => {Start while(Cond){S Step;}} [macro]
-  rule T::Type E1::Exp, E2::Exp, Es::Exps; => T E1; T E2, Es;           [macro-rec]
-  rule T::Type X::Id = E; => T X; X = E;                                [macro]
+  rule if (E) S => if (E) S else {}
+  rule for(Start Cond; Step) {S::Stmt} => {Start while(Cond){S Step;}}
+  rule T::Type E1::Exp, E2::Exp, Es::Exps; => T E1; T E2, Es;           [anywhere]
+  rule T::Type X::Id = E; => T X; X = E;                                [anywhere]
 
   rule class C:Id S => class C extends Object S                     // KOOL
 

--- a/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/Makefile
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/Makefile
@@ -1,8 +1,7 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DEF=kool-typed-static
 EXT=kool
-KOMPILE_FLAGS=--transition "inheritance-cycle transition"
-KOMPILE_BACKEND?=java
+KOMPILE_FLAGS=--enable-search
 KRUN_FLAGS=--output none
 TESTDIR?=../programs
 RESULTDIR=tests

--- a/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/exercises/private-members/tests/cycle.kool.out
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/exercises/private-members/tests/cycle.kool.out
@@ -1,3 +1,11 @@
-  S ==K "Class \"C1\" is in a cycle!\n"
+  {
+    S:String
+  #Equals
+    "Class \"C1\" is in a cycle!\n"
+  }
 #Or
-  S ==K "Class \"C2\" is in a cycle!\n"
+  {
+    S:String
+  #Equals
+    "Class \"C2\" is in a cycle!\n"
+  }

--- a/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.md
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.md
@@ -632,13 +632,13 @@ superclass relation, the second transitively closes it, and the third
 checks for cycles.
 ```k
   rule <baseClass> C </baseClass>
-       <baseClasses> .Set => SetItem(C) </baseClasses>  [structural]
+       <baseClasses> .Set => SetItem(C) </baseClasses>  [structural, priority(25)]
 
   rule <classData>...
          <baseClasses> SetItem(C) Cs:Set (.Set => SetItem(C')) </baseClasses>
        ...</classData>
        <classData>... <className>C</className> <baseClass>C'</baseClass> ...</classData>
-    when notBool(C' in (SetItem(C) Cs))  [structural]
+    when notBool(C' in (SetItem(C) Cs))  [structural, priority(25)]
 
   rule (<T>...
           <className> C </className>
@@ -646,7 +646,7 @@ checks for cycles.
         ...</T> => .Bag)
        <output>... .List => ListItem("Class \"" +String Id2String(C)
                                   +String "\" is in a cycle!\n") </output>
-    [inheritance-cycle]
+    [inheritance-cycle, priority(25)]
 ```
 
 ## New

--- a/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/tests/cycle.kool.out
@@ -1,3 +1,11 @@
-  S ==K "Class \"C1\" is in a cycle!\n"
+  {
+    S:String
+  #Equals
+    "Class \"C1\" is in a cycle!\n"
+  }
 #Or
-  S ==K "Class \"C2\" is in a cycle!\n"
+  {
+    S:String
+  #Equals
+    "Class \"C2\" is in a cycle!\n"
+  }


### PR DESCRIPTION
This updates the lessons kool-typed-static to use the llvm backend, and fixes warnings in that definition and also in kool-untyped and kool-typed-dynamic.

This should not be auto-merged. I will merge it in conjunction with runtimeverification/k-exercises#34