### PR TITLE
Add flag to enable LLVM backend debugging

### DIFF
--- a/docs/cheat_sheet.md
+++ b/docs/cheat_sheet.md
@@ -17,7 +17,7 @@ krun (--search-all)? {file}                         : interpret file, evaluating
 foo-kompiled/parser_PGM {file}                      : ahead of time parse
 kompile (--main-module)? (--syntax-module)? {file}  : generate parser for {file}.k {file}-syntax.k, explicitly state main modules
 kparse <file> | kore-print -                        : parse and unparse a file
-kompile {file} -ccopt -g -ccopt -O1                 : generate debuggable output for {file}.k
+kompile {file} --enable-llvm-debug                  : generate debuggable output for {file}.k
 krun {file} --debugger                              : debug K code
 kprove {file}                                       : Verify specs in {file}
 ```

--- a/docs/ktools.md
+++ b/docs/ktools.md
@@ -90,8 +90,8 @@ module TEST
 endmodule
 ```
 
-You should compile this definition with `--backend llvm -ccopt -g` and without
-`-ccopt -O2` in order to use the debugger most effectively.
+You should compile this definition with `--backend llvm --enable-llvm-debug` to
+use the debugger most effectively.
 
 ### Stepping
 
@@ -272,7 +272,7 @@ Using `rbreak <regex>` you can set breakpoints on multiple functions.
 
 -   `<optimized out>` try kompiling without `-O1`, `-O2`, or `-O3`.
 -   `(gdb) break definition.kore:break -> No source file named definition.kore.`
-send `-ccopt -g` to kompile in order to generate debug info symbols.
+send `--enable-llvm-debug` to kompile in order to generate debug info symbols.
 
 Profiling your K semantics
 --------------------------

--- a/k-distribution/k-tutorial/1_basic/19_debugging/README.md
+++ b/k-distribution/k-tutorial/1_basic/19_debugging/README.md
@@ -20,13 +20,10 @@ You will need GDB in order to complete this lesson. If you do not already
 have GDB installed, then do so. Steps to install GDB are outlined in
 this [GDB Tutorial](http://www.gdbtutorial.com/tutorial/how-install-gdb).
 
-The first thing neccessary in order to debug a K interpreter in GDB is to
-build the interpreter with full debugging support enabled. This can be done
-relatively simply. First, run `kompile` with the command line flags `-ccopt -g -ccopt -O1`.
-The resulting compiled K definition will be ready to support
-debugging.
-
-Note: the 'O' in `-O1` is the letter 'O' not the number 0!
+The first thing neccessary in order to debug a K interpreter in GDB is to build
+the interpreter with full debugging support enabled. This can be done relatively
+simply. First, run `kompile` with the command line flag `--enable-llvm-debug`.
+The resulting compiled K definition will be ready to support debugging.
 
 Once you have a compiled K definition and a program you wish to debug, you
 can start the debugger by passing the `--debugger` flag to `krun`. This will
@@ -44,10 +41,9 @@ module LESSON-19-A
 endmodule
 ```
 
-If we compile this definition with
-`kompile lesson-19-a.k -ccopt -g -ccopt -O1`, and run the program `0` in the
-debugger with `krun -cPGM=0 --debugger`, we will see the following output
-(roughly):
+If we compile this definition with `kompile lesson-19-a.k --enable-llvm-debug`,
+and run the program `0` in the debugger with `krun -cPGM=0 --debugger`, we will
+see the following output (roughly):
 
 ```
 GNU gdb (Ubuntu 9.2-0ubuntu1~20.04) 9.2

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -133,6 +133,11 @@ public class LLVMBackend extends KoreBackend {
             // Arguments after this point are passed on to Clang.
             args.add("--");
 
+            if (options.debug) {
+                args.add("-g");
+                args.add("-O1");
+            }
+
             // For Python bindings, we explicitly leave this unset so that python3-config
             // can decide the proper filename.
             if (executable != null) {
@@ -146,9 +151,12 @@ public class LLVMBackend extends KoreBackend {
                 args.add(outputFile.getCanonicalPath());
             }
 
-            if (kompileOptions.optimize1) args.add("-O1");
-            if (kompileOptions.optimize2) args.add("-O2");
-            if (kompileOptions.optimize3) args.add("-O2"); // clang -O3 does not make the llvm backend any faster
+            if (!options.debug) {
+                if (kompileOptions.optimize1) args.add("-O1");
+                if (kompileOptions.optimize2) args.add("-O2");
+                if (kompileOptions.optimize3) args.add("-O2"); // clang -O3 does not make the llvm backend any faster
+            }
+
             args.addAll(options.ccopts);
 
             if (globalOptions.verbose) {

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
@@ -12,6 +12,9 @@ import java.util.List;
 @RequestScoped
 public class LLVMKompileOptions {
 
+    @Parameter(names="--enable-llvm-debug", description="Enable debugging support for the LLVM backend.")
+    public boolean debug = false;
+
     @Parameter(names="-ccopt", description="Add a command line option to the compiler invocation for the llvm backend.", listConverter=SingletonListConverter.class)
     public List<String> ccopts = new ArrayList<>();
 


### PR DESCRIPTION
The old syntax for enabling debug support was a bit clunky and prone to typos / errors (e.g. I flagged https://github.com/runtimeverification/llvm-backend/issues/666 as an issue without realising that the error I was seeing was due to using `-O0` rather than `-O1`).

This PR adds a new flag to `kompile` (`--enable-llvm-debug`) that abstracts the debugger invocation; internally, it just passes `-g -O1` to Clang as per the old flag.

I plan to follow this up at some point with an integration test for the debugger, but I haven't quite figured out the ergonomics of doing so.