### PR TITLE
Change invocation of `lldb`

### DIFF
--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -33,7 +33,7 @@ expandMacros=true
 filterSubst=
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  DBG_CMD="python3 $(dirname "$0")/../lib/lldb/klldb.py"
+  DBG_CMD="lldb -- "
 else
   DBG_CMD="gdb --args "
 fi


### PR DESCRIPTION
This LLVM backend PR explains the context here in detail: https://github.com/runtimeverification/llvm-backend/pull/684. Requires that PR to be merged+upstreamed before this is merged.

The change here is just a different entrypoint to LLDB; no existing code depends on this.