### PR TITLE
disable some modules in the maude backend for the time being

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -403,7 +403,7 @@ simplify terms.
 ```k
 endmodule
 
-module MAP-KORE-SYMBOLIC [kore,symbolic]
+module MAP-KORE-SYMBOLIC [kore,symbolic,haskell]
   imports MAP
   imports private K-EQUAL
   imports private BOOL
@@ -1169,7 +1169,7 @@ module INT-SYMBOLIC [symbolic]
   rule 0 >>Int _ => 0 [simplification]
 endmodule
 
-module INT-SYMBOLIC-KORE [symbolic, kore]
+module INT-SYMBOLIC-KORE [symbolic, kore, haskell]
   imports INT-COMMON
   imports ML-SYNTAX
   imports private BOOL


### PR DESCRIPTION
These modules contain lemmas that are needed for the Haskell backend, but, due to the fact that the Maude backend implements full matching modulo AC on integer addition and map concatenation, cause the Maude backend to not terminate. We will eventually create separate versions of these modules for the Maude backend as needed in the future.