### PR TITLE
Automatically use `--no-haskell-binary` in macOS regression tests

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -150,17 +150,6 @@
                 patchShebangs tests/regression-new/*
                 substituteInPlace tests/regression-new/append/kparse-twice \
                   --replace '"$(dirname "$0")/../../../bin/kparse"' '"${k}/bin/kparse"'
-                ${
-                # we add the `--no-haskell-binary` flag due to the compact library
-                # (used to create the binary haskell files) being broken on Mac
-                # https://github.com/runtimeverification/haskell-backend/issues/3137
-                lib.optionalString stdenv.isDarwin ''
-                  for mak in include/kframework/*.mak
-                  do
-                    substituteInPlace $mak \
-                      --replace 'KOMPILE_FLAGS+=--no-exc-wrap' 'KOMPILE_FLAGS+=--no-exc-wrap --no-haskell-binary'
-                  done
-                ''}
               '';
               buildFlags = [
                 "K_BIN=${k}/bin"

--- a/k-distribution/include/kframework/ktest.mak
+++ b/k-distribution/include/kframework/ktest.mak
@@ -1,5 +1,7 @@
 SHELL=/bin/bash
 
+UNAME := $(shell uname)
+
 # path to the current makefile
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 # path to binary directory of this distribution
@@ -53,6 +55,11 @@ KOMPILE_BACKEND?=llvm
 # check if .k file exists, if not, check if .md file exists
 # if not, default to .k to give error message
 SOURCE_EXT?=$(or $(and $(wildcard $(DEF).k), k), $(or $(and $(wildcard $(DEF).md), md), k))
+
+ifeq ($(UNAME), Darwin)
+	KOMPILE_FLAGS+=--no-haskell-binary
+endif
+
 KOMPILE_FLAGS+=--no-exc-wrap
 KPROVE_FLAGS+=--no-exc-wrap
 KRUN_FLAGS+=--no-exc-wrap

--- a/k-distribution/tests/regression-new/help/check-git-revision-format
+++ b/k-distribution/tests/regression-new/help/check-git-revision-format
@@ -8,4 +8,4 @@ if [ -z "$GIT_REVISION" ]; then
 fi
 
 VERSION_REGEX='v\d+\.\d+\.\d+-\d+-g[0-9a-z]+(-dirty)?$'
-echo "$GIT_REVISION" | grep -Pq "$VERSION_REGEX"
+echo "$GIT_REVISION" | egrep -q "$VERSION_REGEX"


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/k/issues/3222 by patching the `--no-haskell-binary` flag in at the Makefile level, rather than in Nix.

Also fixes a minor issue where `grep -P` is not available on macOS; we use the portable `egrep` alternative instead in that test.