### PR TITLE
Add g++ to dependencies on debian systems

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN    apt-get update        \
         debhelper            \
         flex                 \
         gcc                  \
+        g++                  \
         git                  \
         libboost-test-dev    \
         libgmp-dev           \

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ On Ubuntu Linux 20.04 (Focal) or 22.04 (Jammy):
 
 ```shell
 git submodule update --init --recursive
-sudo apt-get install build-essential m4 openjdk-11-jdk libfmt-dev libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 python3-dev cmake gcc clang-12 lld-12 llvm-12-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
+sudo apt-get install build-essential m4 openjdk-11-jdk libfmt-dev libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 python3-dev cmake gcc g++ clang-12 lld-12 llvm-12-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 

--- a/package/debian/Dockerfile
+++ b/package/debian/Dockerfile
@@ -18,6 +18,7 @@ RUN    apt-get update            \
         debhelper                \
         flex                     \
         gcc                      \
+        g++                      \
         git                      \
         libboost-dev             \
         libboost-test-dev        \

--- a/package/debian/control.bullseye
+++ b/package/debian/control.bullseye
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-11 , default-jre-headless , flex , gcc , libboost-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , llvm-11
+Depends: bison , clang-11 , default-jre-headless , flex , gcc , g++ , libboost-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-0-2 , libz3-4 , lld-11 , pkg-config , llvm-11
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-12 , default-jre-headless , flex , gcc , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , llvm-12 , pkg-config
+Depends: bison , clang-12 , default-jre-headless , flex , gcc , g++ , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-12 , llvm-12 , pkg-config
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.jammy
+++ b/package/debian/control.jammy
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-14 , default-jre-headless , flex , gcc , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
+Depends: bison , clang-14 , default-jre-headless , flex , gcc , g++ , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter


### PR DESCRIPTION
This seems to somehow be getting pulled in implicitly on CI builds, but I've seen a [couple of instances](https://runtimeverification.slack.com/archives/CBQAELQMR/p1669653189896009) where it goes missing on users' local builds. The changes here make the dependency explicit in the README and Dockerfiles.

Fixes https://github.com/runtimeverification/k/issues/3228