### PR TITLE
Add error message for empty Map collections

### DIFF
--- a/k-distribution/tests/regression-new/checks/emptyMapCollection.k
+++ b/k-distribution/tests/regression-new/checks/emptyMapCollection.k
@@ -1,3 +1,4 @@
+// Copyright (c) K Team. All Rights Reserved.
 module EMPTYMAPCOLLECTION
   configuration
     <cells>

--- a/k-distribution/tests/regression-new/checks/emptyMapCollection.k
+++ b/k-distribution/tests/regression-new/checks/emptyMapCollection.k
@@ -1,0 +1,8 @@
+module EMPTYMAPCOLLECTION
+  configuration
+    <cells>
+      <cell multiplicity="*" type="Map">
+        .Bag
+      </cell>
+    </cells>
+endmodule

--- a/k-distribution/tests/regression-new/checks/emptyMapCollection.k.out
+++ b/k-distribution/tests/regression-new/checks/emptyMapCollection.k.out
@@ -1,9 +1,9 @@
 [Error] Compiler: Cells of type Map expect at least one child cell as their key
 	Source(emptyMapCollection.k)
-	Location(4,7,6,14)
+	Location(5,7,7,14)
 	  .	      v~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-	4 |	      <cell multiplicity="*" type="Map">
-	5 |	        .Bag
-	6 |	      </cell>
+	5 |	      <cell multiplicity="*" type="Map">
+	6 |	        .Bag
+	7 |	      </cell>
 	  .	      ~~~~~~^
 [Error] Compiler: Had 1 parsing errors.

--- a/k-distribution/tests/regression-new/checks/emptyMapCollection.k.out
+++ b/k-distribution/tests/regression-new/checks/emptyMapCollection.k.out
@@ -1,0 +1,9 @@
+[Error] Compiler: Cells of type Map expect at least one child cell as their key
+	Source(emptyMapCollection.k)
+	Location(4,7,6,14)
+	  .	      v~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	4 |	      <cell multiplicity="*" type="Map">
+	5 |	        .Bag
+	6 |	      </cell>
+	  .	      ~~~~~~^
+[Error] Compiler: Had 1 parsing errors.

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -469,7 +469,7 @@ public class GenerateSentencesFromConfigDecl {
                 break;
             default:
                 throw KEMException.compilerError("Unexpected type for multiplicity * cell: " + cellName
-                        + ". Should be one of: Set, Bag, List, Map");
+                        + ". Should be one of: Set, Bag, List, Map", KApply(KLabel("#EmptyK"), Seq(), configAtt));
             }
             SyntaxSort sortDecl = SyntaxSort(Seq(), bagSort, Att().add("hook", type.toUpperCase() + '.' + type).add("cellCollection"));
             Sentence bagSubsort = Production(Seq(), bagSort, Seq(NonTerminal(sort)));

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -475,6 +475,10 @@ public class GenerateSentencesFromConfigDecl {
             Sentence bagSubsort = Production(Seq(), bagSort, Seq(NonTerminal(sort)));
             Sentence bagElement;
             if (type.equals("Map")) {
+                if (childSorts.isEmpty()) {
+                    throw KEMException.compilerError("Cells of type Map expect at least one child cell as their key",
+                            KApply(KLabel("#EmptyK"), Seq(), configAtt));
+                }
                 bagElement = Production(KLabel(bagSort.name() + "Item"), bagSort, Seq(
                         Terminal(bagSort.name() + "Item"),
                         Terminal("("),


### PR DESCRIPTION
Added an error message "Cells of type Map expect at least one child cell as their key" for the case when a Map collection does not contain any cells. Closes #3227 

Also added location tracking to the "Unexpected type for multiplicity * cell..." error.