### PR TITLE
Install C binding headers in Nix

### DIFF
--- a/nix/k.nix
+++ b/nix/k.nix
@@ -47,6 +47,7 @@ let
 
       mkdir -p $out/lib/cmake/kframework && ln -sf ${llvm-backend.src}/cmake/* $out/lib/cmake/kframework/
       ln -sf ${llvm-backend}/include/kllvm $out/include/
+      ln -sf ${llvm-backend}/include/kllvm-c $out/include/
       ln -sf ${llvm-backend}/lib/kllvm $out/lib/
       ln -sf ${llvm-backend}/bin/* $out/bin/
 


### PR DESCRIPTION
Previously, this directory would go missing when building K, and you wouldn't be able to use the installed C binding headers to build a library against.