### PR TITLE
Add check that labels provided to --concrete-rules correspond to actual rules

### DIFF
--- a/k-distribution/tests/regression-new/issue-2321-kprovexCrash/Makefile
+++ b/k-distribution/tests/regression-new/issue-2321-kprovexCrash/Makefile
@@ -1,7 +1,7 @@
 DEF=test
 TESTDIR=.
 KOMPILE_BACKEND=haskell
-KOMPILE_FLAGS=--syntax-module TEST --concrete-rules SERIALIZATION.keccak
+KOMPILE_FLAGS=--syntax-module TEST
 export KORE_EXEC_OPTS=--log-level error
 
 include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/Makefile
+++ b/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/Makefile
@@ -1,0 +1,7 @@
+DEF=test
+EXT=test
+KOMPILE_BACKEND=haskell
+TESTDIR=.
+KOMPILE_FLAGS+=--concrete-rules "FAKE.fake,TEST.assoc,TEST.fake,TEST.distrib"
+
+include ../../../include/kframework/ktest-fail.mak

--- a/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/test.k
+++ b/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/test.k
@@ -1,0 +1,15 @@
+module TEST-SYNTAX
+imports INT-SYNTAX
+syntax Exp ::= Int
+             | Exp "+" Exp
+             | Exp "*" Exp
+endmodule
+
+module TEST
+imports TEST-SYNTAX
+imports INT
+
+rule [assoc]: (X + Y) + Z => X + (Y + Z)
+rule [distrib]: X * (Y + Z) => (X * Y) + (X * Z)
+
+endmodule

--- a/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/test.k
+++ b/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/test.k
@@ -1,3 +1,4 @@
+// Copyright (c) K Team. All Rights Reserved.
 module TEST-SYNTAX
 imports INT-SYNTAX
 syntax Exp ::= Int

--- a/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/test.k.out
+++ b/k-distribution/tests/regression-new/issue-3285-nonexistent-concrete-rule/test.k.out
@@ -1,0 +1,1 @@
+[Error] Critical: Unused concrete rule labels: [FAKE.fake, TEST.fake]

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -134,9 +134,7 @@ public class KoreBackend extends AbstractBackend {
         DefinitionTransformer numberSentences = DefinitionTransformer.fromSentenceTransformer(NumberSentences::number, "number sentences uniquely");
         Function1<Definition, Definition> resolveConfigVar = d -> DefinitionTransformer.fromSentenceTransformer(new ResolveFunctionWithConfig(d, true)::resolveConfigVar, "Adding configuration variable to lhs").apply(d);
         Function1<Definition, Definition> resolveIO = (d -> Kompile.resolveIOStreams(kem, d));
-        Function1<Definition, Definition> markExtraConcreteRules = d -> DefinitionTransformer.fromSentenceTransformer((m, s) ->
-                s instanceof Rule && kompileOptions.extraConcreteRuleLabels.contains(s.att().getOption(Att.LABEL()).getOrElse(() -> null)) ?
-                        Rule.apply(((Rule) s).body(), ((Rule) s).requires(), ((Rule) s).ensures(), s.att().add(Att.CONCRETE())) : s, "mark extra concrete rules").apply(d);
+        Function1<Definition, Definition> markExtraConcreteRules = d -> MarkExtraConcreteRules.mark(d, kompileOptions.extraConcreteRuleLabels);
         Function1<Definition, Definition> removeAnywhereRules =
                 d -> DefinitionTransformer.from(this::removeAnywhereRules,
                         "removing anywhere rules for the Haskell backend").apply(d);

--- a/kernel/src/main/java/org/kframework/compile/AbstractBackend.java
+++ b/kernel/src/main/java/org/kframework/compile/AbstractBackend.java
@@ -1,17 +1,11 @@
 // Copyright (c) K Team. All Rights Reserved.
 package org.kframework.compile;
 
-import org.kframework.attributes.Att;
 import org.kframework.definition.Definition;
-import org.kframework.definition.DefinitionTransformer;
-import org.kframework.definition.Rule;
-import org.kframework.definition.Sentence;
 import scala.Function1;
 
 import javax.annotation.Nullable;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.function.Function;
 
 /**
@@ -24,31 +18,7 @@ public abstract class AbstractBackend implements Backend {
     public Function<Definition, Definition> proofDefinitionNonCachedSteps(
             @Nullable List<String> extraConcreteRuleLabels) {
         Function1<Definition, Definition> markExtraConcrete =
-                def -> markExtraConcreteRules(def, extraConcreteRuleLabels);
+                def -> MarkExtraConcreteRules.mark(def, extraConcreteRuleLabels);
         return markExtraConcrete::apply;
-    }
-
-    protected Definition markExtraConcreteRules(Definition def, @Nullable List<String> extraConcreteRuleLabels) {
-        if (extraConcreteRuleLabels == null) {
-            return def;
-        }
-        HashSet<String> concreteLabelsSet = new HashSet<>(extraConcreteRuleLabels);
-        return DefinitionTransformer.fromSentenceTransformer(
-                (mod, s) -> markExtraConcreteRules(s, concreteLabelsSet), "mark extra concrete rules")
-                .apply(def);
-    }
-
-    /**
-     * Mark with [concrete] rules with labels enumerated in `--concrete-rules`.
-     */
-    private Sentence markExtraConcreteRules(Sentence s, Set<String> extraConcreteRuleLabels) {
-        if (s instanceof org.kframework.definition.Rule) {
-            org.kframework.definition.Rule r = (org.kframework.definition.Rule) s;
-            String label = r.att().getOption(Att.LABEL()).getOrElse(() -> null);
-            if (label != null && extraConcreteRuleLabels.contains(label)) {
-                return Rule.apply(r.body(), r.requires(), r.ensures(), r.att().add(Att.CONCRETE()));
-            }
-        }
-        return s;
     }
 }

--- a/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
+++ b/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
@@ -1,3 +1,4 @@
+// Copyright (c) K Team. All Rights Reserved.
 package org.kframework.compile;
 
 import org.kframework.attributes.Att;

--- a/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
+++ b/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
@@ -1,0 +1,39 @@
+package org.kframework.compile;
+
+import org.kframework.attributes.Att;
+import org.kframework.definition.Definition;
+import org.kframework.definition.DefinitionTransformer;
+import org.kframework.definition.Rule;
+import org.kframework.utils.errorsystem.KEMException;
+
+import javax.annotation.Nullable;
+import java.util.HashSet;
+import java.util.List;
+
+public class MarkExtraConcreteRules {
+
+    /**
+     * Mark with [concrete] rules with labels enumerated in `--concrete-rules`.
+     */
+    public static Definition mark(Definition def, @Nullable List<String> extraConcreteRuleLabels) {
+        if (extraConcreteRuleLabels == null) {
+            return def;
+        }
+        HashSet<String> concreteLabelsSet = new HashSet<>(extraConcreteRuleLabels);
+        Definition result = DefinitionTransformer.fromSentenceTransformer((mod, s) -> {
+            if (s instanceof Rule) {
+                Rule r = (Rule) s;
+                String label = r.att().getOption(Att.LABEL()).getOrElse(() -> null);
+                if (label != null && extraConcreteRuleLabels.contains(label)) {
+                    concreteLabelsSet.remove(label);
+                    return Rule.apply(r.body(), r.requires(), r.ensures(), r.att().add(Att.CONCRETE()));
+                }
+            }
+            return s;
+        }, "mark extra concrete rules").apply(def);
+        if (!concreteLabelsSet.isEmpty()) {
+            throw KEMException.criticalError("Unused concrete rule labels: " + concreteLabelsSet);
+        }
+        return result;
+    }
+}

--- a/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
+++ b/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
@@ -25,7 +25,8 @@ public class MarkExtraConcreteRules {
             if (s instanceof Rule) {
                 Rule r = (Rule) s;
                 String label = r.att().getOption(Att.LABEL()).getOrElse(() -> null);
-                if (label != null && extraConcreteRuleLabels.contains(label)) {
+                if (label != null && concreteLabelsSet.contains(label)) {
+                    // rule labels must be unique, so it's safe to remove from the set as we iterate
                     concreteLabelsSet.remove(label);
                     return Rule.apply(r.body(), r.requires(), r.ensures(), r.att().add(Att.CONCRETE()));
                 }

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -328,9 +328,7 @@ public class Kompile {
         DefinitionTransformer numberSentences = DefinitionTransformer.fromSentenceTransformer(NumberSentences::number, "number sentences uniquely");
         Function1<Definition, Definition> resolveConfigVar = d -> DefinitionTransformer.fromSentenceTransformer(new ResolveFunctionWithConfig(d, false)::resolveConfigVar, "Adding configuration variable to lhs").apply(d);
         Function1<Definition, Definition> resolveIO = (d -> Kompile.resolveIOStreams(kem, d));
-        Function1<Definition, Definition> markExtraConcreteRules = d -> DefinitionTransformer.fromSentenceTransformer((m, s) ->
-                    s instanceof Rule && kompileOptions.extraConcreteRuleLabels.contains(s.att().getOption(Att.LABEL()).getOrElse(() -> null)) ?
-                            Rule.apply(((Rule) s).body(), ((Rule) s).requires(), ((Rule) s).ensures(), s.att().add(Att.CONCRETE())) : s, "mark extra concrete rules").apply(d);
+        Function1<Definition, Definition> markExtraConcreteRules = d -> MarkExtraConcreteRules.mark(d, kompileOptions.extraConcreteRuleLabels);
 
         return def -> resolveIO
                 .andThen(resolveFun)


### PR DESCRIPTION
Closes #3285.

As noted in runtimeverification/evm-semantics#1634, K silently accepts non-existent labels in `--concrete-rules`. This PR adds an error check to ensure each provided label actually has a corresponding rule.