### PR TITLE
Use longer timeouts in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
   ubuntu-jammy:
     name: 'K Ubuntu Jammy Package'
     runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 35
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v3
       - name: 'Build and Test Package'
@@ -90,7 +90,7 @@ jobs:
   ubuntu-focal:
     name: 'K Ubuntu Focal Package'
     runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 35
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v3
       - name: 'Build and Test Package'
@@ -135,7 +135,7 @@ jobs:
   debian-bullseye:
     name: 'K Debian Bullseye Package'
     runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - name: 'Build and Test Package'
@@ -160,7 +160,7 @@ jobs:
   arch:
     name: 'Arch Linux Package'
     runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v3
       - name: 'Build and Test Package'
@@ -185,7 +185,7 @@ jobs:
   macos-build:
     name: 'Build MacOS Package'
     runs-on: macos-11
-    timeout-minutes: 90
+    timeout-minutes: 120
     environment: production
     needs: set-release-id
     steps:
@@ -263,7 +263,7 @@ jobs:
   macos-test:
     name: 'Test MacOS Package'
     runs-on: macos-11
-    timeout-minutes: 30
+    timeout-minutes: 60
     environment: production
     needs: [macos-build, set-release-id]
     steps:
@@ -381,7 +381,7 @@ jobs:
   gh-pages:
     name: 'GitHub Pages deployment'
     runs-on: ubuntu-20.04
-    timeout-minutes: 15
+    timeout-minutes: 30
     needs: [release]
     steps:
       - name: 'Install pandoc/texlive/calibre'


### PR DESCRIPTION
It turns out that the initial timeout values set in this workflow weren't long enough to account for the Stack dependencies being rebuilt. Looking at the failed release jobs, I think that the times set here should be sufficient to allow releases to go through while still catching the "run forever" 6+ hour problems that motivated this change in the first place.