### PR TITLE
Speculative fix for macOS release timeouts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,6 +223,10 @@ jobs:
         id: build
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+          MAVEN_OPTS: >-
+              -Dhttp.keepAlive=false
+              -Dmaven.wagon.http.pool=false
+              -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
         run: |
           PACKAGE=kframework
           VERSION=$(cat kframework/package/version)


### PR DESCRIPTION
This is the [suggested workaround](https://github.com/actions/runner-images/issues/1499#issuecomment-689467080) for maven timing out when trying to download dependencies; the underlying reason is that Azure networking drops long-running connections pooled by Maven.