### PR TITLE
Pass maven opts through to homebrew

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -223,7 +223,7 @@ jobs:
         id: build
         env:
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
-          MAVEN_OPTS: >-
+          HOMEBREW_MAVEN_OPTS: >-
               -Dhttp.keepAlive=false
               -Dmaven.wagon.http.pool=false
               -Dmaven.wagon.httpconnectionManager.ttlSeconds=30


### PR DESCRIPTION
We need to prefix the environment variables here with `HOMEBREW_` so that they don't get filtered out of the build environment.

Can be reviewed and merged once https://github.com/kframework/homebrew-k/pull/24 is merged, so that the environment variables are passed to the formula builder properly.