### PR TITLE
Use `gh` to simplify uploading release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
           tar czvf ${tarball} $(basename ${CURDIR})
           mv ${tarball} ${CURDIR}/
           cd ${CURDIR}
-          gh release upload v${version} ${tarball}
+          gh release upload --clobber v${version} ${tarball}
 
   nix-release:
     name: 'Nix Release'
@@ -90,7 +90,7 @@ jobs:
           set -x
           version=$(cat package/version)
           cp kframework_amd64_ubuntu_jammy.deb kframework_${version}_amd64_ubuntu_jammy
-          gh release upload v${version} kframework_${version}_amd64_ubuntu_jammy.deb
+          gh release upload --clobber v${version} kframework_${version}_amd64_ubuntu_jammy.deb
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -134,7 +134,7 @@ jobs:
           set -x
           version=$(cat package/version)
           cp kframework_amd64_ubuntu_focal.deb kframework_${version}_amd64_ubuntu_focal
-          gh release upload v${version} kframework_${version}_amd64_ubuntu_focal.deb
+          gh release upload --clobber v${version} kframework_${version}_amd64_ubuntu_focal.deb
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -178,7 +178,7 @@ jobs:
           set -x
           version=$(cat package/version)
           cp kframework_amd64_debian_bullseye.deb kframework_${version}_amd64_debian_bullseye
-          gh release upload v${version} kframework_${version}_amd64_debian_bullseye.deb
+          gh release upload --clobber v${version} kframework_${version}_amd64_debian_bullseye.deb
 
   arch:
     name: 'Arch Linux Package'
@@ -202,7 +202,7 @@ jobs:
           set -x
           version=$(cat package/version)
           cp kframework_arch_x86_64.pkg.tar.zst kframework_${version}_arch_x86_64.pkg.tar.zst
-          gh release upload v${version} kframework_${version}_arch_x86_64.pkg.tar.zst
+          gh release upload --clobber v${version} kframework_${version}_arch_x86_64.pkg.tar.zst
 
   macos-build:
     name: 'Build MacOS Package'
@@ -350,7 +350,7 @@ jobs:
         run: |
           set -x
           version=$(cat package/version)
-          gh release upload v${version} homebrew-k-old/${BOTTLE_NAME}
+          gh release upload --clobber v${version} homebrew-k-old/${BOTTLE_NAME}
 
       - name: Add ssh key
         uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,23 +31,18 @@ jobs:
           submodules: recursive
       - name: 'Create source tarball'
         env:
-          RELEASE_ID: ${{ needs.set-release-id.outputs.release_id }}
+         GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
         run: |
           set -x
+          version=$(cat package/version)
+          tarball=kframework-${version}-src.tar.gz
           find . -name .git | xargs rm -r
           CURDIR=$(pwd)
           cd ..
-          tar czvf kframework-${RELEASE_ID}-src.tar.gz $(basename ${CURDIR})
-          mv kframework-${RELEASE_ID}-src.tar.gz ${CURDIR}/
-      - name: 'Upload Source Tarball to Release'
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-        with:
-          asset_content_type: 'application/gzip'
-          asset_name: kframework-${{ needs.set-release-id.outputs.release_id }}-src.tar.gz
-          asset_path: kframework-${{ needs.set-release-id.outputs.release_id }}-src.tar.gz
-          upload_url: ${{ github.event.release.upload_url }}
+          tar czvf ${tarball} $(basename ${CURDIR})
+          mv ${tarball} ${CURDIR}/
+          cd ${CURDIR}
+          gh release upload v${version} ${tarball}
 
   nix-release:
     name: 'Nix Release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,8 @@ jobs:
         run: |
           set -x
           version=$(cat package/version)
-          gh release upload v${version} kframework_amd64_ubuntu_jammy.deb
+          cp kframework_amd64_ubuntu_jammy.deb kframework_${version}_amd64_ubuntu_jammy
+          gh release upload v${version} kframework_${version}_amd64_ubuntu_jammy.deb
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -132,7 +133,8 @@ jobs:
         run: |
           set -x
           version=$(cat package/version)
-          gh release upload v${version} kframework_amd64_ubuntu_focal.deb
+          cp kframework_amd64_ubuntu_focal.deb kframework_${version}_amd64_ubuntu_focal
+          gh release upload v${version} kframework_${version}_amd64_ubuntu_focal.deb
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -175,7 +177,8 @@ jobs:
         run: |
           set -x
           version=$(cat package/version)
-          gh release upload v${version} kframework_amd64_debian_bullseye.deb
+          cp kframework_amd64_debian_bullseye.deb kframework_${version}_amd64_debian_bullseye
+          gh release upload v${version} kframework_${version}_amd64_debian_bullseye.deb
 
   arch:
     name: 'Arch Linux Package'
@@ -198,7 +201,8 @@ jobs:
         run: |
           set -x
           version=$(cat package/version)
-          gh release upload v${version} kframework_arch_x86_64.pkg.tar.zst
+          cp kframework_arch_x86_64.pkg.tar.zst kframework_${version}_arch_x86_64.pkg.tar.zst
+          gh release upload v${version} kframework_${version}_arch_x86_64.pkg.tar.zst
 
   macos-build:
     name: 'Build MacOS Package'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
     runs-on: macos-11
     timeout-minutes: 120
     environment: production
-    needs: set-release-id
+    needs: [set-release-id, source-tarball]
     steps:
       - name: Check out code
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
           submodules: recursive
       - name: 'Create source tarball'
         env:
-         GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
         run: |
           set -x
           version=$(cat package/version)
@@ -84,14 +84,12 @@ jobs:
           build-package: package/debian/build-package jammy
           test-package: package/debian/test-package
       - name: 'Upload Package to Release'
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-        with:
-          asset_content_type: 'application/gzip'
-          asset_name: kframework_amd64_ubuntu_jammy.deb
-          asset_path: ./kframework_amd64_ubuntu_jammy.deb
-          upload_url: ${{ github.event.release.upload_url }}
+        run: |
+          set -x
+          version=$(cat package/version)
+          gh release upload v${version} kframework_amd64_ubuntu_jammy.deb
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -129,14 +127,12 @@ jobs:
           build-package: package/debian/build-package focal
           test-package: package/debian/test-package
       - name: 'Upload Package to Release'
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-        with:
-          asset_content_type: 'application/gzip'
-          asset_name: kframework_amd64_ubuntu_focal.deb
-          asset_path: ./kframework_amd64_ubuntu_focal.deb
-          upload_url: ${{ github.event.release.upload_url }}
+        run: |
+          set -x
+          version=$(cat package/version)
+          gh release upload v${version} kframework_amd64_ubuntu_focal.deb
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -174,14 +170,12 @@ jobs:
           build-package: package/debian/build-package bullseye
           test-package: package/debian/test-package
       - name: 'Upload Package to Release'
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-        with:
-          asset_content_type: 'application/gzip'
-          asset_name: kframework_amd64_debian_bullseye.deb
-          asset_path: ./kframework_amd64_debian_bullseye.deb
-          upload_url: ${{ github.event.release.upload_url }}
+        run: |
+          set -x
+          version=$(cat package/version)
+          gh release upload v${version} kframework_amd64_debian_bullseye.deb
 
   arch:
     name: 'Arch Linux Package'
@@ -199,14 +193,12 @@ jobs:
           test-package: package/arch/test-package
           pkg-name: kframework_arch_x86_64.pkg.tar.zst
       - name: 'Upload Package to Release'
-        uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-        with:
-          asset_content_type: 'application/gzip'
-          asset_name: kframework_arch_x86_64.pkg.tar.zst
-          asset_path: ./kframework_arch_x86_64.pkg.tar.zst
-          upload_url: ${{ github.event.release.upload_url }}
+        run: |
+          set -x
+          version=$(cat package/version)
+          gh release upload v${version} kframework_arch_x86_64.pkg.tar.zst
 
   macos-build:
     name: 'Build MacOS Package'
@@ -347,15 +339,14 @@ jobs:
           kompile test.k --backend llvm
           kompile test.k --backend haskell
 
-      - name: Upload bottle to release
-        uses: actions/upload-release-asset@v1
+      - name: 'Upload Package to Release'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          asset_content_type: 'application/gzip'
-          asset_name: ${{ needs.macos-build.outputs.bottle_path_remote }}
-          asset_path: homebrew-k-old/${{ needs.macos-build.outputs.bottle_path }}
-          upload_url: ${{ github.event.release.upload_url }}
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
+          BOTTLE_NAME: ${{ needs.macos-build.outputs.bottle_path }}
+        run: |
+          set -x
+          version=$(cat package/version)
+          gh release upload v${version} homebrew-k-old/${BOTTLE_NAME}
 
       - name: Add ssh key
         uses: shimataro/ssh-key-action@v2


### PR DESCRIPTION
Potentially subsumes: https://github.com/runtimeverification/k/pull/3295

This fixes the issue here: https://github.com/runtimeverification/k/actions/runs/4639806374/jobs/8211084388

Instead of using some action to upload the release, just use `gh ...` CLI tool directly, which supports the functionality we need.