### PR TITLE
Fix github-script v6 breakage

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -278,7 +278,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo } = context.repo
-            await github.repos.deleteRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }} })
+            await github.rest.repos.deleteRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }} })
 
     outputs:
       bottle_path: ${{ steps.build.outputs.path }}
@@ -377,7 +377,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo } = context.repo
-            await github.repos.deleteRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }} })
+            await github.rest.repos.deleteRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }} })
 
   release:
     name: 'Publish Release'
@@ -391,7 +391,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const { owner, repo } = context.repo
-            await github.repos.updateRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }}, prerelease: false })
+            await github.rest.repos.updateRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }}, prerelease: false })
       - name: 'Update dependents'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}


### PR DESCRIPTION
Fixes this broken release job: https://github.com/runtimeverification/k/actions/runs/4669923923/jobs/8270188816

The underlying issue is that v5 of the Github script action changes the location of some API methods (from `github.*` to `github.rest.*`): https://github.com/actions/github-script#breaking-changes-in-v5

The change made in this PR matches the Octokit documentation as well, so I'm pretty confident it's correct: https://octokit.github.io/rest.js/v19#repos