### PR TITLE
Add `comm` attributes to `==` and `=/=` operations

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -1678,7 +1678,7 @@ module STRING-KORE [kore, symbolic]
   imports private K-EQUAL
   imports STRING-COMMON
 
-  rule S1:String ==K S2:String => S1 ==String S2 [simplification, comm]
+  rule S1:String ==K S2:String => S1 ==String S2 [simplification]
 
 endmodule
 

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -887,8 +887,8 @@ ackends, both arguments will be evaluated.
                 | Bool "orElseBool" Bool  [function, total, klabel(_orElseBool_), symbol, left, smt-hook(or), boolOperation, hook(BOOL.orElse)]
                 | Bool "impliesBool" Bool [function, total, klabel(_impliesBool_), symbol, left, smt-hook(=>), boolOperation, hook(BOOL.implies)]
                 > left:
-                  Bool "==Bool" Bool      [function, total, klabel(_==Bool_), symbol, left, smt-hook(=), hook(BOOL.eq)]
-                | Bool "=/=Bool" Bool     [function, total, klabel(_=/=Bool_), symbol, left, smt-hook(distinct), hook(BOOL.ne)]
+                  Bool "==Bool" Bool      [function, total, klabel(_==Bool_), symbol, left, comm, smt-hook(=), hook(BOOL.eq)]
+                | Bool "=/=Bool" Bool     [function, total, klabel(_=/=Bool_), symbol, left, comm, smt-hook(distinct), hook(BOOL.ne)]
 ```
 
 ### Implementation of Booleans
@@ -1087,8 +1087,8 @@ greater than or equal to, greater than, equal, or unequal to another integer.
                 | Int "<Int" Int          [function, total, klabel(_<Int_), symbol, left, smt-hook(<), latex({#1}\mathrel{<_{\scriptstyle\it Int}}{#2}), hook(INT.lt)]
                 | Int ">=Int" Int         [function, total, klabel(_>=Int_), symbol, left, smt-hook(>=), latex({#1}\mathrel{\geq_{\scriptstyle\it Int}}{#2}), hook(INT.ge)]
                 | Int ">Int" Int          [function, total, klabel(_>Int_), symbol, left, smt-hook(>), latex({#1}\mathrel{>_{\scriptstyle\it Int}}{#2}), hook(INT.gt)]
-                | Int "==Int" Int         [function, total, klabel(_==Int_), symbol, left, smt-hook(=), latex({#1}\mathrel{{=}{=}_{\scriptstyle\it Int}}{#2}), hook(INT.eq)]
-                | Int "=/=Int" Int        [function, total, klabel(_=/=Int_), symbol, left, smt-hook(distinct), latex({#1}\mathrel{{=}{/}{=}_{\scriptstyle\it Int}}{#2}), hook(INT.ne)]
+                | Int "==Int" Int         [function, total, klabel(_==Int_), symbol, left, comm, smt-hook(=), latex({#1}\mathrel{{=}{=}_{\scriptstyle\it Int}}{#2}), hook(INT.eq)]
+                | Int "=/=Int" Int        [function, total, klabel(_=/=Int_), symbol, left, comm, smt-hook(distinct), latex({#1}\mathrel{{=}{/}{=}_{\scriptstyle\it Int}}{#2}), hook(INT.ne)]
 ```
 
 ### Divides
@@ -1176,15 +1176,11 @@ module INT-KORE [kore, symbolic]
   imports private BOOL
   imports INT-COMMON
 
-  rule I1:Int ==K I2:Int => I1 ==Int I2 [simplification]
+  rule I1:Int ==K I2:Int => I1 ==Int I2 [simplification, comm]
   rule {K1 ==Int K2 #Equals true} => {K1 #Equals K2} [simplification]
-  rule {true #Equals K1 ==Int K2} => {K1 #Equals K2} [simplification]
   rule {K1 ==Int K2 #Equals false} => #Not({K1 #Equals K2}) [simplification]
-  rule {false #Equals K1 ==Int K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=Int K2 #Equals true} => #Not({K1 #Equals K2}) [simplification]
-  rule {true #Equals K1 =/=Int K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=Int K2 #Equals false} => {K1 #Equals K2} [simplification]
-  rule {false #Equals K1 =/=Int K2} => {K1 #Equals K2} [simplification]
 
 endmodule
 
@@ -1402,8 +1398,8 @@ IEEE 754 arithmetic. `0.0 ==Float -0.0` is also true.
                 | Float "<Float" Float        [function, left, smt-hook(fp.lt), latex({#1}\mathrel{<_{\scriptstyle\it Float}}{#2}), hook(FLOAT.lt)]
                 | Float ">=Float" Float       [function, left, smt-hook(fp.geq), latex({#1}\mathrel{\geq_{\scriptstyle\it Float}}{#2}), hook(FLOAT.ge)]
                 | Float ">Float" Float        [function, left, smt-hook(fg.gt), latex({#1}\mathrel{>_{\scriptstyle\it Float}}{#2}), hook(FLOAT.gt)]
-                | Float "==Float" Float       [function, left, smt-hook(fp.eq), latex({#1}\mathrel{==_{\scriptstyle\it Float}}{#2}), hook(FLOAT.eq), klabel(_==Float_)]
-                | Float "=/=Float" Float      [function, left, smt-hook((not (fp.eq #1 #2))), latex({#1}\mathrel{\neq_{\scriptstyle\it Float}}{#2})]
+                | Float "==Float" Float       [function, left, comm, smt-hook(fp.eq), latex({#1}\mathrel{==_{\scriptstyle\it Float}}{#2}), hook(FLOAT.eq), klabel(_==Float_)]
+                | Float "=/=Float" Float      [function, left, comm, smt-hook((not (fp.eq #1 #2))), latex({#1}\mathrel{\neq_{\scriptstyle\it Float}}{#2})]
 
   rule F1:Float =/=Float F2:Float => notBool (F1 ==Float F2)
 ```
@@ -1622,8 +1618,8 @@ is less than, less than or equal to, greater than, or greater than or equal to
 another according to the natural lexicographic ordering of strings.
 
 ```k
-  syntax Bool ::= String "==String" String [function, total, left, hook(STRING.eq)]
-                | String "=/=String" String      [function, total, left, hook(STRING.ne)]
+  syntax Bool ::= String "==String" String [function, total, left, comm, hook(STRING.eq)]
+                | String "=/=String" String      [function, total, left, comm, hook(STRING.ne)]
   rule S1:String =/=String S2:String => notBool (S1 ==String S2)
 
   syntax Bool ::= String  "<String" String [function, total, hook(STRING.lt)]
@@ -1678,7 +1674,7 @@ module STRING-KORE [kore, symbolic]
   imports private K-EQUAL
   imports STRING-COMMON
 
-  rule S1:String ==K S2:String => S1 ==String S2 [simplification]
+  rule S1:String ==K S2:String => S1 ==String S2 [simplification, comm]
 
 endmodule
 
@@ -2038,8 +2034,8 @@ module K-EQUAL-SYNTAX
   imports private BASIC-K
 
   syntax Bool ::= left:
-                  K "==K" K           [function, total, smt-hook(=), hook(KEQUAL.eq), klabel(_==K_), symbol, latex({#1}\mathrel{=_K}{#2}), equalEqualK]
-                | K "=/=K" K          [function, total, smt-hook(distinct), hook(KEQUAL.ne), klabel(_=/=K_), symbol, latex({#1}\mathrel{\neq_K}{#2}), notEqualEqualK]
+                  K "==K" K           [function, total, comm, smt-hook(=), hook(KEQUAL.eq), klabel(_==K_), symbol, latex({#1}\mathrel{=_K}{#2}), equalEqualK]
+                | K "=/=K" K          [function, total, comm, smt-hook(distinct), hook(KEQUAL.ne), klabel(_=/=K_), symbol, latex({#1}\mathrel{\neq_K}{#2}), notEqualEqualK]
 
   syntax priorities equalEqualK notEqualEqualK > boolOperation mlOp
 
@@ -2051,15 +2047,11 @@ module K-EQUAL-KORE [kore, symbolic]
   import private BOOL
   import K-EQUAL-SYNTAX
 
-  rule K1:Bool ==K K2:Bool => K1 ==Bool K2 [simplification]
+  rule K1:Bool ==K K2:Bool => K1 ==Bool K2 [simplification, comm]
   rule {K1 ==K K2 #Equals true} => {K1 #Equals K2} [simplification]
-  rule {true #Equals K1 ==K K2} => {K1 #Equals K2} [simplification]
   rule {K1 ==K K2 #Equals false} => #Not({K1 #Equals K2}) [simplification]
-  rule {false #Equals K1 ==K K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=K K2 #Equals true} => #Not({K1 #Equals K2}) [simplification]
-  rule {true #Equals K1 =/=K K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=K K2 #Equals false} => {K1 #Equals K2} [simplification]
-  rule {false #Equals K1 =/=K K2} => {K1 #Equals K2} [simplification]
 
 endmodule
 

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -1176,11 +1176,15 @@ module INT-KORE [kore, symbolic]
   imports private BOOL
   imports INT-COMMON
 
-  rule I1:Int ==K I2:Int => I1 ==Int I2 [simplification, comm]
+  rule I1:Int ==K I2:Int => I1 ==Int I2 [simplification]
   rule {K1 ==Int K2 #Equals true} => {K1 #Equals K2} [simplification]
+  rule {true #Equals K1 ==Int K2} => {K1 #Equals K2} [simplification]
   rule {K1 ==Int K2 #Equals false} => #Not({K1 #Equals K2}) [simplification]
+  rule {false #Equals K1 ==Int K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=Int K2 #Equals true} => #Not({K1 #Equals K2}) [simplification]
+  rule {true #Equals K1 =/=Int K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=Int K2 #Equals false} => {K1 #Equals K2} [simplification]
+  rule {false #Equals K1 =/=Int K2} => {K1 #Equals K2} [simplification]
 
 endmodule
 
@@ -2047,11 +2051,15 @@ module K-EQUAL-KORE [kore, symbolic]
   import private BOOL
   import K-EQUAL-SYNTAX
 
-  rule K1:Bool ==K K2:Bool => K1 ==Bool K2 [simplification, comm]
+  rule K1:Bool ==K K2:Bool => K1 ==Bool K2 [simplification]
   rule {K1 ==K K2 #Equals true} => {K1 #Equals K2} [simplification]
+  rule {true #Equals K1 ==K K2} => {K1 #Equals K2} [simplification]
   rule {K1 ==K K2 #Equals false} => #Not({K1 #Equals K2}) [simplification]
+  rule {false #Equals K1 ==K K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=K K2 #Equals true} => #Not({K1 #Equals K2}) [simplification]
+  rule {true #Equals K1 =/=K K2} => #Not({K1 #Equals K2}) [simplification]
   rule {K1 =/=K K2 #Equals false} => {K1 #Equals K2} [simplification]
+  rule {false #Equals K1 =/=K K2} => {K1 #Equals K2} [simplification]
 
 endmodule
 


### PR DESCRIPTION
Fixes: #3317 
Add the commutative attribute to: 
- `==Bool` and `=/=Bool`
- `==Float` and `=/=Float`
- `==Int` and `=/=Int`
- `==K` and `=/=K`
- `==String` and `=/=String` 