### PR TITLE
Update Matrix links for use in any client

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ $ git remote rm temp-k-fork
 [issue]: https://github.com/runtimeverification/k/issues/new?assignees=&labels=k-bug%2Ck&template=bug-report.yaml&title=%5BK-Bug%5D+%3CTITLE%3E
 [k-repo]: https://github.com/runtimeverification/k
 [license]: https://github.com/runtimeverification/k/blob/master/LICENSE.md
-[matrix]: https://riot.im/app/#/room/#k:matrix.org
+[matrix]: https://matrix.to/#/#k:matrix.org
 [pr]: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests
 [readme]: https://github.com/runtimeverification/k/blob/master/README.md
 [rebase]: https://docs.github.com/en/get-started/using-git/about-git-rebase

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ copyright: Copyright (c) K Team. All Rights Reserved.
 permalink: README.html
 ---
 
-[Join the chat at Riot](https://riot.im/app/#/room/#k:matrix.org)
+[Join the chat on Matrix](https://matrix.to/#/#k:matrix.org)
 
 # Introduction
 

--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -36,7 +36,7 @@ call/cc.
 ## Support
 
 - [Discord Server](https://discord.com/invite/CurfmXNtbN): Most direct way to get support.
-- [Matrix Room](https://riot.im/app/#/room/#k:matrix.org): Another way to get support.
+- [Matrix Room](https://matrix.to/#/#k:matrix.org): Another way to get support.
 - [Stackoverflow](https://stackoverflow.com/questions/tagged/kframework): for general questions to the K user community.
 
 ## Resources


### PR DESCRIPTION
Riot is an old name for a Matrix client (now called Element). This updates the various Matrix links to use the generic `matrix.to` share link format instead of embedding specific client in the link.