### PR TITLE
Add check for manual declaration of isSort

### DIFF
--- a/k-distribution/tests/regression-new/checks/checkIsSort.k
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k
@@ -1,3 +1,4 @@
+// Copyright (c) K Team. All Rights Reserved.
 module CHECKISSORT-SYNTAX
   imports BOOL-SYNTAX
   imports BASIC-K

--- a/k-distribution/tests/regression-new/checks/checkIsSort.k
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k
@@ -4,14 +4,14 @@ module CHECKISSORT-SYNTAX
   imports BASIC-K
 
   syntax Foo ::= Blah(Bool)
-  
+
   syntax Bool ::= isNonAddr(KItem)  [function]
                 | isNotASort(KItem) [function]
-		| isNonAddr(Foo)    [function]
-		| isnonaddr(KItem)  [function]
-		| isNonAddr ( KItem , KItem ) [function]
-		| isFoo(Foo) [function]
-		
+                | isNonAddr(Foo)    [function]
+                | isnonaddr(KItem)  [function]
+                | isNonAddr ( KItem , KItem ) [function]
+                | isFoo(Foo) [function]
+
   syntax NonAddr ::= nonAddr(KItem)
 endmodule
 

--- a/k-distribution/tests/regression-new/checks/checkIsSort.k
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k
@@ -1,0 +1,11 @@
+module CHECKISSORT-SYNTAX
+  imports BOOL-SYNTAX
+  imports BASIC-K
+
+  syntax Bool ::= isNonAddr(KItem) [function]
+  syntax NonAddr ::= nonAddr(KItem)
+endmodule
+
+module CHECKISSORT
+  imports CHECKISSORT-SYNTAX
+endmodule

--- a/k-distribution/tests/regression-new/checks/checkIsSort.k
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k
@@ -3,7 +3,15 @@ module CHECKISSORT-SYNTAX
   imports BOOL-SYNTAX
   imports BASIC-K
 
-  syntax Bool ::= isNonAddr(KItem) [function]
+  syntax Foo ::= Blah(Bool)
+  
+  syntax Bool ::= isNonAddr(KItem)  [function]
+                | isNotASort(KItem) [function]
+		| isNonAddr(Foo)    [function]
+		| isnonaddr(KItem)  [function]
+		| isNonAddr ( KItem , KItem ) [function]
+		| isFoo(Foo) [function]
+		
   syntax NonAddr ::= nonAddr(KItem)
 endmodule
 

--- a/k-distribution/tests/regression-new/checks/checkIsSort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k.out
@@ -1,6 +1,6 @@
 [Error] Compiler: Syntax declaration conflicts with automatically generated isNonAddr predicate.
 	Source(checkIsSort.k)
-	Location(5,19,5,46)
-	5 |	  syntax Bool ::= isNonAddr(KItem) [function]
+	Location(6,19,6,46)
+	6 |	  syntax Bool ::= isNonAddr(KItem) [function]
 	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkIsSort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k.out
@@ -1,0 +1,6 @@
+[Error] Compiler: Syntax declaration conflicts with automatically generated isNonAddr predicate.
+	Source(checkIsSort.k)
+	Location(5,19,5,46)
+	5 |	  syntax Bool ::= isNonAddr(KItem) [function]
+	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Had 1 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkIsSort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k.out
@@ -5,17 +5,17 @@
 	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Syntax declaration conflicts with automatically generated isNonAddr predicate.
 	Source(checkIsSort.k)
-	Location(10,5,10,33)
-	10 |			| isNonAddr(Foo)    [function]
-	   .	    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Location(10,19,10,47)
+	10 |	                | isNonAddr(Foo)    [function]
+	   .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Syntax declaration conflicts with automatically generated isNonAddr predicate.
 	Source(checkIsSort.k)
-	Location(12,5,12,43)
-	12 |			| isNonAddr ( KItem , KItem ) [function]
-	   .	    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Location(12,19,12,57)
+	12 |	                | isNonAddr ( KItem , KItem ) [function]
+	   .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Syntax declaration conflicts with automatically generated isFoo predicate.
 	Source(checkIsSort.k)
-	Location(13,5,13,26)
-	13 |			| isFoo(Foo) [function]
-	   .	    ^~~~~~~~~~~~~~~~~~~~~
+	Location(13,19,13,40)
+	13 |	                | isFoo(Foo) [function]
+	   .	                  ^~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 4 structural errors.

--- a/k-distribution/tests/regression-new/checks/checkIsSort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkIsSort.k.out
@@ -1,6 +1,21 @@
 [Error] Compiler: Syntax declaration conflicts with automatically generated isNonAddr predicate.
 	Source(checkIsSort.k)
-	Location(6,19,6,46)
-	6 |	  syntax Bool ::= isNonAddr(KItem) [function]
-	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~
-[Error] Compiler: Had 1 structural errors.
+	Location(8,19,8,47)
+	8 |	  syntax Bool ::= isNonAddr(KItem)  [function]
+	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Syntax declaration conflicts with automatically generated isNonAddr predicate.
+	Source(checkIsSort.k)
+	Location(10,5,10,33)
+	10 |			| isNonAddr(Foo)    [function]
+	   .	    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Syntax declaration conflicts with automatically generated isNonAddr predicate.
+	Source(checkIsSort.k)
+	Location(12,5,12,43)
+	12 |			| isNonAddr ( KItem , KItem ) [function]
+	   .	    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Syntax declaration conflicts with automatically generated isFoo predicate.
+	Source(checkIsSort.k)
+	Location(13,5,13,26)
+	13 |			| isFoo(Foo) [function]
+	   .	    ^~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Had 4 structural errors.

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -54,6 +54,7 @@ import org.kframework.utils.options.OuterParsingOptions;
 import scala.collection.JavaConverters;
 import scala.Function1;
 import scala.Option;
+import scala.collection.Set$;
 
 import java.io.File;
 import java.io.IOException;
@@ -477,6 +478,8 @@ public class Kompile {
 
         stream(modules).forEach(m -> stream(m.localSentences()).forEach(new CheckLabels(errors)::check));
 
+        checkIsSortPredicates(modules);
+
         if (!errors.isEmpty()) {
             kem.addAllKException(errors.stream().map(e -> e.exception).collect(Collectors.toList()));
             throw KEMException.compilerError("Had " + errors.size() + " structural errors.");
@@ -491,6 +494,29 @@ public class Kompile {
                 return Stream.empty();
             })).collect(Collectors.toSet()));
         }
+    }
+
+    private void checkIsSortPredicates(scala.collection.Set<Module> modules) {
+        Set<String> generatedIsSorts =
+                stream(modules)
+                        .flatMap(m -> stream(m.definedSorts()))
+                        .map(s -> "is" + s.toString())
+                        .collect(Collectors.toSet());
+
+        stream(modules)
+                .flatMap(m -> stream(m.productionsForSort().getOrElse(Sorts.Bool().head(), Set$.MODULE$::<Production>empty)))
+                .collect(Collectors.toSet())
+                .stream()
+                .filter(prod -> prod.items().nonEmpty() && prod.items().head() instanceof Terminal)
+                .forEach(prod -> {
+                    String firstTerminal = ((Terminal) prod.items().head()).value();
+                    if (generatedIsSorts.contains(firstTerminal)) {
+                        errors.add(
+                                KEMException.compilerError(
+                                        "Syntax declaration conflicts with automatically generated " +
+                                                firstTerminal + " predicate.", prod));
+                    }
+                });
     }
 
     public static Definition addSemanticsModule(Definition d) {


### PR DESCRIPTION
Closes #3329 

This PR adds a check to report an error if the user does both of the following:
- declares a sort `syntax S`
- declares a symbol `syntax Bool ::= isS ( _ )`
