### PR TITLE
Revert Maven deployment changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,11 +118,10 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'apt-get install --yes maven'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
+          docker exec k-package-docker-test-jammy-${GITHUB_SHA} /bin/bash -c "mvn --batch-mode deploy"
 
       - name: 'Clean up Docker Container'
         if: always()

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,7 +118,6 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:~/.m2/settings.xml
           docker exec k-package-docker-test-jammy-${GITHUB_SHA} /bin/bash -c "mvn --batch-mode deploy"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,8 +119,7 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
-          docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
+          docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:~/.m2/settings.xml
           docker exec k-package-docker-test-jammy-${GITHUB_SHA} /bin/bash -c "mvn --batch-mode deploy"
 
       - name: 'Clean up Docker Container'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
           pkg-name: kframework_amd64_ubuntu_jammy.deb
           build-package: package/debian/build-package jammy
           test-package: package/debian/test-package
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -91,18 +90,7 @@ jobs:
           version=$(cat package/version)
           cp kframework_amd64_ubuntu_jammy.deb kframework_${version}_amd64_ubuntu_jammy.deb
           gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_amd64_ubuntu_jammy.deb
-
-      - name: Set up Java for publishing to GitHub Maven Packages
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          overwrite-settings: true
-          server-id: runtime.verification
-          server-username: ${{ env.GITHUB_ACTOR }}
-          server-password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Build, Test, Push Dockerhub Image, Push Mvn Packages'
+      - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -118,9 +106,6 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-          docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:~/.m2/settings.xml
-          docker exec k-package-docker-test-jammy-${GITHUB_SHA} /bin/bash -c "mvn --batch-mode deploy"
-
       - name: 'Clean up Docker Container'
         if: always()
         run: |
@@ -141,7 +126,6 @@ jobs:
           pkg-name: kframework_amd64_ubuntu_focal.deb
           build-package: package/debian/build-package focal
           test-package: package/debian/test-package
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -186,7 +170,6 @@ jobs:
           pkg-name: kframework_amd64_debian_bullseye.deb
           build-package: package/debian/build-package bullseye
           test-package: package/debian/test-package
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -211,7 +194,6 @@ jobs:
           build-package: package/arch/build-package
           test-package: package/arch/test-package
           pkg-name: kframework_arch_x86_64.pkg.tar.zst
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
     <repository>
       <id>runtime.verification</id>
       <name>Runtime Verification Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
+      <url>s3://runtimeverificationmaven/internal</url>
     </repository>
     <snapshotRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
+      <url>s3://runtimeverificationmaven/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
The Maven deployment changes are causing us to not have a successful release. I'm reverting them for now, and will re-introduce a simplified version of them that can serve as the starting point for next attempt.