### PR TITLE
Use remote bottle path instead of local

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,7 +350,7 @@ jobs:
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-          BOTTLE_NAME: ${{ needs.macos-build.outputs.bottle_path }}
+          BOTTLE_NAME: ${{ needs.macos-build.outputs.bottle_path_remote }}
         run: |
           set -x
           version=$(cat k-homebrew-checkout/package/version)


### PR DESCRIPTION
The problem here seems to be that we're using a local filename rather than the one that gets uploaded; this PR attempts to fix the problem by threading the post-substitution remote path through to the release upload step.

Should fix #3361 