### PR TITLE
Fix bottle name again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,11 +350,13 @@ jobs:
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-          BOTTLE_NAME: ${{ needs.macos-build.outputs.bottle_path_remote }}
+          BOTTLE_NAME: ${{ needs.macos-build.outputs.bottle_path }}
+          REMOTE_BOTTLE_NAME: ${{ needs.macos-build.outputs.bottle_path_remote }}
         run: |
           set -x
           version=$(cat k-homebrew-checkout/package/version)
-          gh release upload --repo runtimeverification/k --clobber v${version} homebrew-k-old/${BOTTLE_NAME}
+          mv homebrew-k-old/${BOTTLE_NAME} homebrew-k-old/${REMOTE_BOTTLE_NAME}
+          gh release upload --repo runtimeverification/k --clobber v${version} homebrew-k-old/${REMOTE_BOTTLE_NAME}
 
       - name: 'Add ssh key'
         uses: shimataro/ssh-key-action@v2


### PR DESCRIPTION
My previous fix for this issue didn't work:
https://github.com/runtimeverification/k/actions/runs/4829816577/jobs/8606237970

Looking at the failure there, the problem is not that we create two files and upload the wrongly-named one, it's that we create one with the wrong name and need to rename it before uploading.