### PR TITLE
Make new-format rules without antileft the default

### DIFF
--- a/k-distribution/tests/regression-new/issue-3035-antileft/haskell/Makefile
+++ b/k-distribution/tests/regression-new/issue-3035-antileft/haskell/Makefile
@@ -2,6 +2,6 @@ DEF=test
 EXT=test
 TESTDIR=.
 KOMPILE_BACKEND=haskell
-KOMPILE_FLAGS=--syntax-module TEST --disable-kore-antileft
+KOMPILE_FLAGS=--syntax-module TEST
 
 include ../../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/issue-3035-antileft/llvm/Makefile
+++ b/k-distribution/tests/regression-new/issue-3035-antileft/llvm/Makefile
@@ -2,6 +2,6 @@ DEF=test
 EXT=test
 TESTDIR=.
 KOMPILE_BACKEND=llvm
-KOMPILE_FLAGS=--syntax-module TEST --disable-kore-antileft
+KOMPILE_FLAGS=--syntax-module TEST
 
 include ../../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/map-symbolic-tests-haskell/assignment-11-spec.k.out
+++ b/k-distribution/tests/regression-new/map-symbolic-tests-haskell/assignment-11-spec.k.out
@@ -12,8 +12,8 @@
 #And
   <k>
     assignmentResult ( ( MAP
-    X:MyId |-> 1 ) [ Z:MyId <- 3 ]
-    Y:MyId |-> 2 ) ~> .
+    X:MyId |-> 1
+    Y:MyId |-> 2 ) [ Z:MyId <- 3 ] ) ~> .
   </k>
 #And
   {

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -302,7 +302,7 @@ public class ModuleToKORE {
             ruleIndex++;
         }
 
-        if (!options.disableKoreAntileft) {
+        if (options.enableKoreAntileft) {
             semantics.append("\n// priority groups\n");
             genPriorityGroups(priorityList, priorityToPreviousGroup, priorityToAlias, topCellSortStr, semantics);
         }
@@ -1175,7 +1175,7 @@ public class ModuleToKORE {
                 Comparator<KVariable> compareByName = (KVariable v1, KVariable v2) -> v1.name().compareTo(v2.name());
                 java.util.Collections.sort(freeVars, compareByName);
 
-                if (!options.disableKoreAntileft) {
+                if (options.enableKoreAntileft) {
                     genAliasForSemanticsRuleLHS(requires, left, ruleAliasName, freeVars, topCellSortStr,
                             priority, priorityToAlias, sb);
                     sb.append("\n");
@@ -1184,13 +1184,13 @@ public class ModuleToKORE {
                 sb.append("  axiom{} ");
                 sb.append(String.format("\\rewrites{%s} (\n    ", topCellSortStr));
 
-                if (options.disableKoreAntileft) {
-                    genSemanticsRuleLHSNoAlias(requires, left, freeVars, topCellSortStr, priorityToPreviousGroup.get(priority), sb);
-                    sb.append(",\n      ");
-                } else {
+                if (options.enableKoreAntileft) {
                     genSemanticsRuleLHSWithAlias(ruleAliasName, freeVars, topCellSortStr,
                             priorityToPreviousGroup.get(priority), sb);
                     sb.append(",\n    ");
+                } else {
+                    genSemanticsRuleLHSNoAlias(requires, left, freeVars, topCellSortStr, priorityToPreviousGroup.get(priority), sb);
+                    sb.append(",\n      ");
                 }
             } else {
                 // LHS for claims
@@ -1219,14 +1219,15 @@ public class ModuleToKORE {
             }
             sb.append(String.format("\\and{%s} (\n      ", topCellSortStr));
 
-            if (options.disableKoreAntileft) {
-                convert(right, sb);
-                sb.append(", ");
+            if (options.enableKoreAntileft) {
                 convertSideCondition(ensures, topCellSortStr, sb);
+                sb.append(", ");
+                convert(right, sb);
             } else {
-                convertSideCondition(ensures, topCellSortStr, sb);
-                sb.append(", ");
                 convert(right, sb);
+                sb.append(", ");
+                convertSideCondition(ensures, topCellSortStr, sb);
+
             }
 
             sb.append(')');

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -142,6 +142,6 @@ public class KompileOptions implements Serializable {
     @Parameter(names={"--allow-anywhere-haskell"}, description="Disable error message for anywhere rules on the Haskell backend.")
     public boolean allowAnywhereRulesHaskell;
 
-    @Parameter(names="--disable-kore-antileft", description="[EXPERIMENTAL] Disable generation of antileft priority predicates ")
-    public boolean disableKoreAntileft;
+    @Parameter(names="--enable-kore-antileft", description="[DEPRECATED] Enable generation of legacy antileft priority predicates ")
+    public boolean enableKoreAntileft;
 }

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -142,6 +142,6 @@ public class KompileOptions implements Serializable {
     @Parameter(names={"--allow-anywhere-haskell"}, description="Disable error message for anywhere rules on the Haskell backend.")
     public boolean allowAnywhereRulesHaskell;
 
-    @Parameter(names="--enable-kore-antileft", description="[DEPRECATED] Enable generation of legacy antileft priority predicates ")
+    @Parameter(names="--enable-kore-antileft", description="Enable generation of legacy antileft priority predicates ")
     public boolean enableKoreAntileft;
 }


### PR DESCRIPTION
Related to: https://github.com/runtimeverification/k/issues/3035

This PR inverts the previous behaviour of ModuleToKore such that the new-format rewrite rules are generated by default, rather than being gated behind the `--disable-kore-antileft` flag.

Changes in this PR:
* Rename and invert uses of `--disable-kore-antileft` to produce `--enable-kore-antileft`
* Reorder one symbolic Map test on the Haskell backend that seems to apply two rules in a different order if the new format rules are used

This PR's CI run will demonstrate that the new changes allow the full regression test suite to run. I have also completed downstream testing with the following semantics via their Nix flakes, and can add more to this list if required:
* [x] C
* [x] EVM

If this change causes unexpected failures, we can address it in one of two ways depending on the failure:
* Add the `--enable-kore-antileft` flag to a semantics' build system, and fix gradually
* Revert this PR and revisit the entire change