### PR TITLE
Update missing KLabel checks to stabilize error messages

### DIFF
--- a/k-distribution/tests/regression-new/checkWarns/missingKlabel.k
+++ b/k-distribution/tests/regression-new/checkWarns/missingKlabel.k
@@ -4,6 +4,10 @@ endmodule
 
 module MISSINGKLABEL
   imports MISSINGKLABEL-SYNTAX
+  imports BASIC-K
+
+  syntax MyMap ::= KItem "M|->" KItem
+      [ function, total, hook(MAP.element), klabel(_M|->_), symbol, injective, unused]
 
   syntax MyMap ::= MyMap MyMap
       [ left, function, hook(MAP.concat), klabel(_MyMap_), symbol, assoc, comm

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -1816,7 +1816,9 @@ public class ModuleToKORE {
     private void convert(Map<String, Boolean> attributes, Att att, StringBuilder sb, Map<String, KVariable> freeVarsMap, HasLocation location) {
         sb.append("[");
         String conn = "";
-        for (Tuple2<Tuple2<String, String>, ?> attribute : iterable(att.att())) {
+        for (Tuple2<Tuple2<String, String>, ?> attribute :
+            // Sort to stabilize error messages
+            stream(att.att()).sorted(Comparator.comparing(Tuple2::toString)).collect(Collectors.toList())) {
             String name = attribute._1._1;
             String clsName = attribute._1._2;
             Object val = attribute._2;


### PR DESCRIPTION
While working on #3390, I noticed that the missing KLabel error check in ModuleToKORE is done while iterating over a HashMap of attributes, which makes the order of errors unstable. This PR addresses that by sorting the attributes first.