### PR TITLE
Add back Maven packages changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,6 @@ jobs:
           pkg-name: kframework_amd64_ubuntu_jammy.deb
           build-package: package/debian/build-package jammy
           test-package: package/debian/test-package
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -91,18 +90,7 @@ jobs:
           version=$(cat package/version)
           cp kframework_amd64_ubuntu_jammy.deb kframework_${version}_amd64_ubuntu_jammy.deb
           gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_amd64_ubuntu_jammy.deb
-
-      - name: Set up Java for publishing to GitHub Maven Packages
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          overwrite-settings: true
-          server-id: runtime.verification
-          server-username: ${{ env.GITHUB_ACTOR }}
-          server-password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Build, Test, Push Dockerhub Image, Push Mvn Packages'
+      - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -118,12 +106,6 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'apt-get install --yes maven'
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
-          docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
-
       - name: 'Clean up Docker Container'
         if: always()
         run: |
@@ -144,7 +126,6 @@ jobs:
           pkg-name: kframework_amd64_ubuntu_focal.deb
           build-package: package/debian/build-package focal
           test-package: package/debian/test-package
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -189,7 +170,6 @@ jobs:
           pkg-name: kframework_amd64_debian_bullseye.deb
           build-package: package/debian/build-package bullseye
           test-package: package/debian/test-package
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -214,7 +194,6 @@ jobs:
           build-package: package/arch/build-package
           test-package: package/arch/test-package
           pkg-name: kframework_arch_x86_64.pkg.tar.zst
-
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           server-username: ${{ env.GITHUB_ACTOR }}
           server-password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Build, Test, Push Dockerhub Image, Push Mvn Packages'
+      - name: 'Build, Test, Push Dockerhub Image'
         shell: bash {0}
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -118,6 +118,9 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
+      - name: 'Push Maven Packages'
+        continue-on-error: true
+        shell: bash {0}
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'apt-get install --yes maven'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -387,6 +387,48 @@ jobs:
     environment: production
     needs: [nix-release, macos-build, macos-test, source-tarball, ubuntu-jammy, ubuntu-focal, debian-bullseye, set-release-id, arch]
     steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Java for publishing to GitHub Maven Packages
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          overwrite-settings: true
+          server-id: runtime.verification.snapshots
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-docker
+        with:
+          tag: k-release-ci-${{ github.sha }}
+          os: ubuntu
+          distro: jammy
+          llvm: 14
+
+      - name: 'Push Maven Packages'
+        shell: bash {0}
+        env:
+          MAVEN_PASSWORD: ${{ secrets.RV_JENKINS_DEPLOY_TOKEN }}
+        run: |
+          echo "MAVEN_USERNAME=rv-jenkins" > rv-jenkins.env
+          echo "MAVEN_PASSWORD=$MAVEN_PASSWORD" >> rv-jenkins.env
+          cat ~/.m2/settings.xml
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
+          docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
+          docker exec --env-file rv-jenkins.env -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
+
+      - name: 'Tear down Docker'
+        if: always()
+        run: |
+          docker stop --time=0 k-release-ci-${GITHUB_SHA}
+          docker container rm --force k-release-ci-${GITHUB_SHA} || true
+
       - name: Publish release
         uses: actions/github-script@v6.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,17 +92,7 @@ jobs:
           cp kframework_amd64_ubuntu_jammy.deb kframework_${version}_amd64_ubuntu_jammy.deb
           gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_amd64_ubuntu_jammy.deb
 
-      - name: Set up Java for publishing to GitHub Maven Packages
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          overwrite-settings: true
-          server-id: runtime.verification
-          server-username: ${{ env.GITHUB_ACTOR }}
-          server-password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Build, Test, Push Dockerhub Image'
+      - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -118,14 +108,6 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-      - name: 'Push Maven Packages'
-        continue-on-error: true
-        shell: bash {0}
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'apt-get install --yes maven'
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
-          docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
-          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
 
       - name: 'Clean up Docker Container'
         if: always()
@@ -411,6 +393,40 @@ jobs:
     environment: production
     needs: [nix-release, macos-build, macos-test, source-tarball, ubuntu-jammy, ubuntu-focal, debian-bullseye, set-release-id, arch]
     steps:
+      - name: Set up Java for publishing to GitHub Maven Packages
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          overwrite-settings: true
+          server-id: runtime.verification
+          server-username: ${{ env.GITHUB_ACTOR }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-docker
+        continue-on-error: true
+        with:
+          tag: k-release-ci-${{ github.sha }}
+          os: ubuntu
+          distro: jammy
+          llvm: 14
+
+      - name: 'Push Maven Packages'
+        continue-on-error: true
+        shell: bash {0}
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
+          docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
+
+      - name: 'Tear down Docker'
+        if: always()
+        continue-on-error: true
+        run: |
+          docker stop --time=0 k-release-ci-${GITHUB_SHA}
+          docker container rm --force k-release-ci-${GITHUB_SHA} || true
+
       - name: Publish release
         uses: actions/github-script@v6.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,17 @@ jobs:
           cp kframework_amd64_ubuntu_jammy.deb kframework_${version}_amd64_ubuntu_jammy.deb
           gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_amd64_ubuntu_jammy.deb
 
-      - name: 'Build, Test, and Push Dockerhub Image'
+      - name: Set up Java for publishing to GitHub Maven Packages
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          overwrite-settings: true
+          server-id: runtime.verification
+          server-username: ${{ env.GITHUB_ACTOR }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Build, Test, Push Dockerhub Image'
         shell: bash {0}
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -108,6 +118,14 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
+      - name: 'Push Maven Packages'
+        continue-on-error: true
+        shell: bash {0}
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'apt-get install --yes maven'
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
+          docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
 
       - name: 'Clean up Docker Container'
         if: always()
@@ -393,40 +411,6 @@ jobs:
     environment: production
     needs: [nix-release, macos-build, macos-test, source-tarball, ubuntu-jammy, ubuntu-focal, debian-bullseye, set-release-id, arch]
     steps:
-      - name: Set up Java for publishing to GitHub Maven Packages
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          overwrite-settings: true
-          server-id: runtime.verification
-          server-username: ${{ env.GITHUB_ACTOR }}
-          server-password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: 'Set up Docker'
-        uses: ./.github/actions/with-docker
-        continue-on-error: true
-        with:
-          tag: k-release-ci-${{ github.sha }}
-          os: ubuntu
-          distro: jammy
-          llvm: 14
-
-      - name: 'Push Maven Packages'
-        continue-on-error: true
-        shell: bash {0}
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
-          docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
-
-      - name: 'Tear down Docker'
-        if: always()
-        continue-on-error: true
-        run: |
-          docker stop --time=0 k-release-ci-${GITHUB_SHA}
-          docker container rm --force k-release-ci-${GITHUB_SHA} || true
-
       - name: Publish release
         uses: actions/github-script@v6.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,7 +102,7 @@ jobs:
           server-username: ${{ env.GITHUB_ACTOR }}
           server-password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 'Build, Test, Push Dockerhub Image'
+      - name: 'Build, Test, Push Dockerhub Image, Push Mvn Packages'
         shell: bash {0}
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -118,9 +118,6 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
-      - name: 'Push Maven Packages'
-        continue-on-error: true
-        shell: bash {0}
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'apt-get install --yes maven'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,7 @@ jobs:
           pkg-name: kframework_amd64_ubuntu_jammy.deb
           build-package: package/debian/build-package jammy
           test-package: package/debian/test-package
+
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -90,7 +91,18 @@ jobs:
           version=$(cat package/version)
           cp kframework_amd64_ubuntu_jammy.deb kframework_${version}_amd64_ubuntu_jammy.deb
           gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_amd64_ubuntu_jammy.deb
-      - name: 'Build, Test, and Push Dockerhub Image'
+
+      - name: Set up Java for publishing to GitHub Maven Packages
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          overwrite-settings: true
+          server-id: runtime.verification
+          server-username: ${{ env.GITHUB_ACTOR }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Build, Test, Push Dockerhub Image, Push Mvn Packages'
         shell: bash {0}
         env:
           DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}
@@ -106,6 +118,12 @@ jobs:
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend llvm'
           docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'cd ~ && kompile test.k --backend haskell'
           docker image push ${DOCKERHUB_REPO}:${version_tag}
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'apt-get install --yes maven'
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
+          docker cp ~/.m2/settings.xml k-package-docker-test-jammy-${GITHUB_SHA}:/tmp/settings.xml
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
+          docker exec -t k-package-docker-test-jammy-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
+
       - name: 'Clean up Docker Container'
         if: always()
         run: |
@@ -126,6 +144,7 @@ jobs:
           pkg-name: kframework_amd64_ubuntu_focal.deb
           build-package: package/debian/build-package focal
           test-package: package/debian/test-package
+
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -170,6 +189,7 @@ jobs:
           pkg-name: kframework_amd64_debian_bullseye.deb
           build-package: package/debian/build-package bullseye
           test-package: package/debian/test-package
+
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -194,6 +214,7 @@ jobs:
           build-package: package/arch/build-package
           test-package: package/arch/test-package
           pkg-name: kframework_arch_x86_64.pkg.tar.zst
+
       - name: 'Upload Package to Release'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -130,8 +130,8 @@ jobs:
           distribution: 'adopt'
           overwrite-settings: true
           server-id: runtime.verification.snapshots
-          server-username: JENKINS_USERNAME
-          server-password: RV_JENKINS_DEPLOY_TOKEN
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
       - name: 'Set up Docker'
         uses: ./.github/actions/with-docker
         with:
@@ -142,9 +142,11 @@ jobs:
 
       - name: 'Push Maven Packages'
         shell: bash {0}
+        env:
+          MAVEN_PASSWORD: ${{ secrets.RV_JENKINS_DEPLOY_TOKEN }}
         run: |
-          echo "JENKINS_USERNAME=rv-jenkins" > rv-jenkins.env
-          echo "RV_JENKINS_DEPLOY_TOKEN=$RV_JENKINS_DEPLOY_TOKEN" >> rv-jenkins.env
+          echo "MAVEN_USERNAME=rv-jenkins" > rv-jenkins.env
+          echo "MAVEN_PASSWORD=$MAVEN_PASSWORD" >> rv-jenkins.env
           cat ~/.m2/settings.xml
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -131,7 +131,7 @@ jobs:
           overwrite-settings: true
           server-id: runtime.verification.snapshots
           server-username: JENKINS_USERNAME
-          server-password: JENKINS_GITHUB_PAT
+          server-password: RV_JENKINS_DEPLOY_TOKEN
       - name: 'Set up Docker'
         uses: ./.github/actions/with-docker
         with:
@@ -144,7 +144,7 @@ jobs:
         shell: bash {0}
         run: |
           echo "JENKINS_USERNAME=rv-jenkins" > rv-jenkins.env
-          echo "JENKINS_GITHUB_PAT=$JENKINS_GITHUB_PAT" >> rv-jenkins.env
+          echo "RV_JENKINS_DEPLOY_TOKEN=$RV_JENKINS_DEPLOY_TOKEN" >> rv-jenkins.env
           cat ~/.m2/settings.xml
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -130,8 +130,8 @@ jobs:
           distribution: 'adopt'
           overwrite-settings: true
           server-id: runtime.verification
-          server-username: ${{ env.GITHUB_ACTOR }}
-          server-password: ${{ secrets.GITHUB_TOKEN }}
+          server-username: rv-jenkins
+          server-password: ${{ secrets.JENKINS_GITHUB_PAT }}
 
       - name: 'Set up Docker'
         uses: ./.github/actions/with-docker

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -113,52 +113,6 @@ jobs:
           docker stop --time=0 k-ci-${GITHUB_SHA}
           docker container rm --force k-ci-${GITHUB_SHA} || true
 
-  test-maven-deployment:
-    name: 'Test Maven Deployment'
-    runs-on: [self-hosted, linux, normal]
-    needs: version-sync
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v3
-        with:
-          submodules: recursive
-
-      - name: Set up Java for publishing to GitHub Maven Packages
-        uses: actions/setup-java@v3
-        with:
-          java-version: '11'
-          distribution: 'adopt'
-          overwrite-settings: true
-          server-id: runtime.verification.snapshots
-          server-username: MAVEN_USERNAME
-          server-password: MAVEN_PASSWORD
-      - name: 'Set up Docker'
-        uses: ./.github/actions/with-docker
-        with:
-          tag: k-release-ci-${{ github.sha }}
-          os: ubuntu
-          distro: jammy
-          llvm: 14
-
-      - name: 'Push Maven Packages'
-        shell: bash {0}
-        env:
-          MAVEN_PASSWORD: ${{ secrets.RV_JENKINS_DEPLOY_TOKEN }}
-        run: |
-          echo "MAVEN_USERNAME=rv-jenkins" > rv-jenkins.env
-          echo "MAVEN_PASSWORD=$MAVEN_PASSWORD" >> rv-jenkins.env
-          cat ~/.m2/settings.xml
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
-          docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
-          docker exec --env-file rv-jenkins.env -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
-
-      - name: 'Tear down Docker'
-        if: always()
-        run: |
-          docker stop --time=0 k-release-ci-${GITHUB_SHA}
-          docker container rm --force k-release-ci-${GITHUB_SHA} || true
-
   test-package-ubuntu-jammy:
     name: 'K Ubuntu Jammy Package'
     runs-on: [self-hosted, linux, normal]

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -143,6 +143,7 @@ jobs:
 
       - name: 'Push Maven Packages'
         shell: bash {0}
+        run: |
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -129,7 +129,7 @@ jobs:
           java-version: '11'
           distribution: 'adopt'
           overwrite-settings: true
-          server-id: runtime.verification
+          server-id: runtime.verification.snapshots
           server-username: rv-jenkins
           server-password: ${{ secrets.JENKINS_GITHUB_PAT }}
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -130,9 +130,8 @@ jobs:
           distribution: 'adopt'
           overwrite-settings: true
           server-id: runtime.verification.snapshots
-          server-username: rv-jenkins
-          server-password: ${{ secrets.JENKINS_GITHUB_PAT }}
-
+          server-username: JENKINS_USERNAME
+          server-password: JENKINS_GITHUB_PAT
       - name: 'Set up Docker'
         uses: ./.github/actions/with-docker
         with:
@@ -144,10 +143,12 @@ jobs:
       - name: 'Push Maven Packages'
         shell: bash {0}
         run: |
+          echo "JENKINS_USERNAME=rv-jenkins" > rv-jenkins.env
+          echo "JENKINS_GITHUB_PAT=$JENKINS_GITHUB_PAT" >> rv-jenkins.env
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
+          docker exec --env-file rv-jenkins.env -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
 
       - name: 'Tear down Docker'
         if: always()

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -145,6 +145,7 @@ jobs:
         run: |
           echo "JENKINS_USERNAME=rv-jenkins" > rv-jenkins.env
           echo "JENKINS_GITHUB_PAT=$JENKINS_GITHUB_PAT" >> rv-jenkins.env
+          cat ~/.m2/settings.xml
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
           docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -113,6 +113,47 @@ jobs:
           docker stop --time=0 k-ci-${GITHUB_SHA}
           docker container rm --force k-ci-${GITHUB_SHA} || true
 
+  test-maven-deployment:
+    name: 'Test Maven Deployment'
+    runs-on: [self-hosted, linux, normal]
+    needs: version-sync
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Set up Java for publishing to GitHub Maven Packages
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+          overwrite-settings: true
+          server-id: runtime.verification
+          server-username: ${{ env.GITHUB_ACTOR }}
+          server-password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-docker
+        with:
+          tag: k-release-ci-${{ github.sha }}
+          os: ubuntu
+          distro: jammy
+          llvm: 14
+
+      - name: 'Push Maven Packages'
+        shell: bash {0}
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
+          docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
+
+      - name: 'Tear down Docker'
+        if: always()
+        run: |
+          docker stop --time=0 k-release-ci-${GITHUB_SHA}
+          docker container rm --force k-release-ci-${GITHUB_SHA} || true
+
   test-package-ubuntu-jammy:
     name: 'K Ubuntu Jammy Package'
     runs-on: [self-hosted, linux, normal]

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
     <repository>
       <id>runtime.verification</id>
       <name>Runtime Verification Repository</name>
-      <url>s3://runtimeverificationmaven/internal</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
     </repository>
     <snapshotRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/test-maven-deployment</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,14 @@
     <pluginRepository>
       <id>runtime.verification</id>
       <name>Runtime Verification Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
+      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/internal</url>
       <snapshots><enabled>false</enabled></snapshots>
       <releases><enabled>true</enabled></releases>
     </pluginRepository>
     <pluginRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
+      <url>https://maven.pkg.github.com/runtimeverification/test-maven-deployment</url>
       <snapshots><enabled>true</enabled></snapshots>
       <releases><enabled>false</enabled></releases>
     </pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -43,14 +43,14 @@
     <pluginRepository>
       <id>runtime.verification</id>
       <name>Runtime Verification Repository</name>
-      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/internal</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
       <snapshots><enabled>false</enabled></snapshots>
       <releases><enabled>true</enabled></releases>
     </pluginRepository>
     <pluginRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/snapshots</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
       <snapshots><enabled>true</enabled></snapshots>
       <releases><enabled>false</enabled></releases>
     </pluginRepository>

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
     <repository>
       <id>runtime.verification</id>
       <name>Runtime Verification Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
+      <url>s3://runtimeverificationmaven/internal</url>
     </repository>
     <snapshotRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
+      <url>s3://runtimeverificationmaven/snapshots</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <pluginRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/test-maven-deployment</url>
+      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/snapshots</url>
       <snapshots><enabled>true</enabled></snapshots>
       <releases><enabled>false</enabled></releases>
     </pluginRepository>
@@ -65,7 +65,7 @@
     <snapshotRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>s3://runtimeverificationmaven/snapshots</url>
+      <url>https://maven.pkg.github.com/runtimeverification/test-maven-deployment</url>
     </snapshotRepository>
   </distributionManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
     <repository>
       <id>runtime.verification</id>
       <name>Runtime Verification Repository</name>
-      <url>s3://runtimeverificationmaven/internal</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
     </repository>
     <snapshotRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>s3://runtimeverificationmaven/snapshots</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
This is a revert of the revert in #3369, which reverted all our changes to try to get maven github packages deployment working.

I brought it back in this PR and modified the workflow so that if the push to github packages fails, the workflow will ignore the failure and continue on.

This is a temporary change; I intend to make it so that failures fail the release once I get it working; however, this allows us to make further changes in the near future to try to experiment with fixing the package deployment without preventing releases from going through in the meantime.

I also made some changes that I hope will fix the reason why it was failing previously.