### PR TITLE
Setting `--directory` as deprecated

### DIFF
--- a/k-distribution/include/kframework/ktest-fail.mak
+++ b/k-distribution/include/kframework/ktest-fail.mak
@@ -28,7 +28,7 @@ kompile: $(TESTS)
 dummy:
 
 %.k %.md: dummy
-	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG_FAIL) $@ -d $(DEFDIR) 2>&1 | sed 's!'`pwd`'/\(\./\)\{0,2\}!!g' $(CHECK) $@.out $(CHECK2)
+	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG_FAIL) $@ --output-definition $(DEFDIR)/$(basename $@)-kompiled 2>&1 | sed 's!'`pwd`'/\(\./\)\{0,2\}!!g' $(CHECK) $@.out $(CHECK2)
 
 # run all tests and regenerate output files
 update-results: kompile

--- a/k-distribution/include/kframework/ktest.mak
+++ b/k-distribution/include/kframework/ktest.mak
@@ -75,7 +75,7 @@ all: kompile krun proofs searches strat kast kast-bison kparse
 kompile: $(KOMPILED_DIR)/timestamp
 
 $(KOMPILED_DIR)/timestamp: $(DEF).$(SOURCE_EXT)
-	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG) $< -d $(DEFDIR)
+	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG) $< --output-definition $(KOMPILED_DIR)
 
 krun: $(TESTS)
 
@@ -100,62 +100,62 @@ update-results: CHECK=>
 # specified in the makefile prior to including ktest.mak.
 %.$(EXT): kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(PIPEFAIL) (cat $@.in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $@ $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $@.out
+	$(PIPEFAIL) (cat $@.in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $@ $(KRUN_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $@.out
 else
-	$(PIPEFAIL) (cat $(RESULTDIR)/$(notdir $@).in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $@ $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(PIPEFAIL) (cat $(RESULTDIR)/$(notdir $@).in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $@ $(KRUN_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 krun.nopgm: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(PIPEFAIL) (cat $@.in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $@.out
+	$(PIPEFAIL) (cat $@.in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $@.out
 else
-	$(PIPEFAIL) (cat $(RESULTDIR)/$(notdir $@).in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(PIPEFAIL) (cat $(RESULTDIR)/$(notdir $@).in 2>/dev/null || true) | $(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 %-spec.k %-spec.md: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_PROVER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CONSIDER_PROVER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out
 else
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_PROVER_ERRORS) $(REMOVE_PATHS) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CONSIDER_PROVER_ERRORS) $(REMOVE_PATHS) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 %-broken-spec.k %-broken-spec.md: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out
 else
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 %.search: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(PIPEFAIL) $(KSEARCH) $@ $(KSEARCH_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $@.out
+	$(PIPEFAIL) $(KSEARCH) $@ $(KSEARCH_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $@.out
 else
-	$(PIPEFAIL) $(KSEARCH) $@ $(KSEARCH_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(PIPEFAIL) $(KSEARCH) $@ $(KSEARCH_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 %.strat: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(PIPEFAIL) $(KRUN_OR_LEGACY) $@.input $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) -cSTRATEGY="$(shell cat $@)" $(CHECK) $@.out
+	$(PIPEFAIL) $(KRUN_OR_LEGACY) $@.input $(KRUN_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) -cSTRATEGY="$(shell cat $@)" $(CHECK) $@.out
 else
-	$(PIPEFAIL) $(KRUN_OR_LEGACY) $@.input $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) -cSTRATEGY="$(shell cat $@)" $(CHECK) $(RESULT_DIR)/$(notdir $@).out
+	$(PIPEFAIL) $(KRUN_OR_LEGACY) $@.input $(KRUN_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) -cSTRATEGY="$(shell cat $@)" $(CHECK) $(RESULT_DIR)/$(notdir $@).out
 endif
 
 %.kast: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(PIPEFAIL) $(KAST) $@ $(KAST_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $@.out
+	$(PIPEFAIL) $(KAST) $@ $(KAST_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $@.out
 else
-	$(PIPEFAIL) $(KAST) $@ $(KAST_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(PIPEFAIL) $(KAST) $@ $(KAST_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 %.kparse: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(PIPEFAIL) $(KPARSE) $@ $(KPARSE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $@.out
+	$(PIPEFAIL) $(KPARSE) $@ $(KPARSE_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $@.out
 else
-	$(PIPEFAIL) $(KPARSE) $@ $(KPARSE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(PIPEFAIL) $(KPARSE) $@ $(KPARSE_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 %.kast-bison: kompile
-	$(KAST) $(KAST_FLAGS) $(DEBUG) -d $(DEFDIR) bison_parser
+	$(KAST) $(KAST_FLAGS) $(DEBUG) --definition $(KOMPILED_DIR) bison_parser
 ifeq ($(TESTDIR),$(RESULTDIR))
 	$(PIPEFAIL) ./bison_parser $@ $(CHECK) $@.out
 else

--- a/k-distribution/src/main/scripts/bin/kore-print
+++ b/k-distribution/src/main/scripts/bin/kore-print
@@ -46,7 +46,7 @@ $KORE_PRINT arguments:
       --color [on|off]     Enable/disable ANSI color codes. Overrides default,
                            which is determined based on whether stdout is a
                            terminal
-  -d, --directory DIR      Look for a kompiled directory ending in "-kompiled"
+  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
                            under the directory DIR
       --definition DIR     Exact path to the kompiled directory.
   -h, --help               Display this help and exit
@@ -92,6 +92,7 @@ do
       ;;
 
       -d|--directory)
+      echo "[Warning]: -d/--directory is deprecated. Use --definition instead." >&2
       dir="$2"
       shift
       ;;
@@ -194,7 +195,7 @@ else
 fi
 
 if ! $hasKompiledDir; then
-  error 1 'Could not find a compiled definition. Use --directory to specify one.'
+  error 1 'Could not find a compiled definition. Use --definition to specify one.'
 fi
 
 if [ ! -f "$kompiledDir/syntaxDefinition.kore" ]; then

--- a/k-distribution/src/main/scripts/bin/kparse
+++ b/k-distribution/src/main/scripts/bin/kparse
@@ -46,7 +46,7 @@ $(k_util_usage)
 
 $KPARSE options:
 
-  -d, --directory DIR      Look for a kompiled directory ending in "-kompiled"
+  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
                            under the directory DIR
   -h, --help               Display this help and exit
       --definition DIR     Exact path to the kompiled directory.
@@ -74,6 +74,7 @@ do
   else
     case "$arg" in
       -d|--directory)
+      echo "[Warning]: -d/--directory is deprecated. Use --definition instead." >&2
       dir="$2"
       shift
       ;;
@@ -171,7 +172,7 @@ else
 fi
 
 if ! $hasKompiledDir; then
-  error 1 'Could not find a compiled definition. Use --directory or --definition to specify one.'
+  error 1 'Could not find a compiled definition. Use --definition to specify one.'
 fi
 
 if [ ! -f "$kompiledDir/syntaxDefinition.kore" ]; then

--- a/k-distribution/src/main/scripts/bin/kparse-gen
+++ b/k-distribution/src/main/scripts/bin/kparse-gen
@@ -48,7 +48,7 @@ $KPARSE_GEN options:
       --bison-file FILE    C file that should be linked into the generated
                            parser
       --bison-stack-max-depth  Maximum size of bison stack. Default: 10000
-  -d, --directory DIR      Look for a kompiled directory ending in "-kompiled"
+  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
                            under the directory DIR
       --definition DIR     Exact path to the kompiled directory.
   -g, --glr                Generate a GLR parser instead of an LR(1) parser
@@ -85,6 +85,7 @@ do
       ;;
 
       -d|--directory)
+      echo "[Warning]: -d/--directory is deprecated. Use --definition instead."
       dir="$2"
       shift
       ;;
@@ -161,7 +162,7 @@ else
 fi
 
 if ! $hasKompiledDir; then
-  error 1 'Could not find a compiled definition. Use --directory to specify one.'
+  error 1 'Could not find a compiled definition. Use --definition to specify one.'
 fi
 
 if [ ! -f "$kompiledDir/syntaxDefinition.kore" ]; then
@@ -181,4 +182,4 @@ if [ -z "${sort+unset}" ]; then
   fi
 fi
 
-execute "$KAST_UTIL" ${bisonFiles[@]} --bison-stack-max-depth "$stackDepth" --directory "$dir" $glr --module "$module" --sort "$sort" "$output_file"
+execute "$KAST_UTIL" ${bisonFiles[@]} --bison-stack-max-depth "$stackDepth" --definition "$kompiledDir" $glr --module "$module" --sort "$sort" "$output_file"

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -532,7 +532,7 @@ else
   fi
   abs_kompiled_dir=`echo "$(cd "$(dirname "$kompiledDir")"; pwd -P)/$(basename "$kompiledDir")"`
   # llvm-krun creates temp files in the cwd so execute it in $tempDir instead
-  (cd $tempDir; execute llvm-krun $configVars --definition "$abs_kompiled_dir" $llvm_krun_flags --dry-run -nm -o "$(basename $input_file)")
+  (cd $tempDir; execute llvm-krun $configVars --directory "$abs_kompiled_dir" $llvm_krun_flags --dry-run -nm -o "$(basename $input_file)")
 fi
 
 # Expand macros

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -113,7 +113,7 @@ $KRUN options:
                            parser. This can be overridden with -p.
       --debugger           Launch the backend in a debugging console.
                            Currently only supported on LLVM backend.
-  -d, --directory DIR      Look for a kompiled directory ending in "-kompiled"
+  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
                            under the directory DIR.
       --dry-run            Do not execute backend, but instead print the
                            command that would be executed to stdout.
@@ -228,6 +228,7 @@ do
       ;;
 
       -d|--directory)
+      echo "[Warning]: -d/--directory is deprecated. Use --definition instead." >&2
       dir="$2"
       shift
       ;;
@@ -444,7 +445,7 @@ else
 fi
 
 if ! $hasKompiledDir; then
-  error 1 'Could not find a compiled definition. Use --directory to specify one.'
+  error 1 'Could not find a compiled definition. Use --definition to specify one.'
 fi
 
 # Process configuration variables
@@ -531,7 +532,7 @@ else
   fi
   abs_kompiled_dir=`echo "$(cd "$(dirname "$kompiledDir")"; pwd -P)/$(basename "$kompiledDir")"`
   # llvm-krun creates temp files in the cwd so execute it in $tempDir instead
-  (cd $tempDir; execute llvm-krun $configVars --directory "$abs_kompiled_dir" $llvm_krun_flags --dry-run -nm -o "$(basename $input_file)")
+  (cd $tempDir; execute llvm-krun $configVars --definition "$abs_kompiled_dir" $llvm_krun_flags --dry-run -nm -o "$(basename $input_file)")
 fi
 
 # Expand macros

--- a/k-distribution/tests/regression-new/bad-flags/Makefile
+++ b/k-distribution/tests/regression-new/bad-flags/Makefile
@@ -8,7 +8,7 @@ ALLOW_FAIL=
 .PHONY: all clean update-results
 all:
 	$(KOMPILE) $(CHECK) no-flags.out $(ALLOW_FAIL)
-	$(KOMPILE) $(KOMPILE_FLAGS) --badflag --extra --backend $(KOMPILE_BACKEND) $(DEBUG) $(DEF).$(SOURCE_EXT) -d $(DEFDIR) $(CHECK) extra-flags.out $(ALLOW_FAIL)
+	$(KOMPILE) $(KOMPILE_FLAGS) --badflag --extra --backend $(KOMPILE_BACKEND) $(DEBUG) $(DEF).$(SOURCE_EXT) ---output-definition $(DEF)-kompiled $(CHECK) extra-flags.out $(ALLOW_FAIL)
 
 include ../../../include/kframework/ktest.mak
 

--- a/k-distribution/tests/regression-new/cell-bag-sort-llvm/Makefile
+++ b/k-distribution/tests/regression-new/cell-bag-sort-llvm/Makefile
@@ -1,3 +1,3 @@
-KOMPILE_FLAGS=-w none
+-KOMPILE_FLAGS=-w none
 
 include ../../../include/kframework/ktest-fail.mak

--- a/k-distribution/tests/regression-new/concrete-function-cache/Makefile
+++ b/k-distribution/tests/regression-new/concrete-function-cache/Makefile
@@ -6,9 +6,9 @@ KOMPILE_FLAGS=--concrete-rules "A.f2"
 
 %-spec.k %-spec.md: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
 else
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/concrete-function/Makefile
+++ b/k-distribution/tests/regression-new/concrete-function/Makefile
@@ -6,9 +6,9 @@ KOMPILE_FLAGS=--concrete-rules "A.f1"
 
 %-spec.k %-spec.md: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
 else
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/issue-1489-claimLoc/Makefile
+++ b/k-distribution/tests/regression-new/issue-1489-claimLoc/Makefile
@@ -5,9 +5,9 @@ KOMPILE_FLAGS=--syntax-module CLAIMLOC
 
 %-spec.k %-spec.md: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
 else
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/issue-1683-cfgVarsWarns/Makefile
+++ b/k-distribution/tests/regression-new/issue-1683-cfgVarsWarns/Makefile
@@ -7,4 +7,4 @@ KRUN_FLAGS=-cA=.K
 
 include ../../../include/kframework/ktest.mak
 %.$(EXT): kompile
-	$(KRUN_OR_LEGACY) $@ $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out
+	$(KRUN_OR_LEGACY) $@ $(KRUN_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out

--- a/k-distribution/tests/regression-new/issue-2146-duplicateModules/Makefile
+++ b/k-distribution/tests/regression-new/issue-2146-duplicateModules/Makefile
@@ -4,6 +4,6 @@ TESTDIR=.
 KOMPILE_FLAGS=--syntax-module TEST
 
 %.k %.md: dummy
-	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG_FAIL) $@ -d $(DEFDIR) 2>&1 | sed '1s!Source.*!Source...!' | sed 's!'`pwd`'/\(\./\)\{0,2\}!!g' $(CHECK) $@.out $(CHECK2)
+	$(KOMPILE) $(KOMPILE_FLAGS) --backend $(KOMPILE_BACKEND) $(DEBUG_FAIL) $@ --output-definition $(DEF)-kompiled 2>&1 | sed '1s!Source.*!Source...!' | sed 's!'`pwd`'/\(\./\)\{0,2\}!!g' $(CHECK) $@.out $(CHECK2)
 
 include ../../../include/kframework/ktest-fail.mak

--- a/k-distribution/tests/regression-new/issue-2273/Makefile
+++ b/k-distribution/tests/regression-new/issue-2273/Makefile
@@ -7,7 +7,7 @@ include ../../../include/kframework/ktest.mak
 
 %.kast: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(KAST) $@ $(KAST_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out
+	$(KAST) $@ $(KAST_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $@.out
 else
-	$(KAST) $@ $(KAST_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(KAST) $@ $(KAST_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif

--- a/k-distribution/tests/regression-new/issue-946/Makefile
+++ b/k-distribution/tests/regression-new/issue-946/Makefile
@@ -4,4 +4,4 @@ KOMPILE_FLAGS=--syntax-module TEST
 
 include ../../../include/kframework/ktest.mak
 krun: kompile
-	$(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) output
+	$(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CHECK) output

--- a/k-distribution/tests/regression-new/ite-bug/Makefile
+++ b/k-distribution/tests/regression-new/ite-bug/Makefile
@@ -5,9 +5,9 @@ KOMPILE_BACKEND=haskell
 
 %-spec.k %-spec.md: kompile
 ifeq ($(TESTDIR),$(RESULTDIR))
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $@.out
 else
-	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) -d $(DEFDIR) $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
+	$(KPROVE) $@ $(KPROVE_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CONSIDER_ERRORS) $(REMOVE_PATHS) | sed 's!kore-exec: \[[0-9]*\]!kore-exec: []!g' $(CHECK) $(RESULTDIR)/$(notdir $@).out
 endif
 
 include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/parseKORE2/Makefile
+++ b/k-distribution/tests/regression-new/parseKORE2/Makefile
@@ -4,4 +4,4 @@ KOMPILE_FLAGS=--syntax-module TEST
 
 include ../../../include/kframework/ktest.mak
 krun: kompile
-	$(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) -d $(DEFDIR) $(CHECK) output
+	$(KRUN_OR_LEGACY) $(KRUN_FLAGS) $(DEBUG) --definition $(DEF)-kompiled $(CHECK) output

--- a/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
@@ -6,6 +6,7 @@ import com.google.inject.Provider;
 import com.google.inject.Provides;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.KompileOptions;
+import org.kframework.main.GlobalOptions;
 import org.kframework.utils.BinaryLoader;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -19,6 +20,8 @@ import org.kframework.utils.options.DefinitionLoadingOptions;
 import java.io.File;
 import java.io.FilenameFilter;
 import java.util.Map;
+
+import static org.kframework.utils.errorsystem.KException.ExceptionType.*;
 
 public class DefinitionLoadingModule extends AbstractModule {
 
@@ -72,6 +75,9 @@ public class DefinitionLoadingModule extends AbstractModule {
                     whereDir = workingDir;
                 }
             } else {
+                KExceptionManager kem = new KExceptionManager(new GlobalOptions());
+                kem.registerCriticalWarning(DEPRECATED_DIRECTORY_FLAG, "Using --directory is deprecated. Use --definition instead.");
+                kem.print();
                 File f = new File(options.directory);
                 if (f.isAbsolute()) {
                     whereDir = f;

--- a/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
@@ -76,7 +76,7 @@ public class DefinitionLoadingModule extends AbstractModule {
                 }
             } else {
                 KExceptionManager kem = new KExceptionManager(new GlobalOptions());
-                kem.registerCriticalWarning(DEPRECATED_DIRECTORY_FLAG, "Using --directory is deprecated. Use --definition instead.");
+                kem.registerCriticalWarning(DEPRECATED_DIRECTORY_FLAG, "Using --directory is deprecated. Use --output-definition instead.");
                 kem.print();
                 File f = new File(options.directory);
                 if (f.isAbsolute()) {
@@ -103,7 +103,7 @@ public class DefinitionLoadingModule extends AbstractModule {
 
             if (directory == null) {
                 throw KEMException.criticalError("Could not find a compiled definition. " +
-                        "Use --directory or --definition to specify one.");
+                        "Use --definition to specify one.");
             }
         }
         if (!directory.isDirectory()) {

--- a/kernel/src/main/java/org/kframework/utils/inject/OuterParsingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/OuterParsingModule.java
@@ -4,7 +4,9 @@ package org.kframework.utils.inject;
 import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import org.apache.commons.io.FilenameUtils;
+import org.kframework.main.GlobalOptions;
 import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.DefinitionDir;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.KompiledDir;
@@ -13,6 +15,8 @@ import org.kframework.utils.options.OuterParsingOptions;
 import org.kframework.utils.options.OutputDirectoryOptions;
 
 import java.io.File;
+
+import static org.kframework.utils.errorsystem.KException.ExceptionType.*;
 
 /**
  * Provides the information needed for tools that parse definitions from source to have access to {@link FileUtil}.
@@ -42,6 +46,9 @@ public class OuterParsingModule extends AbstractModule {
                 return f;
             return new File(workingDir, output.outputDirectory);
         } else if (output.directory != null) {
+            KExceptionManager kem = new KExceptionManager(new GlobalOptions());
+            kem.registerCompilerWarning(DEPRECATED_DIRECTORY_FLAG, "The --directory option is deprecated. Please use --output-definition instead.");
+            kem.print();
             File f = new File(output.directory);
             if (!f.isAbsolute())
                 f = new File(workingDir, output.directory).getAbsoluteFile();

--- a/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
@@ -12,7 +12,7 @@ public class DefinitionLoadingOptions {
     @Inject
     public DefinitionLoadingOptions(Void v) {}
 
-    @Parameter(names={"--directory", "-d"}, description="Path to the directory in which the kompiled " +
+    @Parameter(names={"--directory", "-d"}, description="[DEPRECATED] Path to the directory in which the kompiled " +
             "K definition resides. The default is the unique, only directory with the suffix '-kompiled' " +
             "in the current directory.")
     public String directory;

--- a/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
@@ -13,7 +13,7 @@ public class OutputDirectoryOptions implements Serializable {
     @Inject
     public OutputDirectoryOptions(Void v) {}
 
-    @Parameter(names={"--directory", "-d"}, description="Path to the directory in which the output resides. An output can be either a kompiled K definition or a document which depends on the type of backend. The default is the directory containing the main definition file.")
+    @Parameter(names={"--directory", "-d"}, description="[DEPRECATED] Path to the directory in which the output resides. An output can be either a kompiled K definition or a document which depends on the type of backend. The default is the directory containing the main definition file.")
     public String directory;
 
     @Parameter(names={"--output-definition", "-o"}, description="Path to the exact directory in which the output resides.")

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -122,6 +122,7 @@ public class KException implements Serializable, HasLocation {
         NON_LR_GRAMMAR,
         IGNORED_ATTRIBUTE,
         REMOVED_ANYWHERE,
+        DEPRECATED_DIRECTORY_FLAG,
         FIRST_HIDDEN, // warnings below here are hidden by default
         MISSING_HOOK_JAVA,
         USELESS_RULE,


### PR DESCRIPTION
This PR sets the flag `--directory` as deprecated and prints a warning when it's used on the following tools:
- kprove
- krun
- kast
- kparse
- kompile

For `kompile`, the recommended flag to use instead is `--output-definition`.
For other tools, the recommend flag is `--definition`.

Fixes: #3276 