### PR TITLE
Update `make clean` to account for a few missed test artifacts

### DIFF
--- a/k-distribution/include/kframework/ktest.mak
+++ b/k-distribution/include/kframework/ktest.mak
@@ -1,4 +1,3 @@
-
 SHELL=/bin/bash
 
 UNAME := $(shell uname)

--- a/k-distribution/include/kframework/ktest.mak
+++ b/k-distribution/include/kframework/ktest.mak
@@ -1,3 +1,4 @@
+
 SHELL=/bin/bash
 
 UNAME := $(shell uname)
@@ -164,6 +165,9 @@ endif
 
 clean:
 	rm -rf $(KOMPILED_DIR) .depend-tmp .depend .kompile-* .krun-* .kprove-* kore-exec.tar.gz
+ifeq ($(KOMPILE_BACKEND),kore)
+	rm -f $(DEF).kore
+endif
 
 .depend:
 	@$(KDEP) $(KDEP_FLAGS) $(DEF).$(SOURCE_EXT) > .depend-tmp

--- a/k-distribution/tests/regression-new/issue-1169/Makefile
+++ b/k-distribution/tests/regression-new/issue-1169/Makefile
@@ -12,4 +12,4 @@ $(KOMPILED_DIR)/timestamp: $(DEF).k
 	mv test2-kompiled $(KOMPILED_DIR)
 
 clean:
-	rm -rf test2-kompiled test-kompiled
+	rm -rf test2.k test2-kompiled test-kompiled


### PR DESCRIPTION
- Update `ktest.mak` to clean `$(DEF).kore` when `KOMPILE_BACKEND` is `kore`
- Update `regresson-new/issue-1169/Makefile` to clean the generated `test2.k` file

Fixes an annoyance I was having where these left over files would get reported as Checkstyle errors.
