### PR TITLE
Replacing deprecated option flag at tutorial tests

### DIFF
--- a/k-distribution/k-tutorial/1_basic/commands.sh
+++ b/k-distribution/k-tutorial/1_basic/commands.sh
@@ -1,63 +1,63 @@
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-A --syntax-module LESSON-02-A -d build/02a
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-B --syntax-module LESSON-02-B -d build/02b
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-C --syntax-module LESSON-02-C -d build/02c
-kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-D --syntax-module LESSON-02-D -d build/02d
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-A --syntax-module LESSON-03-A -d build/03a
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-B --syntax-module LESSON-03-B -d build/03b
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-C --syntax-module LESSON-03-C -d build/03c
-kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-D --syntax-module LESSON-03-D -d build/03d --gen-bison-parser
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-A --syntax-module LESSON-04-A -d build/04a
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-B --syntax-module LESSON-04-B -d build/04b
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-C --syntax-module LESSON-04-C -d build/04c
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-D --syntax-module LESSON-04-D -d build/04d
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-E --syntax-module LESSON-04-E -d build/04e
-kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-F --syntax-module LESSON-04-F -d build/04f
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-A --syntax-module LESSON-05-A -d build/05a
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-B --syntax-module LESSON-05-B -d build/05b
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-C --syntax-module LESSON-05-C -d build/05c
-kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-D --syntax-module LESSON-05-D -d build/05d
-kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-A --syntax-module LESSON-06-A  -d build/06a
-kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-B --syntax-module LESSON-06-B  -d build/06b
-kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-C -d build/06c
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-A --syntax-module LESSON-07-A -d build/07a
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-B --syntax-module LESSON-07-B -d build/07b
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-C --syntax-module LESSON-07-C -d build/07c
-kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-D --syntax-module LESSON-07-D -d build/07d
-kompile 08_literate_programming/README.md --md-selector "k & ! exclude" --main-module LESSON-08 --syntax-module LESSON-08 -d build/08
-kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-A --syntax-module LESSON-09-A -d build/09a
-kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-B --syntax-module LESSON-09-B -d build/09b
-kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-C --syntax-module LESSON-09-C -d build/09c
-kompile 10_strings/README.md --md-selector "k & ! exclude" --main-module LESSON-10 --syntax-module LESSON-10 -d build/10
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-A --syntax-module LESSON-11-A -d build/11a
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-B --syntax-module LESSON-11-B -d build/11b
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-C --syntax-module LESSON-11-C -d build/11c
-kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-D --syntax-module LESSON-11-D -d build/11d
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-A -d build/12a
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-B -d build/12b
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-C --syntax-module LESSON-12-C -d build/12c
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-D --syntax-module LESSON-12-D -d build/12d
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-E --syntax-module LESSON-12-E -d build/12e
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-F --syntax-module LESSON-12-F -d build/12f
-kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-G --syntax-module LESSON-12-G  -d build/12g
-kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-A --syntax-module LESSON-13-A -d build/13a
-kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-B -d build/13b
-kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-C -d build/13c
-kompile 14_evaluation_order/README.md --md-selector "k & ! exclude & ! alias" --main-module LESSON-14-A -d build/14a
-kompile 14_evaluation_order/README.md --md-selector "k & ! exclude & ! alias" --main-module LESSON-14-B -d build/14b
-kompile 14_evaluation_order/README.md --md-selector "k & ! exclude" --main-module LESSON-14-C -d build/14c
-kompile 14_evaluation_order/README.md --md-selector "k & ! exclude & ! alias" --main-module LESSON-14-D -d build/14d
-kompile 15_configurations/README.md --md-selector "k & ! exclude" --main-module LESSON-15-A -d build/15a
-kompile 15_configurations/README.md --md-selector "k & ! exclude" --main-module LESSON-15-B -d build/15b
-kompile 15_configurations/README.md --md-selector "k & ! exclude" --main-module LESSON-15-C -d build/15c
-kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-A -d build/16a
-kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-B -d build/16b
-kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-C -d build/16c
-kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-A --syntax-module LESSON-17-A -d build/17a
-kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-B --syntax-module LESSON-17-B -d build/17b
-kompile 18_equality_and_conditionals/README.md --md-selector "k & ! exclude" --main-module LESSON-18 --syntax-module LESSON-18 -d build/18
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-A --syntax-module LESSON-19-A -d build/19a
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-B --syntax-module LESSON-19-B -d build/19b
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-C --syntax-module LESSON-19-C -d build/19c
-kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-D --syntax-module LESSON-19-D -d build/19d
-kompile 20_backends/README.md --backend haskell --md-selector "k & ! exclude" --main-module LESSON-20 --syntax-module LESSON-20 -d build/20
-kompile 21_symbolic_execution/README.md --backend haskell --md-selector "k & ! exclude" --main-module LESSON-21 --syntax-module LESSON-21 -d build/21
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-A --syntax-module LESSON-02-A --output-definition build/02a
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-B --syntax-module LESSON-02-B --output-definition build/02b
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-C --syntax-module LESSON-02-C --output-definition build/02c
+kompile 02_basics/README.md --md-selector "k & ! exclude" --main-module LESSON-02-D --syntax-module LESSON-02-D --output-definition build/02d
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-A --syntax-module LESSON-03-A --output-definition build/03a
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-B --syntax-module LESSON-03-B --output-definition build/03b
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-C --syntax-module LESSON-03-C --output-definition build/03c
+kompile 03_parsing/README.md --md-selector "k & ! exclude" --main-module LESSON-03-D --syntax-module LESSON-03-D --output-definition build/03d --gen-bison-parser
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-A --syntax-module LESSON-04-A --output-definition build/04a
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-B --syntax-module LESSON-04-B --output-definition build/04b
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-C --syntax-module LESSON-04-C --output-definition build/04c
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-D --syntax-module LESSON-04-D --output-definition build/04d
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-E --syntax-module LESSON-04-E --output-definition build/04e
+kompile 04_disambiguation/README.md --md-selector "k & ! exclude" --main-module LESSON-04-F --syntax-module LESSON-04-F --output-definition build/04f
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-A --syntax-module LESSON-05-A --output-definition build/05a
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-B --syntax-module LESSON-05-B --output-definition build/05b
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-C --syntax-module LESSON-05-C --output-definition build/05c
+kompile 05_modules/README.md --md-selector "k & ! exclude" --main-module LESSON-05-D --syntax-module LESSON-05-D --output-definition build/05d
+kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-A --syntax-module LESSON-06-A  --output-definition build/06a
+kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-B --syntax-module LESSON-06-B  --output-definition build/06b
+kompile 06_ints_and_bools/README.md --md-selector "k & ! exclude" --main-module LESSON-06-C --output-definition build/06c
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-A --syntax-module LESSON-07-A --output-definition build/07a
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-B --syntax-module LESSON-07-B --output-definition build/07b
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-C --syntax-module LESSON-07-C --output-definition build/07c
+kompile 07_side_conditions/README.md --md-selector "k & ! exclude" --main-module LESSON-07-D --syntax-module LESSON-07-D --output-definition build/07d
+kompile 08_literate_programming/README.md --md-selector "k & ! exclude" --main-module LESSON-08 --syntax-module LESSON-08 --output-definition build/08
+kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-A --syntax-module LESSON-09-A --output-definition build/09a
+kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-B --syntax-module LESSON-09-B --output-definition build/09b
+kompile 09_unparsing/README.md --md-selector "k & ! exclude" --main-module LESSON-09-C --syntax-module LESSON-09-C --output-definition build/09c
+kompile 10_strings/README.md --md-selector "k & ! exclude" --main-module LESSON-10 --syntax-module LESSON-10 --output-definition build/10
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-A --syntax-module LESSON-11-A --output-definition build/11a
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-B --syntax-module LESSON-11-B --output-definition build/11b
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-C --syntax-module LESSON-11-C --output-definition build/11c
+kompile 11_casts/README.md --md-selector "k & ! exclude" --main-module LESSON-11-D --syntax-module LESSON-11-D --output-definition build/11d
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-A --output-definition build/12a
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-B --output-definition build/12b
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-C --syntax-module LESSON-12-C --output-definition build/12c
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-D --syntax-module LESSON-12-D --output-definition build/12d
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-E --syntax-module LESSON-12-E --output-definition build/12e
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-F --syntax-module LESSON-12-F --output-definition build/12f
+kompile 12_syntactic_lists/README.md --md-selector "k & ! exclude" --main-module LESSON-12-G --syntax-module LESSON-12-G  --output-definition build/12g
+kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-A --syntax-module LESSON-13-A --output-definition build/13a
+kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-B --output-definition build/13b
+kompile 13_rewrite_rules/README.md --md-selector "k & ! exclude" --main-module LESSON-13-C --output-definition build/13c
+kompile 14_evaluation_order/README.md --md-selector "k & ! exclude & ! alias" --main-module LESSON-14-A --output-definition build/14a
+kompile 14_evaluation_order/README.md --md-selector "k & ! exclude & ! alias" --main-module LESSON-14-B --output-definition build/14b
+kompile 14_evaluation_order/README.md --md-selector "k & ! exclude" --main-module LESSON-14-C --output-definition build/14c
+kompile 14_evaluation_order/README.md --md-selector "k & ! exclude & ! alias" --main-module LESSON-14-D --output-definition build/14d
+kompile 15_configurations/README.md --md-selector "k & ! exclude" --main-module LESSON-15-A --output-definition build/15a
+kompile 15_configurations/README.md --md-selector "k & ! exclude" --main-module LESSON-15-B --output-definition build/15b
+kompile 15_configurations/README.md --md-selector "k & ! exclude" --main-module LESSON-15-C --output-definition build/15c
+kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-A --output-definition build/16a
+kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-B --output-definition build/16b
+kompile 16_collections/README.md --md-selector "k & ! exclude" --main-module LESSON-16-C --output-definition build/16c
+kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-A --syntax-module LESSON-17-A --output-definition build/17a
+kompile 17_cell_multiplicity/README.md --md-selector "k & ! exclude" --main-module LESSON-17-B --syntax-module LESSON-17-B --output-definition build/17b
+kompile 18_equality_and_conditionals/README.md --md-selector "k & ! exclude" --main-module LESSON-18 --syntax-module LESSON-18 --output-definition build/18
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-A --syntax-module LESSON-19-A --output-definition build/19a
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-B --syntax-module LESSON-19-B --output-definition build/19b
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-C --syntax-module LESSON-19-C --output-definition build/19c
+kompile 19_debugging/README.md --md-selector "k & ! exclude" --main-module LESSON-19-D --syntax-module LESSON-19-D --output-definition build/19d
+kompile 20_backends/README.md --backend haskell --md-selector "k & ! exclude" --main-module LESSON-20 --syntax-module LESSON-20 --output-definition build/20
+kompile 21_symbolic_execution/README.md --backend haskell --md-selector "k & ! exclude" --main-module LESSON-21 --syntax-module LESSON-21 --output-definition build/21

--- a/k-distribution/k-tutorial/2_intermediate/commands.sh
+++ b/k-distribution/k-tutorial/2_intermediate/commands.sh
@@ -1,1 +1,1 @@
-kompile 01_macros/README.md --md-selector "k & ! exclude" --main-module LESSON-01 --syntax-module LESSON-01 -d build/01
+kompile 01_macros/README.md --md-selector "k & ! exclude" --main-module LESSON-01 --syntax-module LESSON-01 --output-definition build/01

--- a/k-distribution/pl-tutorial/1_k/4_imp++/lesson_1/Makefile
+++ b/k-distribution/pl-tutorial/1_k/4_imp++/lesson_1/Makefile
@@ -3,4 +3,4 @@ include $(MAKEFILE_PATH)/../../2_imp/lesson_1/Makefile
 KOMPILE_FLAGS+=--enable-search
 
 tests/div.imp: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search $(CHECK) $@.out

--- a/k-distribution/pl-tutorial/1_k/4_imp++/lesson_6/Makefile
+++ b/k-distribution/pl-tutorial/1_k/4_imp++/lesson_6/Makefile
@@ -8,7 +8,7 @@ include ${K_HOME}/include/kframework/ktest.mak
 
 
 tests/div.imp: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search $(CHECK) $@.out
 
 tests/spawn.imp: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --pattern "<store> Store </store> <output> ListItem(_) ListItem(_) ListItem(#buffer(Out:String)) </output>" $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --pattern "<store> Store </store> <output> ListItem(_) ListItem(_) ListItem(#buffer(Out:String)) </output>" $(CHECK) $@.out

--- a/k-distribution/pl-tutorial/1_k/4_imp++/lesson_7/Makefile.concrete
+++ b/k-distribution/pl-tutorial/1_k/4_imp++/lesson_7/Makefile.concrete
@@ -1,6 +1,7 @@
 MAKEFILE_PATH := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 DEF=imp
 DEFDIR=concrete
+KOMPILED=$(DEFDIR)/$(DEF)-kompiled
 EXT=imp
 KOMPILE_FLAGS+=--gen-glr-bison-parser --enable-search
 KRUN_FLAGS=--output none
@@ -10,7 +11,7 @@ include ${K_HOME}/include/kframework/ktest.mak
 
 
 tests/div.imp: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(KOMPILED) --search $(CHECK) $@.out
 
 tests/spawn.imp: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --pattern "<output> ListItem(_) ListItem(_) ListItem(#buffer(Out:String)) </output>" $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(KOMPILED) --search --pattern "<output> ListItem(_) ListItem(_) ListItem(#buffer(Out:String)) </output>" $(CHECK) $@.out

--- a/k-distribution/pl-tutorial/2_languages/1_simple/1_untyped/Makefile
+++ b/k-distribution/pl-tutorial/2_languages/1_simple/1_untyped/Makefile
@@ -10,7 +10,7 @@ include $(MAKEFILE_PATH)/../../../find-k.mak
 include ${K_HOME}/include/kframework/ktest.mak
 
 tests/threads/threads_05.simple: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --bound 5 $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --bound 5 $(CHECK) $@.out
 
 tests/exceptions/exceptions_07.simple \
 tests/threads/threads_01.simple \
@@ -19,4 +19,4 @@ tests/threads/threads_04.simple \
 tests/threads/threads_06.simple \
 tests/threads/threads_09.simple \
 tests/diverse/div-nondet.simple: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --pattern '<output> ListItem(#ostream(1)) ListItem("off") ListItem(#buffer(S:String)) </output>' $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --pattern '<output> ListItem(#ostream(1)) ListItem("off") ListItem(#buffer(S:String)) </output>' $(CHECK) $@.out

--- a/k-distribution/pl-tutorial/2_languages/1_simple/2_typed/2_dynamic/Makefile
+++ b/k-distribution/pl-tutorial/2_languages/1_simple/2_typed/2_dynamic/Makefile
@@ -7,7 +7,7 @@ KOMPILE_FLAGS=--enable-search
 KRUN_FLAGS=--output none
 
 %/threads/threads_05.simple: kompile
-	cat tests/threads_05.simple.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --bound 5 $(CHECK) tests/threads_05.simple.out
+	cat tests/threads_05.simple.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --bound 5 $(CHECK) tests/threads_05.simple.out
 
 %/exceptions/exceptions_07.simple \
 %/threads/threads_01.simple \
@@ -16,7 +16,7 @@ KRUN_FLAGS=--output none
 %/threads/threads_06.simple \
 %/threads/threads_09.simple \
 %/diverse/div-nondet.simple: kompile
-	cat tests/$(notdir $@).in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --pattern '<output> ListItem(#ostream(1)) ListItem("off") ListItem(#buffer(S:String)) </output>' $(CHECK) tests/$(notdir $@).out
+	cat tests/$(notdir $@).in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --pattern '<output> ListItem(#ostream(1)) ListItem("off") ListItem(#buffer(S:String)) </output>' $(CHECK) tests/$(notdir $@).out
 
 %/diverse/dekker.simple \
 %/threads/threads_03.simple \

--- a/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/Makefile
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/Makefile
@@ -7,7 +7,7 @@ TESTDIR?=../programs
 RESULTDIR=tests
 
 %/cycle.kool: kompile
-	cat tests/cycle.kool.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --pattern '<output> ListItem(#ostream(1)) ListItem("off") ListItem(#buffer(S:String)) </output>' $(CHECK) tests/cycle.kool.out
+	cat tests/cycle.kool.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --pattern '<output> ListItem(#ostream(1)) ListItem("off") ListItem(#buffer(S:String)) </output>' $(CHECK) tests/cycle.kool.out
 
 %/return-object.kool: kompile
 	true

--- a/k-distribution/pl-tutorial/2_languages/3_fun/1_untyped/1_environment/Makefile
+++ b/k-distribution/pl-tutorial/2_languages/3_fun/1_untyped/1_environment/Makefile
@@ -7,7 +7,7 @@ KOMPILE_FLAGS?=--enable-search
 KRUN_FLAGS?=--pattern "<k> V:K </k>"
 
 %/references-5.fun: kompile
-	cat tests/references-5.fun.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --pattern "<k> V:K </k>" $(CHECK) tests/references-5.fun.out
+	cat tests/references-5.fun.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --pattern "<k> V:K </k>" $(CHECK) tests/references-5.fun.out
 
 include $(MAKEFILE_PATH)/../../../../find-k.mak
 include ${K_HOME}/include/kframework/ktest.mak

--- a/k-distribution/pl-tutorial/2_languages/3_fun/1_untyped/1_environment/exercises/io/Makefile
+++ b/k-distribution/pl-tutorial/2_languages/3_fun/1_untyped/1_environment/exercises/io/Makefile
@@ -5,7 +5,7 @@ include $(MAKEFILE_PATH)/../../Makefile
 tests/ex-%.fun: KRUN_FLAGS+=--output none
 
 tests/ex-12.fun: kompile
-	cat tests/ex-12.fun.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) --search --pattern "<output>... ListItem(#buffer(S:String)) </output>" $(CHECK) tests/ex-12.fun.out
+	cat tests/ex-12.fun.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled --search --pattern "<output>... ListItem(#buffer(S:String)) </output>" $(CHECK) tests/ex-12.fun.out
 
 tests/references-5.fun: kompile
 	true

--- a/k-distribution/pl-tutorial/2_languages/4_logik/basic/Makefile
+++ b/k-distribution/pl-tutorial/2_languages/4_logik/basic/Makefile
@@ -8,13 +8,13 @@ include $(MAKEFILE_PATH)/../../../find-k.mak
 include ${K_HOME}/include/kframework/ktest.mak
 
 tests/reverse-slow-2.logik: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) $(KRUN_FLAGS) --bound 1 $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled $(KRUN_FLAGS) --bound 1 $(CHECK) $@.out
 tests/reverse-slow-palindromes-1.logik: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) $(KRUN_FLAGS) --bound 5 $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled $(KRUN_FLAGS) --bound 5 $(CHECK) $@.out
 tests/append-4.logik: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) $(KRUN_FLAGS) --bound 5 $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled $(KRUN_FLAGS) --bound 5 $(CHECK) $@.out
 tests/reverse-fast-2.logik: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) $(KRUN_FLAGS) --bound 1 $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled $(KRUN_FLAGS) --bound 1 $(CHECK) $@.out
 tests/reverse-fast-palindromes-1.logik: kompile
-	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ -d $(DEFDIR) $(KRUN_FLAGS) --bound 5 $(CHECK) $@.out
+	cat $@.in 2>/dev/null | $(KRUN_OR_LEGACY) $@ --definition $(DEF)-kompiled $(KRUN_FLAGS) --bound 5 $(CHECK) $@.out
 	

--- a/k-distribution/tests/regression-new/kdep-options/remake-depend/Makefile
+++ b/k-distribution/tests/regression-new/kdep-options/remake-depend/Makefile
@@ -1,3 +1,5 @@
-KDEP_FLAGS= --remake-depend -d OutputDirectoryTest --no-prelude
+DEF=$(basename $@)
+KOMPILED_DIR=$(DEF)-kompiled
+KDEP_FLAGS= --remake-depend --output-definition OutputDirectoryTest/$(KOMPILED_DIR) --no-prelude
 
 include ../../../../include/kframework/ktest-kdep.mak

--- a/k-distribution/tests/regression-new/kdep-options/simple/Makefile
+++ b/k-distribution/tests/regression-new/kdep-options/simple/Makefile
@@ -1,3 +1,5 @@
-KDEP_FLAGS= -d OutputDirectoryTest --no-prelude -I IncludeDirTest
+DEF=$(basename $@)
+KOMPILED_DIR=$(DEF)-kompiled
+KDEP_FLAGS= --output-definition OutputDirectoryTest/$(KOMPILED_DIR) --no-prelude -I IncludeDirTest
 
 include ../../../../include/kframework/ktest-kdep.mak

--- a/kernel/src/main/java/org/kframework/kdep/KDepFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kdep/KDepFrontEnd.java
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  * <p>
  * <pre>
  *     .depend:
- *             kdep definition.k -d "directory" -I includes > .depend
+ *             kdep definition.k --output-directory "kompiled directory" -I includes > .depend
  *
  *     include .depend
  * </pre>


### PR DESCRIPTION
This PR replaces the use of `-d`/`--directory` with `--output-definition` and `--definition` on `kdep` options tests,  `k-tutorial` and `pl-tutorial` tests.