### PR TITLE
Pretty print NonTerminal names in generated txt files

### DIFF
--- a/kore/src/main/scala/org/kframework/definition/outer-to-string.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-to-string.scala
@@ -60,7 +60,7 @@ trait TerminalToString {
 
 trait NonTerminalToString {
   self: NonTerminal =>
-  override def toString = sort.toString()
+  override def toString = if (name.isDefined) name.get + ":" + sort.toString() else sort.toString()
 }
 
 trait RegexTerminalToString {


### PR DESCRIPTION
Pretty print the NonTerminal names in parsed.txt and compiled.txt.
```
  syntax Exp ::= f(x:Int, y:Int) // source
  syntax Exp ::= "f" "(" x:Int "," y:Int ")" [klabel(f)] // parsed.txt
  ...{"node":"KNonTerminal","sort":{"node":"KSort","name":"Int"},"name":"x"}... // json
``