### PR TITLE
Revert "Remove dead code HaskellKRunOptions"

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackendKModule.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackendKModule.java
@@ -40,8 +40,23 @@ public class HaskellBackendKModule extends AbstractKModule {
     }
 
     @Override
+    public List<Pair<Class<?>, Boolean>> krunOptions() {
+        return Collections.singletonList(Pair.of(HaskellKRunOptions.class, true));
+    }
+
+    @Override
     public List<Pair<Class<?>, Boolean>> kompileOptions() {
         return Collections.singletonList(Pair.of(HaskellKompileOptions.class, true));
+    }
+
+    @Override
+    public List<Module> getKRunModules() {
+        return Collections.singletonList(new AbstractModule() {
+            @Override
+            protected void configure() {
+                installHaskellRewriter(binder());
+            }
+        });
     }
 
     private void installHaskellRewriter(Binder binder) {

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKRunOptions.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKRunOptions.java
@@ -1,0 +1,33 @@
+// Copyright (c) Runtime Verification, Inc. All Rights Reserved.
+package org.kframework.backend.haskell;
+
+import com.beust.jcommander.Parameter;
+import org.kframework.backend.kore.ModuleToKORE;
+import org.kframework.utils.inject.RequestScoped;
+import org.kframework.utils.options.BaseEnumConverter;
+
+@RequestScoped
+public class HaskellKRunOptions {
+
+    @Parameter(names="--haskell-backend-command", description="Command to run the Haskell backend execution engine.")
+    public String haskellBackendCommand = "kore-exec";
+
+    @Parameter(names="--haskell-backend-home", description="Directory where the Haskell backend source installation resides.")
+    public String haskellBackendHome = System.getenv("KORE_HOME");
+
+    @Parameter(names="--default-claim-type", converter = SentenceTypeConverter.class, description="Default type for claims. Values: [all-path|one-path].")
+    public ModuleToKORE.SentenceType defaultClaimType = ModuleToKORE.SentenceType.ALL_PATH;
+
+    public static class SentenceTypeConverter extends BaseEnumConverter<ModuleToKORE.SentenceType> {
+
+        public SentenceTypeConverter(String optionName) {
+            super(optionName);
+        }
+
+        @Override
+        public Class<ModuleToKORE.SentenceType> enumClass() {
+            return ModuleToKORE.SentenceType.class;
+        }
+    }
+
+}

--- a/kernel/src/main/java/org/kframework/main/AbstractKModule.java
+++ b/kernel/src/main/java/org/kframework/main/AbstractKModule.java
@@ -60,6 +60,33 @@ public abstract class AbstractKModule implements KModule {
     }
 
     @Override
+    public List<Module> getKRunModules() {
+        return Lists.newArrayList(new AbstractModule() {
+
+            @Override
+            protected void configure() {
+                bindOptions(AbstractKModule.this::krunOptions, binder());
+            }
+        });
+    }
+
+    @Override
+    public List<Module> getKEqModules(List<Module> definitionSpecificModules) {
+        return Lists.newArrayList();
+    }
+
+    @Override
+    public List<Module> getDefinitionSpecificKEqModules() {
+        return Lists.newArrayList(new AbstractModule() {
+
+            @Override
+            protected void configure() {
+                //bind backend implementations of tools to their interfaces
+            }
+        });
+    }
+
+    @Override
     public List<Module> getKProveModules() {
         return Lists.newArrayList(new AbstractModule() {
 

--- a/kernel/src/main/java/org/kframework/main/KModule.java
+++ b/kernel/src/main/java/org/kframework/main/KModule.java
@@ -9,5 +9,8 @@ public interface KModule {
 
     List<Module> getKompileModules();
     List<Module> getKastModules();
+    List<Module> getKRunModules();
+    List<Module> getKEqModules(List<Module> definitionSpecificModules);
+    List<Module> getDefinitionSpecificKEqModules();
     List<Module> getKProveModules();
 }


### PR DESCRIPTION
Reverts runtimeverification/k#3419

Turns out I was wrong. This is used by `kprove`.
Thanks @jberthold for pointing this out.
This is breaking the integration tests for the haskell backend so it is high priority.