### PR TITLE
Remove all uses of the defunct [transition] attribute

### DIFF
--- a/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.md
+++ b/k-distribution/pl-tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.md
@@ -771,9 +771,6 @@ of the language need to insert runtime checks for downcasting to be safe.
                               +String "\" and \"" +String Id2String(C2)
                               +String "\" are incompatible!\n") </output>
     when notBool(C1 in S2) andBool notBool(C2 in S1)
-    [transition]
-    // ugly solution to avoid non-confluence (rule may apply before
-    // extendsAll is populated); strategies will solve the problem nicely.
 ```
 
 ## Cleanup tasks

--- a/k-distribution/pl-tutorial/2_languages/4_logik/basic/logik.md
+++ b/k-distribution/pl-tutorial/2_languages/4_logik/basic/logik.md
@@ -319,7 +319,6 @@ Pick a clause and generate a fresh instance of it when the
   rule <fresh> . => #renameVariables(C) </fresh> <clause> C </clause>
        <k> T:Term ...</k>
   requires #unifiable(T,head(C))
-    [transition]
 
   syntax Term ::= head(Clause) [function]
   rule head(L.) => L

--- a/k-distribution/src/test/resources/compiler-tests/strategies_imp.k
+++ b/k-distribution/src/test/resources/compiler-tests/strategies_imp.k
@@ -10,7 +10,7 @@ module IMP-SYNTAX
 
   syntax AExp  ::= Int | Id
                  | AExp "/" AExp              [left, strict]
-                 > AExp "+" AExp              [left, strict, transition]
+                 > AExp "+" AExp              [left, strict]
                  | "(" AExp ")"               [bracket]
   syntax BExp  ::= Bool
                  | AExp "<=" AExp             [seqstrict, latex({#1}\leq{#2})]

--- a/kernel/src/main/java/org/kframework/compile/ResolveHeatCoolAttribute.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveHeatCoolAttribute.java
@@ -79,10 +79,6 @@ public class ResolveHeatCoolAttribute {
         if (att.contains("heat")) {
             return BooleanUtils.and(requires, BooleanUtils.not(predicate));
         } else if (att.contains("cool")) {
-            if (transitions.stream().anyMatch(att::contains)) {
-                // if the cooling rule is a super strict, then tag the isKResult predicate and drop it during search
-                predicate = KApply(predicate.klabel(), predicate.klist(), predicate.att().add(Att.TRANSITION()));
-            }
             return BooleanUtils.and(requires, predicate);
         }
         throw new AssertionError("unreachable");

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -141,7 +141,6 @@ object Att {
   val TOKEN = "token"
   val TOP_RULE = "topRule"
   val TOTAL = "total"
-  val TRANSITION = "transition"
   val TRUSTED = "trusted"
   val UNBOUND_VARIABLES = "unboundVariables"
   val UNIT = "unit"


### PR DESCRIPTION
The transition attribute is now dead code, so this PR removes all instances of it.

This should be merged in tandem with runtimeverification/k-exercises/pull/36