### PR TITLE
Add an integration shell for haskell-backend

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -169,10 +169,12 @@
             };
         };
         defaultPackage = packages.k;
+        devShells.kore-integration-tests = pkgs.kore-tests (pkgs.k-framework haskell-backend-bins);
       }) // {
         overlays.llvm-backend = llvm-backend.overlays.default;
         overlays.z3 = haskell-backend.overlay;
 
         overlay = nixpkgs.lib.composeManyExtensions allOverlays;
+
       };
 }

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -107,4 +107,5 @@ in runCommand (lib.removeSuffix "-maven" unwrapped.name) {
   ln -sf ${haskell-backend}/bin/kore-exec $out/bin/kore-exec
   ln -sf ${haskell-backend}/bin/kore-parser $out/bin/kore-parser
   ln -sf ${haskell-backend}/bin/kore-repl $out/bin/kore-repl
+  ln -sf ${haskell-backend}/bin/kore-match-disjunction $out/bin/kore-match-disjunction
 ''

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -104,4 +104,7 @@ in runCommand (lib.removeSuffix "-maven" unwrapped.name) {
   done
 
   ln -sf ${haskell-backend}/bin/kore-rpc $out/bin/kore-rpc
+  ln -sf ${haskell-backend}/bin/kore-exec $out/bin/kore-exec
+  ln -sf ${haskell-backend}/bin/kore-parser $out/bin/kore-parser
+  ln -sf ${haskell-backend}/bin/kore-repl $out/bin/kore-repl
 ''


### PR DESCRIPTION
This PR adds a way to run integration tests for the `haskell-backend` via flakes. The problem with integration tests in flakes spanning multiple repositories is that `k` imports `haskell-backend` and `haskell-backend` then imports back `k` to run the integration tests. Nix flakes does not like circular dependencies however, so instead of bundling the integration tests into a nix derivation, we just build the development shell necessary for running the tests (this shell includes the haskell-backend, k, z3, gnumake, etc.)

Via this change, we can simply call

```
nix develop github:runtimeverification/k/sam/nix-kore-integration-shell#kore-integration-tests \
                --override-input haskell-backend . --update-input haskell-backend
```

inside the `haskell-backend` repo, and run the integration tests in the newly opened shell which will contain all the necessary dependencies, including `k` with the local checkout of `haskell-backend`.