### PR TITLE
Improving kore-print script

### DIFF
--- a/k-distribution/src/main/scripts/bin/kore-print
+++ b/k-distribution/src/main/scripts/bin/kore-print
@@ -15,15 +15,14 @@ outputFile=-
 outputMode=pretty
 
 # setup temp files
-now=`date +"%Y-%m-%d-%H-%M-%S"`
-tempDir="$(mktemp -d .kore-print-${now}-XXXXXXXXXX)"
+now=$(date +"%Y-%m-%d-%H-%M-%S")
+tempDir="$(mktemp -d .kore-print-"${now}"-XXXXXXXXXX)"
 tempFiles=("$tempDir")
 trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT
 
 KORE_PRINT=$(basename "$0")
 KAST_UTIL="$(dirname "$0")/kast"
 
-ktool="${KORE_PRINT}"
 source "$(dirname "$0")/../lib/kframework/k-util.sh"
 
 print_usage () {
@@ -215,7 +214,7 @@ fi
 
 case "$outputMode" in
   pretty)
-  output "$outputFile" kprint "$kompiledDir" "$input_file" $color $filterSubst
+  output "$outputFile" kprint "$kompiledDir" "$input_file" "$color" "$filterSubst"
   ;;
 
   kore)

--- a/k-distribution/src/main/scripts/bin/kore-print
+++ b/k-distribution/src/main/scripts/bin/kore-print
@@ -24,7 +24,7 @@ trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT
 KORE_PRINT=$(basename "$0")
 KAST_UTIL="$(dirname "$0")/kast"
 
-export ktool="${KORE_PRINT}"
+export KTOOL="${KORE_PRINT}"
 source "$(dirname "$0")/../lib/kframework/k-util.sh"
 
 print_usage () {
@@ -141,7 +141,7 @@ do
       ;;
 
       -v| --verbose)
-      verboseFlag=" --verbose"
+      verboseFlag="--verbose"
       verbose=1
       shift
       ;;
@@ -207,7 +207,7 @@ fi
 
 if [ ! -f "$kompiledDir/syntaxDefinition.kore" ]; then
   (
-  if [ -n "$verbose" ]; then
+  if [ "$verbose" = true ]; then
     set -x
   fi
   execute "$KAST_UTIL" --input kore "${ORIG_ARGV[@]}" "$verboseFlag"
@@ -226,7 +226,7 @@ if [ "$outputFile" = "-" ]; then
 fi
 
 (
-if [ -n "$verbose" ]; then
+if [ "$verbose" = true ]; then
   set -x
 fi
 case "$outputMode" in

--- a/k-distribution/src/main/scripts/bin/kore-print
+++ b/k-distribution/src/main/scripts/bin/kore-print
@@ -11,6 +11,7 @@ dir=.
 kompiledDir=
 filterSubst=true
 literal=false
+verboseFlag=
 outputFile=-
 outputMode=pretty
 
@@ -23,6 +24,7 @@ trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT
 KORE_PRINT=$(basename "$0")
 KAST_UTIL="$(dirname "$0")/kast"
 
+export ktool="${KORE_PRINT}"
 source "$(dirname "$0")/../lib/kframework/k-util.sh"
 
 print_usage () {
@@ -138,6 +140,12 @@ do
       trap - INT TERM EXIT
       ;;
 
+      -v| --verbose)
+      verboseFlag=" --verbose"
+      verbose=1
+      shift
+      ;;
+
       --version)
       kompile --version
       exit 0
@@ -198,8 +206,13 @@ if ! $hasKompiledDir; then
 fi
 
 if [ ! -f "$kompiledDir/syntaxDefinition.kore" ]; then
-  execute "$KAST_UTIL" --input kore "${ORIG_ARGV[@]}"
+  (
+  if [ -n "$verbose" ]; then
+    set -x
+  fi
+  execute "$KAST_UTIL" --input kore "${ORIG_ARGV[@]}" "$verboseFlag"
   exit $?
+  )
 fi
 
 if [[ "$input_file" == "-" ]]; then
@@ -212,6 +225,10 @@ if [ "$outputFile" = "-" ]; then
   outputFile=/dev/stdout
 fi
 
+(
+if [ -n "$verbose" ]; then
+  set -x
+fi
 case "$outputMode" in
   pretty)
   output "$outputFile" kprint "$kompiledDir" "$input_file" "$color" "$filterSubst"
@@ -228,4 +245,4 @@ case "$outputMode" in
   execute "$KAST_UTIL" --input kore "${ORIG_ARGV[@]}"
   ;;
 esac
- 
+)

--- a/k-distribution/src/main/scripts/bin/kparse
+++ b/k-distribution/src/main/scripts/bin/kparse
@@ -22,7 +22,7 @@ trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT
 KPARSE=$(basename "$0")
 KAST_UTIL="$(dirname "$0")/kast"
 
-ktool="${KPARSE}"
+export KTOOL="${KPARSE}"
 source "$(dirname "$0")/../lib/kframework/k-util.sh"
 
 print_usage () {

--- a/k-distribution/src/main/scripts/bin/kparse-gen
+++ b/k-distribution/src/main/scripts/bin/kparse-gen
@@ -23,7 +23,7 @@ trap 'rm -rf ${tempFiles[*]}' INT TERM EXIT
 KPARSE_GEN=$(basename "$0")
 KAST_UTIL="$(dirname "$0")/kast"
 
-ktool="${KPARSE_GEN}"
+export KTOOL="${KPARSE_GEN}"
 source "$(dirname "$0")/../lib/kframework/k-util.sh"
 
 print_usage () {

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -74,7 +74,7 @@ keepTempsIfDryRun () {
 
 KRUN=$(basename "$0")
 
-ktool="${KRUN}"
+export KTOOL="${KRUN}"
 source "$(dirname "$0")/../lib/kframework/k-util.sh"
 if ${verbose}; then
   llvm_krun_flags="${llvm_krun_flags} -v"

--- a/k-distribution/src/main/scripts/lib/k-util.sh
+++ b/k-distribution/src/main/scripts/lib/k-util.sh
@@ -9,7 +9,7 @@
 # You can use this script by adding the following line (minus the comment) to
 # your script:
 #
-# ktool=TOOL_NAME
+# KTOOL=TOOL_NAME
 # source "$(dirname "$0")/../lib/kframework/k-util.sh"
 
 # initialize flags

--- a/k-distribution/src/main/scripts/lib/k-util.sh
+++ b/k-distribution/src/main/scripts/lib/k-util.sh
@@ -23,8 +23,8 @@ result=0
 error () {
   local result
   result="$1" ; shift
-  printf "[Error] ${ktool}: $*\n" | ${fold_lines} 1>&2
-  exit ${result}
+  printf "[Error] ${KTOOL}: $*\n" | ${fold_lines} 1>&2
+  exit "${result}"
 }
 
 k_util_usage() {


### PR DESCRIPTION
Fixes: #3429 
- This simple PR improves the `kore-print` script
- Implement the necessary infrastructure to make the `-v`/`--verbose` mode work on this tool to print intermediate steps