### PR TITLE
Update projects description

### DIFF
--- a/web/pages/index.md
+++ b/web/pages/index.md
@@ -37,7 +37,7 @@ call/cc.
 
 - [Discord Server](https://discord.com/invite/CurfmXNtbN): Most direct way to get support.
 - [Matrix Room](https://matrix.to/#/#k:matrix.org): Another way to get support.
-- [Stackoverflow](https://stackoverflow.com/questions/tagged/kframework): for general questions to the K user community.
+- [Telegram](https://t.me/rv_inc): for newsletters and general announcements.
 
 ## Resources
 

--- a/web/pages/projects.md
+++ b/web/pages/projects.md
@@ -4,6 +4,9 @@ copyright: Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 
 # Projects using K
 
+A list of projects using the K framework. If you are working on something interesting, and you want to share it with the community,
+let us know on our [socials](https://kframework.org/#support), and we will feature you on this list.
+
 <br>
 
 ## Featured


### PR DESCRIPTION
to encourage people to share their work on our projects page.
I've also replaced the Stackoverflow link with Telegram.
I'm not sure if anyone is monitoring Stackoverflow. We don't have the Slack notifications anymore since they were broken at some point.