### PR TITLE
Fix error message when missing sort

### DIFF
--- a/k-distribution/tests/regression-new/checks/noImportFloat.k
+++ b/k-distribution/tests/regression-new/checks/noImportFloat.k
@@ -1,7 +1,7 @@
 // Copyright (c) K Team. All Rights Reserved.
 module NOIMPORTFLOAT-SYNTAX
   imports DOMAINS-SYNTAX
-   syntax Pgm ::= foo(Float) | bar()
+   syntax Pgm ::= foo(x:Float) | bar()
 endmodule
 
 

--- a/k-distribution/tests/regression-new/checks/noImportFloat.k.out
+++ b/k-distribution/tests/regression-new/checks/noImportFloat.k.out
@@ -1,5 +1,5 @@
 [Error] Compiler: Could not find sorts: [Float]
 	Source(noImportFloat.k)
-	Location(4,19,4,29)
-	4 |	   syntax Pgm ::= foo(Float) | bar()
-	  .	                  ^~~~~~~~~~
+	Location(4,19,4,31)
+	4 |	   syntax Pgm ::= foo(x:Float) | bar()
+	  .	                  ^~~~~~~~~~~~

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -360,8 +360,8 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
   def checkSorts (): Unit = localSentences foreach {
     case p@Production(_, params, _, items, _) =>
       val res = items collect
-      { case nt: NonTerminal if !p.isSortVariable(nt.sort) && !definedSorts.contains(nt.sort.head) && !sortSynonymMap.contains(nt.sort) => nt
-        case nt: NonTerminal if nt.sort.params.nonEmpty && (nt.sort.params.toSet & params.toSet).isEmpty && !definedInstantiations.getOrElse(nt.sort.head, Set()).contains(nt.sort) => nt
+      { case nt: NonTerminal if !p.isSortVariable(nt.sort) && !definedSorts.contains(nt.sort.head) && !sortSynonymMap.contains(nt.sort) => nt.sort
+        case nt: NonTerminal if nt.sort.params.nonEmpty && (nt.sort.params.toSet & params.toSet).isEmpty && !definedInstantiations.getOrElse(nt.sort.head, Set()).contains(nt.sort) => nt.sort
       }
       if (res.nonEmpty)
         throw KEMException.compilerError("Could not find sorts: " + res.asJava, p)


### PR DESCRIPTION
In https://github.com/runtimeverification/k/pull/3420 I added pretty printing for labeled NonTerminals in productions.
This made it so error messages for missing sorts would also include the label, which made it look weird.
This PR fixes that problem and updates the test.
```
// currently
[Error] Compiler: Could not find sorts: [x:A]
	Source(/home/radu/work/test/test.k)
	Location(15,18,15,24)
	15 |	  syntax Exp ::= f(x:A)
	   .	                 ^~~~~~
// fixed
[Error] Compiler: Could not find sorts: [A]
	Source(/home/radu/work/test/test.k)
	Location(15,18,15,24)
	15 |	  syntax Exp ::= f(x:A)
	   .	                 ^~~~~~
```