### PR TITLE
Throw error message when finding duplicate attributes

### DIFF
--- a/k-distribution/tests/regression-new/checks/duplicateAttRule.k
+++ b/k-distribution/tests/regression-new/checks/duplicateAttRule.k
@@ -1,0 +1,7 @@
+// Copyright (c) K Team. All Rights Reserved.
+module DUPLICATEATTRULE
+
+  syntax Foo  ::= a()
+  rule a() => .K [concrete, concrete]
+
+endmodule

--- a/k-distribution/tests/regression-new/checks/duplicateAttRule.k.out
+++ b/k-distribution/tests/regression-new/checks/duplicateAttRule.k.out
@@ -1,0 +1,5 @@
+[Error] Outer Parser: Duplicate attribute: concrete
+	Source(duplicateAttRule.k)
+	Location(5,29,5,37)
+	5 |	  rule a() => .K [concrete, concrete]
+	  .	                            ^~~~~~~~

--- a/k-distribution/tests/regression-new/checks/duplicateAttSyntax.k
+++ b/k-distribution/tests/regression-new/checks/duplicateAttSyntax.k
@@ -1,0 +1,6 @@
+// Copyright (c) K Team. All Rights Reserved.
+module DUPLICATEATTSYNTAX
+
+  syntax Foo  ::= a() [left, left]
+
+endmodule

--- a/k-distribution/tests/regression-new/checks/duplicateAttSyntax.k.out
+++ b/k-distribution/tests/regression-new/checks/duplicateAttSyntax.k.out
@@ -1,0 +1,5 @@
+[Error] Outer Parser: Duplicate attribute: left
+	Source(duplicateAttSyntax.k)
+	Location(4,30,4,34)
+	4 |	  syntax Foo  ::= a() [left, left]
+	  .	                             ^~~~

--- a/k-distribution/tests/regression-new/concrete-haskell/a1-spec.k
+++ b/k-distribution/tests/regression-new/concrete-haskell/a1-spec.k
@@ -4,11 +4,11 @@ imports A
 
 rule (X +Int Y) +Int Z => Z +Int (X +Int Y) [simplification, symbolic(X), concrete(Y, Z)]
 
-rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
 
 rule X +Int (Y +Int Z) => Z +Int (X +Int Y) [simplification, concrete(X, Y), symbolic(Z)]
 
-rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
 
 rule final(n +Int _M:Int) => 0 [simplification, concrete(_M)]
 

--- a/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a1-spec.k
+++ b/k-distribution/tests/regression-new/issue-2287-simpl-rules-in-kprovex/a1-spec.k
@@ -6,9 +6,9 @@ module VERIFICATION
   import TEST
 
   rule (X +Int Y) +Int Z => Z +Int (X +Int Y) [simplification, symbolic(X), concrete(Y, Z)]
-  rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+  rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
   rule X +Int (Y +Int Z) => Z +Int (X +Int Y) [simplification, concrete(X, Y), symbolic(Z)]
-  rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+  rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
   rule final(n +Int M:Int) => 0 requires M >=Int 0 [simplification, concrete(M)]
 endmodule
 

--- a/k-distribution/tests/regression-new/issue-2812-kprove-filter-claims/claims/a1-spec.k
+++ b/k-distribution/tests/regression-new/issue-2812-kprove-filter-claims/claims/a1-spec.k
@@ -6,9 +6,9 @@ module VERIFICATION
   import TEST
 
   rule (X +Int Y) +Int Z => Z +Int (X +Int Y) [simplification, symbolic(X), concrete(Y, Z)]
-  rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+  rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
   rule X +Int (Y +Int Z) => Z +Int (X +Int Y) [simplification, concrete(X, Y), symbolic(Z)]
-  rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+  rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
   rule final(n +Int M:Int) => 0 requires M >=Int 0 [simplification, concrete(M)]
 
   claim [s1]:

--- a/k-distribution/tests/regression-new/issue-2812-kprove-filter-claims/exclude/a1-spec.k
+++ b/k-distribution/tests/regression-new/issue-2812-kprove-filter-claims/exclude/a1-spec.k
@@ -6,9 +6,9 @@ module VERIFICATION
   import TEST
 
   rule (X +Int Y) +Int Z => Z +Int (X +Int Y) [simplification, symbolic(X), concrete(Y, Z)]
-  rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+  rule (X +Int Y) +Int Z => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
   rule X +Int (Y +Int Z) => Z +Int (X +Int Y) [simplification, concrete(X, Y), symbolic(Z)]
-  rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X), symbolic(Y), concrete(Z)]
+  rule X +Int (Y +Int Z) => Y +Int (X +Int Z) [simplification, concrete(X, Z), symbolic(Y)]
   rule final(n +Int M:Int) => 0 requires M >=Int 0 [simplification, concrete(M)]
 
   claim [pass1]:

--- a/kernel/src/main/java/org/kframework/kil/ASTNode.java
+++ b/kernel/src/main/java/org/kframework/kil/ASTNode.java
@@ -5,6 +5,7 @@ import org.kframework.attributes.Att;
 import org.kframework.attributes.HasLocation;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
+import org.kframework.utils.errorsystem.KEMException;
 
 import java.io.Serializable;
 import java.util.Optional;
@@ -97,7 +98,9 @@ public abstract class ASTNode implements Serializable, HasLocation {
      * @param key
      * @param val
      */
-    public void unsafeAddBuiltInOrRawAttribute(String key, String val) {
+    public void unsafeAddBuiltInOrRawAttribute(String key, String val, Source source, Location loc) {
+        if (att.contains(Att.getBuiltinKeyOptional(key).orElse(Att.unsafeRawKey(key))))
+            throw KEMException.outerParserError("Duplicate attribute: " + key, source, loc);
         att = att.add(Att.getBuiltinKeyOptional(key).orElse(Att.unsafeRawKey(key)), val);
     }
 

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -366,8 +366,8 @@ public class Outer {
       parser.source = this.source;
       parser.module = this.module;
       parser.items = this.items;
-      parser.beginLine = offsetLine(str, sentenceBeginLine, sentenceBeginColumn, offset + i);
-      parser.beginColumn = offsetLine(str, sentenceBeginLine, sentenceBeginColumn, offset + i);
+      parser.beginLine = 0;
+      parser.beginColumn = 0;
       try {
         StringSentence ss = new StringSentence(content.substring(0, i), startLine, startColumn, type, label);
         parser.AttributesEOF(ss);
@@ -376,6 +376,19 @@ public class Outer {
         /* Our guess was wrong. Try another position. */
       } catch (TokenMgrException e) {
         /* Our guess was wrong. Try another position. */
+      } catch (KEMException e) {
+          // if we found an exception inside attributes, adjust the location
+          // information according to the start position of the attributes
+          Location loc = e.exception.getLocation();
+          int beginLine = offsetLine(str, sentenceBeginLine, sentenceBeginColumn, offset + i) - 1;
+          int beginColumn = offsetColumn(str, sentenceBeginLine, sentenceBeginColumn, offset + i) - 1;
+          Location newLoc = Location.apply(
+                          loc.startLine() + beginLine,
+                          loc.startLine() == 1 ? loc.startColumn() + beginColumn : beginColumn,
+                          loc.endLine() + beginLine,
+                          loc.endLine() == 1 ? loc.endColumn() + beginColumn : loc.endColumn()
+                          );
+          throw e.withLocation(newLoc, source);
       }
     }
     return new StringSentence(content, startLine, startColumn, type, label);
@@ -670,7 +683,7 @@ void Tag(ASTNode node) :
     ( val = String() ")"
     | TagContent(sb) ")" { val = sb.toString() + special(); } )
     { SwitchTo(ATTR_STATE); })?
-  { node.unsafeAddBuiltInOrRawAttribute(key, val); }
+  { node.unsafeAddBuiltInOrRawAttribute(key, val, source, Location.apply(loc.startLine(), loc.startColumn(), token.endLine, token.endColumn + 1)); }
 }
 
 /** Parses the value of an attribute and appends it to 'sb' */


### PR DESCRIPTION
Do a check early on at outer parsing since we lose the information after that.
For rules, the location information is only approximate since we parse attributes in two stages and fiddle with the indexes.
Line numbers should indicate +1 at most.

I'm expecting this to break some semantics. I already found some issues with our regression tests.