### PR TITLE
Update K frontend to download packages from github instead of s3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -412,7 +412,6 @@ jobs:
 
       - name: 'Push Maven Packages'
         shell: bash {0}
-        continue-on-error: true
         env:
           MAVEN_PASSWORD: ${{ secrets.RV_JENKINS_DEPLOY_TOKEN }}
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -24,44 +24,25 @@
 
   <repositories>
     <repository>
-      <id>runtime.verification</id>
-      <name>Runtime Verification Repository</name>
-      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/internal</url>
-      <snapshots><enabled>false</enabled></snapshots>
-      <releases><enabled>true</enabled></releases>
-    </repository>
-    <repository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/snapshots</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
       <snapshots><enabled>true</enabled></snapshots>
-      <releases><enabled>false</enabled></releases>
+      <releases><enabled>true</enabled></releases>
     </repository>
   </repositories>
 
   <pluginRepositories>
     <pluginRepository>
-      <id>runtime.verification</id>
-      <name>Runtime Verification Repository</name>
-      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/internal</url>
-      <snapshots><enabled>false</enabled></snapshots>
-      <releases><enabled>true</enabled></releases>
-    </pluginRepository>
-    <pluginRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://s3.us-east-2.amazonaws.com/runtimeverificationmaven/snapshots</url>
+      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
       <snapshots><enabled>true</enabled></snapshots>
-      <releases><enabled>false</enabled></releases>
+      <releases><enabled>true</enabled></releases>
     </pluginRepository>
   </pluginRepositories>
 
   <distributionManagement>
-    <repository>
-      <id>runtime.verification</id>
-      <name>Runtime Verification Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
-    </repository>
     <snapshotRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
@@ -116,13 +97,6 @@
   </reporting>
 
   <build>
-    <extensions>
-      <extension>
-        <groupId>com.github.platform-team</groupId>
-        <artifactId>aws-maven</artifactId>
-        <version>6.0.0</version>
-      </extension>
-    </extensions>
     <pluginManagement>
       <plugins>
         <plugin>


### PR DESCRIPTION
This should be the final PR needed to fully migrate the K frontend away from our maven s3 bucket. We do 3 things:

* Make it so the release fails if github package deployment fails; we didn't do this previously only because we were testing the workflow.
* Change the path we look for packages to download from looking at s3 to looking at github packages.
* Clean up the POM and remove unnecessary stuff. This includes both removing references to s3 and also removing the unused rv-maven-public-release repo.