### PR TITLE
Deploy artifacts to CloudRepo

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -414,9 +414,9 @@ jobs:
         shell: bash {0}
         continue-on-error: true
         env:
-          MAVEN_PASSWORD: ${{ secrets.RV_JENKINS_DEPLOY_TOKEN }}
+          MAVEN_PASSWORD: ${{ secrets.CLOUDREPO_PASSWORD }}
         run: |
-          echo "MAVEN_USERNAME=rv-jenkins" > rv-jenkins.env
+          echo "MAVEN_USERNAME=devops@runtimeverification.com" > rv-jenkins.env
           echo "MAVEN_PASSWORD=$MAVEN_PASSWORD" >> rv-jenkins.env
           cat ~/.m2/settings.xml
           docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'

--- a/pom.xml
+++ b/pom.xml
@@ -60,12 +60,12 @@
     <repository>
       <id>runtime.verification</id>
       <name>Runtime Verification Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public-release</url>
+      <url>https://runtimeverification.mycloudrepo.io/repositories/runtimeverification</url>
     </repository>
     <snapshotRepository>
       <id>runtime.verification.snapshots</id>
       <name>Runtime Verification Snapshot Repository</name>
-      <url>https://maven.pkg.github.com/runtimeverification/rv-maven-public</url>
+      <url>https://runtimeverification.mycloudrepo.io/repositories/runtimeverification</url>
     </snapshotRepository>
   </distributionManagement>
 


### PR DESCRIPTION
This should be a relatively minor fix to the workflow and the POM to tell it to deploy artifacts to CloudRepo instead of to GitHub Packages. Nothing we've changed here so far will break if the free trial of CloudRepo ends; we just won't be able to access what we deploy there anymore.

I have tested that the follow-up update that changes the POM to download artifacts from CloudRepo will in fact work as designed to build K. We can do that change next, although it will break K's build after that change is merged if we don't pay for continued access. The cost appears to be $79/mo but it's possible we might be able to get it free since we are publishing open source software. We'll have to inquire.