### PR TITLE
attempt to fix crash in maven deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -419,9 +419,9 @@ jobs:
           echo "MAVEN_USERNAME=devops@runtimeverification.com" > rv-jenkins.env
           echo "MAVEN_PASSWORD=$MAVEN_PASSWORD" >> rv-jenkins.env
           cat ~/.m2/settings.xml
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p ~/.m2'
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mkdir -p /home/github-user/.m2'
           docker cp ~/.m2/settings.xml k-release-ci-${GITHUB_SHA}:/tmp/settings.xml
-          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml ~/.m2/settings.xml'
+          docker exec -t k-release-ci-${GITHUB_SHA} bash -c 'mv /tmp/settings.xml /home/github-user/.m2/settings.xml'
           docker exec --env-file rv-jenkins.env -t k-release-ci-${GITHUB_SHA} bash -c "mvn --batch-mode deploy"
 
       - name: 'Tear down Docker'


### PR DESCRIPTION
Right now the maven deploy step is crashing due to a mismatch between the private runner's home directory and the home directory of the user in the Docker image. This is an attempt to fix that.