### PR TITLE
Commit flake.lock

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -732,16 +732,16 @@
     },
     "nixpkgs_5": {
       "locked": {
-        "lastModified": 1685573264,
-        "narHash": "sha256-Zffu01pONhs/pqH07cjlF10NnMDLok8ix5Uk4rhOnZQ=",
+        "lastModified": 1687379288,
+        "narHash": "sha256-cSuwfiqYfeVyqzCRkU9AvLTysmEuSal8nh6CYr+xWog=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "380be19fbd2d9079f677978361792cb25e8a3635",
+        "rev": "ef0bc3976340dab9a4e087a0bcff661a8b2e87f3",
         "type": "github"
       },
       "original": {
         "id": "nixpkgs",
-        "ref": "nixos-22.05",
+        "ref": "nixos-23.05",
         "type": "indirect"
       }
     },


### PR DESCRIPTION
A recent change to the flake inputs didn't  update  the flake lock file, causing the install in kup to fail with

```
error: cannot write modified lock file of flake 'github:runtimeverification/k' (use '--no-write-lock-file' to ignore)
(use '--show-trace' to show detailed location information)
```