### PR TITLE
add haskell attribute to SET-KORE-SYMBOLIC

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -814,7 +814,7 @@ The following lemmas are simplifications that the Haskell backend can
 apply to simplify expressions of sort `Set`.
 
 ```k
-module SET-KORE-SYMBOLIC [kore,symbolic]
+module SET-KORE-SYMBOLIC [kore,symbolic,haskell]
   imports SET
   imports private K-EQUAL
   imports private BOOL


### PR DESCRIPTION
Previously this attribute was placed on MAP-KORE-SYMBOLIC to exclude that module from the Maude backend. We do the same now for sets.