### PR TITLE
.github/workflows/update-deps: sync up booster release tag too

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - '_update-deps/runtimeverification/haskell-backend'
       - '_update-deps/runtimeverification/llvm-backend'
+      - '_update-deps/runtimeverification/hs-backend-booster'
   workflow_dispatch:
 # Stop in progress workflows on the same branch and same workflow to use latest committed code
 concurrency:
@@ -40,8 +41,11 @@ jobs:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
 
-      - name: 'Update Nix flake inputs from submodules'
+      - name: 'Update Nix flake inputs from submodules/release-tags'
         run: |
+          set -euxo pipefail
+          booster_version=$(cat deps/hs-backend-booster_release)
+          sed -i 's!      url = "github:runtimeverification/hs-backend-booster/[0-9a-f]*";!      url = "github:runtimeverification/hs-backend-booster/'${booster_version}'";!' flake.nix
           nix flake update
           GC_DONT_GC=1 nix run .#update-from-submodules
           if git add 'flake.lock' && git commit -m 'Sync flake inputs to submodules'; then


### PR DESCRIPTION
Blocked on: https://github.com/runtimeverification/hs-backend-booster/pull/226

This allows us to automatically get updates from the booster backend into K as well:

- A new file `deps/hs-backend-booster_release` is added which tracks the release of the booster to use. The devops repo has been updated to make these updates https://github.com/runtimeverification/devops/commit/03af53c1a9b872be84f81c6345a0e9a03a489b6e.
- The update-deps job is changed to make sure the nix flake stays in sync, by copying the `deps/hs-backend-booster_release` tag over to the `flake.nix` file, and then calling `nix flake update`.