### PR TITLE
JSON creation - use object factory

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -171,8 +171,10 @@ public class Kompile {
 
         if (kompileOptions.emitJson) {
             try {
+                Stopwatch sw = new Stopwatch(globalOptions);
                 files.saveToKompiled("parsed.json",   new String(ToJson.apply(parsedDef),          "UTF-8"));
                 files.saveToKompiled("compiled.json", new String(ToJson.apply(kompiledDefinition), "UTF-8"));
+                sw.printIntermediate("  Emit parsed & compiled JSON");
             } catch (UnsupportedEncodingException e) {
                 throw KEMException.criticalError("Unsupported encoding `UTF-8` when saving JSON definition.");
             }

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -42,13 +42,9 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.DataOutputStream;
 import java.io.ByteArrayOutputStream;
+import java.util.Collections;
 
-import javax.json.Json;
-import javax.json.JsonArrayBuilder;
-import javax.json.JsonObject;
-import javax.json.JsonObjectBuilder;
-import javax.json.JsonWriter;
-import javax.json.JsonStructure;
+import javax.json.*;
 
 import scala.Option;
 import scala.Tuple2;
@@ -68,13 +64,15 @@ public class ToJson {
 // ToJson Definition Objects //
 ///////////////////////////////
 
+    private static final JsonBuilderFactory factory = Json.createBuilderFactory(Collections.emptyMap());
+
     public static byte[] apply(Definition def) {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         try {
             DataOutputStream data = new DataOutputStream(out);
             JsonWriter jsonWriter = Json.createWriter(data);
 
-            JsonObjectBuilder term = Json.createObjectBuilder();
+            JsonObjectBuilder term = factory.createObjectBuilder();
             term.add("format", "KAST");
             term.add("version", version);
             term.add("term", toJson(def));
@@ -94,15 +92,15 @@ public class ToJson {
             DataOutputStream data = new DataOutputStream(out);
             JsonWriter jsonWriter = Json.createWriter(data);
 
-            JsonObjectBuilder term = Json.createObjectBuilder();
+            JsonObjectBuilder term = factory.createObjectBuilder();
             term.add("format", "KAST");
             term.add("version", version);
-            JsonObjectBuilder jmodlist = Json.createObjectBuilder();
+            JsonObjectBuilder jmodlist = factory.createObjectBuilder();
 
             jmodlist.add("node", JsonParser.KFLATMODULELIST);
             jmodlist.add("mainModule", mainSpecModule);
 
-            JsonArrayBuilder jmods = Json.createArrayBuilder();
+            JsonArrayBuilder jmods = factory.createArrayBuilder();
             for (Module m : mods) {
                 jmods.add(toJson(m));
             }
@@ -119,9 +117,9 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(Definition def) {
-        JsonObjectBuilder jdef = Json.createObjectBuilder();
+        JsonObjectBuilder jdef = factory.createObjectBuilder();
 
-        JsonArrayBuilder mods = Json.createArrayBuilder();
+        JsonArrayBuilder mods = factory.createArrayBuilder();
         for (Module m : JavaConverters.setAsJavaSet(def.modules())) {
             mods.add(toJson(m));
         }
@@ -138,13 +136,13 @@ public class ToJson {
         // Emit user groups as group(_) to prevent conflicts between user groups and internals
         att = att.withUserGroupsAsGroupAtt();
 
-        JsonObjectBuilder jatt = Json.createObjectBuilder();
+        JsonObjectBuilder jatt = factory.createObjectBuilder();
         jatt.add("node", JsonParser.KATT);
 
-        JsonObjectBuilder jattKeys = Json.createObjectBuilder();
+        JsonObjectBuilder jattKeys = factory.createObjectBuilder();
         for (Tuple2<Att.Key,String> attKeyPair : JavaConverters.seqAsJavaList(att.att().keys().toSeq())) {
             if (attKeyPair._1().key().equals(Location.class.getName())) {
-                JsonArrayBuilder locarr = Json.createArrayBuilder();
+                JsonArrayBuilder locarr = factory.createArrayBuilder();
                 Location loc = att.get(Location.class);
                 locarr.add(loc.startLine());
                 locarr.add(loc.startColumn());
@@ -184,20 +182,20 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(FlatModule mod) {
-        JsonObjectBuilder jmod = Json.createObjectBuilder();
+        JsonObjectBuilder jmod = factory.createObjectBuilder();
 
         jmod.add("node", JsonParser.KFLATMODULE);
 
-        JsonArrayBuilder imports = Json.createArrayBuilder();
+        JsonArrayBuilder imports = factory.createArrayBuilder();
         stream(mod.imports()).forEach(i -> {
-          JsonObjectBuilder jimp = Json.createObjectBuilder();
+          JsonObjectBuilder jimp = factory.createObjectBuilder();
           jimp.add("node", JsonParser.KIMPORT);
           jimp.add("name", i.name());
           jimp.add("isPublic", i.isPublic());
           imports.add(jimp.build());
         });
 
-        JsonArrayBuilder sentences = Json.createArrayBuilder();
+        JsonArrayBuilder sentences = factory.createArrayBuilder();
         mod.localSentences().foreach(s -> sentences.add(toJson(s)));
 
         jmod.add("name", mod.name());
@@ -224,13 +222,13 @@ public class ToJson {
         if (sen instanceof SyntaxLexical)       return toJson((SyntaxLexical) sen);
         if (sen instanceof Production)          return toJson((Production) sen);
 
-        JsonObjectBuilder jsen = Json.createObjectBuilder();
+        JsonObjectBuilder jsen = factory.createObjectBuilder();
         jsen.add("node", "badsentence");
         return jsen.build();
     }
 
     public static JsonStructure toJson(Context con) {
-        JsonObjectBuilder jcon = Json.createObjectBuilder();
+        JsonObjectBuilder jcon = factory.createObjectBuilder();
 
         jcon.add("node", JsonParser.KCONTEXT);
         jcon.add("body", toJson(con.body()));
@@ -241,7 +239,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(RuleOrClaim rule) {
-        JsonObjectBuilder jrule = Json.createObjectBuilder();
+        JsonObjectBuilder jrule = factory.createObjectBuilder();
 
         jrule.add("node", rule instanceof Rule ? JsonParser.KRULE : JsonParser.KCLAIM);
         jrule.add("body", toJson(rule.body()));
@@ -253,13 +251,13 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(SyntaxPriority syn) {
-        JsonObjectBuilder jsyn = Json.createObjectBuilder();
+        JsonObjectBuilder jsyn = factory.createObjectBuilder();
 
         jsyn.add("node", JsonParser.KSYNTAXPRIORITY);
 
-        JsonArrayBuilder priArray = Json.createArrayBuilder();
+        JsonArrayBuilder priArray = factory.createArrayBuilder();
         for (Set<Tag> pri : JavaConverters.seqAsJavaList(syn.priorities())) {
-            JsonArrayBuilder tagArray = Json.createArrayBuilder();
+            JsonArrayBuilder tagArray = factory.createArrayBuilder();
             pri.foreach(t -> tagArray.add(t.name()));
             priArray.add(tagArray);
         }
@@ -271,12 +269,12 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(SyntaxAssociativity syn) {
-        JsonObjectBuilder jsyn = Json.createObjectBuilder();
+        JsonObjectBuilder jsyn = factory.createObjectBuilder();
 
         jsyn.add("node", JsonParser.KSYNTAXASSOCIATIVITY);
         jsyn.add("assoc", syn.assoc().toString());
 
-        JsonArrayBuilder tagArray = Json.createArrayBuilder();
+        JsonArrayBuilder tagArray = factory.createArrayBuilder();
         syn.tags().foreach(t -> tagArray.add(t.name()));
         jsyn.add("tags", tagArray);
 
@@ -286,7 +284,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(Configuration con) {
-        JsonObjectBuilder jcon = Json.createObjectBuilder();
+        JsonObjectBuilder jcon = factory.createObjectBuilder();
 
         jcon.add("node", JsonParser.KCONFIGURATION);
         jcon.add("body", toJson(con.body()));
@@ -297,7 +295,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(Bubble bub) {
-        JsonObjectBuilder jbub = Json.createObjectBuilder();
+        JsonObjectBuilder jbub = factory.createObjectBuilder();
 
         jbub.add("node", JsonParser.KBUBBLE);
         jbub.add("sentenceType", bub.sentenceType());
@@ -308,12 +306,12 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(SyntaxSort syn) {
-        JsonObjectBuilder jsyn = Json.createObjectBuilder();
+        JsonObjectBuilder jsyn = factory.createObjectBuilder();
 
         jsyn.add("node", JsonParser.KSYNTAXSORT);
         jsyn.add("sort", toJson(syn.sort()));
 
-        JsonArrayBuilder params = Json.createArrayBuilder();
+        JsonArrayBuilder params = factory.createArrayBuilder();
         JavaConverters.seqAsJavaList(syn.params()).forEach(p -> params.add(toJson(p)));
         jsyn.add("params", params.build());
 
@@ -323,7 +321,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(SortSynonym syn) {
-        JsonObjectBuilder jsyn = Json.createObjectBuilder();
+        JsonObjectBuilder jsyn = factory.createObjectBuilder();
 
         jsyn.add("node", JsonParser.KSORTSYNONYM);
         jsyn.add("newSort", toJson(syn.newSort()));
@@ -334,7 +332,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(SyntaxLexical syn) {
-        JsonObjectBuilder jsyn = Json.createObjectBuilder();
+        JsonObjectBuilder jsyn = factory.createObjectBuilder();
 
         jsyn.add("node", JsonParser.KSYNTAXLEXICAL);
         jsyn.add("name", syn.name());
@@ -345,7 +343,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(Production pro) {
-        JsonObjectBuilder jpro = Json.createObjectBuilder();
+        JsonObjectBuilder jpro = factory.createObjectBuilder();
 
         jpro.add("node", JsonParser.KPRODUCTION);
 
@@ -354,11 +352,11 @@ public class ToJson {
             jpro.add("klabel", toJson(klabel.get()));
         }
 
-        JsonArrayBuilder productionItems = Json.createArrayBuilder();
+        JsonArrayBuilder productionItems = factory.createArrayBuilder();
         JavaConverters.seqAsJavaList(pro.items()).forEach(p -> productionItems.add(toJson(p)));
         jpro.add("productionItems", productionItems.build());
 
-        JsonArrayBuilder params = Json.createArrayBuilder();
+        JsonArrayBuilder params = factory.createArrayBuilder();
         JavaConverters.seqAsJavaList(pro.params()).forEach(p -> params.add(toJson(p)));
         jpro.add("params", params.build());
 
@@ -369,7 +367,7 @@ public class ToJson {
     }
 
     public static JsonObject toJson(ProductionItem prod) {
-        JsonObjectBuilder jsonProduction = Json.createObjectBuilder();
+        JsonObjectBuilder jsonProduction = factory.createObjectBuilder();
 
         if (prod instanceof NonTerminal) {
             NonTerminal t = (NonTerminal) prod;
@@ -394,7 +392,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(Sort sort) {
-        JsonObjectBuilder jsort = Json.createObjectBuilder();
+        JsonObjectBuilder jsort = factory.createObjectBuilder();
 
         jsort.add("node", JsonParser.KSORT);
         // store sort and its parameters as a flat string
@@ -412,7 +410,7 @@ public class ToJson {
             DataOutputStream data = new DataOutputStream(out);
             JsonWriter jsonWriter = Json.createWriter(data);
 
-            JsonObjectBuilder kterm = Json.createObjectBuilder();
+            JsonObjectBuilder kterm = factory.createObjectBuilder();
             kterm.add("format", "KAST");
             kterm.add("version", version);
             kterm.add("term", toJson(k));
@@ -432,7 +430,7 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(K k) {
-        JsonObjectBuilder knode = Json.createObjectBuilder();
+        JsonObjectBuilder knode = factory.createObjectBuilder();
         if (k instanceof KToken) {
             KToken tok = (KToken) k;
 
@@ -447,7 +445,7 @@ public class ToJson {
             knode.add("node", JsonParser.KAPPLY);
             knode.add("label", toJson(((KApply) k).klabel()));
 
-            JsonArrayBuilder args = Json.createArrayBuilder();
+            JsonArrayBuilder args = factory.createArrayBuilder();
             for (K item : app.klist().asIterable()) {
                 args.add(toJson(item));
             }
@@ -461,7 +459,7 @@ public class ToJson {
 
             knode.add("node", JsonParser.KSEQUENCE);
 
-            JsonArrayBuilder items = Json.createArrayBuilder();
+            JsonArrayBuilder items = factory.createArrayBuilder();
             for (K item : seq.asIterable()) {
                 items.add(toJson(item));
             }
@@ -506,10 +504,10 @@ public class ToJson {
     }
 
     public static JsonStructure toJson(KLabel kl) {
-        JsonObjectBuilder jkl = Json.createObjectBuilder();
+        JsonObjectBuilder jkl = factory.createObjectBuilder();
         jkl.add("node", "KLabel");
         jkl.add("name", kl.name());
-        JsonArrayBuilder params = Json.createArrayBuilder();
+        JsonArrayBuilder params = factory.createArrayBuilder();
         for (Sort s : mutable(kl.params()))
             params.add(toJson(s));
         jkl.add("params", params.build());


### PR DESCRIPTION
Make the JSON creation faster by using a factory when creating objects.
Tested with an extract from the EVM semantics found here: #3491
Before and after:
```
  Emit parsed & compiled JSON                                = 43.295s
  Emit parsed & compiled JSON                                =  1.985s
```
It's still slow, but it's progress.