### PR TITLE
Fix release build

### DIFF
--- a/.github/actions/with-docker/action.yml
+++ b/.github/actions/with-docker/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: 'LLVM version to use.'
     required: false
     default: 15
+  jdk:
+    description: 'JDK version to use.'
+    required: false
+    default: 17
   dockerfile:
     description: 'Hardcode the path of the dockerfile to use.'
     required: false
@@ -33,6 +37,7 @@ runs:
       BASE_OS: ${{ inputs.os }}
       BASE_DISTRO: ${{ inputs.distro }}
       LLVM_VERSION: ${{ inputs.llvm }}
+      JDK_VERSION: ${{ inputs.jdk }}
       DOCKERFILE: ${{ inputs.dockerfile }}
     run: |
       set -euxo pipefail
@@ -73,6 +78,7 @@ runs:
           --build-arg Z3_VERSION=${Z3_VERSION}                        \
           --build-arg K_VERSION=${K_VERSION}                          \
           --build-arg LLVM_VERSION=${LLVM_VERSION}                    \
+          --build-arg JDK_VERSION=${JDK_VERSION}                      \
           --build-arg USER=${USER} --build-arg USER_ID=${USER_ID}     \
           --build-arg GROUP=${GROUP} --build-arg GROUP_ID=${GROUP_ID}
 

--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -22,6 +22,7 @@ ENV TZ America/Chicago
 ENV DEBIAN_FRONTEND=noninteractive
 
 ARG LLVM_VERSION
+ARG JDK_VERSION
 
 RUN    apt-get update              \
     && apt-get install --yes       \
@@ -53,7 +54,7 @@ RUN    apt-get update              \
         llvm-${LLVM_VERSION}-tools \
         locales                    \
         maven                      \
-        openjdk-17-jdk             \
+        openjdk-${JDK_VERSION}-jdk \
         parallel                   \
         pkg-config                 \
         python3                    \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -123,6 +123,7 @@ jobs:
           os: ubuntu
           distro: focal
           llvm: 12
+          jdk: 11
           pkg-name: kframework_amd64_ubuntu_focal.deb
           build-package: package/debian/build-package focal
           test-package: package/debian/test-package

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ On Ubuntu Linux 20.04 (Focal):
 
 ```shell
 git submodule update --init --recursive
-sudo apt-get install build-essential m4 openjdk-17-jdk libfmt-dev libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 python3-dev cmake gcc g++ clang-12 lld-12 llvm-12-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
+sudo apt-get install build-essential m4 openjdk-11-jdk libfmt-dev libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 python3-dev cmake gcc g++ clang-12 lld-12 llvm-12-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 
@@ -187,6 +187,10 @@ See the notes below.
     You can test if it works by calling `mvn -version` in a terminal.
     This will provide the information about the JDK Maven is using, in case
     it is the wrong one.
+
+    Note that on Ubuntu Focal, the default Maven version is not compatible with
+    newer versions of the JDK; for K's Maven build to work, please ensure you
+    have version 11 installed.
 
 5.   Haskell Stack
 

--- a/package/arch/Dockerfile.maven-cache
+++ b/package/arch/Dockerfile.maven-cache
@@ -20,6 +20,7 @@ ADD pom.xml                                                    /home/$USER/.tmp-
 ADD llvm-backend/pom.xml                                       /home/$USER/.tmp-maven/llvm-backend/
 ADD llvm-backend/src/main/native/llvm-backend/matching/pom.xml /home/$USER/.tmp-maven/llvm-backend/src/main/native/llvm-backend/matching/
 ADD haskell-backend/pom.xml                                    /home/$USER/.tmp-maven/haskell-backend/
+ADD hs-backend-booster/pom.xml                                 /home/$USER/.tmp-maven/hs-backend-booster/
 ADD kernel/pom.xml                                             /home/$USER/.tmp-maven/kernel/
 ADD k-distribution/pom.xml                                     /home/$USER/.tmp-maven/k-distribution/
 ADD kore/pom.xml                                               /home/$USER/.tmp-maven/kore/

--- a/package/debian/control.focal
+++ b/package/debian/control.focal
@@ -2,7 +2,7 @@ Source: kframework
 Section: devel
 Priority: optional
 Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
-Build-Depends: clang-12 , cmake , debhelper (>=9) , flex , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-17-jdk , python3 , python3-dev , python3-distutils , python3-pip , zlib1g-dev
+Build-Depends: clang-12 , cmake , debhelper (>=9) , flex , libboost-test-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libyaml-dev , maven , openjdk-11-jdk , python3 , python3-dev , python3-distutils , python3-pip , zlib1g-dev
 Standards-Version: 3.9.6
 Homepage: https://github.com/runtimeverification/k
 


### PR DESCRIPTION
This PR addresses two issues with the release build:
* The Arch linux Maven dependency dockerfile wasn't copying the new booster `pom.xml`.
* On Ubuntu Focal, JDK 17 is incompatible at runtime with the default version of Maven. A comment noting this is added to the README, and all relevant install instructions have been updated.

I've tested the fixes by running them in the PR environment, then rebasing out. As best as I can tell without running the full release build, the issues are fixed.