### PR TITLE
Fix release JDK version

### DIFF
--- a/.github/actions/test-package/action.yml
+++ b/.github/actions/test-package/action.yml
@@ -11,6 +11,10 @@ inputs:
   llvm:
     description: 'LLVM version to use.'
     required: true
+  jdk:
+    description: 'JDK version to use.'
+    required: false
+    default: 17
   dockerfile:
     description: 'Hardcode the path of the dockerfile to use.'
     required: false
@@ -45,6 +49,7 @@ runs:
       os: ${{ inputs.os }}
       distro: ${{ inputs.distro }}
       llvm: ${{ inputs.llvm }}
+      jdk: ${{ inputs.jdk }}
       dockerfile: ${{ inputs.dockerfile }}
 
   - name: 'Build Package: ${{ inputs.distro }}'


### PR DESCRIPTION
This fixes one final place where we weren't passing the correct JDK version; this particular part of the testing workflow is hard to run outside of the actual release job so it didn't get caught in #3512.