### PR TITLE
AddKoreAttribute as a Frontend Kompiler Pass

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -348,7 +348,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
 
             @Override
             public RewriterResult prove(Module rules, Boolean reuseDef) {
-                Module kompiledModule = KoreBackend.getKompiledModule(module, true);
+                Module kompiledModule = KoreBackend.getKompiledModule(module, true, kompileOptions);
                 ModuleToKORE converter = new ModuleToKORE(kompiledModule, def.topCellInitializer, kompileOptions, kem);
                 String defPath = reuseDef ? files.resolveKompiled("definition.kore").getAbsolutePath() : saveKoreDefinitionToTemp(converter);
                 String specPath = saveKoreSpecToTemp(converter, rules);

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -98,9 +98,7 @@ public class KoreBackend extends AbstractBackend {
           mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
         }
         mainModule = ModuleTransformer.from(new GenerateMapCeilAxioms(mainModule, kompileOptions)::gen, "Generate map ceil axioms").apply(mainModule);
-        
-        Module finalMainModule = mainModule;
-        mainModule =  ModuleTransformer.fromSentenceTransformerAtt((m, s) -> new AddKoreAttributes(finalMainModule, kompileOptions).add(s), "Add kore attributes").apply(mainModule);
+        mainModule = ModuleTransformer.fromSentenceTransformerAtt(new AddKoreAttributes(mainModule, kompileOptions)::add, "Add kore attributes").apply(mainModule);
 
         return mainModule;
     }

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -97,19 +97,7 @@ public class KoreBackend extends AbstractBackend {
         if (hasAnd) {
           mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
         }
-
-        // mainModule = ModuleTransformer.fromSentenceTransformer(new AddKoreAttributes(mainModule, kompileOptions)::add, "add attributes").apply(mainModule);
-        mainModule =  ModuleTransformer.fromSentenceTransformer((m, s) -> {
-            AddKoreAttributes addKoreAttributes = new AddKoreAttributes(m, kompileOptions);
-            if (s instanceof Production) {
-                //System.err.println("Before: " + s.att());
-                Sentence newSentence = addKoreAttributes.add(s);
-                //System.err.println("After: " + newSentence.att());
-                return newSentence;
-            } else {
-                return s;
-            }
-        }, "add attributes").apply(mainModule);
+        mainModule =  ModuleTransformer.fromSentenceTransformerAtt((m, s) -> { return new AddKoreAttributes(m, kompileOptions).add(s); }, "Add kore attributes").apply(mainModule);
 
         return mainModule;
     }

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -95,7 +95,7 @@ public class KoreBackend extends AbstractBackend {
     public static Module getKompiledModule(Module mainModule, boolean hasAnd, KompileOptions kompileOptions) {
         mainModule = ModuleTransformer.fromSentenceTransformer(new AddSortInjections(mainModule)::addInjections, "Add sort injections").apply(mainModule);
         if (hasAnd) {
-          mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule, hasAnd)::resolve, "Minimize term construction").apply(mainModule);
+          mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
         }
         mainModule = ModuleTransformer.from(new GenerateMapCeilAxioms(mainModule, kompileOptions)::gen, "Generate map ceil axioms").apply(mainModule);
         

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -68,7 +68,7 @@ public class KoreBackend extends AbstractBackend {
      * @param hasAnd whether the backend in question supports and-patterns during pattern matching.
      */
     protected String getKompiledString(CompiledDefinition def, boolean hasAnd) {
-        Module mainModule = getKompiledModule(def.kompiledDefinition.mainModule(), hasAnd);
+        Module mainModule = getKompiledModule(def.kompiledDefinition.mainModule(), hasAnd, def.kompileOptions);
         ModuleToKORE converter = new ModuleToKORE(mainModule, def.topCellInitializer, def.kompileOptions);
         return getKompiledString(converter, files, heatCoolEquations, tool);
     }
@@ -92,11 +92,25 @@ public class KoreBackend extends AbstractBackend {
         return semantics.toString();
     }
 
-    public static Module getKompiledModule(Module mainModule, boolean hasAnd) {
+    public static Module getKompiledModule(Module mainModule, boolean hasAnd, KompileOptions kompileOptions) {
         mainModule = ModuleTransformer.fromSentenceTransformer(new AddSortInjections(mainModule)::addInjections, "Add sort injections").apply(mainModule);
         if (hasAnd) {
           mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
         }
+
+        // mainModule = ModuleTransformer.fromSentenceTransformer(new AddKoreAttributes(mainModule, kompileOptions)::add, "add attributes").apply(mainModule);
+        mainModule =  ModuleTransformer.fromSentenceTransformer((m, s) -> {
+            AddKoreAttributes addKoreAttributes = new AddKoreAttributes(m, kompileOptions);
+            if (s instanceof Production) {
+                //System.err.println("Before: " + s.att());
+                Sentence newSentence = addKoreAttributes.add(s);
+                //System.err.println("After: " + newSentence.att());
+                return newSentence;
+            } else {
+                return s;
+            }
+        }, "add attributes").apply(mainModule);
+
         return mainModule;
     }
 

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -97,7 +97,7 @@ public class KoreBackend extends AbstractBackend {
         if (hasAnd) {
           mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
         }
-        mainModule =  ModuleTransformer.fromSentenceTransformer((m, s) -> new AddKoreAttributes(m, kompileOptions).add(s), "Add kore attributes").apply(mainModule);
+        mainModule =  ModuleTransformer.fromSentenceTransformerAtt((m, s) -> new AddKoreAttributes(m, kompileOptions).add(s), "Add kore attributes").apply(mainModule);
 
         return mainModule;
     }

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -97,7 +97,7 @@ public class KoreBackend extends AbstractBackend {
         if (hasAnd) {
           mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
         }
-        mainModule =  ModuleTransformer.fromSentenceTransformerAtt((m, s) -> { return new AddKoreAttributes(m, kompileOptions).add(s); }, "Add kore attributes").apply(mainModule);
+        mainModule =  ModuleTransformer.fromSentenceTransformer((m, s) -> new AddKoreAttributes(m, kompileOptions).add(s), "Add kore attributes").apply(mainModule);
 
         return mainModule;
     }

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -95,9 +95,10 @@ public class KoreBackend extends AbstractBackend {
     public static Module getKompiledModule(Module mainModule, boolean hasAnd, KompileOptions kompileOptions) {
         mainModule = ModuleTransformer.fromSentenceTransformer(new AddSortInjections(mainModule)::addInjections, "Add sort injections").apply(mainModule);
         if (hasAnd) {
-          mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
+          mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule, hasAnd)::resolve, "Minimize term construction").apply(mainModule);
         }
-        mainModule =  ModuleTransformer.fromSentenceTransformerAtt((m, s) -> new AddKoreAttributes(m, kompileOptions).add(s), "Add kore attributes").apply(mainModule);
+        Module finalMainModule = mainModule;
+        mainModule =  ModuleTransformer.fromSentenceTransformerAtt((m, s) -> new AddKoreAttributes(finalMainModule, kompileOptions).add(s), "Add kore attributes").apply(mainModule);
 
         return mainModule;
     }

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -373,7 +373,7 @@ public class ModuleToKORE {
     private void translateSymbol(Map<Att.Key, Boolean> attributes,
                                  KLabel label, Production prod, StringBuilder sb) {
         sb.append("  ");
-        if (isFunction(prod) && prod.att().contains(Att.HOOK()) && isRealHook(prod.att())) {
+        if (isFunction(prod) && prod.att().contains(Att.HOOK()) && module.isRealHook(prod.att(), immutable(options.hookNamespaces))) {
             sb.append("hooked-");
         }
         sb.append("symbol ");
@@ -744,17 +744,6 @@ public class ModuleToKORE {
         sb.append("(), ");
         convert(lesser.klabel().get(), lesser, sb);
         sb.append("())] // overloaded production\n");
-    }
-
-    private boolean isRealHook(Att att) {
-      String hook = att.get(Att.HOOK());
-      if (hook.startsWith("ARRAY.")) {
-        return false;
-      }
-      if (options.hookNamespaces.stream().anyMatch(ns -> hook.startsWith(ns + "."))) {
-        return true;
-      }
-      return Hooks.namespaces.stream().anyMatch(ns -> hook.startsWith(ns + "."));
     }
 
     private static boolean isBuiltinProduction(Production prod) {

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -413,7 +413,8 @@ public class ModuleToKORE {
         sb.append(") : ");
         convert(prod.sort(), prod, sb);
         sb.append(" ");
-        Att koreAtt = addKoreAttributes(prod, functionRules, overloads);
+        Att koreAtt = prod.att();//addKoreAttributes(prod, functionRules, overloads);
+        //System.out.println("koreAtt: " + koreAtt);
         convert(attributes, koreAtt, sb, null, null);
         sb.append("\n");
     }
@@ -1475,12 +1476,12 @@ public class ModuleToKORE {
     }
 
     private boolean isConstructor(Production prod, SetMultimap<KLabel, Rule> functionRules) {
-        Att att = addKoreAttributes(prod, functionRules, java.util.Collections.emptySet());
+        Att att = prod.att();//addKoreAttributes(prod, functionRules, java.util.Collections.emptySet());
         return att.contains(Att.CONSTRUCTOR());
     }
 
     private boolean isFunctional(Production prod, SetMultimap<KLabel, Rule> functionRules) {
-        Att att = addKoreAttributes(prod, functionRules, java.util.Collections.emptySet());
+        Att att = prod.att();//addKoreAttributes(prod, functionRules, java.util.Collections.emptySet());
         return att.contains(Att.FUNCTIONAL());
     }
 

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -10,7 +10,6 @@ import org.kframework.attributes.Att;
 import org.kframework.attributes.HasLocation;
 import org.kframework.attributes.Source;
 import org.kframework.builtin.BooleanUtils;
-import org.kframework.builtin.Hooks;
 import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Sorts;
 import org.kframework.compile.AddSortInjections;
@@ -21,12 +20,9 @@ import org.kframework.definition.Claim;
 import org.kframework.definition.Module;
 import org.kframework.definition.NonTerminal;
 import org.kframework.definition.Production;
-import org.kframework.definition.ProductionItem;
 import org.kframework.definition.Rule;
 import org.kframework.definition.RuleOrClaim;
 import org.kframework.definition.Sentence;
-import org.kframework.definition.Tag;
-import org.kframework.definition.Terminal;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.InjectedKLabel;
 import org.kframework.kore.K;
@@ -42,14 +38,12 @@ import org.kframework.kore.KVariable;
 import org.kframework.kore.Sort;
 import org.kframework.kore.SortHead;
 import org.kframework.kore.VisitK;
-import org.kframework.unparser.Formatter;
 import org.kframework.utils.StringUtil;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KException;
 import org.kframework.utils.errorsystem.KExceptionManager;
 import scala.Option;
 import scala.Tuple2;
-import scala.collection.JavaConverters;
 import scala.collection.Seq;
 
 import java.util.ArrayList;
@@ -67,7 +61,6 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.kframework.Collections.*;
-import static org.kframework.definition.Constructors.*;
 import static org.kframework.kore.KORE.*;
 
 class RuleInfo {

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -62,17 +62,6 @@ public class AddKoreAttributes {
         return KList(stream(assoc).filter(t -> t._1().name().equals(klabel.name())).map(t -> KApply(KLabel(t._2().name()))).collect(Collectors.toList()));
     }
 
-    private boolean isRealHook(Att att) {
-        String hook = att.get(Att.HOOK());
-        if (hook.startsWith("ARRAY.")) {
-            return false;
-        }
-        if (options.hookNamespaces.stream().anyMatch(ns -> hook.startsWith(ns + "."))) {
-            return true;
-        }
-        return Hooks.namespaces.stream().anyMatch(ns -> hook.startsWith(ns + "."));
-    }
-
     public synchronized Sentence add(Sentence s) {
         if (!(s instanceof Production))
             return s;
@@ -110,7 +99,7 @@ public class AddKoreAttributes {
         isConstructor &= !isAnywhere;
 
         Att att = prod.att().remove(Att.CONSTRUCTOR());
-        if (att.contains(Att.HOOK()) && !isRealHook(att)) {
+        if (att.contains(Att.HOOK()) && !module.isRealHook(att, immutable(options.hookNamespaces))) {
             att = att.remove(Att.HOOK());
         }
         if (isConstructor) {

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -1,3 +1,4 @@
+// Copyright (c) K Team. All Rights Reserved.
 package org.kframework.compile;
 
 import com.google.common.collect.HashMultimap;

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -172,20 +172,8 @@ public class AddKoreAttributes {
 
         Production prod = (Production) s;
 
-        List<Rule> sortedRules = new ArrayList<>(JavaConverters.seqAsJavaList(module.sortedRules()));
-        if (options.backend.equals("haskell")) {
-            module.sortedProductions().toStream().filter(this::isGeneratedInKeysOp).toStream().foreach(
-                    p -> {
-                        if (!options.disableCeilSimplificationRules) {
-                            genMapCeilAxioms(p, sortedRules);
-                        }
-                        return p;
-                    }
-            );
-        }
-
         SetMultimap<KLabel, Rule> functionRules = HashMultimap.create();
-        for (Rule rule : sortedRules) {
+        for (Rule rule : iterable(module.sortedRules())) {
             K left = RewriteToTop.toLeft(rule.body());
 
             if (left instanceof KApply) {

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -1,0 +1,331 @@
+package org.kframework.compile;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.SetMultimap;
+import org.kframework.Collections;
+import org.kframework.attributes.Att;
+import org.kframework.backend.kore.ConstructorChecks;
+import org.kframework.builtin.BooleanUtils;
+import org.kframework.builtin.Hooks;
+import org.kframework.builtin.KLabels;
+import org.kframework.builtin.Sorts;
+import org.kframework.definition.Module;
+import org.kframework.definition.NonTerminal;
+import org.kframework.definition.Production;
+import org.kframework.definition.ProductionItem;
+import org.kframework.definition.Rule;
+import org.kframework.definition.Sentence;
+import org.kframework.definition.Tag;
+import org.kframework.definition.Terminal;
+import org.kframework.kompile.KompileOptions;
+import org.kframework.kore.K;
+import org.kframework.kore.KApply;
+import org.kframework.kore.KLabel;
+import org.kframework.kore.KList;
+import org.kframework.kore.KORE;
+import org.kframework.kore.KVariable;
+import org.kframework.kore.Sort;
+import org.kframework.unparser.Formatter;
+import org.kframework.utils.errorsystem.KEMException;
+import scala.Option;
+import scala.Tuple2;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.kframework.Collections.*;
+import static org.kframework.definition.Constructors.*;
+import static org.kframework.kore.KORE.*;
+
+public class AddKoreAttributes {
+
+    private final Module module;
+    private final KompileOptions options;
+
+    public AddKoreAttributes(Module m, KompileOptions kompileOptions) {
+        this.module = m;
+        this.options = kompileOptions;
+    }
+
+    private boolean isFunction(Production prod) {
+        return prod.att().contains(Att.FUNCTION());
+    }
+
+    private KList getAssoc(scala.collection.Set<Tuple2<Tag, Tag>> assoc, KLabel klabel) {
+        return KList(stream(assoc).filter(t -> t._1().name().equals(klabel.name())).map(t -> KApply(KLabel(t._2().name()))).collect(Collectors.toList()));
+    }
+
+    static boolean hasHookValue(Att atts, String value) {
+        return atts.contains(Att.HOOK()) &&
+                atts.get(Att.HOOK()).equals(value);
+    }
+
+    private void genMapCeilAxioms(Production prod, Collection<Rule> rules) {
+        Sort mapSort = prod.nonterminal(1).sort();
+        scala.collection.Set<Production> mapProds = module.productionsForSort().apply(mapSort.head());
+        Production concatProd = mapProds.find(p -> hasHookValue(p.att(), "MAP.concat")).get();
+        Production elementProd = mapProds.find(p -> hasHookValue(p.att(), "MAP.element")).get();
+        Seq<NonTerminal> nonterminals = elementProd.nonterminals();
+        Sort sortParam = Sort(AddSortInjections.SORTPARAM_NAME, Sort("Q"));
+
+        // rule
+        //   #Ceil(MapItem(K1, K2, ..., Kn) Rest:Map)
+        // =>
+        //  {(@K1 in_keys(@Rest)) #Equals false} #And #Ceil(@K2) #And ... #And #Ceil(@Kn)
+        // Note: The {_ in_keys(_) #Equals false} condition implies
+        // #Ceil(@K1) and #Ceil(@Rest).
+        // [simplification]
+
+        K restMapSet = KVariable("@Rest", Att.empty().add(Sort.class, mapSort));
+        KLabel ceilMapLabel = KLabel(KLabels.ML_CEIL.name(), mapSort, sortParam);
+        KLabel andLabel = KLabel(KLabels.ML_AND.name(), sortParam);
+
+        // arguments of MapItem and their #Ceils
+        List<K> setArgs = new ArrayList<>();
+        K setArgsCeil = KApply(KLabel(KLabels.ML_TRUE.name(), sortParam));
+        for (int i = 0; i < nonterminals.length(); i++) {
+            Sort sort = nonterminals.apply(i).sort();
+            KVariable setVar = KVariable("@K" + i, Att.empty().add(Sort.class, sort));
+            setArgs.add(setVar);
+            if (i > 0) {
+                KLabel ceil = KLabel(KLabels.ML_CEIL.name(), sort, sortParam);
+                setArgsCeil = KApply(andLabel, setArgsCeil, KApply(ceil, setVar));
+            }
+        }
+        Seq<K> setArgsSeq = JavaConverters.iterableAsScalaIterable(setArgs).toSeq();
+
+        KLabel equalsLabel = KLabel(KLabels.ML_EQUALS.name(), Sorts.Bool(), sortParam);
+        Rule ceilMapRule =
+                Rule(
+                        KRewrite(
+                                KApply(ceilMapLabel,
+                                        KApply(concatProd.klabel().get(),
+                                                KApply(elementProd.klabel().get(),
+                                                        setArgsSeq,
+                                                        Att.empty()
+                                                ),
+                                                restMapSet
+                                        )
+                                )
+                                ,
+                                KApply(andLabel,
+                                        KApply(equalsLabel,
+                                                KApply(prod.klabel().get(),
+                                                        setArgs.get(0),
+                                                        restMapSet
+                                                ),
+                                                BooleanUtils.FALSE
+                                        ),
+                                        setArgsCeil
+                                )
+                        )
+                        , BooleanUtils.TRUE
+                        , BooleanUtils.TRUE
+                        , Att.empty().add(Att.SIMPLIFICATION())
+                );
+        rules.add(ceilMapRule);
+    }
+
+    private boolean isRealHook(Att att) {
+        String hook = att.get(Att.HOOK());
+        if (hook.startsWith("ARRAY.")) {
+            return false;
+        }
+        if (options.hookNamespaces.stream().anyMatch(ns -> hook.startsWith(ns + "."))) {
+            return true;
+        }
+        return Hooks.namespaces.stream().anyMatch(ns -> hook.startsWith(ns + "."));
+    }
+
+    public static final Production INJ_PROD = Production(KLabel(KLabels.INJ, Sort("S1"), Sort("S2")), Sort("S2"), Seq(NonTerminal(Sort("S1"))), Att());
+
+    private Production production(KApply term) {
+        return production(term, false);
+    }
+    private Production production(KApply term, boolean instantiatePolySorts) {
+        KLabel klabel = term.klabel();
+        if (klabel.name().equals(KLabels.INJ))
+            return instantiatePolySorts ? INJ_PROD.substitute(term.klabel().params()) : INJ_PROD;
+        Option<scala.collection.Set<Production>> prods = module.productionsFor().get(klabel.head());
+        if (!(prods.nonEmpty() && prods.get().size() == 1))
+            throw KEMException.compilerError("Expected to find exactly one production for KLabel: " + klabel + " found: " + prods.getOrElse(Collections::Set).size());
+        return instantiatePolySorts ? prods.get().head().substitute(term.klabel().params()) : prods.get().head();
+    }
+
+    private boolean isGeneratedInKeysOp(Production prod) {
+        Option<String> hook = prod.att().getOption(Att.HOOK());
+        if (hook.isEmpty()) return false;
+        if (!hook.get().equals("MAP.in_keys")) return false;
+        return (!prod.klabel().isEmpty());
+    }
+
+    public synchronized Sentence add(Sentence s) {
+        Production prod = (Production) s;
+
+        List<Rule> sortedRules = new ArrayList<>(JavaConverters.seqAsJavaList(module.sortedRules()));
+        if (options.backend.equals("haskell")) {
+            module.sortedProductions().toStream().filter(this::isGeneratedInKeysOp).toStream().foreach(
+                    p -> {
+                        if (!options.disableCeilSimplificationRules) {
+                            genMapCeilAxioms(p, sortedRules);
+                        }
+                        return p;
+                    }
+            );
+        }
+
+        SetMultimap<KLabel, Rule> functionRules = HashMultimap.create();
+        for (Rule rule : sortedRules) {
+            K left = RewriteToTop.toLeft(rule.body());
+
+            if (left instanceof KApply) {
+                KApply kapp = (KApply) left;
+                try {
+                    Production prod2 = production(kapp);
+                    if (prod2.att().contains(Att.FUNCTION()) || rule.att().contains(Att.ANYWHERE())
+                            || ExpandMacros.isMacro(rule)) {
+                        functionRules.put(kapp.klabel(), rule);
+                    }
+                } catch (KEMException e) {
+                    // ignore as this will be generated later
+                }
+            }
+        }
+
+        Set<Production> overloads = new HashSet<>();
+        for (Production lesser : iterable(module.overloads().elements())) {
+            for (Production greater : iterable(module.overloads().relations().get(lesser).getOrElse(Collections::<Production>Set))) {
+                overloads.add(greater);
+            }
+        }
+
+        boolean isFunctional = !isFunction(prod) || prod.att().contains(Att.TOTAL());
+        boolean isConstructor = !isFunction(prod);
+        isConstructor &= !prod.att().contains(Att.ASSOC());
+        isConstructor &= !prod.att().contains(Att.COMM());
+        isConstructor &= !prod.att().contains(Att.IDEM());
+        isConstructor &= !(prod.att().contains(Att.FUNCTION()) && prod.att().contains(Att.UNIT()));
+
+        // Later we might set !isConstructor because there are anywhere rules,
+        // but if a symbol is a constructor at this point, then it is still
+        // injective.
+        boolean isInjective = isConstructor;
+
+        boolean isMacro = false;
+        boolean isAnywhere = overloads.contains(prod);
+        if (prod.klabel().isDefined()) {
+            for (Rule r : functionRules.get(prod.klabel().get())) {
+                isMacro |= ExpandMacros.isMacro(r);
+                isAnywhere |= r.att().contains(Att.ANYWHERE());
+            }
+        }
+        isConstructor &= !isMacro;
+        isConstructor &= !isAnywhere;
+
+        Att att = prod.att().remove(Att.CONSTRUCTOR());
+        if (att.contains(Att.HOOK()) && !isRealHook(att)) {
+            att = att.remove(Att.HOOK());
+        }
+        if (isConstructor) {
+            att = att.add(Att.CONSTRUCTOR());
+        }
+        if (isFunctional) {
+            att = att.add(Att.FUNCTIONAL());
+        }
+        if (isAnywhere) {
+            att = att.add(Att.ANYWHERE());
+        }
+        if (isInjective) {
+            att = att.add(Att.INJECTIVE());
+        }
+        if (isMacro) {
+            att = att.add(Att.MACRO());
+        }
+        // update format attribute with structure expected by backend
+        String format = att.getOptional(Att.FORMAT()).orElse(Formatter.defaultFormat(prod.items().size()));
+        int nt = 1;
+        boolean hasFormat = true;
+        boolean printName = stream(prod.items()).noneMatch(pi -> pi instanceof NonTerminal && ((NonTerminal) pi).name().isEmpty());
+        boolean printEllipses = false;
+
+        for (int i = 0; i < prod.items().size(); i++) {
+            if (prod.items().apply(i) instanceof NonTerminal) {
+                String replacement;
+                if (printName && prod.isPrefixProduction()) {
+                    replacement = ((NonTerminal) prod.items().apply(i)).name().get() + ": %" + (nt++);
+                    printEllipses = true;
+                } else {
+                    replacement = "%" + (nt++);
+                }
+                format = format.replaceAll("%" + (i+1) + "(?![0-9])", replacement);
+            } else if (prod.items().apply(i) instanceof Terminal) {
+                format = format.replaceAll("%" + (i+1) + "(?![0-9])", "%c" + ((Terminal)prod.items().apply(i)).value().replace("\\", "\\\\").replace("$", "\\$").replace("%", "%%") + "%r");
+            } else {
+                hasFormat = false;
+            }
+        }
+        if (printEllipses && format.contains("(")) {
+            int idxLParam = format.indexOf("(") + 1;
+            format = format.substring(0, idxLParam) + "... " + format.substring(idxLParam);
+        }
+        if (hasFormat) {
+            att = att.add(Att.FORMAT(), format);
+            if (att.contains(Att.COLOR())) {
+                boolean escape = false;
+                StringBuilder colors = new StringBuilder();
+                String conn = "";
+                for (int i = 0; i < format.length(); i++) {
+                    if (escape && format.charAt(i) == 'c') {
+                        colors.append(conn).append(att.get(Att.COLOR()));
+                        conn = ",";
+                    }
+                    if (format.charAt(i) == '%') {
+                        escape = true;
+                    } else {
+                        escape = false;
+                    }
+                }
+                att = att.add(Att.COLORS(), colors.toString());
+            }
+            StringBuilder sb = new StringBuilder();
+            for (ProductionItem pi : iterable(prod.items())) {
+                if (pi instanceof NonTerminal) {
+                    sb.append('0');
+                } else {
+                    sb.append('1');
+                }
+            }
+            att = att.add(Att.TERMINALS(), sb.toString());
+            if (prod.klabel().isDefined()) {
+                List<K> lessThanK = new ArrayList<>();
+                Option<scala.collection.Set<Tag>> lessThan = module.priorities().relations().get(Tag(prod.klabel().get().name()));
+                if (lessThan.isDefined()) {
+                    for (Tag t : iterable(lessThan.get())) {
+                        if (ConstructorChecks.isBuiltinLabel(KLabel(t.name()))) {
+                            continue;
+                        }
+                        lessThanK.add(KApply(KLabel(t.name())));
+                    }
+                }
+                att = att.add(Att.PRIORITIES(), KList.class, KORE.KList(lessThanK));
+                att = att.remove(Att.LEFT());
+                att = att.remove(Att.RIGHT());
+                att = att.add(Att.LEFT(), KList.class, getAssoc(module.leftAssoc(), prod.klabel().get()));
+                att = att.add(Att.RIGHT(), KList.class, getAssoc(module.rightAssoc(), prod.klabel().get()));
+            }
+        } else {
+            att = att.remove(Att.FORMAT());
+        }
+
+        // This attribute is a frontend attribute only and is removed from the kore
+        // Since it has no meaning outside the frontend
+        att.remove(Att.ORIGINAL_PRD(), Production.class);
+        return prod.withAtt(att);
+    }
+}

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -166,6 +166,9 @@ public class AddKoreAttributes {
     }
 
     public synchronized Sentence add(Sentence s) {
+        if (!(s instanceof Production))
+            return s;
+
         Production prod = (Production) s;
 
         List<Rule> sortedRules = new ArrayList<>(JavaConverters.seqAsJavaList(module.sortedRules()));

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -1,15 +1,9 @@
 // Copyright (c) K Team. All Rights Reserved.
 package org.kframework.compile;
 
-import com.google.common.collect.HashMultimap;
-import com.google.common.collect.SetMultimap;
 import org.kframework.Collections;
 import org.kframework.attributes.Att;
 import org.kframework.backend.kore.ConstructorChecks;
-import org.kframework.builtin.BooleanUtils;
-import org.kframework.builtin.Hooks;
-import org.kframework.builtin.KLabels;
-import org.kframework.builtin.Sorts;
 import org.kframework.definition.Module;
 import org.kframework.definition.NonTerminal;
 import org.kframework.definition.Production;
@@ -20,21 +14,14 @@ import org.kframework.definition.Tag;
 import org.kframework.definition.Terminal;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.kore.K;
-import org.kframework.kore.KApply;
 import org.kframework.kore.KLabel;
 import org.kframework.kore.KList;
 import org.kframework.kore.KORE;
-import org.kframework.kore.KVariable;
-import org.kframework.kore.Sort;
 import org.kframework.unparser.Formatter;
-import org.kframework.utils.errorsystem.KEMException;
 import scala.Option;
 import scala.Tuple2;
-import scala.collection.JavaConverters;
-import scala.collection.Seq;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -54,8 +41,8 @@ public class AddKoreAttributes {
         this.options = kompileOptions;
     }
 
-    private boolean isFunction(Production prod) {
-        return prod.att().contains(Att.FUNCTION());
+    private boolean isNotFunction(Production prod) {
+        return !prod.att().contains(Att.FUNCTION());
     }
 
     private KList getAssoc(scala.collection.Set<Tuple2<Tag, Tag>> assoc, KLabel klabel) {
@@ -75,8 +62,8 @@ public class AddKoreAttributes {
             }
         }
 
-        boolean isFunctional = !isFunction(prod) || prod.att().contains(Att.TOTAL());
-        boolean isConstructor = !isFunction(prod);
+        boolean isFunctional = isNotFunction(prod) || prod.att().contains(Att.TOTAL());
+        boolean isConstructor = isNotFunction(prod);
         isConstructor &= !prod.att().contains(Att.ASSOC());
         isConstructor &= !prod.att().contains(Att.COMM());
         isConstructor &= !prod.att().contains(Att.IDEM());
@@ -155,11 +142,7 @@ public class AddKoreAttributes {
                         colors.append(conn).append(att.get(Att.COLOR()));
                         conn = ",";
                     }
-                    if (format.charAt(i) == '%') {
-                        escape = true;
-                    } else {
-                        escape = false;
-                    }
+                    escape = format.charAt(i) == '%';
                 }
                 att = att.add(Att.COLORS(), colors.toString());
             }

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -190,15 +190,11 @@ public class AddKoreAttributes {
 
             if (left instanceof KApply) {
                 KApply kapp = (KApply) left;
-                try {
                     Production prod2 = production(kapp);
                     if (prod2.att().contains(Att.FUNCTION()) || rule.att().contains(Att.ANYWHERE())
                             || ExpandMacros.isMacro(rule)) {
                         functionRules.put(kapp.klabel(), rule);
                     }
-                } catch (KEMException e) {
-                    // ignore as this will be generated later
-                }
             }
         }
 

--- a/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
+++ b/kernel/src/main/java/org/kframework/compile/AddKoreAttributes.java
@@ -62,77 +62,6 @@ public class AddKoreAttributes {
         return KList(stream(assoc).filter(t -> t._1().name().equals(klabel.name())).map(t -> KApply(KLabel(t._2().name()))).collect(Collectors.toList()));
     }
 
-    static boolean hasHookValue(Att atts, String value) {
-        return atts.contains(Att.HOOK()) &&
-                atts.get(Att.HOOK()).equals(value);
-    }
-
-    private void genMapCeilAxioms(Production prod, Collection<Rule> rules) {
-        Sort mapSort = prod.nonterminal(1).sort();
-        scala.collection.Set<Production> mapProds = module.productionsForSort().apply(mapSort.head());
-        Production concatProd = mapProds.find(p -> hasHookValue(p.att(), "MAP.concat")).get();
-        Production elementProd = mapProds.find(p -> hasHookValue(p.att(), "MAP.element")).get();
-        Seq<NonTerminal> nonterminals = elementProd.nonterminals();
-        Sort sortParam = Sort(AddSortInjections.SORTPARAM_NAME, Sort("Q"));
-
-        // rule
-        //   #Ceil(MapItem(K1, K2, ..., Kn) Rest:Map)
-        // =>
-        //  {(@K1 in_keys(@Rest)) #Equals false} #And #Ceil(@K2) #And ... #And #Ceil(@Kn)
-        // Note: The {_ in_keys(_) #Equals false} condition implies
-        // #Ceil(@K1) and #Ceil(@Rest).
-        // [simplification]
-
-        K restMapSet = KVariable("@Rest", Att.empty().add(Sort.class, mapSort));
-        KLabel ceilMapLabel = KLabel(KLabels.ML_CEIL.name(), mapSort, sortParam);
-        KLabel andLabel = KLabel(KLabels.ML_AND.name(), sortParam);
-
-        // arguments of MapItem and their #Ceils
-        List<K> setArgs = new ArrayList<>();
-        K setArgsCeil = KApply(KLabel(KLabels.ML_TRUE.name(), sortParam));
-        for (int i = 0; i < nonterminals.length(); i++) {
-            Sort sort = nonterminals.apply(i).sort();
-            KVariable setVar = KVariable("@K" + i, Att.empty().add(Sort.class, sort));
-            setArgs.add(setVar);
-            if (i > 0) {
-                KLabel ceil = KLabel(KLabels.ML_CEIL.name(), sort, sortParam);
-                setArgsCeil = KApply(andLabel, setArgsCeil, KApply(ceil, setVar));
-            }
-        }
-        Seq<K> setArgsSeq = JavaConverters.iterableAsScalaIterable(setArgs).toSeq();
-
-        KLabel equalsLabel = KLabel(KLabels.ML_EQUALS.name(), Sorts.Bool(), sortParam);
-        Rule ceilMapRule =
-                Rule(
-                        KRewrite(
-                                KApply(ceilMapLabel,
-                                        KApply(concatProd.klabel().get(),
-                                                KApply(elementProd.klabel().get(),
-                                                        setArgsSeq,
-                                                        Att.empty()
-                                                ),
-                                                restMapSet
-                                        )
-                                )
-                                ,
-                                KApply(andLabel,
-                                        KApply(equalsLabel,
-                                                KApply(prod.klabel().get(),
-                                                        setArgs.get(0),
-                                                        restMapSet
-                                                ),
-                                                BooleanUtils.FALSE
-                                        ),
-                                        setArgsCeil
-                                )
-                        )
-                        , BooleanUtils.TRUE
-                        , BooleanUtils.TRUE
-                        , Att.empty().add(Att.SIMPLIFICATION())
-                );
-        rules.add(ceilMapRule);
-    }
-
     private boolean isRealHook(Att att) {
         String hook = att.get(Att.HOOK());
         if (hook.startsWith("ARRAY.")) {
@@ -157,13 +86,6 @@ public class AddKoreAttributes {
         if (!(prods.nonEmpty() && prods.get().size() == 1))
             throw KEMException.compilerError("Expected to find exactly one production for KLabel: " + klabel + " found: " + prods.getOrElse(Collections::Set).size());
         return instantiatePolySorts ? prods.get().head().substitute(term.klabel().params()) : prods.get().head();
-    }
-
-    private boolean isGeneratedInKeysOp(Production prod) {
-        Option<String> hook = prod.att().getOption(Att.HOOK());
-        if (hook.isEmpty()) return false;
-        if (!hook.get().equals("MAP.in_keys")) return false;
-        return (!prod.klabel().isEmpty());
     }
 
     public synchronized Sentence add(Sentence s) {

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -3,23 +3,18 @@
 package org.kframework.definition
 
 import com.google.common.collect.{HashMultimap, SetMultimap}
-
 import java.util.Optional
-import java.lang.Comparable
 import javax.annotation.Nonnull
-import dk.brics.automaton.{BasicAutomata, RegExp, RunAutomaton, SpecialOperations}
+import dk.brics.automaton.{RegExp, RunAutomaton, SpecialOperations}
+
 import org.kframework.POSet
 import org.kframework.attributes.{Att, AttValue, HasLocation, Location, Source}
-import org.kframework.definition.Constructors._
-import org.kframework.kore.Unapply.{KApply, KLabel}
-import org.kframework.kore
 import org.kframework.kore.KORE.Sort
 import org.kframework.kore._
 import org.kframework.utils.errorsystem.KEMException
 import org.kframework.builtin.{Hooks, Sorts}
 import org.kframework.compile.RewriteToTop
 
-import java.util
 import scala.annotation.meta.param
 import scala.collection.JavaConverters._
 import collection._

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -7,7 +7,6 @@ import com.google.common.collect.{HashMultimap, SetMultimap}
 import java.util.Optional
 import java.lang.Comparable
 import javax.annotation.Nonnull
-
 import dk.brics.automaton.{BasicAutomata, RegExp, RunAutomaton, SpecialOperations}
 import org.kframework.POSet
 import org.kframework.attributes.{Att, AttValue, HasLocation, Location, Source}
@@ -17,9 +16,10 @@ import org.kframework.kore
 import org.kframework.kore.KORE.Sort
 import org.kframework.kore._
 import org.kframework.utils.errorsystem.KEMException
-import org.kframework.builtin.{Sorts,Hooks}
+import org.kframework.builtin.{Hooks, Sorts}
 import org.kframework.compile.RewriteToTop
 
+import java.util
 import scala.annotation.meta.param
 import scala.collection.JavaConverters._
 import collection._
@@ -283,7 +283,7 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
     val hook = att.get(Att.HOOK)
     if (hook.startsWith("ARRAY.")) return false
     if (hookNamespaces.exists(ns => hook.startsWith(ns + "."))) return true
-    Hooks.namespaces.stream.anyMatch((ns: String) => hook.startsWith(ns + "."))
+    Hooks.namespaces.asScala.exists((ns: String) => hook.startsWith(ns + "."))
   }
 
   private val INJ_PROD = Constructors.Production(KORE.KLabel("inj", Sort("S1"), Sort("S2")), Sort("S2"), Seq(Constructors.NonTerminal(Sort("S1"))))

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -17,7 +17,7 @@ import org.kframework.kore
 import org.kframework.kore.KORE.Sort
 import org.kframework.kore._
 import org.kframework.utils.errorsystem.KEMException
-import org.kframework.builtin.Sorts
+import org.kframework.builtin.{Sorts,Hooks}
 import org.kframework.compile.RewriteToTop
 
 import scala.annotation.meta.param
@@ -278,6 +278,13 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
   //      if (ps.groupBy(_.att).size != 1)
   //        throw DivergingAttributesForTheSameKLabel(ps)
   //  }
+
+  def isRealHook(att: Att, hookNamespaces: Seq[String]): Boolean = {
+    val hook = att.get(Att.HOOK)
+    if (hook.startsWith("ARRAY.")) return false
+    if (hookNamespaces.exists(ns => hook.startsWith(ns + "."))) return true
+    Hooks.namespaces.stream.anyMatch((ns: String) => hook.startsWith(ns + "."))
+  }
 
   private val INJ_PROD = Constructors.Production(KORE.KLabel("inj", Sort("S1"), Sort("S2")), Sort("S2"), Seq(Constructors.NonTerminal(Sort("S1"))))
 

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -2,10 +2,9 @@
 
 package org.kframework.definition
 
-import java.util.function.BiFunction
 import org.kframework.attributes.{Location, Source}
 import org.kframework.definition
-import org.kframework.kore.{AttCompare, K, KApply, KToken}
+import org.kframework.kore.{K, KApply, KToken}
 import org.kframework.utils.errorsystem.KEMException
 
 object ModuleTransformer {

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -23,6 +23,8 @@ object ModuleTransformer {
         m
     }, name)
 
+  def fromSentenceTransformerAtt(f: java.util.function.UnaryOperator[Sentence], name: String): ModuleTransformer =
+    fromSentenceTransformerAtt((m: Module, s: Sentence) => f(s), name)
   def fromSentenceTransformerAtt(f: (Module, Sentence) => Sentence, name: String): ModuleTransformer =
     ModuleTransformer(m => {
       val newSentences = mapWithTrace(m.localSentences.toSet)(f, m, name)


### PR DESCRIPTION
Part of #3444

This PR creates a new compiler pass that adds the Kore attributes to productions before `ModuleToKore`.  This is part of the effort to refactor the `ModuleToKore` infrastructure to simplify it by decoupling functions and actions that can be done before the translation and that aren't related to (kore) code emission.

Besides extracting the `AddKoreAttrubutes` function from `ModuleToKore.java`, this PR also simplifies function calls such as `isFunctional` and `isConstructor` only to test if the attribute is present on the given production.