### PR TITLE
Compare Attributes on Transformers

### DIFF
--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -368,17 +368,14 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
     case _ =>
   }
 
-  def checkAtts (other: Set[Sentence]) : Boolean = {
-    val sortedSentences = sentences.toSeq.sortBy(_.source.get)
-    val sortedOther = other.toSeq.sortBy(_.source.get)
+  def checkAtts(other: Set[Sentence]): Boolean = {
+    if (sentences != other)
+      return false
 
-    sortedSentences.zip(sortedOther).forall {
-      case (s1, s2) => if (s1.att != s2.att) return false
-                       else true
-      case        _ => false
-    }
-
-    true
+    val atts = sentences.collect({ case p: Production => p.att }).toSet
+    val otherAtts = other.collect({ case p: Production => p.att }).toSet
+    val diff = atts -- otherAtts
+    diff.isEmpty
   }
 
   def checkUserLists(): Unit = localSentences foreach {

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -372,10 +372,20 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
     if (sentences != other)
       return false
 
-    val atts = sentences.collect({ case p: Production => p.att }).toSet
-    val otherAtts = other.collect({ case p: Production => p.att }).toSet
-    val diff = atts -- otherAtts
-    diff.isEmpty
+    val productionsSorted = sentences.collect({ case p: Production => p }).toSeq.sorted
+    val otherProductionSorted = other.collect({ case p: Production => p }).toSeq.sorted
+
+    if (productionsSorted != otherProductionSorted)
+      return false
+
+    for (i <- productionsSorted.indices) {
+      val p1 = productionsSorted(i)
+      val p2 = otherProductionSorted(i)
+      if (!p1.att.equals(p2.att))
+        return false
+    }
+
+    true
   }
 
   def checkUserLists(): Unit = localSentences foreach {

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -369,10 +369,16 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
   }
 
   def checkAtts (other: Set[Sentence]) : Boolean = {
-    val atts = sentences.collect({ case p: Production => p.att }).toSet
-    val otherAtts = other.collect({ case p: Production => p.att }).toSet
-    val diff = atts -- otherAtts
-    diff.isEmpty
+    val sortedSentences = sentences.toSeq.sortBy(_.source.get)
+    val sortedOther = other.toSeq.sortBy(_.source.get)
+
+    sortedSentences.zip(sortedOther).forall {
+      case (s1, s2) => if (s1.att != s2.att) return false
+                       else true
+      case        _ => false
+    }
+
+    true
   }
 
   def checkUserLists(): Unit = localSentences foreach {

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -368,6 +368,13 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
     case _ =>
   }
 
+  def checkAtts (other: Set[Sentence]) : Boolean = {
+    val atts = sentences.collect({ case p: Production => p.att }).toSet
+    val otherAtts = other.collect({ case p: Production => p.att }).toSet
+    val diff = atts -- otherAtts
+    diff.isEmpty
+  }
+
   def checkUserLists(): Unit = localSentences foreach {
     case p@Production(_, _, srt, _, atts) =>
       if (atts.contains(Att.USER_LIST)) {

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -16,7 +16,7 @@ object ModuleTransformer {
 
   def fromSentenceTransformer(f: (Module, Sentence) => Sentence, name: String): ModuleTransformer =
     ModuleTransformer(m => {
-      val newSentences = map(m.localSentences.toSet)(f, m, name)
+      val newSentences = applyFunctionToSentences(m.localSentences.toSet)(f, m, name)
       if (newSentences != m.localSentences)
         Module(m.name, m.imports, newSentences, m.att)
       else
@@ -25,7 +25,7 @@ object ModuleTransformer {
 
   def fromSentenceTransformerAtt(f: (Module, Sentence) => Sentence, name: String): ModuleTransformer =
     ModuleTransformer(m => {
-      val newSentences = map(m.localSentences.toSet)(f, m, name)
+      val newSentences = applyFunctionToSentences(m.localSentences.toSet)(f, m, name)
       if (newSentences != m.localSentences || !m.checkAtts(newSentences))
         Module(m.name, m.imports, newSentences, m.att)
       else
@@ -59,7 +59,7 @@ object ModuleTransformer {
     case _ => new ModuleTransformer(f, name)
   }
 
-  def map(sentences: Set[Sentence])(f: (Module, Sentence) => Sentence, m: Module, name: String): Set[Sentence] =
+  def applyFunctionToSentences(sentences: Set[Sentence])(f: (Module, Sentence) => Sentence, m: Module, name: String): Set[Sentence] =
     sentences.map { s =>
       try {
         f(m, s)

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -59,7 +59,7 @@ object ModuleTransformer {
     case _ => new ModuleTransformer(f, name)
   }
 
-  def mapWithTrace(sentences: Set[Sentence])(f: (Module, Sentence) => Sentence, m: Module, name: String): Set[Sentence] =
+  private def mapWithTrace(sentences: Set[Sentence])(f: (Module, Sentence) => Sentence, m: Module, name: String): Set[Sentence] =
     sentences.map { s =>
       try {
         f(m, s)

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -16,7 +16,7 @@ object ModuleTransformer {
 
   def fromSentenceTransformer(f: (Module, Sentence) => Sentence, name: String): ModuleTransformer =
     ModuleTransformer(m => {
-      val newSentences = applyFunctionToSentences(m.localSentences.toSet)(f, m, name)
+      val newSentences = mapWithTrace(m.localSentences.toSet)(f, m, name)
       if (newSentences != m.localSentences)
         Module(m.name, m.imports, newSentences, m.att)
       else
@@ -25,7 +25,7 @@ object ModuleTransformer {
 
   def fromSentenceTransformerAtt(f: (Module, Sentence) => Sentence, name: String): ModuleTransformer =
     ModuleTransformer(m => {
-      val newSentences = applyFunctionToSentences(m.localSentences.toSet)(f, m, name)
+      val newSentences = mapWithTrace(m.localSentences.toSet)(f, m, name)
       if (newSentences != m.localSentences || !m.checkAtts(newSentences))
         Module(m.name, m.imports, newSentences, m.att)
       else
@@ -59,7 +59,7 @@ object ModuleTransformer {
     case _ => new ModuleTransformer(f, name)
   }
 
-  def applyFunctionToSentences(sentences: Set[Sentence])(f: (Module, Sentence) => Sentence, m: Module, name: String): Set[Sentence] =
+  def mapWithTrace(sentences: Set[Sentence])(f: (Module, Sentence) => Sentence, m: Module, name: String): Set[Sentence] =
     sentences.map { s =>
       try {
         f(m, s)

--- a/kore/src/main/scala/org/kframework/definition/transformers.scala
+++ b/kore/src/main/scala/org/kframework/definition/transformers.scala
@@ -26,7 +26,7 @@ object ModuleTransformer {
   def fromSentenceTransformerAtt(f: (Module, Sentence) => Sentence, name: String): ModuleTransformer =
     ModuleTransformer(m => {
       val newSentences = map(m.localSentences.toSet)(f, m, name)
-      if (newSentences != m.localSentences || m.checkAtts(newSentences))
+      if (newSentences != m.localSentences || !m.checkAtts(newSentences))
         Module(m.name, m.imports, newSentences, m.att)
       else
         m


### PR DESCRIPTION
This PR is part of #3444.

It introduces an additional check to verify when updating the Module is necessary.
This solves an old issue on the caching transformation that wasn't updating the module when only attributes were modified on the `localSentences` of the module.