### PR TITLE
[ModuleToKore Refactoring] Creatign `GenerateMapCeilAxioms` compiler pass

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -348,7 +348,7 @@ public class HaskellRewriter implements Function<Definition, Rewriter> {
 
             @Override
             public RewriterResult prove(Module rules, Boolean reuseDef) {
-                Module kompiledModule = KoreBackend.getKompiledModule(module, true);
+                Module kompiledModule = KoreBackend.getKompiledModule(module, true, kompileOptions);
                 ModuleToKORE converter = new ModuleToKORE(kompiledModule, def.topCellInitializer, kompileOptions, kem);
                 String defPath = reuseDef ? files.resolveKompiled("definition.kore").getAbsolutePath() : saveKoreDefinitionToTemp(converter);
                 String specPath = saveKoreSpecToTemp(converter, rules);

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -68,7 +68,7 @@ public class KoreBackend extends AbstractBackend {
      * @param hasAnd whether the backend in question supports and-patterns during pattern matching.
      */
     protected String getKompiledString(CompiledDefinition def, boolean hasAnd) {
-        Module mainModule = getKompiledModule(def.kompiledDefinition.mainModule(), hasAnd);
+        Module mainModule = getKompiledModule(def.kompiledDefinition.mainModule(), hasAnd, def.kompileOptions);
         ModuleToKORE converter = new ModuleToKORE(mainModule, def.topCellInitializer, def.kompileOptions);
         return getKompiledString(converter, files, heatCoolEquations, tool);
     }
@@ -92,11 +92,13 @@ public class KoreBackend extends AbstractBackend {
         return semantics.toString();
     }
 
-    public static Module getKompiledModule(Module mainModule, boolean hasAnd) {
+    public static Module getKompiledModule(Module mainModule, boolean hasAnd, KompileOptions kompileOptions) {
         mainModule = ModuleTransformer.fromSentenceTransformer(new AddSortInjections(mainModule)::addInjections, "Add sort injections").apply(mainModule);
         if (hasAnd) {
           mainModule = ModuleTransformer.fromSentenceTransformer(new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction").apply(mainModule);
         }
+        mainModule = ModuleTransformer.from(new GenerateMapCeilAxioms(mainModule, kompileOptions)::gen, "Generate map ceil axioms").apply(mainModule);
+
         return mainModule;
     }
 

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -7,7 +7,6 @@ import com.google.common.collect.ListMultimap;
 import com.google.common.collect.SetMultimap;
 import org.kframework.Collections;
 import org.kframework.attributes.Att;
-import org.kframework.attributes.Att.Key;
 import org.kframework.attributes.HasLocation;
 import org.kframework.attributes.Source;
 import org.kframework.builtin.BooleanUtils;
@@ -187,19 +186,8 @@ public class ModuleToKORE {
         }
         translateSorts(tokenSorts, attributes, collectionSorts, semantics);
 
-        List<Rule> sortedRules = new ArrayList<>(JavaConverters.seqAsJavaList(module.sortedRules()));
-        if (options.backend.equals("haskell")) {
-            module.sortedProductions().toStream().filter(this::isGeneratedInKeysOp).foreach(
-                    prod -> {
-                        if (!options.disableCeilSimplificationRules) {
-                            genMapCeilAxioms(prod, sortedRules);
-                        }
-                        return prod;
-                    }
-            );
-        }
         SetMultimap<KLabel, Rule> functionRules = HashMultimap.create();
-        for (Rule rule : sortedRules) {
+        for (Rule rule: iterable(module.sortedRules())) {
             K left = RewriteToTop.toLeft(rule.body());
             if (left instanceof KApply) {
                 KApply kapp = (KApply) left;
@@ -292,7 +280,7 @@ public class ModuleToKORE {
         macros.append("// macros\n");
         int ruleIndex = 0;
         ListMultimap<Integer, String> priorityToAlias = ArrayListMultimap.create();
-        for (Rule rule : sortedRules) {
+        for (Rule rule : iterable(module.sortedRules())) {
             if (ExpandMacros.isMacro(rule)) {
                 convertRule(rule, ruleIndex, heatCoolEq, topCellSortStr, attributes, functionRules,
                         priorityToPreviousGroup, priorityToAlias, sentenceType, macros);

--- a/kernel/src/main/java/org/kframework/compile/GenerateMapCeilAxioms.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateMapCeilAxioms.java
@@ -1,3 +1,4 @@
+// Copyright (c) K Team. All Rights Reserved.
 package org.kframework.compile;
 
 import org.kframework.attributes.Att;

--- a/kernel/src/main/java/org/kframework/compile/GenerateMapCeilAxioms.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateMapCeilAxioms.java
@@ -1,0 +1,133 @@
+package org.kframework.compile;
+
+import org.kframework.attributes.Att;
+import org.kframework.builtin.BooleanUtils;
+import org.kframework.builtin.KLabels;
+import org.kframework.builtin.Sorts;
+import org.kframework.definition.Constructors;
+import org.kframework.definition.Module;
+import org.kframework.definition.NonTerminal;
+import org.kframework.definition.Production;
+import org.kframework.definition.Rule;
+import org.kframework.kompile.KompileOptions;
+import org.kframework.kore.K;
+import org.kframework.kore.KLabel;
+import org.kframework.kore.KORE;
+import org.kframework.kore.KVariable;
+import org.kframework.kore.Sort;
+import scala.Option;
+import scala.collection.JavaConverters;
+import scala.collection.Seq;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.kframework.kore.KORE.*;
+
+public class GenerateMapCeilAxioms {
+
+    private final Module module;
+    private final KompileOptions options;
+    public GenerateMapCeilAxioms(Module m, KompileOptions kompileOptions) {
+        this.module = m;
+        this.options = kompileOptions;
+    }
+
+    public Module gen(Module m) {
+        return m.replaceSortedRules(genRule());
+    }
+
+    private Seq<Rule> genRule() {
+        List<Rule> sortedRules = new ArrayList<>(JavaConverters.seqAsJavaList(module.sortedRules()));
+        if (options.backend.equals("haskell")) {
+            module.sortedProductions().toStream().filter(this::isGeneratedInKeysOp).toStream().foreach(
+                    p -> {
+                        if (!options.disableCeilSimplificationRules) {
+                            genMapCeilAxioms(p, sortedRules);
+                        }
+                        return p;
+                    }
+            );
+        }
+        return JavaConverters.asScalaBuffer(sortedRules).toSeq();
+    }
+
+    private boolean isGeneratedInKeysOp(Production prod) {
+        Option<String> hook = prod.att().getOption(Att.HOOK());
+        if (hook.isEmpty()) return false;
+        if (!hook.get().equals("MAP.in_keys")) return false;
+        return (!prod.klabel().isEmpty());
+    }
+
+    private void genMapCeilAxioms(Production prod, Collection<Rule> rules) {
+        Sort mapSort = prod.nonterminal(1).sort();
+        scala.collection.Set<Production> mapProds = module.productionsForSort().apply(mapSort.head());
+        Production concatProd = mapProds.find(p -> hasHookValue(p.att(), "MAP.concat")).get();
+        Production elementProd = mapProds.find(p -> hasHookValue(p.att(), "MAP.element")).get();
+        Seq<NonTerminal> nonterminals = elementProd.nonterminals();
+        Sort sortParam = KORE.Sort(AddSortInjections.SORTPARAM_NAME, KORE.Sort("Q"));
+
+        // rule
+        //   #Ceil(MapItem(K1, K2, ..., Kn) Rest:Map)
+        // =>
+        //  {(@K1 in_keys(@Rest)) #Equals false} #And #Ceil(@K2) #And ... #And #Ceil(@Kn)
+        // Note: The {_ in_keys(_) #Equals false} condition implies
+        // #Ceil(@K1) and #Ceil(@Rest).
+        // [simplification]
+
+        K restMapSet = KVariable("@Rest", Att.empty().add(Sort.class, mapSort));
+        KLabel ceilMapLabel = KORE.KLabel(KLabels.ML_CEIL.name(), mapSort, sortParam);
+        KLabel andLabel = KORE.KLabel(KLabels.ML_AND.name(), sortParam);
+
+        // arguments of MapItem and their #Ceils
+        List<K> setArgs = new ArrayList<>();
+        K setArgsCeil = KApply(KORE.KLabel(KLabels.ML_TRUE.name(), sortParam));
+        for (int i = 0; i < nonterminals.length(); i++) {
+            Sort sort = nonterminals.apply(i).sort();
+            KVariable setVar = KORE.KVariable("@K" + i, Att.empty().add(Sort.class, sort));
+            setArgs.add(setVar);
+            if (i > 0) {
+                KLabel ceil = KORE.KLabel(KLabels.ML_CEIL.name(), sort, sortParam);
+                setArgsCeil = KApply(andLabel, setArgsCeil, KApply(ceil, setVar));
+            }
+        }
+        Seq<K> setArgsSeq = JavaConverters.iterableAsScalaIterable(setArgs).toSeq();
+
+        KLabel equalsLabel = KORE.KLabel(KLabels.ML_EQUALS.name(), Sorts.Bool(), sortParam);
+        Rule ceilMapRule = Constructors.Rule(
+                KRewrite(
+                        KApply(ceilMapLabel,
+                                KApply(concatProd.klabel().get(),
+                                        KApply(elementProd.klabel().get(),
+                                                setArgsSeq,
+                                                Att.empty()
+                                        ),
+                                        restMapSet
+                                )
+                        )
+                        ,
+                        KApply(andLabel,
+                                KApply(equalsLabel,
+                                        KApply(prod.klabel().get(),
+                                                setArgs.get(0),
+                                                restMapSet
+                                        ),
+                                        BooleanUtils.FALSE
+                                ),
+                                setArgsCeil
+                        )
+                )
+                , BooleanUtils.TRUE
+                , BooleanUtils.TRUE
+                , Att.empty().add(Att.SIMPLIFICATION())
+        );
+        rules.add(ceilMapRule);
+    }
+
+    static boolean hasHookValue(Att atts, String value) {
+        return atts.contains(Att.HOOK()) &&
+                atts.get(Att.HOOK()).equals(value);
+    }
+
+}

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -261,6 +261,10 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
 
   lazy val sortedRules: Seq[Rule] = rules.toSeq.sorted
 
+  def replaceSortedRules(newSortedRules: Seq[Rule]): Module = {
+    Module(name, imports, localSentences.filterNot(_.isInstanceOf[Rule]) ++ newSortedRules, att)
+  }
+
   lazy val localRules: Set[Rule] = localSentences collect { case r: Rule => r }
   lazy val localClaims: Set[Claim] = localSentences collect { case r: Claim => r }
   lazy val localRulesAndClaims: Set[RuleOrClaim] = Set[RuleOrClaim]().++(localClaims).++(localRules)


### PR DESCRIPTION
This PR is part of #3444.

It creates the compiler pass `GenerateMapCeilAxioms` that call `GenMapCeilAxioms` before ModuleToKore.
This modification is necessary to simplify the `ModuleToKore` structure as this computation only happens when `Haskell Backend` is used and can be computed earlier.