### PR TITLE
Make K derivation extensible with llvm libraries

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
               '';
             };
           in {
-            k-framework = haskell-backend-bins:
+            k-framework = { haskell-backend-bins, llvm-kompile-libs }:
               prev.callPackage ./nix/k.nix {
                 inherit (prev) llvm-backend;
                 booster = booster-backend.packages.${prev.system}.kore-rpc-booster;
@@ -76,6 +76,7 @@
                 else
                   prev.gdb;
                 version = "${k-version}-${self.rev or "dirty"}";
+                inherit llvm-kompile-libs;
               };
           })
       ];
@@ -115,7 +116,13 @@
       in rec {
 
         packages = rec {
-          k = pkgs.k-framework haskell-backend-bins;
+          k = pkgs.k-framework {
+            inherit haskell-backend-bins;
+            llvm-kompile-libs = with pkgs; {
+              procps = [ "-I${procps}/include" "-L${procps}/lib" ];
+              openssl = [ "-I${openssl.dev}/include" "-L${openssl.out}/lib" ];
+            };
+          };
 
           # This is a copy of the `nix/update-maven.sh` script, which should be
           # eventually removed. Having this inside the flake provides a uniform

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -1,6 +1,6 @@
 { src, clang, stdenv, lib, mavenix, runCommand, makeWrapper, bison, flex, gcc
 , git, gmp, jdk, mpfr, ncurses, pkgconfig, python3, z3, haskell-backend, booster ? null
-, prelude-kore, llvm-backend, debugger, version }:
+, prelude-kore, llvm-backend, debugger, version, llvm-kompile-libs }:
 
 let
   unwrapped = mavenix.buildMaven {
@@ -87,28 +87,41 @@ in let
   # PATH used at runtime
   hostPATH = lib.makeBinPath hostInputs;
 
-in runCommand (lib.removeSuffix "-maven" unwrapped.name) {
-  nativeBuildInputs = [ makeWrapper ];
-  passthru = { inherit unwrapped; };
-  inherit unwrapped;
-} ''
-  mkdir -p $out/bin
+  final = current-llvm-kompile-libs:
+    runCommand (lib.removeSuffix "-maven" unwrapped.name) {
+      nativeBuildInputs = [ makeWrapper ];
+      passthru = {
+        inherit unwrapped;
+      } // builtins.mapAttrs
+        (_: paths: final (current-llvm-kompile-libs ++ paths))
+        llvm-kompile-libs;
+      inherit unwrapped;
+    } ''
+      mkdir -p $out/bin
 
-  # Wrap bin/ to augment PATH.
-  for prog in $unwrapped/bin/*
-  do
-    makeWrapper $prog $out/bin/$(basename $prog) --prefix PATH : ${hostPATH}
-  done
+      # Wrap bin/ to augment PATH.
+      for prog in $unwrapped/bin/*
+      do
+        makeWrapper $prog $out/bin/$(basename $prog) \
+          --prefix PATH : ${hostPATH} ${
+            lib.optionalString (current-llvm-kompile-libs != [ ]) ''
+              --set NIX_LLVM_KOMPILE_LIBS "${
+                lib.strings.concatStringsSep " "
+                (lib.lists.unique current-llvm-kompile-libs)
+              }"''
+          }
+      done
 
-  # Link each top-level package directory, for dependents that need that.
-  for each in include lib share
-  do
-    ln -sf $unwrapped/$each $out/$each
-  done
+      # Link each top-level package directory, for dependents that need that.
+      for each in include lib share
+      do
+        ln -sf $unwrapped/$each $out/$each
+      done
 
-  ln -sf ${haskell-backend}/bin/kore-rpc $out/bin/kore-rpc
-  ln -sf ${haskell-backend}/bin/kore-exec $out/bin/kore-exec
-  ln -sf ${haskell-backend}/bin/kore-parser $out/bin/kore-parser
-  ln -sf ${haskell-backend}/bin/kore-repl $out/bin/kore-repl
-  ln -sf ${haskell-backend}/bin/kore-match-disjunction $out/bin/kore-match-disjunction
-''
+      ln -sf ${haskell-backend}/bin/kore-rpc $out/bin/kore-rpc
+      ln -sf ${haskell-backend}/bin/kore-exec $out/bin/kore-exec
+      ln -sf ${haskell-backend}/bin/kore-parser $out/bin/kore-parser
+      ln -sf ${haskell-backend}/bin/kore-repl $out/bin/kore-repl
+      ln -sf ${haskell-backend}/bin/kore-match-disjunction $out/bin/kore-match-disjunction
+    '';
+in final [ ]


### PR DESCRIPTION
This PR introduces a way of building custom configurations of K, currently adding the `procps` and `openssl` libraries to the path for llvm-kompile to use when building/linking against the blockchain plugin in KEVM.

To build this version of k run `nix build .#k.openssl.procps`

There will be a follow-up to add this functionality to kup so we can do `kup shell k.openssl.procps`