### PR TITLE
Z3 tests radu

### DIFF
--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -314,9 +314,12 @@ public class ParseInModule implements Serializable, AutoCloseable {
         if (scanner != null) {
             scanner.close();
         }
+        int infCount = 0;
         for (TypeInferencer inferencer : inferencers) {
             inferencer.close();
+            infCount++;
         }
+        //System.out.println("-z3 closing: " + infCount);
         inferencers.clear();
     }
 

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
@@ -95,7 +95,7 @@ public class TypeInferencer implements AutoCloseable {
           throw KEMException.criticalError("Could not start z3 process, tried " + noTries + " times.", e);
       }
     }
-    System.out.println("-new z3 thread: " + Thread.currentThread().getId() + " z3# " + z3Count.getAndIncrement());
+    //System.out.println("-new z3 thread: " + Thread.currentThread().getId() + " z3# " + z3Count.getAndIncrement());
     z3 = new PrintStream(process.getOutputStream());
     output = new BufferedReader(new InputStreamReader(process.getInputStream()));
   }


### PR DESCRIPTION
For testing.
I do not recommend merging this.
On a healthy system, we should not get the "too many open files" error.
The proper way to handle this, is to implement a custom Z3 type inferencer and remove the dependency completely.