### PR TITLE
nix flake fixes

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -890,7 +890,6 @@
         "immer-src": "immer-src",
         "mavenix": "mavenix",
         "nixpkgs": [
-          "haskell-backend",
           "nixpkgs"
         ],
         "pybind11-src": "pybind11-src",

--- a/flake.nix
+++ b/flake.nix
@@ -32,7 +32,7 @@
           llvm-backend-build-type = "Release"; })
         mavenix.overlay
         llvm-backend.overlays.default
-        haskell-backend.overlay # used only to override the z3 version to the same one as used by the haskell backend.
+        haskell-backend.overlays.z3 # used only to override the z3 version to the same one as used by the haskell backend.
         (final: prev:
           let
             k-version =
@@ -187,7 +187,7 @@
         devShells.kore-integration-tests = pkgs.kore-tests (pkgs.k-framework { inherit haskell-backend-bins; llvm-kompile-libs = []; });
       }) // {
         overlays.llvm-backend = llvm-backend.overlays.default;
-        overlays.z3 = haskell-backend.overlay;
+        overlays.z3 = haskell-backend.overlays.z3;
 
         overlay = nixpkgs.lib.composeManyExtensions allOverlays;
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,7 @@
       inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
     };
     llvm-backend.url = "github:runtimeverification/llvm-backend";
-    llvm-backend.inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
+    llvm-backend.inputs.nixpkgs.follows = "nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     rv-utils.url = "github:runtimeverification/rv-nix-tools";
     mavenix.url = "github:goodlyrottenapple/mavenix";

--- a/flake.nix
+++ b/flake.nix
@@ -184,7 +184,7 @@
             };
         };
         defaultPackage = packages.k;
-        devShells.kore-integration-tests = pkgs.kore-tests (pkgs.k-framework haskell-backend-bins);
+        devShells.kore-integration-tests = pkgs.kore-tests (pkgs.k-framework { inherit haskell-backend-bins; llvm-kompile-libs = []; });
       }) // {
         overlays.llvm-backend = llvm-backend.overlays.default;
         overlays.z3 = haskell-backend.overlay;


### PR DESCRIPTION
This includes the following fixes, necessary for integration tests in CI for both haskell and booster backends:
- [llvm-backend/nixpkgs should follow k's nixpkgs](https://github.com/runtimeverification/k/commit/719d847f308e33bf5918de97395c43f9351f5e45)
- [fix haskell-backend integration shell](https://github.com/runtimeverification/k/commit/2a3994cb849864ae20d49d78752bdf915196f3e4)