### PR TITLE
Fix Java 19

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -145,7 +145,7 @@
     <dependency>
       <groupId>org.kframework.dependencies</groupId>
       <artifactId>nailgun-server</artifactId>
-      <version>0.9.2-SNAPSHOT</version>
+      <version>1.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.kframework.dependencies</groupId>

--- a/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
+++ b/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
@@ -9,6 +9,7 @@ import org.eclipse.lsp4j.services.LanguageClientAware;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.kframework.main.Main;
 
 import java.net.URISyntaxException;
 import java.util.ArrayList;

--- a/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
+++ b/kernel/src/main/java/org/kframework/lsp/KLanguageServer.java
@@ -98,7 +98,7 @@ public class KLanguageServer implements LanguageServer, LanguageClientAware {
 
     @Override
     public void exit() {
-        System.exit(shutdown);
+        Main.exit(shutdown);
     }
 
     @Override

--- a/kernel/src/main/java/org/kframework/main/Main.java
+++ b/kernel/src/main/java/org/kframework/main/Main.java
@@ -64,6 +64,16 @@ public class Main {
         return isNailgun;
     }
 
+    private static NGContext context = null;
+
+    public static void exit(int exitCode) {
+      if (context != null) {
+          context.exit(exitCode);
+      } else {
+          System.exit(exitCode);
+      }
+    }
+
     public static void nailMain(NGContext context) {
         long startTime = System.nanoTime();
         KServerFrontEnd kserver = KServerFrontEnd.instance();
@@ -71,10 +81,11 @@ public class Main {
             context.assertLoopbackClient();
         }
         isNailgun = true;
+        Main.context = context;
         if (context.getArgs().length >= 1) {
             String[] args2 = Arrays.copyOfRange(context.getArgs(), 1, context.getArgs().length);
             int result = kserver.run(context.getArgs()[0], args2, new File(context.getWorkingDirectory()), (Map) context.getEnv(), startTime);
-            System.exit(result);
+            context.exit(result);
             return;
         }
         invalidJarArguments();
@@ -195,7 +206,7 @@ public class Main {
         }
         if (modules.size() == 0) {
             //boot error, we should have printed it already
-            System.exit(1);
+            Main.exit(1);
         }
         Injector injector = Guice.createInjector(modules);
         return injector;
@@ -203,6 +214,6 @@ public class Main {
 
     private static void invalidJarArguments() {
         System.err.println("The first argument of the K java compiler not recognized. Try -kompile, -kast, -kdep, -kserver, or -klsp.");
-        System.exit(1);
+        Main.exit(1);
     }
 }

--- a/kernel/src/main/java/org/kframework/main/Main.java
+++ b/kernel/src/main/java/org/kframework/main/Main.java
@@ -85,7 +85,7 @@ public class Main {
         if (context.getArgs().length >= 1) {
             String[] args2 = Arrays.copyOfRange(context.getArgs(), 1, context.getArgs().length);
             int result = kserver.run(context.getArgs()[0], args2, new File(context.getWorkingDirectory()), (Map) context.getEnv(), startTime);
-            context.exit(result);
+            exit(result);
             return;
         }
         invalidJarArguments();

--- a/kernel/src/main/java/org/kframework/parser/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/ParserUtils.java
@@ -17,6 +17,7 @@ import org.kframework.kil.loader.Context;
 import org.kframework.kompile.Kompile;
 import org.kframework.kore.convertors.KILtoKORE;
 import org.kframework.main.GlobalOptions;
+import org.kframework.main.Main;
 import org.kframework.parser.inner.ApplySynonyms;
 import org.kframework.parser.inner.CollectProductionsVisitor;
 import org.kframework.parser.outer.ExtractFencedKCodeFromMarkdown;
@@ -319,7 +320,7 @@ public class ParserUtils {
             previousModules.addAll(loadModules(new HashSet<>(), context, Kompile.REQUIRE_PRELUDE_K, Source.apply("Auto imported prelude"), currentDirectory, lookupDirectories, requiredFiles, preprocess, leftAssoc));
         Set<Module> modules = loadModules(previousModules, context, definitionText, source, currentDirectory, lookupDirectories, requiredFiles, preprocess, leftAssoc);
         if (preprocess) {
-          System.exit(0);
+          Main.exit(0);
         }
         modules.addAll(previousModules); // add the previous modules, since load modules is not additive
         Module mainModule = getMainModule(mainModuleName, modules);

--- a/kernel/src/main/java/org/kframework/utils/ExitOnTimeoutThread.java
+++ b/kernel/src/main/java/org/kframework/utils/ExitOnTimeoutThread.java
@@ -1,6 +1,8 @@
 // Copyright (c) K Team. All Rights Reserved.
 package org.kframework.utils;
 
+import org.kframework.main.Main;
+
 /**
  * A daemon thread that awaits given timeout, then exits Java process.
  *
@@ -20,7 +22,7 @@ public class ExitOnTimeoutThread extends Thread {
         try {
             Thread.sleep(timeoutMillis);
             System.err.println("K process timeout...");
-            System.exit(124); //bash timeout exit code is 124
+            Main.exit(124); //bash timeout exit code is 124
         } catch (InterruptedException e) {
             //normal termination, ignoring
         }

--- a/nix/mavenix.lock
+++ b/nix/mavenix.lock
@@ -7330,20 +7330,20 @@
       "sha1": "e8848369738c03e40af5507686216f9b8b44b6a3"
     },
     {
-      "path": "org/kframework/dependencies/nailgun-all/0.9.2-SNAPSHOT/nailgun-all-0.9.2-20230607.181102-1.pom",
-      "sha1": "8df6d953da07969c6ef1c2a4d603d1611f59398b"
+      "path": "org/kframework/dependencies/nailgun-all/1.0.0-SNAPSHOT/nailgun-all-1.0.0-20230817.181106-1.pom",
+      "sha1": "81f6a397361513f34b26d5f43d329df888f2feaa"
     },
     {
-      "path": "org/kframework/dependencies/nailgun-server/0.9.2-SNAPSHOT/nailgun-server-0.9.2-20230607.180952-1.jar",
-      "sha1": "f8e63a87a62ae13eb86d89e96351c92f2b427a77"
+      "path": "org/kframework/dependencies/nailgun-server/1.0.0-SNAPSHOT/nailgun-server-1.0.0-20230817.181113-1.jar",
+      "sha1": "04e2c42db23399a624ac3c4dce874a66749379c7"
     },
     {
-      "path": "org/kframework/dependencies/nailgun-server/0.9.2-SNAPSHOT/nailgun-server-0.9.2-20230607.180952-1.jar",
-      "sha1": "f8e63a87a62ae13eb86d89e96351c92f2b427a77"
+      "path": "org/kframework/dependencies/nailgun-server/1.0.0-SNAPSHOT/nailgun-server-1.0.0-20230817.181113-1.jar",
+      "sha1": "04e2c42db23399a624ac3c4dce874a66749379c7"
     },
     {
-      "path": "org/kframework/dependencies/nailgun-server/0.9.2-SNAPSHOT/nailgun-server-0.9.2-20230607.180952-1.pom",
-      "sha1": "66ffaa15d6dd45fd5e7e6c1c391b1f89efe2fb9c"
+      "path": "org/kframework/dependencies/nailgun-server/1.0.0-SNAPSHOT/nailgun-server-1.0.0-20230817.181113-1.pom",
+      "sha1": "3c8bc01cd1f032dd7d78f2e3d6198e4d51502693"
     },
     {
       "path": "org/kframework/dependencies/ng/0.9.2-k4.0/ng-0.9.2-k4.0-linux.uexe",
@@ -8209,12 +8209,12 @@
       "path": "com/google/code/gson/gson"
     },
     {
-      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>org.kframework.dependencies</groupId>\n  <artifactId>nailgun-all</artifactId>\n  <version>0.9.2-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20230607.181102</timestamp>\n      <buildNumber>1</buildNumber>\n    </snapshot>\n    <lastUpdated>20230607181102</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>0.9.2-20230607.181102-1</value>\n        <updated>20230607181102</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
-      "path": "org/kframework/dependencies/nailgun-all/0.9.2-SNAPSHOT"
+      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>org.kframework.dependencies</groupId>\n  <artifactId>nailgun-all</artifactId>\n  <version>1.0.0-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20230817.181106</timestamp>\n      <buildNumber>1</buildNumber>\n    </snapshot>\n    <lastUpdated>20230817181106</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>1.0.0-20230817.181106-1</value>\n        <updated>20230817181106</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
+      "path": "org/kframework/dependencies/nailgun-all/1.0.0-SNAPSHOT"
     },
     {
-      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>org.kframework.dependencies</groupId>\n  <artifactId>nailgun-server</artifactId>\n  <version>0.9.2-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20230607.180952</timestamp>\n      <buildNumber>1</buildNumber>\n    </snapshot>\n    <lastUpdated>20230607180952</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>jar</extension>\n        <value>0.9.2-20230607.180952-1</value>\n        <updated>20230607180952</updated>\n      </snapshotVersion>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>0.9.2-20230607.180952-1</value>\n        <updated>20230607180952</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
-      "path": "org/kframework/dependencies/nailgun-server/0.9.2-SNAPSHOT"
+      "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>org.kframework.dependencies</groupId>\n  <artifactId>nailgun-server</artifactId>\n  <version>1.0.0-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20230817.181113</timestamp>\n      <buildNumber>1</buildNumber>\n    </snapshot>\n    <lastUpdated>20230817181113</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>jar</extension>\n        <value>1.0.0-20230817.181113-1</value>\n        <updated>20230817181113</updated>\n      </snapshotVersion>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>1.0.0-20230817.181113-1</value>\n        <updated>20230817181113</updated>\n      </snapshotVersion>\n      <snapshotVersion>\n        <classifier>sources</classifier>\n        <extension>jar</extension>\n        <value>1.0.0-20230817.181113-1</value>\n        <updated>20230817181113</updated>\n      </snapshotVersion>\n      <snapshotVersion>\n        <classifier>javadoc</classifier>\n        <extension>jar</extension>\n        <value>1.0.0-20230817.181113-1</value>\n        <updated>20230817181113</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",
+      "path": "org/kframework/dependencies/nailgun-server/1.0.0-SNAPSHOT"
     },
     {
       "content": "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<metadata modelVersion=\"1.1.0\">\n  <groupId>org.kframework.dependencies</groupId>\n  <artifactId>ng</artifactId>\n  <version>1.0.0-k5.0-SNAPSHOT</version>\n  <versioning>\n    <snapshot>\n      <timestamp>20230607.181452</timestamp>\n      <buildNumber>1</buildNumber>\n    </snapshot>\n    <lastUpdated>20230607181452</lastUpdated>\n    <snapshotVersions>\n      <snapshotVersion>\n        <extension>pom</extension>\n        <value>1.0.0-k5.0-20230607.181452-1</value>\n        <updated>20230607181452</updated>\n      </snapshotVersion>\n      <snapshotVersion>\n        <classifier>osx</classifier>\n        <extension>uexe</extension>\n        <value>1.0.0-k5.0-20230607.181452-1</value>\n        <updated>20230607181452</updated>\n      </snapshotVersion>\n    </snapshotVersions>\n  </versioning>\n</metadata>",


### PR DESCRIPTION
This PR fixes K on Java 19 by dealing with the problems relating to nailgun and kserver that were causing it to crash. We do this primarily by updating to a newer version of nailgun with a fix for the issue that it had, but we need to call a different function to exit if Nailgun is active in order to make use of the fix, so there is a slight refactoring to how we call the exit function in K now.

Not tested yet; don't merge.