### PR TITLE
print no-junk with flat multi-or

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -713,6 +713,9 @@ public class ModuleToKORE {
         sbTemp.append("  axiom{} ");
         boolean hasToken = false;
         int numTerms = 0;
+        sbTemp.append("\\left-assoc{}(\\or{");
+        convert(sort, sbTemp);
+        sbTemp.append("} (");
         for (Production prod : iterable(mutable(module.productionsForSort()).getOrDefault(sort.head(), Set()).toSeq().sorted(Production.ord()))) {
             if (isFunction(prod) || prod.isSubsort() || isBuiltinProduction(prod)) {
                 continue;
@@ -721,9 +724,6 @@ public class ModuleToKORE {
                 continue;
             }
             numTerms++;
-            sbTemp.append("\\or{");
-            convert(sort, sbTemp);
-            sbTemp.append("} (");
             if (prod.att().contains(Att.TOKEN()) && !hasToken) {
                 convertTokenProd(sort, sbTemp);
                 hasToken = true;
@@ -753,9 +753,6 @@ public class ModuleToKORE {
         for (Sort s : iterable(module.sortedAllSorts())) {
             if (module.subsorts().lessThan(s, sort) && !sort.equals(Sorts.K())) {
                 numTerms++;
-                sbTemp.append("\\or{");
-                convert(sort, sbTemp);
-                sbTemp.append("} (");
                 sbTemp.append("\\exists{");
                 convert(sort, sbTemp);
                 sbTemp.append("} (Val:");
@@ -773,20 +770,13 @@ public class ModuleToKORE {
         Att sortAtt = module.sortAttributesFor().get(sort.head()).getOrElse(() -> KORE.Att());
         if (!hasToken && sortAtt.contains(Att.TOKEN())) {
             numTerms++;
-            sbTemp.append("\\or{");
-            convert(sort, sbTemp);
-            sbTemp.append("} (");
             convertTokenProd(sort, sbTemp);
             sbTemp.append(", ");
             hasToken = true;
         }
         sbTemp.append("\\bottom{");
         convert(sort, sbTemp);
-        sbTemp.append("}()");
-        for (int i = 0; i < numTerms; i++) {
-            sbTemp.append(")");
-        }
-        sbTemp.append(" [constructor{}()] // no junk");
+        sbTemp.append("}())) [constructor{}()] // no junk");
         if (hasToken && !METAVAR) {
             sbTemp.append(" (TODO: fix bug with \\dv)");
         }

--- a/kore/src/main/scala/org/kframework/parser/kore/Default.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/Default.scala
@@ -171,20 +171,12 @@ object implementation {
 
     def Alias(ctr: String, params: Seq[i.Sort]): i.Alias = d.Alias(ctr, params)
 
-    def LeftAssoc(p: i.Pattern): i.Pattern = {
-      p match {
-        case i.Application(head, ps) => {
-          ps.reduceLeft((accum, p) => Application(head, Seq(accum, p)))
-        }
-      }
+    def LeftAssoc(ctr: (i.Pattern, i.Pattern) => i.Pattern, args: Seq[i.Pattern]): i.Pattern = {
+      args.reduceLeft((accum, p) => ctr(accum, p))
     }
 
-    def RightAssoc(p: i.Pattern): i.Pattern = {
-      p match {
-        case i.Application(head, ps) => {
-          ps.reduceRight((p, accum) => Application(head, Seq(p, accum)))
-        }
-      }
+    def RightAssoc(ctr: (i.Pattern, i.Pattern) => i.Pattern, args: Seq[i.Pattern]): i.Pattern = {
+      args.reduceRight((p, accum) => ctr(p, accum))
     }
   }
 }

--- a/kore/src/main/scala/org/kframework/parser/kore/Interface.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/Interface.scala
@@ -551,7 +551,7 @@ trait Builders {
 
   def Alias(str: String, params: Seq[Sort]): Alias
 
-  def LeftAssoc(p: Pattern): Pattern
+  def LeftAssoc(ctr: (Pattern, Pattern) => Pattern, ps: Seq[Pattern]): Pattern
 
-  def RightAssoc(p: Pattern): Pattern
+  def RightAssoc(ctr: (Pattern, Pattern) => Pattern, ps: Seq[Pattern]): Pattern
 }

--- a/kore/src/main/scala/org/kframework/parser/kore/parser/TextToKore.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/parser/TextToKore.scala
@@ -527,17 +527,69 @@ class TextToKore(b: Builders = DefaultBuilders) {
             consumeWithLeadingWhitespaces("{")
             consumeWithLeadingWhitespaces("}")
             consumeWithLeadingWhitespaces("(")
-            val p = parsePattern()
+            val ctr = scanner.nextWithSkippingWhitespaces() match {
+              case '\\' =>
+                val c1 = scanner.next()
+                val c2 = scanner.next()
+                (c1, c2) match {
+                  case ('a', 'n') => // and
+                    consume("d")
+                    consumeWithLeadingWhitespaces("{")
+                    val s = parseSort()
+                    consumeWithLeadingWhitespaces("}")
+                    (p1: kore.Pattern, p2: kore.Pattern) => b.And(s, p1, p2)
+                  case ('o', 'r') => // or
+                    consumeWithLeadingWhitespaces("{")
+                    val s = parseSort()
+                    consumeWithLeadingWhitespaces("}")
+                    (p1: kore.Pattern, p2: kore.Pattern) => b.Or(s, p1, p2)
+                }
+              case c => // variable or application
+                val id = parseId() // previousParsingLevel is set here
+                consumeWithLeadingWhitespaces("{")
+                val params = parseList(() => parseSort(parsingLevel = previousParsingLevel), ',', '}')
+                consumeWithLeadingWhitespaces("}")
+                (p1: kore.Pattern, p2: kore.Pattern) => b.Application(b.SymbolOrAlias(id, params), Seq(p1, p2))
+            }
+            consumeWithLeadingWhitespaces("(")
+            val args = parseList(() => parsePattern(), ',', ')')
             consumeWithLeadingWhitespaces(")")
-            b.LeftAssoc(p)
+            consumeWithLeadingWhitespaces(")")
+            b.LeftAssoc(ctr, args)
           case ('r', 'i') => // right-assoc
             consume("ght-assoc")
             consumeWithLeadingWhitespaces("{")
             consumeWithLeadingWhitespaces("}")
             consumeWithLeadingWhitespaces("(")
-            val p = parsePattern()
+            val ctr = scanner.nextWithSkippingWhitespaces() match {
+              case '\\' =>
+                val c1 = scanner.next()
+                val c2 = scanner.next()
+                (c1, c2) match {
+                  case ('a', 'n') => // and
+                    consume("d")
+                    consumeWithLeadingWhitespaces("{")
+                    val s = parseSort()
+                    consumeWithLeadingWhitespaces("}")
+                    (p1: kore.Pattern, p2: kore.Pattern) => b.And(s, p1, p2)
+                  case ('o', 'r') => // or
+                    consumeWithLeadingWhitespaces("{")
+                    val s = parseSort()
+                    consumeWithLeadingWhitespaces("}")
+                    (p1: kore.Pattern, p2: kore.Pattern) => b.Or(s, p1, p2)
+                }
+              case c => // variable or application
+                val id = parseId() // previousParsingLevel is set here
+                consumeWithLeadingWhitespaces("{")
+                val params = parseList(() => parseSort(parsingLevel = previousParsingLevel), ',', '}')
+                consumeWithLeadingWhitespaces("}")
+                (p1: kore.Pattern, p2: kore.Pattern) => b.Application(b.SymbolOrAlias(id, params), Seq(p1, p2))
+            }
+            consumeWithLeadingWhitespaces("(")
+            val args = parseList(() => parsePattern(), ',', ')')
             consumeWithLeadingWhitespaces(")")
-            b.RightAssoc(p)
+            consumeWithLeadingWhitespaces(")")
+            b.RightAssoc(ctr, args)
           // case ('s', 'u') => // subset
           //   consume("bset")
           //   consumeWithLeadingWhitespaces("{")

--- a/kore/src/test/scala/org/kframework/parser/kore/parser/TextToKoreTest.scala
+++ b/kore/src/test/scala/org/kframework/parser/kore/parser/TextToKoreTest.scala
@@ -1,0 +1,34 @@
+// Copyright (c) K Team. All Rights Reserved.
+
+package org.kframework.parser.kore.parser
+
+import org.junit.{Assert, Test}
+
+import org.kframework.parser.kore.implementation.{DefaultBuilders => b}
+
+class TextToKoreTest {
+  @Test def testMultiOr(): Unit = {
+    val kore1 = "\\left-assoc{}(\\or{SortInt{}}(\\dv{SortInt{}}(\"1\"), \\dv{SortInt{}}(\"2\"), \\dv{SortInt{}}(\"3\")))"
+    val parser = new TextToKore()
+    val ast1 = parser.parsePattern(kore1)
+    val int = b.CompoundSort("SortInt", Seq())
+    Assert.assertEquals(b.Or(int, b.Or(int, b.DomainValue(int, "1"), b.DomainValue(int, "2")), b.DomainValue(int, "3")), ast1)
+
+    val kore2 = "\\right-assoc{}(\\or{SortInt{}}(\\dv{SortInt{}}(\"1\"), \\dv{SortInt{}}(\"2\"), \\dv{SortInt{}}(\"3\")))"
+    val ast2 = parser.parsePattern(kore2)
+    Assert.assertEquals(b.Or(int, b.DomainValue(int, "1"), b.Or(int, b.DomainValue(int, "2"), b.DomainValue(int, "3"))), ast2)
+  }
+
+  @Test def testMultiAnd(): Unit = {
+    val kore1 = "\\left-assoc{}(\\and{SortInt{}}(\\dv{SortInt{}}(\"1\"), \\dv{SortInt{}}(\"2\"), \\dv{SortInt{}}(\"3\")))"
+    val parser = new TextToKore()
+    val ast1 = parser.parsePattern(kore1)
+    val int = b.CompoundSort("SortInt", Seq())
+    Assert.assertEquals(b.And(int, b.And(int, b.DomainValue(int, "1"), b.DomainValue(int, "2")), b.DomainValue(int, "3")), ast1)
+
+    val kore2 = "\\right-assoc{}(\\and{SortInt{}}(\\dv{SortInt{}}(\"1\"), \\dv{SortInt{}}(\"2\"), \\dv{SortInt{}}(\"3\")))"
+    val ast2 = parser.parsePattern(kore2)
+    Assert.assertEquals(b.And(int, b.DomainValue(int, "1"), b.And(int, b.DomainValue(int, "2"), b.DomainValue(int, "3"))), ast2)
+  }
+
+}


### PR DESCRIPTION
The Maude backend Kore-RPC server doesn't start with as much stack space as kompile, and this was leading it to not have enough stack space to parse the definition.kore that was generated by kompile, primarily because of the deeply nested \or patterns. In general, we want to try to avoid situations with potentially arbitrarily deeply nested KORE because it makes things more difficult for recursive descent parsers.

Luckily, we already have a solution to this problem. The llvm and haskell backend both support the \left-assoc symbol to be used in conjunction with \or, which allows a flat multi-or-like representation that still ultimately parses to the same term in the end. This allows the recursive descent parser to parse the axioms in question with a constant amount of stack space, no matter how many productions or sorts exist in the definition.