### PR TITLE
Make no junk right associative

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -713,7 +713,7 @@ public class ModuleToKORE {
         sbTemp.append("  axiom{} ");
         boolean hasToken = false;
         int numTerms = 0;
-        sbTemp.append("\\left-assoc{}(\\or{");
+        sbTemp.append("\\right-assoc{}(\\or{");
         convert(sort, sbTemp);
         sbTemp.append("} (");
         for (Production prod : iterable(mutable(module.productionsForSort()).getOrDefault(sort.head(), Set()).toSeq().sorted(Production.ord()))) {


### PR DESCRIPTION
The recent changes broke the haskell backend because they changed the associativity of the no junk axioms. We are hoping that this will address those issues.