### PR TITLE
Allow some rule-only attributes on sentences that desugar into rules

### DIFF
--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -203,10 +203,9 @@ object Att {
   // Some helpers with scala reflection to make declaring class object sets more compact
   // If these break for some reason, replace their usage with Set(classOf[T1], classOf[T2], ...)
   private def onlyon[T: ClassTag](): Set[Class[_]] = Set(classTag[T].runtimeClass)
-  private def onlyon2[T1: ClassTag, T2: ClassTag](): Set[Class[_]] =
-    Set(classTag[T1].runtimeClass, classTag[T2].runtimeClass)
-  private def onlyon3[T1: ClassTag, T2: ClassTag, T3: ClassTag](): Set[Class[_]] =
-    Set(classTag[T1].runtimeClass, classTag[T2].runtimeClass, classTag[T3].runtimeClass)
+  private def onlyon2[T1: ClassTag, T2: ClassTag](): Set[Class[_]] = onlyon[T1] ++ onlyon[T2]
+  private def onlyon3[T1: ClassTag, T2: ClassTag, T3: ClassTag](): Set[Class[_]] = onlyon2[T1, T2] ++ onlyon[T3]
+  private def onlyon4[T1: ClassTag, T2: ClassTag, T3: ClassTag, T4:ClassTag](): Set[Class[_]] = onlyon3[T1, T2, T3] ++ onlyon[T4]
 
   /*
    * Built-in attribute keys which can appear in user source code
@@ -275,10 +274,10 @@ object Att {
   final val PREC = Key.builtin("prec", KeyParameter.Required, onlyon[Production])
   final val PREFER = Key.builtin("prefer", KeyParameter.Forbidden, onlyon[Production])
   final val PRESERVES_DEFINEDNESS = Key.builtin("preserves-definedness", KeyParameter.Forbidden, onlyon[Rule])
-  final val PRIORITY = Key.builtin("priority", KeyParameter.Required, onlyon2[Production, Rule])
+  final val PRIORITY = Key.builtin("priority", KeyParameter.Required, onlyon4[Context, ContextAlias, Production, Rule])
   final val PRIVATE = Key.builtin("private", KeyParameter.Forbidden, onlyon2[Module, Production])
   final val PUBLIC = Key.builtin("public", KeyParameter.Forbidden, onlyon2[Module, Production])
-  final val RESULT = Key.builtin("result", KeyParameter.Required, onlyon3[ContextAlias, Context, Rule])
+  final val RESULT = Key.builtin("result", KeyParameter.Required, onlyon4[Context, ContextAlias, Production, Rule])
   final val RETURNS_UNIT = Key.builtin("returnsUnit", KeyParameter.Forbidden, onlyon[Production])
   final val RIGHT = Key.builtin("right", KeyParameter.Forbidden, onlyon[Production])
   final val SEQSTRICT = Key.builtin("seqstrict", KeyParameter.Optional, onlyon[Production])
@@ -296,7 +295,7 @@ object Att {
   final val TOTAL = Key.builtin("total", KeyParameter.Forbidden, onlyon[Production])
   final val TRUSTED = Key.builtin("trusted", KeyParameter.Forbidden, onlyon[Claim])
   final val TYPE = Key.builtin("type", KeyParameter.Required, onlyon[Production])
-  final val UNBOUND_VARIABLES = Key.builtin("unboundVariables", KeyParameter.Required, onlyon[RuleOrClaim])
+  final val UNBOUND_VARIABLES = Key.builtin("unboundVariables", KeyParameter.Required, onlyon4[Context, ContextAlias, Production, RuleOrClaim])
   final val UNIT = Key.builtin("unit", KeyParameter.Required, onlyon[Production])
   final val UNPARSE_AVOID = Key.builtin("unparseAvoid", KeyParameter.Forbidden, onlyon[Production])
   final val UNUSED = Key.builtin("unused", KeyParameter.Forbidden, onlyon[Production])


### PR DESCRIPTION
#3481

Strict Productions, ContextAliases, and Contexts desugar into Rules. So, some rule-only attributes should also be allowed on them.