### PR TITLE
Testing run nix-flake on self hosted linux machine

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -137,8 +137,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-20.04
-            os: ubuntu-20.04
+          - runner: [self-hosted, linux, normal]
           - runner: macos-13
             os: macos-13
           - runner: MacM1


### PR DESCRIPTION
This PR is a temporary fix to the `error: writing to file: No space left on device` issue on  Nix Flake ubuntu-20.04 CI.

The problem seems to be in nix downloading multiple versions of the same package.  @goodlyrottenapple will investigate it further in the near future.

This fix is meant only to unlock the CI for the various PRs that need to be tested with Nix Flake running on a Ubuntu machine.

From @goodlyrottenapple as well: "Doesn't need to be specific ubuntu version"