### PR TITLE
Fix token constructor error

### DIFF
--- a/k-distribution/tests/regression-new/checks/tokenCheck.k
+++ b/k-distribution/tests/regression-new/checks/tokenCheck.k
@@ -1,5 +1,6 @@
 // Copyright (c) K Team. All Rights Reserved.
 module TOKENCHECK-SYNTAX
+  imports ID-SYNTAX
   syntax X ::= "abc" [token]
 
 endmodule
@@ -17,4 +18,5 @@ module TOKENCHECK
   syntax Int ::= "foo" [macro]
   rule foo => 3
 
+  syntax Id ::= Foo(Id)
 endmodule

--- a/k-distribution/tests/regression-new/checks/tokenCheck.k.out
+++ b/k-distribution/tests/regression-new/checks/tokenCheck.k.out
@@ -1,11 +1,16 @@
 [Error] Compiler: Sort X was declared as a token. Productions of this sort can only contain [function] or [token] labels.
 	Source(tokenCheck.k)
-	Location(11,16,11,22)
-	11 |	  syntax X ::= fail()
+	Location(12,16,12,22)
+	12 |	  syntax X ::= fail()
 	   .	               ^~~~~~
 [Error] Compiler: Sort Y was declared as a token. Productions of this sort can only contain [function] or [token] labels.
 	Source(tokenCheck.k)
-	Location(14,16,14,17)
-	14 |	  syntax Y ::= Z
+	Location(15,16,15,17)
+	15 |	  syntax Y ::= Z
 	   .	               ^
-[Error] Compiler: Had 2 structural errors.
+[Error] Compiler: Sort Id was declared as a token. Productions of this sort can only contain [function] or [token] labels.
+	Source(tokenCheck.k)
+	Location(21,17,21,24)
+	21 |	  syntax Id ::= Foo(Id)
+	   .	                ^~~~~~~
+[Error] Compiler: Had 3 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckTokens.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckTokens.java
@@ -40,7 +40,7 @@ public class CheckTokens {
             return;
         }
 
-        if (!m.tokenProductionsFor().contains(p.sort()) // We only care about sorts that have been declared as tokens.
+        if (!m.tokenSorts().contains(p.sort()) // We only care about sorts that have been declared as tokens.
                 || p.klabel().isDefined() && m.macroKLabels().contains(p.klabel().get())) {
             return;
         }

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -202,6 +202,11 @@ case class Module(val name: String, val imports: Set[Import], localSentences: Se
     }).fold(Map())(mergeMultiset)
   }
 
+  lazy val tokenSorts: Set[Sort] = {
+    sentences.collect({ case p:Production if p.att.contains(Att.TOKEN) => p.sort
+                        case s:SyntaxSort if s.att.contains(Att.TOKEN) => s.sort})
+  }
+
   lazy val tokenProductionsFor: Map[Sort, Set[Production]] =
     productions
       .collect({ case p if p.att.contains(Att.TOKEN) => p })


### PR DESCRIPTION
Fixes #3460

Apparently we already had a check for this error, but it didn't take into consideration productions of the form:
`syntax Id [token]` since these are represented as `SyntaxSort` and not `Productions`.

This is a fix for the old issue: #2241