### PR TITLE
Fix parsing left/right-assoc kore terms in kast

### DIFF
--- a/kore/src/main/scala/org/kframework/parser/kore/parser/TextToKore.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/parser/TextToKore.scala
@@ -545,6 +545,7 @@ class TextToKore(b: Builders = DefaultBuilders) {
                     (p1: kore.Pattern, p2: kore.Pattern) => b.Or(s, p1, p2)
                 }
               case c => // variable or application
+                scanner.putback(c)
                 val id = parseId() // previousParsingLevel is set here
                 consumeWithLeadingWhitespaces("{")
                 val params = parseList(() => parseSort(parsingLevel = previousParsingLevel), ',', '}')
@@ -579,6 +580,7 @@ class TextToKore(b: Builders = DefaultBuilders) {
                     (p1: kore.Pattern, p2: kore.Pattern) => b.Or(s, p1, p2)
                 }
               case c => // variable or application
+                scanner.putback(c)
                 val id = parseId() // previousParsingLevel is set here
                 consumeWithLeadingWhitespaces("{")
                 val params = parseList(() => parseSort(parsingLevel = previousParsingLevel), ',', '}')

--- a/kore/src/test/scala/org/kframework/parser/kore/parser/TextToKoreTest.scala
+++ b/kore/src/test/scala/org/kframework/parser/kore/parser/TextToKoreTest.scala
@@ -31,4 +31,17 @@ class TextToKoreTest {
     Assert.assertEquals(b.And(int, b.DomainValue(int, "1"), b.And(int, b.DomainValue(int, "2"), b.DomainValue(int, "3"))), ast2)
   }
 
+  @Test def testAssocApplication(): Unit = {
+    val parser = new TextToKore()
+    val int = b.CompoundSort("SortInt", Seq())
+
+    val koreLeft = "\\left-assoc{}(Lbl'Unds'Map'Unds{}(\\dv{SortInt{}}(\"1\"), \\dv{SortInt{}}(\"1\")))"
+    val astLeft = parser.parsePattern(koreLeft)
+    Assert.assertEquals(b.Application(b.SymbolOrAlias("Lbl'Unds'Map'Unds", Seq()), Seq(b.DomainValue(int, "1"), b.DomainValue(int, "1"))), astLeft)
+
+    val koreRight = "\\right-assoc{}(Lbl'Unds'Map'Unds{}(\\dv{SortInt{}}(\"1\"), \\dv{SortInt{}}(\"1\")))"
+    val astRight = parser.parsePattern(koreRight)
+    Assert.assertEquals(b.Application(b.SymbolOrAlias("Lbl'Unds'Map'Unds", Seq()), Seq(b.DomainValue(int, "1"), b.DomainValue(int, "1"))), astRight)
+  }
+
 }


### PR DESCRIPTION
fixes: #3634 