### PR TITLE
Installing dependences to bencher execution on develop

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -70,6 +70,10 @@ jobs:
             --workdir /opt/workspace                                           \
             -v "${workspace}:/opt/workspace"                                   \
             ${BASE_OS}:${BASE_DISTRO}
+      - name: 'Setting up dependencies'
+        run: |
+          set -euxo pipefail
+          docker exec -t k-profiling-tests-${GITHUB_SHA} /bin/bash -c './k-distribution/tests/profiling/setup_profiling.sh SKIP_K_BUILD'
       - name: 'Getting Performance Tests Results'
         run: |
           set -euxo pipefail

--- a/k-distribution/tests/profiling/setup_profiling.sh
+++ b/k-distribution/tests/profiling/setup_profiling.sh
@@ -6,8 +6,11 @@ export DEBIAN_FRONTEND=noninteractive
 export BENCHER_VERSION="0.3.10"
 apt-get update
 apt-get upgrade --yes
-apt-get install --yes make time sudo wget
-apt-get install --yes ./kframework.deb
+apt-get install --yes python3 git curl make time sudo wget
+# Build K if no flag was given and don't execute if flag was given
+if [ $# -eq 0 ]; then
+    apt-get install --yes ./kframework.deb
+fi
 
 wget https://github.com/bencherdev/bencher/releases/download/v"${BENCHER_VERSION}"/bencher_"${BENCHER_VERSION}"_amd64.deb
 sudo dpkg -i bencher_"${BENCHER_VERSION}"_amd64.deb


### PR DESCRIPTION
Follow up to #3627
This fix is necessary due to the lack of dependencies such as `python3`, `curl`,  and `bencher` on the test container: [error](https://github.com/runtimeverification/k/actions/runs/6173858635/job/16757140239). 


Running this container is lighter than using the `with-docker` version of CI, and we can pass the various environment variables needed by GitHub and Bencher API!