### PR TITLE
Improving  kompile's `--help` and `--help-hidden` messages using descriptors

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
@@ -7,7 +7,7 @@ import org.kframework.utils.inject.RequestScoped;
 @RequestScoped
 public class HaskellKompileOptions {
 
-    @Parameter(names="--haskell-backend-command", description="Command to run the Haskell backend execution engine.", hidden = true)
+    @Parameter(names="--haskell-backend-command", description="Command to run the Haskell backend execution engine.", descriptionKey = "command", hidden = true)
     public String haskellBackendCommand = "kore-exec";
 
     @Parameter(names="--no-haskell-binary", description="Use the textual KORE format in the haskell backend instead of the binary KORE format. This is a development option, but may be necessary on MacOS due to known issues with the binary format.")

--- a/k-distribution/src/main/scripts/lib/k-util.sh
+++ b/k-distribution/src/main/scripts/lib/k-util.sh
@@ -33,7 +33,7 @@ k_util_usage() {
   --no-exc-wrap     Do not wrap messages to 80 chars (keep long lines).
   --profile         Print coarse process timing information. Format printed:
                     exit-code wall-time user-time system-time command args*
-  --temp-dir        Put temp files in this location. Default: /tmp/.<tool>-xxx
+  --temp-dir PATH   Put temp files in this location. Default: /tmp/.<tool>-xxx
   -v, --verbose     Print significant sub-commands executed.
 HERE
 }

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -117,7 +117,7 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--bison-file", description="C file containing functions to link into bison parser.", descriptionKey = "file", hidden = true)
     public String bisonFile;
 
-    @Parameter(names="--bison-stack-max-depth", description="Maximum size of bison parsing stack (default: 10000).", descriptionKey = "size", hidden = true)
+    @Parameter(names="--bison-stack-max-depth", description="Maximum size of bison parsing stack.", descriptionKey = "size", hidden = true)
     public long bisonStackMaxDepth = 10000;
 
     @Parameter(names="--bison-parser-library", description="Generate a shared library rather than an executable for Bison parsers", hidden = true)

--- a/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileOptions.java
@@ -49,7 +49,7 @@ public class KompileOptions implements Serializable {
     public OutputDirectoryOptions outputDirectory = new OutputDirectoryOptions();
 
     // Common options
-    @Parameter(names="--backend", description="Choose a backend. <backend> is one of [llvm|haskell|kore]. Each creates the kompiled K definition.")
+    @Parameter(names="--backend", description="Choose a backend. <backend> is one of [llvm|haskell|kore]. Each creates the kompiled K definition.", descriptionKey = "backend")
     public String backend = Backends.LLVM;
 
     @Parameter(names="--main-module", description="Specify main module in which a program starts to execute. This information is used by 'krun'. The default is the name of the given K definition file without the extension (.k).")
@@ -62,7 +62,7 @@ public class KompileOptions implements Serializable {
         return mainModule;
     }
 
-    @Parameter(names="--syntax-module", description="Specify main module for syntax. This information is used by 'krun'. (Default: <main-module>-SYNTAX).")
+    @Parameter(names="--syntax-module", description="Specify main module for syntax. This information is used by 'krun'. (Default: <main-module>-SYNTAX).", descriptionKey = "module")
     private String syntaxModule;
 
     public String syntaxModule(FileUtil files) {
@@ -75,7 +75,7 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--coverage", description="Generate coverage data when executing semantics.")
     public boolean coverage;
 
-    @Parameter(names="--hook-namespaces", listConverter=StringListConverter.class, description="<string> is a whitespace-separated list of namespaces to include in the hooks defined in the definition", hidden = true)
+    @Parameter(names="--hook-namespaces", listConverter=StringListConverter.class, description="<string> is a whitespace-separated list of namespaces to include in the hooks defined in the definition", descriptionKey = "string", hidden = true)
     public List<String> hookNamespaces = Collections.emptyList();
 
     @Parameter(names="-O1", description="Optimize in ways that improve performance and code size, but interfere with debugging and increase compilation time slightly.")
@@ -96,8 +96,7 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--read-only-kompiled-directory", description="Files in the generated kompiled directory should be read-only to other frontend tools.", hidden = true)
     public boolean readOnlyKompiledDirectory = false;
 
-    @Parameter(names="--concrete-rules", description="List of rule labels to be considered concrete, in addition to " +
-            "rules marked with `[concrete]` attribute")
+    @Parameter(names="--concrete-rules", description="List of rule labels to be considered concrete, in addition to rules marked with `[concrete]` attribute", descriptionKey = "labels")
     public List<String> extraConcreteRuleLabels = Collections.emptyList();
 
     @ParametersDelegate
@@ -115,10 +114,10 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--gen-glr-bison-parser", description="Emit GLR bison parser for the PGM configuration variable within the syntax module of your definition into the kompiled definition.")
     public boolean genGlrBisonParser;
 
-    @Parameter(names="--bison-file", description="C file containing functions to link into bison parser.", hidden = true)
+    @Parameter(names="--bison-file", description="C file containing functions to link into bison parser.", descriptionKey = "file", hidden = true)
     public String bisonFile;
 
-    @Parameter(names="--bison-stack-max-depth", description="Maximum size of bison parsing stack (default: 10000).", hidden = true)
+    @Parameter(names="--bison-stack-max-depth", description="Maximum size of bison parsing stack (default: 10000).", descriptionKey = "size", hidden = true)
     public long bisonStackMaxDepth = 10000;
 
     @Parameter(names="--bison-parser-library", description="Generate a shared library rather than an executable for Bison parsers", hidden = true)
@@ -129,10 +128,10 @@ public class KompileOptions implements Serializable {
     @Parameter(names="--top-cell", description="Choose the top configuration cell when more than one is provided. Does nothing if only one top cell exists.")
     public String topCell;
 
-    @Parameter(names="--debug-type-inference", description="Filename and source line of rule to debug type inference for. This is generally an option used only by maintainers.", hidden = true)
+    @Parameter(names="--debug-type-inference", description="Filename and source line of rule to debug type inference for. This is generally an option used only by maintainers.", descriptionKey = "file", hidden = true)
     public String debugTypeInference;
 
-    @Parameter(names={"--post-process"}, description="JSON KAST => JSON KAST converter to run on definition after kompile pipeline.", hidden = true)
+    @Parameter(names={"--post-process"}, description="JSON KAST => JSON KAST converter to run on definition after kompile pipeline.", descriptionKey = "command", hidden = true)
     public String postProcess;
 
     // TODO(dwightguth): remove this when it is no longer needed

--- a/kernel/src/main/java/org/kframework/kompile/KompileUsageFormatter.java
+++ b/kernel/src/main/java/org/kframework/kompile/KompileUsageFormatter.java
@@ -195,12 +195,16 @@ public class KompileUsageFormatter implements IUsageFormatter {
             WrappedParameter parameter = pd.getParameter();
             String description = pd.getDescription();
             boolean hasDescription = !description.isEmpty();
+            String descriptionKey = pd.getParameter().getParameter().descriptionKey();
+            descriptionKey = descriptionKey.isEmpty() ? "" : " <" + descriptionKey + ">";
 
             // First line, command name
             out.append(indent)
                     .append("  ")
                     .append(parameter.required() ? "* " : "  ")
-                    .append(pd.getNames())
+                    .append(pd.getLongestName())
+                    .append(descriptionKey)
+                    .append(Arrays.stream(pd.getParameter().names()).count() > 1 ? ", " + pd.getParameter().names()[1] + descriptionKey : "")
                     .append("\n");
 
             if (hasDescription) {

--- a/kernel/src/main/java/org/kframework/main/GlobalOptions.java
+++ b/kernel/src/main/java/org/kframework/main/GlobalOptions.java
@@ -121,13 +121,13 @@ public final class GlobalOptions {
     @Parameter(names="--debug-warnings", description="Print debugging output messages and error/warning stack traces")
     public boolean debugWarnings = false;
 
-    @Parameter(names={"--warnings", "-w"}, converter=WarningsConverter.class, description="Warning level. Values: [all|normal|none]")
+    @Parameter(names={"--warnings", "-w"}, converter=WarningsConverter.class, description="Warning level. Values: [all|normal|none]", descriptionKey = "level")
     public Warnings warnings = Warnings.NORMAL;
 
-    @Parameter(names="-W", description="Enable specific warning categories. Values: [non-exhaustive-match|undeleted-temp-dir|missing-hook-java|missing-syntax-module|invalid-exit-code|deprecated-backend|invalid-config-var|future-error|unused-var|proof-lint|useless-rule|unresolved-function-symbol|malformed-markdown|invalidated-cache|unused-symbol|removed-anywhere]", converter=ExceptionTypeConverter.class)
+    @Parameter(names="-W", description="Enable specific warning categories. Values: [non-exhaustive-match|undeleted-temp-dir|missing-hook-java|missing-syntax-module|invalid-exit-code|deprecated-backend|invalid-config-var|future-error|unused-var|proof-lint|useless-rule|unresolved-function-symbol|malformed-markdown|invalidated-cache|unused-symbol|removed-anywhere]", descriptionKey = "warning", converter=ExceptionTypeConverter.class)
     public List<ExceptionType> enableWarnings = Collections.emptyList();
 
-    @Parameter(names="-Wno", description="Disable specific warning categories.", converter=ExceptionTypeConverter.class)
+    @Parameter(names="-Wno", description="Disable specific warning categories.", descriptionKey = "warning", converter=ExceptionTypeConverter.class)
     public List<ExceptionType> disableWarnings = Collections.emptyList();
 
     @Parameter(names={"--warnings-to-errors", "-w2e"}, description="Convert warnings to errors.")
@@ -139,13 +139,13 @@ public final class GlobalOptions {
                     "The wait time is the argument of this option, in format like 10ms/10s/10m/10h. " +
                     "Useful if K is interrupted by Ctrl+C, because it allows the backend to detect " +
                     "interruption and print diagnostics information. Currently interruption detection is implemented " +
-                    "in Java Backend. If K is invoked from KServer (e.g. Nailgun), the option is ignored.", hidden = true)
+                    "in Java Backend. If K is invoked from KServer (e.g. Nailgun), the option is ignored.", descriptionKey = "time", hidden = true)
     public Duration shutdownWaitTime;
 
     @Parameter(names = {"--timeout"}, converter = DurationConverter.class,
             description = "If option is set, timeout for this process, in format like 10ms/10s/10m/10h. " +
                     "Using this option is preferred compared to bash timeout command, which has known limitations " +
-                    "when invoked from scripts.", hidden = true)
+                    "when invoked from scripts.", descriptionKey = "duration", hidden = true)
     public Duration timeout;
 
     @Parameter(names={"--no-exc-wrap"}, description="Do not wrap exception messages to 80 chars. Keep long lines.", hidden = true)
@@ -155,6 +155,6 @@ public final class GlobalOptions {
         return debug || debugWarnings;
     }
 
-    @Parameter(names={"--temp-dir"}, description="Put temp files in this location. Default is /tmp/.<tool>-xxx")
+    @Parameter(names={"--temp-dir"}, description="Put temp files in this location. Default is /tmp/.<tool>-xxx", descriptionKey = "path")
     public String tempDir = null;
 }

--- a/kernel/src/main/java/org/kframework/utils/options/InnerParsingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/InnerParsingOptions.java
@@ -18,6 +18,6 @@ public class InnerParsingOptions implements Serializable {
     @Inject
     public InnerParsingOptions(Void v) {}
 
-    @Parameter(names="--profile-rule-parsing", description="Generate time in milliseconds to parse each rule in the semantics.", hidden = true)
+    @Parameter(names="--profile-rule-parsing", description="Store in this file time taken in ms to parse each rule in the semantics.", descriptionKey = "file", hidden = true)
     public String profileRules;
 }

--- a/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OuterParsingOptions.java
@@ -43,12 +43,12 @@ public class OuterParsingOptions implements Serializable {
     }
 
 
-    @Parameter(names="-I", description="Add a directory to the search path for requires statements.")
+    @Parameter(names="-I", description="Add a directory to the search path for requires statements.", descriptionKey = "path")
     public List<String> includes = new ArrayList<>();
 
     @Parameter(names="--no-prelude", description="Do not implicitly require prelude.md.", hidden = true)
     public boolean noPrelude = false;
 
-    @Parameter(names="--md-selector", description="Preprocessor: for .md files, select only the md code blocks that match the selector expression. Ex:'k&(!a|b)'.")
+    @Parameter(names="--md-selector", description="Preprocessor: for .md files, select only the md code blocks that match the selector expression. Ex:'k&(!a|b)'.", descriptionKey = "expression")
     public String mdSelector = "k";
 }

--- a/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
@@ -13,9 +13,9 @@ public class OutputDirectoryOptions implements Serializable {
     @Inject
     public OutputDirectoryOptions(Void v) {}
 
-    @Parameter(names={"--directory", "-d"}, description="[DEPRECATED] Path to the directory in which the output resides. An output can be either a kompiled K definition or a document which depends on the type of backend. The default is the directory containing the main definition file.", hidden = true)
+    @Parameter(names={"--directory", "-d"}, description="[DEPRECATED] Path to the directory in which the output resides. An output can be either a kompiled K definition or a document which depends on the type of backend. The default is the directory containing the main definition file.", descriptionKey = "path", hidden = true)
     public String directory;
 
-    @Parameter(names={"--output-definition", "-o"}, description="Path to the exact directory in which the output resides.")
+    @Parameter(names={"--output-definition", "-o"}, description="Path to the exact directory in which the output resides.", descriptionKey = "path")
     public String outputDirectory;
 }

--- a/kernel/src/main/java/org/kframework/utils/options/SMTOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/SMTOptions.java
@@ -14,7 +14,7 @@ public class SMTOptions implements Serializable {
     @Inject
     public SMTOptions(Void v) {}
 
-    @Parameter(names="--smt", converter=SMTSolverConverter.class, description="SMT solver to use for checking constraints. <solver> is one of [z3|none].", hidden = true)
+    @Parameter(names="--smt", converter=SMTSolverConverter.class, description="SMT solver to use for checking constraints. <solver> is one of [z3|none].", descriptionKey = "executable", hidden = true)
     public SMTSolver smt = SMTSolver.Z3;
 
     public static class SMTSolverConverter extends BaseEnumConverter<SMTSolver> {
@@ -38,7 +38,7 @@ public class SMTOptions implements Serializable {
     @Parameter(names="--maps-as-int-array", description="Abstracts map values as an array of ints.", hidden = true)
     public boolean mapAsIntArray = false;
 
-    @Parameter(names={"--smt-prelude", "--smt_prelude"}, description="Path to the SMT prelude file.", hidden = true)
+    @Parameter(names={"--smt-prelude", "--smt_prelude"}, description="Path to the SMT prelude file.", descriptionKey = "path", hidden = true)
     public String smtPrelude;
 
     @Parameter(names="--smt-timeout", description="Timeout for calls to the SMT solver, in milliseconds.", hidden = true)
@@ -48,6 +48,6 @@ public class SMTOptions implements Serializable {
             "JNI is slightly faster, but can potentially lead to JVM crash.", hidden = true)
     public boolean z3JNI = false;
 
-    @Parameter(names="--z3-tactic", description="The solver tactic to use to check satisfiability in Z3.", hidden = true)
+    @Parameter(names="--z3-tactic", description="The path to solver tactic to use to check satisfiability in Z3.", descriptionKey = "solver", hidden = true)
     public String z3Tactic;
 }

--- a/kernel/src/main/java/org/kframework/utils/options/SMTOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/SMTOptions.java
@@ -14,7 +14,7 @@ public class SMTOptions implements Serializable {
     @Inject
     public SMTOptions(Void v) {}
 
-    @Parameter(names="--smt", converter=SMTSolverConverter.class, description="SMT solver to use for checking constraints. <solver> is one of [z3|none].", descriptionKey = "executable", hidden = true)
+    @Parameter(names="--smt", converter=SMTSolverConverter.class, description="SMT solver to use for checking constraints. <executable> is one of [z3|none].", descriptionKey = "executable", hidden = true)
     public SMTSolver smt = SMTSolver.Z3;
 
     public static class SMTSolverConverter extends BaseEnumConverter<SMTSolver> {

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
@@ -43,6 +43,6 @@ public class LLVMKompileOptions {
     @Parameter(names="--llvm-kompile-type", description="Specifies the llvm backend's output type. Valid choices are main (build an interpreter), library (build an interpreter, but don't link a main function), search (same as main, but the interpreter does search instead of single-path execution), static (same as library, but no '-l' flags are passed during linking. Used for making a partially linked object file) and python (build a Python bindings module for this definition)", descriptionKey = "type", hidden = true)
     public String llvmKompileType = "main";
 
-    @Parameter(names="--llvm-kompile-output", description="Name of the output binary from the llvm backend.", descriptionKey = "binary", hidden = true)
+    @Parameter(names="--llvm-kompile-output", description="Name of the output binary from the llvm backend.", descriptionKey = "file", hidden = true)
     public String llvmKompileOutput = null;
 }

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMKompileOptions.java
@@ -15,7 +15,7 @@ public class LLVMKompileOptions {
     @Parameter(names="--enable-llvm-debug", description="Enable debugging support for the LLVM backend.")
     public boolean debug = false;
 
-    @Parameter(names="-ccopt", description="Add a command line option to the compiler invocation for the llvm backend.", listConverter=SingletonListConverter.class, hidden = true)
+    @Parameter(names="-ccopt", description="Add a command line option to the compiler invocation for the llvm backend.", descriptionKey = "options", listConverter=SingletonListConverter.class, hidden = true)
     public List<String> ccopts = new ArrayList<>();
 
     public static class SingletonListConverter implements IStringConverter<List<String>> {
@@ -25,13 +25,13 @@ public class LLVMKompileOptions {
         }
     }
 
-    @Parameter(names="--heuristic", description="A string of single characters representing a sequence of heuristics to use during pattern matching compilation. Valid choices are f, d, b, a, l, r, n, p, q, _, N, L, R.", hidden = true)
+    @Parameter(names="--heuristic", description="A string of single characters representing a sequence of heuristics to use during pattern matching compilation. Valid choices are f, d, b, a, l, r, n, p, q, _, N, L, R.", descriptionKey = "heuristics", hidden = true)
     public String heuristic = "qbaL";
 
     @Parameter(names="--iterated", description="Generate iterated pattern matching optimization; time-consuming but significantly reduces matching time.", hidden = true)
     public boolean iterated = false;
 
-    @Parameter(names="--iterated-threshold", description="Threshold heuristic to use when choosing which axioms to optimize. A value of 0 turns the optimization off; a value of 1 turns the optimization on for every axiom. Values in between (expressed as a fraction of two integers, e.g. 1/2), control the aggressiveness of the optimization. Higher values increase compilation times extremely, but also increase the effectiveness of the optimization. Consider decreasing this threshold if compilation is too slow.", hidden = true)
+    @Parameter(names="--iterated-threshold", description="Threshold heuristic to use when choosing which axioms to optimize. A value of 0 turns the optimization off; a value of 1 turns the optimization on for every axiom. Values in between (expressed as a fraction of two integers, e.g. 1/2), control the aggressiveness of the optimization. Higher values increase compilation times extremely, but also increase the effectiveness of the optimization. Consider decreasing this threshold if compilation is too slow.", descriptionKey = "value", hidden = true)
     public String iteratedThreshold = "1/2";
 
     @Parameter(names="--no-llvm-kompile", description="Do not invoke llvm-kompile. Useful if you want to do it yourself when building with the LLVM backend.", hidden = true)
@@ -40,9 +40,9 @@ public class LLVMKompileOptions {
     @Parameter(names="--enable-search", description="By default, to reduce compilation time, `krun --search` is disabled on the LLVM backend. Pass this flag to enable it.")
     public boolean enableSearch;
 
-    @Parameter(names="--llvm-kompile-type", description="Specifies the llvm backend's output type. Valid choices are main (build an interpreter), library (build an interpreter, but don't link a main function), search (same as main, but the interpreter does search instead of single-path execution), static (same as library, but no '-l' flags are passed during linking. Used for making a partially linked object file) and python (build a Python bindings module for this definition)", hidden = true)
+    @Parameter(names="--llvm-kompile-type", description="Specifies the llvm backend's output type. Valid choices are main (build an interpreter), library (build an interpreter, but don't link a main function), search (same as main, but the interpreter does search instead of single-path execution), static (same as library, but no '-l' flags are passed during linking. Used for making a partially linked object file) and python (build a Python bindings module for this definition)", descriptionKey = "type", hidden = true)
     public String llvmKompileType = "main";
 
-    @Parameter(names="--llvm-kompile-output", description="Name of the output binary from the llvm backend.", hidden = true)
+    @Parameter(names="--llvm-kompile-output", description="Name of the output binary from the llvm backend.", descriptionKey = "binary", hidden = true)
     public String llvmKompileOutput = null;
 }


### PR DESCRIPTION
Fixes #3619

This PR enhances the usability of `kompile --help` and `kompile --help-hidden` by providing descriptors to the flags to help the user understand when an argument needs to be provided to the flag.


Ex.:

Before
``` 
kompile --help
Usage: kompile [options] <file>
  Options:
    --backend
      Choose a backend. <backend> is one of [llvm|haskell|kore]. Each creates 
      the kompiled K definition.
      Default: llvm

```

Now:
```
kompile --help
Usage: kompile [options] <file>
  Options:
    --backend <backend>
      Choose a backend. <backend> is one of [llvm|haskell|kore]. Each creates 
      the kompiled K definition.
      Default: llvm
```