### PR TITLE
Adding arguments to `kast` flags

### DIFF
--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -101,20 +101,23 @@ public final class KastOptions {
         return files.get().resolveWorkingDirectory(parameters.get(0));
     }
 
-    @Parameter(names="--bison-file", description="C file containing functions to link into bison parser.", hidden = true)
+    @Parameter(names="--bison-file", descriptionKey = "file", hidden = true,
+            description="C file containing functions to link into bison parser.")
     public String bisonFile;
 
-    @Parameter(names="--bison-stack-max-depth", description="Maximum size of bison parsing stack (default: 10000).", hidden = true)
+    @Parameter(names="--bison-stack-max-depth", descriptionKey = "size", hidden = true,
+            description="Maximum size of bison parsing stack.")
     public long bisonStackMaxDepth = 10000;
 
-    @Parameter(names={"--expression", "-e"}, description="An expression to parse passed on the command " +
-    "line. It is an error to provide both this option and a file to parse.")
+    @Parameter(names={"--expression", "-e"}, descriptionKey = "expression",
+            description="An expression to parse passed on the command line. It is an error to provide both this " +
+                    "option and a file to parse.")
     private String expression;
 
-    @Parameter(names={"--sort", "-s"}, converter=SortTypeConverter.class, description="The start sort for the default parser. " +
-            "The default is the sort of $PGM from the configuration. A sort may also be specified " +
-            "with the 'KRUN_SORT' environment variable, in which case it is used if the option is " +
-            "not specified on the command line.")
+    @Parameter(names={"--sort", "-s"}, descriptionKey = "sort", converter=SortTypeConverter.class,
+            description="The start sort for the default parser. The default is the sort of $PGM from the configuration. " +
+                    "A sort may also be specified with the 'KRUN_SORT' environment variable, in which case it is used " +
+                    "if the option is not specified on the command line.")
     public Sort sort;
 
     public static class SortTypeConverter implements IStringConverter<Sort> {
@@ -125,17 +128,20 @@ public final class KastOptions {
         }
     }
 
-    @Parameter(names={"--module", "-m"}, description="Parse text in the specified module. Defaults to the syntax module of the definition.")
+    @Parameter(names={"--module", "-m"}, descriptionKey = "module",
+            description="Parse text in the specified module. Defaults to the syntax module of the definition.")
     public String module;
 
     @Parameter(names="--expand-macros", description="Also expand macros in the parsed string.")
     public boolean expandMacros = false;
 
-    @Parameter(names={"--input", "-i"}, converter=InputModeConverter.class,
+    @Parameter(names={"--input", "-i"}, descriptionKey = "mode", converter=InputModeConverter.class,
             description="How to read kast input in. <mode> is either [program|binary|kast|json|kore|rule].")
     public InputModes input = InputModes.PROGRAM;
 
-    @Parameter(names={"--steps"}, description="Apply specified kompilation steps to the parsed term. Only for --input rule. Use --steps help for a detailed description of available steps.")
+    @Parameter(names={"--steps"}, descriptionKey = "steps",
+            description="Apply specified kompilation steps to the parsed term. Only for --input rule. " +
+                    "Use --steps help for a detailed description of available steps.")
     public List<KastFrontEnd.KompileSteps> steps = Lists.newArrayList(KastFrontEnd.KompileSteps.anonVars);
 
     public static class InputModeConverter extends BaseEnumConverter<InputModes> {

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -31,9 +31,9 @@ public class PrintOptions {
     public PrintOptions(Void v) {
     }
 
-    @Parameter(names = "--color", description = "Use colors in output.", descriptionKey = "mode",
+    @Parameter(names = "--color", description = "Use colors in output. Default is on.", descriptionKey = "mode",
             converter=ColorModeConverter.class)
-    private ColorSetting color = ColorSetting.ON;
+    private ColorSetting color;
 
     public ColorSetting color(boolean ttyStdout, Map<String, String> env) {
         boolean colorize = outputFile == null && ttyStdout;

--- a/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
+++ b/kernel/src/main/java/org/kframework/unparser/PrintOptions.java
@@ -31,8 +31,9 @@ public class PrintOptions {
     public PrintOptions(Void v) {
     }
 
-    @Parameter(names = "--color", description = "Use colors in output. Default is on.", converter=ColorModeConverter.class)
-    private ColorSetting color;
+    @Parameter(names = "--color", description = "Use colors in output.", descriptionKey = "mode",
+            converter=ColorModeConverter.class)
+    private ColorSetting color = ColorSetting.ON;
 
     public ColorSetting color(boolean ttyStdout, Map<String, String> env) {
         boolean colorize = outputFile == null && ttyStdout;
@@ -65,10 +66,11 @@ public class PrintOptions {
         }
     }
 
-    @Parameter(names="--output-file", description="Store output in the file instead of displaying it.")
+    @Parameter(names="--output-file", description="Store output in the file instead of displaying it.",
+            descriptionKey = "file")
     public String outputFile;
 
-    @Parameter(names={"--output", "-o"}, converter=OutputModeConverter.class,
+    @Parameter(names={"--output", "-o"}, descriptionKey = "mode", converter=OutputModeConverter.class,
             description="How to display krun results. <mode> is either [pretty|program|kast|binary|json|latex|kore|none].")
     public OutputModes output = OutputModes.PRETTY;
 
@@ -84,16 +86,20 @@ public class PrintOptions {
         }
     }
 
-    @Parameter(names={"--output-omit"}, listConverter=StringListConverter.class, description="KLabels to omit from the output.")
+    @Parameter(names={"--output-omit"}, descriptionKey = "KLabels", listConverter=StringListConverter.class,
+            description="KLabels to omit from the output.")
     public List<String> omittedKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--output-tokenize"}, listConverter=StringListConverter.class, description="KLabels to tokenize underneath (reducing output size).")
+    @Parameter(names={"--output-tokenize"}, descriptionKey = "KLabels", listConverter=StringListConverter.class,
+            description="KLabels to tokenize underneath (reducing output size).")
     public List<String> tokenizedKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--output-flatten"}, listConverter=StringListConverter.class, description="(Assoc) KLabels to flatten into one list.")
+    @Parameter(names={"--output-flatten"}, descriptionKey = "KLabels", listConverter=StringListConverter.class,
+            description="(Assoc) KLabels to flatten into one list.")
     public List<String> flattenedKLabels = new ArrayList<String>();
 
-    @Parameter(names={"--output-tokast"}, listConverter=StringListConverter.class, description="KLabels to output as KAST tokens.")
+    @Parameter(names={"--output-tokast"}, descriptionKey = "KLabels", listConverter=StringListConverter.class,
+            description="KLabels to output as KAST tokens.")
     public List<String> tokastKLabels = new ArrayList<String>();
 
     @Parameter(names={"--no-alpha-renaming"}, listConverter=StringListConverter.class, description="Do not alpha rename anonymous variables in output.")

--- a/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
@@ -14,10 +14,10 @@ public class DefinitionLoadingOptions {
 
     @Parameter(names={"--directory", "-d"}, description="[DEPRECATED] Path to the directory in which the kompiled " +
             "K definition resides. The default is the unique, only directory with the suffix '-kompiled' " +
-            "in the current directory.", hidden = true)
+            "in the current directory.", descriptionKey = "path", hidden = true)
     public String directory;
 
-    @Parameter(names={"--definition"}, description="Exact path to the kompiled directory.")
+    @Parameter(names={"--definition"}, description="Exact path to the kompiled directory.", descriptionKey = "path")
     public String inputDirectory;
 
     public DefinitionLoadingOptions(String dir) {


### PR DESCRIPTION
Follow up of #3619 and #3638!

This PR enhances the usability of `kast --help` and `kast --help-hidden` by providing flag descriptors to help the user understand when an argument needs to be provided to the flag.


Ex.:

Before
``` 
kast --help
Usage: kast [options] <file>
  Options:
    --color
      Use colors in output. Default is on.
      Possible Values: [OFF, ON, EXTENDED]
```

Now:
```
Usage: kast [options] <file>
  Options:
    --color <mode>
      Use colors in output.
      Default: ON
      Possible Values: [OFF, ON, EXTENDED]
```

Among others, this PR introduces the following arguments to the respective parameters:
<!DOCTYPE html>

parameter | argument
-- | --
--color |  \<mode>
--expression, -e | \<expression>
--input, -i | \<mode>
--module, -m | \<module>
--output, -o | \<mode>
--output-file | \<file>
--output-flatten | \<KLabels>
--output-omit | \<KLabels>
--output-tokast | \<KLabels>
--output-tokenize | \<KLabels>
--sort, -s | \<sort>
--steps | \<steps>
--definition | \<path>
--directory, -d | \<path>

