### PR TITLE
Fix K Version on Debian

### DIFF
--- a/k-distribution/src/main/scripts/lib/k
+++ b/k-distribution/src/main/scripts/lib/k
@@ -5,6 +5,7 @@ ulimit -s "$(ulimit -H -s)"
 K_BASE="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
 GIT_DESCRIBE="${K_BASE}/kframework/git-describe.out"
 TIMESTAMP="${K_BASE}/kframework/timestamp.out"
+version=
 
 for flag in "$@"; do
     if [[ "$flag" == "--version" ]]; then


### PR DESCRIPTION
Fixes #3646 

This simple PR fixes the K script by creating the `version` variable. This fixes error #3646 where the condition ` if [[ -z "${version}" ]]; then` was false, and therefore the correct value of version wasn't set correctly, instead, some trash was set to $version. 