### PR TITLE
Clean up flake inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@
       # NB booster-backend will bring in another dependency on haskell-backend,
       # but the two are not necessarily the same (different more often than not).
       # We get two transitive dependencies on haskell-nix.
-      inputs.k-framework.follows = "";
       inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
     };
     llvm-backend.url = "github:runtimeverification/llvm-backend";


### PR DESCRIPTION
Get rid of the following warning:

```
warning: input 'booster-backend' has an override for a non-existent input 'k-framework'
```