### PR TITLE
Fixing `develop.yml` workflow

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -70,12 +70,6 @@ jobs:
             --workdir /opt/workspace                                           \
             -v "${workspace}:/opt/workspace"                                   \
             ${BASE_OS}:${BASE_DISTRO}
-      - name: 'Copy K Framework'
-        run: |
-          set -euxo pipefail
-          workspace=$(pwd)
-          docker cp ${workspace}/. k-posting-profiling-tests-${GITHUB_SHA}:/opt/workspace
-
       - name: 'Setting up dependencies'
         run: |
           set -euxo pipefail

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -54,7 +54,7 @@ jobs:
           BENCHER_ADAPTER: json
         run: |
           set -euxo pipefail
-          docker run --name k-posting-profiling-tests-${GITHUB_SHA}                                   \
+          docker run --name k-posting-profiling-tests-${GITHUB_SHA}            \
             --rm -it --detach                                                  \
             -e BENCHER_API_TOKEN=$BENCHER_API_TOKEN                            \
             -e BENCHER_PROJECT=$BENCHER_PROJECT                                \
@@ -66,7 +66,9 @@ jobs:
             -e GITHUB_EVENT_NAME=$GITHUB_EVENT_NAME                            \
             -e GITHUB_REPOSITORY=$GITHUB_REPOSITORY                            \
             -e GITHUB_REF=$GITHUB_REF                                          \
+            -e GITHUB_SHA=${GITHUB_SHA}                                        \
             --workdir /opt/workspace                                           \
+            -v "${workspace}:/opt/workspace"                                   \
             ${BASE_OS}:${BASE_DISTRO}
       - name: 'Copy K Framework'
         run: |
@@ -81,8 +83,7 @@ jobs:
       - name: 'Getting Performance Tests Results'
         run: |
           set -euxo pipefail
-          docker exec -t k-posting-profiling-tests-${GITHUB_SHA} /bin/bash -c 'git config --global --add safe.directory /opt/workspace'
-          docker exec -t k-posting-profiling-tests-${GITHUB_SHA} /bin/bash -c 'python3 k-distribution/tests/profiling/post_results_to_develop.py'
+          docker exec -t k-posting-profiling-tests-${GITHUB_SHA} /bin/bash -c './k-distribution/tests/profiling/post_results_to_develop.py ${GITHUB_SHA}'
       - name: 'Posting Performance Tests Results'
         run: |
           set -euxo pipefail

--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -54,7 +54,6 @@ jobs:
           BENCHER_ADAPTER: json
         run: |
           set -euxo pipefail
-          workspace=$(pwd)
           docker run --name k-posting-profiling-tests-${GITHUB_SHA}                                   \
             --rm -it --detach                                                  \
             -e BENCHER_API_TOKEN=$BENCHER_API_TOKEN                            \
@@ -68,8 +67,13 @@ jobs:
             -e GITHUB_REPOSITORY=$GITHUB_REPOSITORY                            \
             -e GITHUB_REF=$GITHUB_REF                                          \
             --workdir /opt/workspace                                           \
-            -v "${workspace}:/opt/workspace"                                   \
             ${BASE_OS}:${BASE_DISTRO}
+      - name: 'Copy K Framework'
+        run: |
+          set -euxo pipefail
+          workspace=$(pwd)
+          docker cp ${workspace}/. k-posting-profiling-tests-${GITHUB_SHA}:/opt/workspace
+
       - name: 'Setting up dependencies'
         run: |
           set -euxo pipefail
@@ -77,14 +81,15 @@ jobs:
       - name: 'Getting Performance Tests Results'
         run: |
           set -euxo pipefail
-          docker exec -t k-posting-profiling-tests-${GITHUB_SHA} /bin/bash -c './k-distribution/tests/profiling/post_results_to_develop.py'
+          docker exec -t k-posting-profiling-tests-${GITHUB_SHA} /bin/bash -c 'git config --global --add safe.directory /opt/workspace'
+          docker exec -t k-posting-profiling-tests-${GITHUB_SHA} /bin/bash -c 'python3 k-distribution/tests/profiling/post_results_to_develop.py'
       - name: 'Posting Performance Tests Results'
         run: |
           set -euxo pipefail
           docker exec -t k-posting-profiling-tests-${GITHUB_SHA} /bin/bash -c 'bencher run            \
             --if-branch "develop" --else-if-branch "master"                    \
             --file .profiling-results.json --err --ci-only-on-alert            \
-            --github-actions "${GITHUB_TOKEN}" 'echo "Exporting report"'
+            --github-actions "${GITHUB_TOKEN}" "echo Exporting report"'
       - name: 'Tear down Docker'
         if: always()
         run: |

--- a/k-distribution/tests/profiling/post_results_to_develop.py
+++ b/k-distribution/tests/profiling/post_results_to_develop.py
@@ -36,6 +36,9 @@ branch_command = ['curl', '-L', '-H', 'Accept:', 'application/vnd.github+json',
                   '\"X-GitHub-Api-Version:', '2022-11-28\"', API_URL]
 FROM_BRANCH = json.loads(execute_command(branch_command))[0]['head']['label']
 
+# If FROM_BRANCH contains user information get only the branch name
+if ':' in FROM_BRANCH: FROM_BRANCH = FROM_BRANCH.split(':')[1]
+
 print("Exporting last bencher report from", FROM_BRANCH, "to", TO_BRANCH)
 
 # This command will generate a JSON file with a list containing the last reports
@@ -48,6 +51,8 @@ data = json.loads(execute_command(bencher_command))
 # Collect all elemnts where the key 'project' is 'k_framework'
 k_framework = [item for item in data if item['project']['slug'] == 'k-framework'
                and item['branch']['slug'] == FROM_BRANCH]
+
+print("Found", len(k_framework), "reports for k-framework in", FROM_BRANCH)
 
 # Append the last 6 reports to the list, they correspond to the last performance
 # execution on the last commit in FROM_BRANCH
@@ -64,7 +69,7 @@ for i in range(0,6):
 
     branch = item['branch']
     print("Appended:", benchmark_name, "created in", item['created'],
-          "on branch", branch['name'], "with version", branch['version']['number'])
+          "on branch", branch['name'], "with id", branch['version']['number'])
 
     data.update({benchmark_name: {metric_name_size: {"value": value_size},
                                   metric_name_memory: {"value": value_memory}}

--- a/k-distribution/tests/profiling/post_results_to_develop.py
+++ b/k-distribution/tests/profiling/post_results_to_develop.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 import json
+import sys
 import subprocess
 
-COMMIT_SHA=''
+COMMIT_SHA = sys.argv[1]
 FROM_BRANCH=''
 TO_BRANCH='develop'
 
@@ -23,10 +24,6 @@ def execute_command(command):
         exit(1)
 
     return result.stdout
-
-# git command to get the last commit in develop
-commit_command = [ 'git', 'log', '--format=\"%H\"', '-n', '1' ]
-COMMIT_SHA = execute_command(commit_command).strip('\"').strip('\"\n')
 
 # curl command to get the branch name of last commit in develop
 API_URL = 'https://api.github.com/repos/runtimeverification/k/commits/' \


### PR DESCRIPTION
This PR fixes the develop workflow by:
- Modifying the `post_results_to_develop.py` script to get only the branch's name without the user and adding one more logging message.
- Modifying the `develop.yml` to set the `${COMMIT_SHA}` env variable and use it as a parameter to the above script, so we don't have to use the `git` command inside the container raising ownership issues and fixing a mismatch of `'` and `"` on the `bencher run` posting command.