### PR TITLE
Check if macros were expanded in `ensures` and `requires`

### DIFF
--- a/k-distribution/tests/regression-new/checks/expandMacroEnsures.k
+++ b/k-distribution/tests/regression-new/checks/expandMacroEnsures.k
@@ -1,3 +1,5 @@
+// Copyright (c) K Team. All Rights Reserved.
+
 module EXPANDMACROENSURES
     imports INT
     imports BOOL

--- a/k-distribution/tests/regression-new/checks/expandMacroEnsures.k
+++ b/k-distribution/tests/regression-new/checks/expandMacroEnsures.k
@@ -1,0 +1,11 @@
+module EXPANDMACROENSURES
+    imports INT
+    imports BOOL
+
+    syntax Int  ::= #foo ( Int ) [function]
+    syntax Bool ::= #baz ( Int ) [alias]
+
+//    rule #baz ( X ) => X // NOTE I should be defined !!
+
+    rule #foo( X ) => X       ensures  #baz( X )
+endmodule

--- a/k-distribution/tests/regression-new/checks/expandMacroEnsures.k.out
+++ b/k-distribution/tests/regression-new/checks/expandMacroEnsures.k.out
@@ -1,9 +1,9 @@
 [Error] Compiler: Rule contains macro symbol that was not expanded
 	Source(expandMacroEnsures.k)
-	Location(10,10,10,49)
-	10 |	    rule #foo( X ) => X       ensures  #baz( X )
+	Location(12,10,12,49)
+	12 |	    rule #foo( X ) => X       ensures  #baz( X )
 	   .	         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 structural errors after macro expansion.
   while executing phase "expand macros" on sentence at
 	Source(expandMacroEnsures.k)
-	Location(10,10,10,49)
+	Location(12,10,12,49)

--- a/k-distribution/tests/regression-new/checks/expandMacroEnsures.k.out
+++ b/k-distribution/tests/regression-new/checks/expandMacroEnsures.k.out
@@ -1,0 +1,9 @@
+[Error] Compiler: Rule contains macro symbol that was not expanded
+	Source(expandMacroEnsures.k)
+	Location(10,10,10,49)
+	10 |	    rule #foo( X ) => X       ensures  #baz( X )
+	   .	         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Had 1 structural errors after macro expansion.
+  while executing phase "expand macros" on sentence at
+	Source(expandMacroEnsures.k)
+	Location(10,10,10,49)

--- a/k-distribution/tests/regression-new/checks/expandMacroRequires.k
+++ b/k-distribution/tests/regression-new/checks/expandMacroRequires.k
@@ -1,0 +1,11 @@
+module EXPANDMACROREQUIRES
+    imports INT
+    imports BOOL
+
+    syntax Int  ::= #foo ( Int ) [function]
+    syntax Bool ::= #bar ( Int ) [alias]
+
+//    rule #bar ( X ) => X >Int 0 // NOTE I should be defined !!
+
+    rule #foo( X ) => X       requires #bar( X )
+endmodule

--- a/k-distribution/tests/regression-new/checks/expandMacroRequires.k
+++ b/k-distribution/tests/regression-new/checks/expandMacroRequires.k
@@ -1,3 +1,5 @@
+// Copyright (c) K Team. All Rights Reserved.
+
 module EXPANDMACROREQUIRES
     imports INT
     imports BOOL

--- a/k-distribution/tests/regression-new/checks/expandMacroRequires.k.out
+++ b/k-distribution/tests/regression-new/checks/expandMacroRequires.k.out
@@ -1,0 +1,9 @@
+[Error] Compiler: Rule contains macro symbol that was not expanded
+	Source(expandMacroRequires.k)
+	Location(10,10,10,49)
+	10 |	    rule #foo( X ) => X       requires #bar( X )
+	   .	         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Had 1 structural errors after macro expansion.
+  while executing phase "expand macros" on sentence at
+	Source(expandMacroRequires.k)
+	Location(10,10,10,49)

--- a/k-distribution/tests/regression-new/checks/expandMacroRequires.k.out
+++ b/k-distribution/tests/regression-new/checks/expandMacroRequires.k.out
@@ -1,9 +1,9 @@
 [Error] Compiler: Rule contains macro symbol that was not expanded
 	Source(expandMacroRequires.k)
-	Location(10,10,10,49)
-	10 |	    rule #foo( X ) => X       requires #bar( X )
+	Location(12,10,12,49)
+	12 |	    rule #foo( X ) => X       requires #bar( X )
 	   .	         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 1 structural errors after macro expansion.
   while executing phase "expand macros" on sentence at
 	Source(expandMacroRequires.k)
-	Location(10,10,10,49)
+	Location(12,10,12,49)

--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -188,16 +188,20 @@ public class ExpandMacros {
          * contain macros that have not been expanded.
          */
         if (s instanceof RuleOrClaim){
-            new VisitK() {
+            VisitK visitor = new VisitK() {
                 @Override
                 public void apply(KApply k) {
                     Option<Att> atts = mod.attributesFor().get(k.klabel());
                     if (atts.isDefined() && mod.attributesFor().apply(k.klabel()).getMacro().isDefined()) {
                         errors.add(KEMException.compilerError("Rule contains macro symbol that was not expanded", s));
                     }
-                    k.klist().items().stream().forEach(i -> super.apply(i));
+                    k.klist().items().forEach(super::apply);
                 }
-            }.accept(((RuleOrClaim) s).body());
+            };
+
+            visitor.accept(((RuleOrClaim) s).body());
+            visitor.accept(((RuleOrClaim) s).requires());
+            visitor.accept(((RuleOrClaim) s).ensures());
         }
 
         if (!errors.isEmpty()) {


### PR DESCRIPTION
Fixes #3585

This is a simple PR that extends the verification of expanded macros from checking just the rule `body` also to check its `ensures` and `requires`.