### PR TITLE
add AST term for LeftAssoc and RightAssoc in case you want to serialize them

### DIFF
--- a/kore/src/main/scala/org/kframework/parser/kore/Default.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/Default.scala
@@ -71,6 +71,10 @@ object implementation {
 
     case class StringLiteral(str: String) extends i.StringLiteral
 
+    case class LeftAssocTerm(p: i.Pattern) extends i.LeftAssocTerm
+
+    case class RightAssocTerm(p: i.Pattern) extends i.RightAssocTerm
+
     case class SortVariable(name: String) extends i.SortVariable {
       override def toString = name
       override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(this)
@@ -158,6 +162,10 @@ object implementation {
     // def Subset(s: i.Sort, rs: i.Sort, _1: Pattern, _2: Pattern): i.Pattern = d.Subset(s, rs, _1, _2)
 
     def StringLiteral(str: String): i.Pattern = d.StringLiteral(str)
+
+    def LeftAssocTerm(p: i.Pattern): i.Pattern = d.LeftAssocTerm(p)
+
+    def RightAssocTerm(p: i.Pattern): i.Pattern =  d.RightAssocTerm(p)
 
     // def DomainValue(sortStr: String, valueStr: String): Pattern = d.DomainValue(sortStr, valueStr)
 

--- a/kore/src/main/scala/org/kframework/parser/kore/Interface.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/Interface.scala
@@ -385,6 +385,22 @@ object StringLiteral {
   def unapply(arg: StringLiteral): Option[String] = Some(arg.str)
 }
 
+trait LeftAssocTerm extends Pattern {
+  def p: Pattern
+}
+
+object LeftAssocTerm {
+  def unapply(arg: LeftAssocTerm): Option[Pattern] = Some(arg.p)
+}
+
+trait RightAssocTerm extends Pattern {
+  def p: Pattern
+}
+
+object RightAssocTerm {
+  def unapply(arg: RightAssocTerm): Option[Pattern] = Some(arg.p)
+}
+
 // Domain Values are needed to merge Kore to K.
 // The data structure for DomainValue is temporary.
 // It is designed and implemented just to make sure that we can
@@ -554,4 +570,8 @@ trait Builders {
   def LeftAssoc(ctr: (Pattern, Pattern) => Pattern, ps: Seq[Pattern]): Pattern
 
   def RightAssoc(ctr: (Pattern, Pattern) => Pattern, ps: Seq[Pattern]): Pattern
+
+  def LeftAssocTerm(p: Pattern): Pattern
+
+  def RightAssocTerm(p: Pattern): Pattern
 }


### PR DESCRIPTION
The intuition here is that \left-assoc and \right-assoc are syntactic sugar, so the parser implicitly desugars them. However, you may still want to construct instances of these terms if you are construcing a KORE AST that you will later write somewhere using I/O. Thus we create these classes and methods in order to facilitate being able to do so.