### PR TITLE
Packaging: Move `version` into lib/kframework

### DIFF
--- a/k-distribution/src/main/assembly/bin.xml
+++ b/k-distribution/src/main/assembly/bin.xml
@@ -69,7 +69,7 @@
     </fileSet>
     <fileSet>
       <directory>${project.parent.basedir}/package</directory>
-      <outputDirectory>/lib</outputDirectory>
+      <outputDirectory>/lib/kframework</outputDirectory>
       <includes>
         <include>version</include>
       </includes>

--- a/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
+++ b/kernel/src/main/java/org/kframework/utils/file/JarInfo.java
@@ -85,7 +85,7 @@ public class JarInfo {
             // the release version if we're not (e.g. from a release tarball).
             String version = mf.getMainAttributes().getValue("Implementation-Git-Describe");
             if (version.isEmpty()) {
-                version = "v" + FileUtils.readFileToString(new File(kBase + "/lib/version")).trim();
+                version = "v" + FileUtils.readFileToString(new File(kBase + "/lib/kframework/version")).trim();
             }
 
             System.out.println("K version:    " + version);


### PR DESCRIPTION
For #3675 

We're installing `version` into `/usr/lib/version`. This change moves it to `/usr/lib/kframework/version`.