### PR TITLE
Introduces `--debugger-command` flag to krun

### DIFF
--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -37,12 +37,14 @@ filterSubst=
 if [[ "$OSTYPE" == "darwin"* ]]; then
   LLDB_FILE="$(dirname "$0")/../lib/kllvm/lldb/k_lldb_path"
   if [ -f "$LLDB_FILE" ]; then
-    DBG_CMD="$(cat "$LLDB_FILE") -- "
+    DBG_EXE="$(cat "$LLDB_FILE")"
   else
-    DBG_CMD="lldb --"
+    DBG_EXE="lldb"
   fi
+  DBG_CMD=" -- "
 else
-  DBG_CMD="gdb --args "
+  DBG_EXE="gdb"
+  DBG_CMD=" --args "
 fi
 
 
@@ -112,6 +114,8 @@ $KRUN options:
                            parser. This can be overridden with -p.
       --debugger           Launch the backend in a debugging console.
                            Currently only supported on LLVM backend.
+      --debugger-command FILE  Execute GDB commands from FILE to debug program.
+                               Currently only supported on LLVM backend.
   -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
                            under the directory DIR.
       --dry-run            Do not execute backend, but instead print the
@@ -392,7 +396,16 @@ do
       ;;
 
       --debugger)
-      cmdprefix="$DBG_CMD"
+      cmdprefix="$DBG_EXE $DBG_CMD"
+      ;;
+
+      --debugger-command)
+      if [[ "$DBG_EXE" == "gdb" ]]; then
+        cmdprefix="$DBG_EXE -x $2 $DBG_CMD"
+      else
+        cmdprefix="$DBG_EXE -s $2 $DBG_CMD"
+      fi
+      shift
       ;;
 
       --statistics)

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -41,9 +41,11 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   else
     DBG_EXE="lldb"
   fi
-  DBG_CMD=" -- "
+  DBG_CMD=" --"
+  DBG_FLAG=" -s "
 else
   DBG_EXE="gdb"
+  DBG_FLAG=" -x "
   DBG_CMD=" --args "
 fi
 
@@ -400,13 +402,19 @@ do
       ;;
 
       --debugger-command)
-      if [[ "$DBG_EXE" == "gdb" ]]; then
-        cmdprefix="$DBG_EXE -x $2 $DBG_CMD"
-      else
-        cmdprefix="$DBG_EXE -s $2 $DBG_CMD"
-      fi
+        debugCommandFile="$2"
+        cmdprefix="$DBG_EXE $DBG_FLAG $debugCommandFile $DBG_CMD"
       shift
       ;;
+
+      --debugger-batch)
+      if [[ $cmdprefix == *gdb* || $cmdprefix == *lldb* ]]; then
+        cmdprefix="$DBG_EXE --batch $DBG_FLAG $debugCommandFile $DBG_CMD"
+      else
+        DBG_CMD=" --batch $DBG_CMD"
+      fi
+      ;;
+
 
       --statistics)
       statistics=true

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -116,6 +116,8 @@ $KRUN options:
                            parser. This can be overridden with -p.
       --debugger           Launch the backend in a debugging console.
                            Currently only supported on LLVM backend.
+      --debugger-batch     Launch the backend in a debugging console in batch
+                           mode. Currently only supported on LLVM backend.
       --debugger-command FILE  Execute GDB commands from FILE to debug program.
                                Currently only supported on LLVM backend.
   -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"


### PR DESCRIPTION
This PR reflects a new modification on the `llvm-krun` from the llvm-backend.

This new flag enables the user to pass a file with debug commands to its debugger and run them in a non-interactive mode!

This new flag also allows testing the debugger on our current CI.