### PR TITLE
Test K version output on packaging

### DIFF
--- a/package/test-package
+++ b/package/test-package
@@ -23,5 +23,16 @@ sort_int = kllvm.ast.CompositeSort("SortInt")
 assert str(sort_int) == "SortInt{}"
 HERE
 
+# Make sure that the version of the various components is correct comparing to
+# the KServer version that uses JVM.
+KOMPILE_VERSION=$(kompile --version | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g[0-9a-z]+(-dirty)?')
+KSERVER_VERSION=$(kserver --version | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g[0-9a-z]+(-dirty)?')
+
+if [ "$KOMPILE_VERSION" != "$KSERVER_VERSION" ]; then
+    echo "KOMPILE_VERSION: $KOMPILE_VERSION"
+    echo "KSERVER_VERSION: $KSERVER_VERSION"
+    exit 1
+fi
+
 # Make sure that the Haskell Backend Booster has been installed properly.
 kore-rpc-booster --help

--- a/package/test-package
+++ b/package/test-package
@@ -25,8 +25,9 @@ HERE
 
 # Make sure that the version of the various components is correct comparing to
 # the KServer version that uses JVM.
-KOMPILE_VERSION=$(kompile --version | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g[0-9a-z]+(-dirty)?')
-KSERVER_VERSION=$(kserver --version | grep -oP 'v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g[0-9a-z]+(-dirty)?')
+VERSION_REGEX='v[0-9]+\.[0-9]+\.[0-9]+-[0-9]+-g[0-9a-z]+(-dirty)?'
+KOMPILE_VERSION=$(kompile --version | grep -oP "${VERSION_REGEX}")
+KSERVER_VERSION=$(kserver --version | grep -oP "${VERSION_REGEX}")
 
 if [ "$KOMPILE_VERSION" != "$KSERVER_VERSION" ]; then
     echo "KOMPILE_VERSION: $KOMPILE_VERSION"


### PR DESCRIPTION
Follow-up to #3691.

This PR creates a simple test on the `test-package` to check whether a modification on K breaks the `--version` output, as the current regression test couldn't catch recent problems with it.

The test is pretty simple: it uses the old system of getting `--version` from the JVM execution of `kserver` and checks it against the `kompile --version` that uses the k script implementation that avoids JVM startup to output the tool's version. If they are the same, the test succeeds and fails otherwise! 

This PR should fail until #3691 gets merged!