### PR TITLE
Point to new `release.nix` upload action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,7 +63,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
 
       - name: Upload release.nix
-        uses: ttuegel/upload-release.nix@v1.0
+        uses: runtimeverification/upload-release.nix@v1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
GitHub have deprecated the `hub` tool (https://github.com/runtimeverification/devops/issues/167), which we use via the `upload-release.nix` action to attach that Nix file to published K releases. As part of this deprecation, the K release was broken by `hub` being removed from the default public runner.

This PR (and associated changes) attempts to fix the issue by:
* Forking the action from Tom Tuegel's repo to the RV namespace; given we rely on this code and are the only consumers of it we should probably have it located as such.
* Amending the upload script to use `gh`:
  * The environment variable for the GitHub auth token is different between the two tools.
  * They have slightly different syntax at the command line, but from the documentation appear to be broadly compatible in terms of filenames, tags etc.
* Versioning a new release of the action under the RV org.
* Pointing the K release job at that version.

This process is difficult to test outside of the context of an actual K release going through, and so I propose to merge this PR and babysit the resulting release job to see what happens. If it does not work, we can revert to Tom's action easily and will be no worse off than we were initially.

Our fork of the release action is here: https://github.com/runtimeverification/upload-release.nix; the changes relevant to this PR are in commit [`0b1594f`](https://github.com/runtimeverification/upload-release.nix/commit/0b1594f89d03a0050f2bcc2e0b3b9f70ce42f695)