### PR TITLE
Use `macos-13` everywhere

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -302,7 +302,7 @@ jobs:
 
   macos-test:
     name: 'Test MacOS Package'
-    runs-on: macos-11
+    runs-on: macos-13
     timeout-minutes: 60
     environment: production
     needs: [macos-build, set-release-id]


### PR DESCRIPTION
A recent change to update the version of macOS we use to perform Homebrew CI has led to the versions getting out of sync; this PR ensures that they're consistent.