### PR TITLE
Use new Z3 image location

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_DISTRO
 ARG K_VERSION
 
 ARG Z3_VERSION
-FROM runtimeverificationinc/${BASE_OS}-${BASE_DISTRO}-z3:${Z3_VERSION} as Z3
+FROM runtimeverificationinc/z3:${BASE_OS}-${BASE_DISTRO}-${Z3_VERSION} as Z3
 
 ARG BASE_OS
 ARG BASE_DISTRO


### PR DESCRIPTION
This PR points the K CI dockerfile to the new Z3 image repository from https://github.com/runtimeverification/z3-images/pull/4