### PR TITLE
Bump calibre version in release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,7 @@ jobs:
         run: |
           sudo apt update --yes
           sudo apt install --yes wget texlive-xetex
-          sudo wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin version=5.42.0
+          sudo wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin version=5.44.0
           sudo wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-amd64.deb -O /tmp/pandoc.deb
           sudo dpkg -i /tmp/pandoc.deb
       - name: 'Checkout code and set up web build'


### PR DESCRIPTION
The K release job is [failing](https://github.com/runtimeverification/k/actions/runs/6487939393/job/17621794366) because Calibre 5 has been updated, and the older version is no longer being signed by the maintainers. This PR bumps the version to avoid this happening.

The error in the failing job is:
```
__main__.HTTPError: https://code.calibre-ebook.com/signatures/calibre-5.42.0-x86_64.txz.sha512 returned an unsupported http response code: 404 (Not Found)
```

We can see that bumping the version will fix the problem:
```console
$ curl -kLI http://code.calibre-ebook.com/signatures/calibre-5.42.0-x86_64.txz.sha512
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Thu, 12 Oct 2023 08:37:51 GMT
Content-Type: text/html
Content-Length: 162
Connection: close
Location: https://code.calibre-ebook.com/signatures/calibre-5.42.0-x86_64.txz.sha512

HTTP/2 404
server: nginx
date: Thu, 12 Oct 2023 08:37:51 GMT
content-type: text/html; charset=utf-8
content-length: 146

$ curl -kLI http://code.calibre-ebook.com/signatures/calibre-5.44.0-x86_64.txz.sha512
HTTP/1.1 301 Moved Permanently
Server: nginx
Date: Thu, 12 Oct 2023 08:37:57 GMT
Content-Type: text/html
Content-Length: 162
Connection: close
Location: https://code.calibre-ebook.com/signatures/calibre-5.44.0-x86_64.txz.sha512

HTTP/2 200
server: nginx
date: Thu, 12 Oct 2023 08:37:57 GMT
content-type: text/plain; charset=utf-8
content-length: 128
last-modified: Fri, 17 Jun 2022 04:14:51 GMT
etag: "62abffbb-80"
accept-ranges: bytes
```