### PR TITLE
Rephrase `sed` invocation for macOS

### DIFF
--- a/k-distribution/tests/regression-new/context-labels/Makefile
+++ b/k-distribution/tests/regression-new/context-labels/Makefile
@@ -4,7 +4,7 @@ KOMPILE_BACKEND=haskell
 KPROVE_FLAGS+=--debugger --debug-script context-spec.k.in
 KORE_REPL_OPTS=--log-entries DebugAppliedLabeledRewriteRule
 export KORE_REPL_OPTS
-CONSIDER_PROVER_ERRORS=2>&1 | sed 's!\[[0-9]\+]!!g' # Hacking in a sed command here to remove strings of the form '[23452]'
+CONSIDER_PROVER_ERRORS=2>&1 | sed 's!\[[0-9][0-9]*]!!g' # Hacking in a sed command here to remove strings of the form '[23452]'
 
 include ../../../include/kframework/ktest.mak
 


### PR DESCRIPTION
This PR fixes a really tiny papercut in the regression test suite; out of the box on macOS, the version of `sed` that's installed [doesn't understand the `+` regex operator](https://stackoverflow.com/questions/4453760/how-to-escape-plus-sign-on-mac-os-x-bsd-sed), which causes one test to fail by not slicing out a non-deterministic part of some test output.

Rather than trying to install a better version of `sed` for this one case, we just rephrase the regex in question to use `*` instead.