### PR TITLE
Drop mentions of Focal from packaging and install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,16 +80,6 @@ sudo apt-get install build-essential m4 openjdk-17-jdk libfmt-dev libgmp-dev lib
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 
-On Ubuntu Linux 20.04 (Focal):
-
-**Note**: the installation process is very similar to the above, the only difference is that clang, lld and llvm-tools have to be version 12.
-
-```shell
-git submodule update --init --recursive
-sudo apt-get install build-essential m4 openjdk-11-jdk libfmt-dev libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 python3-dev cmake gcc g++ clang-12 lld-12 llvm-12-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
-curl -sSL https://get.haskellstack.org/ | sh
-```
-
 On Arch Linux:
 
 ```shell
@@ -187,10 +177,6 @@ See the notes below.
     You can test if it works by calling `mvn -version` in a terminal.
     This will provide the information about the JDK Maven is using, in case
     it is the wrong one.
-
-    Note that on Ubuntu Focal, the default Maven version is not compatible with
-    newer versions of the JDK; for K's Maven build to work, please ensure you
-    have version 11 installed.
 
 5.   Haskell Stack
 

--- a/k-distribution/INSTALL.md
+++ b/k-distribution/INSTALL.md
@@ -40,7 +40,7 @@ Install through packages
 
 We currently strive to provide packages for the following platforms:
 
--   Ubuntu Focal Fossa (20.04) and Jammy Jellyfish (22.04)
+-   Ubuntu Jammy Jellyfish (22.04)
 -   Debian Bookworm
 -   Arch Linux
 -   macOS Catalina (10.15), Big Sur (11) and Monterey (12) via Homebrew
@@ -52,7 +52,7 @@ Pre-installation Notes
 -   We **do not** currently support running K natively on Windows. To use K on
     Windows 10, you are encouraged to install the
     [Windows Subsystem for Linux (version 2)](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
-    and follow the instructions for installing Ubuntu Focal.
+    and follow the instructions for installing Ubuntu Jammy.
 
     If you have already installed WSL, before proceeding, you will need to
     enter the WSL environment. You can do this by:
@@ -65,7 +65,7 @@ Pre-installation Notes
     you will need to use a virtual machine (VM) software. We assume you have:
 
     1.  Created a virtual machine
-    2.  Installed a Linux distribution (e.g. Ubuntu Focal Fossa) on your
+    2.  Installed a Linux distribution (e.g. Ubuntu Jammy Jellyfish) on your
         virtual machine
 
     Consult your virtual machine software if you need help with the above
@@ -109,12 +109,6 @@ requires about ~1.4GB of dependencies and will take some time.
 
 -   On Linux systems, K will typically be installed under `/usr`.
 -   On macOS/brew, K will typically be installed under `/usr/local`.
-
-### Ubuntu Focal (20.04)
-
-```sh
-sudo apt install ./kframework_amd64_ubuntu_jammy.deb
-```
 
 ### Ubuntu Jammy (22.04)
 


### PR DESCRIPTION
As part of https://github.com/runtimeverification/k/issues/3591, we are dropping support for Ubuntu Focal so that we can upgrade to JVM 17.

In https://github.com/runtimeverification/k/pull/3600, we removed Focal from our CI and packaging workflows. This PR removes any remaining textual references to Ubuntu Focal from the K documentation; no actual code is affected by this change.