### PR TITLE
Slimmer nix runtime closure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
             k-framework = { haskell-backend-bins, llvm-kompile-libs }:
               prev.callPackage ./nix/k.nix {
                 inherit (prev) llvm-backend;
+                clang = prev."clang_${toString final.llvm-version}";
                 booster = booster-backend.packages.${prev.system}.kore-rpc-booster;
                 mavenix = { inherit (prev) buildMaven; };
                 haskell-backend = haskell-backend-bins;

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -77,7 +77,10 @@ in let
     flex
     (if stdenv.isDarwin then clang else gcc)
     gmp
-    (if stdenv.isDarwin then jre_minimal else jre_minimal.override { jdk = jdk.override { headless = true; }; })
+    (jre_minimal.override {
+      modules = [ "java.base" "java.desktop" "java.logging" "java.rmi" ];
+      jdk = if stdenv.isDarwin then jdk else jdk.override { headless = true; };
+    })
     mpfr
     ncurses
     pkgconfig

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -1,6 +1,6 @@
 { src, clang, stdenv, lib, mavenix, runCommand, makeWrapper, bison, flex, gcc
-, git, gmp, jdk, mpfr, ncurses, pkgconfig, python3, z3, haskell-backend, booster ? null
-, prelude-kore, llvm-backend, llvm-backend-matching, debugger, version, llvm-kompile-libs }:
+, git, gmp, jre_minimal, mpfr, ncurses, pkgconfig, python3, z3, haskell-backend, booster ? null
+, prelude-kore, llvm-backend, debugger, version, llvm-kompile-libs }:
 
 let
   unwrapped = mavenix.buildMaven {
@@ -75,7 +75,7 @@ in let
     flex
     (if stdenv.isDarwin then clang else gcc)
     gmp
-    jdk
+    jre_minimal
     mpfr
     ncurses
     pkgconfig
@@ -123,6 +123,5 @@ in let
       ln -sf ${haskell-backend}/bin/kore-parser $out/bin/kore-parser
       ln -sf ${haskell-backend}/bin/kore-repl $out/bin/kore-repl
       ln -sf ${haskell-backend}/bin/kore-match-disjunction $out/bin/kore-match-disjunction
-      ln -sf ${llvm-backend-matching}/bin/llvm-backend-matching $out/bin/llvm-backend-matching
     '';
 in final [ ]

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -77,7 +77,7 @@ in let
     flex
     (if stdenv.isDarwin then clang else gcc)
     gmp
-    (jre_minimal.override { jdk = jdk.override { headless = true; }; })
+    (if stdenv.isDarwin then jre_minimal else jre_minimal.override { jdk = jdk.override { headless = true; }; })
     mpfr
     ncurses
     pkgconfig

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -47,7 +47,7 @@ let
         fi
       done
 
-      mkdir -p $out/lib/cmake/kframework && ln -sf ${llvm-backend.src}/cmake/* $out/lib/cmake/kframework/
+      mkdir -p $out/lib/cmake/kframework && cp ${llvm-backend.src}/cmake/* $out/lib/cmake/kframework/
       ln -sf ${llvm-backend}/include/kllvm $out/include/
       ln -sf ${llvm-backend}/include/kllvm-c $out/include/
       ln -sf ${llvm-backend}/lib/kllvm $out/lib/

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -1,6 +1,7 @@
 { src, clang, stdenv, lib, mavenix, runCommand, makeWrapper, bison, flex, gcc
-, git, gmp, jre_minimal, mpfr, ncurses, pkgconfig, python3, z3, haskell-backend, booster ? null
-, prelude-kore, llvm-backend, debugger, version, llvm-kompile-libs }:
+, git, gmp, jdk, jre_minimal, mpfr, ncurses, pkgconfig, python3, z3
+, haskell-backend, booster ? null, prelude-kore, llvm-backend, debugger, version
+, llvm-kompile-libs }:
 
 let
   unwrapped = mavenix.buildMaven {
@@ -52,7 +53,8 @@ let
       ln -sf ${llvm-backend}/lib/kllvm $out/lib/
       ln -sf ${llvm-backend}/lib/scripts $out/lib/
       ln -sf ${llvm-backend}/bin/* $out/bin/
-      ${lib.optionalString (booster != null ) "ln -sf ${booster}/bin/* $out/bin/"}
+      ${lib.optionalString (booster != null)
+      "ln -sf ${booster}/bin/* $out/bin/"}
 
       prelude_kore="$out/include/kframework/kore/prelude.kore"
       mkdir -p "$(dirname "$prelude_kore")"
@@ -75,7 +77,7 @@ in let
     flex
     (if stdenv.isDarwin then clang else gcc)
     gmp
-    jre_minimal
+    (jre_minimal.override { jdk = jdk.override { headless = true; }; })
     mpfr
     ncurses
     pkgconfig


### PR DESCRIPTION
Fixes #3732 

Closure size M1 Mac:
<img width="1085" alt="image" src="https://github.com/runtimeverification/k/assets/10553895/78c910a0-cd64-445e-89af-f67df9a4cd94">

Closure size Linux:
<img width="1085" alt="image" src="https://github.com/runtimeverification/k/assets/10553895/509803d7-ec1d-4126-9ffb-2cb5cd83d418">

Note that the Linux version also includes gdb

I also did not attempt to remove gcc because for some reason clang depends on it anyway in the llvm-backend, hence we would have to remove it there first.