### PR TITLE
Bump JDK requirement to 17

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ The following dependencies are needed either at build time or runtime:
 *   [fmt](https://fmt.dev/)
 *   [gcc](https://gcc.gnu.org/)
 *   [gmp](https://gmplib.org/)
-*   [jdk](https://openjdk.java.net/) (version 11 or greater)
+*   [jdk](https://openjdk.java.net/) (version 17 or greater)
 *   [libjemalloc](https://github.com/jemalloc/jemalloc)
 *   [libyaml](https://pyyaml.org/wiki/LibYAML)
 *   [llvm](https://llvm.org/) (We require version 10 or greater for clang, lld, and llvm-tools. On some distributions, the utilities below are also needed and packaged separately.)
@@ -135,10 +135,10 @@ See the notes below.
 
 ### Installation Notes
 
-1.  Java Development Kit (required JDK11 or higher)
+1.  Java Development Kit (required JDK 17 or higher)
 
     *   Linux: Download from package manager
-        (e.g. `sudo apt-get install openjdk-11-jdk`).
+        (e.g. `sudo apt-get install openjdk-17-jdk`).
 
     *   macOS/brew: Download from package manager
         (e.g. `brew install java`).
@@ -418,10 +418,6 @@ Common build-time error messages:
     + You may run into this issue if target/generated-sources/javacc is not added to the
       build path of your IDE. Generally this is solved by regenerating your project /
       re-syncing it with the pom.xml.
-
--   `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.1:compile
-     (default-compile) on project k-core: Fatal error compiling: invalid target release: 11 -> [Help 1]`
-    + You either do not have Java 11 installed, or `$JAVA_HOME` does not point to a Java 11 JDK.
 
 -   `[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.7:run
      (build-haskell) on project haskell-backend: An Ant BuildException has occured: exec returned: 1`

--- a/package/debian/control.bookworm
+++ b/package/debian/control.bookworm
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-14 , default-jre-headless , flex , gcc , g++ , libboost-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libsecp256k1-1 , libyaml-0-2 , libz3-4 , lld-14 , pkg-config , llvm-14
+Depends: bison , clang-14 , openjdk-17-jre-headless , flex , gcc , g++ , libboost-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libsecp256k1-1 , libyaml-0-2 , libz3-4 , lld-14 , pkg-config , llvm-14
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/package/debian/control.jammy
+++ b/package/debian/control.jammy
@@ -10,7 +10,7 @@ Package: kframework
 Architecture: any
 Section: devel
 Priority: optional
-Depends: bison , clang-14 , default-jre-headless , flex , gcc , g++ , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libsecp256k1-0 , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
+Depends: bison , clang-14 , openjdk-17-jre-headless , flex , gcc , g++ , libboost-dev , libffi-dev , libfmt-dev , libgmp-dev , libjemalloc-dev , libmpfr-dev , libsecp256k1-0 , libtinfo-dev , libyaml-0-2 , libz3-4 , lld-14 , llvm-14 , pkg-config
 Recommends: z3
 Description: K framework toolchain
  Includes K Framework compiler for K language definitions, and K interpreter

--- a/pom.xml
+++ b/pom.xml
@@ -145,8 +145,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
           <configuration>
-            <source>11</source>
-            <target>11</target>
+            <source>17</source>
+            <target>17</target>
           </configuration>
         </plugin>
         <!-- Antrun plugin for running arbitrary shell commands (building subprojects) -->


### PR DESCRIPTION
This PR bumps the compiler version used by Maven to build the K distribution from 11 to 17; no substantial further changes are required (other than documentation) as we already install version 17 or a rolling release in all of our packaging code. One minor required change was to pin the JRE version on Ubuntu and Debian to 17, rather than using the default version (11).

Once this change is merged, we can investigate whether there are any places in the K source where we could take advantage of new Java features.

Part of https://github.com/runtimeverification/k/issues/3699