### PR TITLE
Fix release by installing Calibre 6

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,7 @@ jobs:
       - name: 'Install pandoc/texlive/calibre'
         run: |
           sudo apt update --yes
-          sudo apt install --yes wget texlive-xetex
+          sudo apt install --yes wget texlive-xetex libegl1 libopengl0
           sudo wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin version=5.44.0
           sudo wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-amd64.deb -O /tmp/pandoc.deb
           sudo dpkg -i /tmp/pandoc.deb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -425,7 +425,7 @@ jobs:
         run: |
           sudo apt update --yes
           sudo apt install --yes wget texlive-xetex libegl1 libopengl0
-          sudo wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin version=5.44.0
+          sudo wget -nv -O- https://download.calibre-ebook.com/linux-installer.sh | sh /dev/stdin version=6.29.0
           sudo wget https://github.com/jgm/pandoc/releases/download/2.18/pandoc-2.18-1-amd64.deb -O /tmp/pandoc.deb
           sudo dpkg -i /tmp/pandoc.deb
       - name: 'Checkout code and set up web build'


### PR DESCRIPTION
This PR is a repeat fix for https://github.com/runtimeverification/k/issues/3710; I realise that the issue has recurred because the 5.x releases of Calibre are being invalidated faster as they are "out of date". To address this, I tested the relevant part of the release job with Calibre 6.29 in the PR CI here; it all appears to work fine.