### PR TITLE
Check for Java 17 when running K tools

### DIFF
--- a/k-distribution/src/main/scripts/lib/checkJava
+++ b/k-distribution/src/main/scripts/lib/checkJava
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-MIN_VERSION="8"
+MIN_VERSION="17"
 echoerr() { echo "$@" 1>&2; }
 
 if type -p java >/dev/null; then


### PR DESCRIPTION
This script is responsible for checking the installed Java version when we run a K tool; it appears to have been missed out when we bumped the required version of Java from 8 to 11, and then to 17.