### PR TITLE
Update nix install script

### DIFF
--- a/package/nix/install
+++ b/package/nix/install
@@ -35,7 +35,9 @@ in your shell."
     if [[ $REPLY =~ ^[Yy]$ ]]
     then
       echo "Downloading nix and running the installer..."
-      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm
+      curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm \
+      --extra-conf "trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= k-framework.cachix.org-1:jeyMXB2h28gpNRjuVkehg+zLj62ma1RnyyopA/20yFE= k-framework-binary.cachix.org-1:pJedQ8iG19BW3v/DMMmiRVtwRBGO3fyMv2Ws0OpBADs=" \
+      --extra-conf "substituters = https://cache.nixos.org https://k-framework.cachix.org"
       if [ -e '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh' ]; then
           . '/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh'
       else


### PR DESCRIPTION
This change sets the trusted public keys and substituters for the k-framework cachix cache, which makes for a smoother experience since the user won't be prompted to install the cache by kup