### PR TITLE
Revert to nix-community/mavenix in nix build

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -190,15 +190,15 @@
         "utils": "utils_3"
       },
       "locked": {
-        "lastModified": 1689018333,
-        "narHash": "sha256-sthxx50rj0E7gv38oeMj8GZOp7i1776P1qZsM7pVLd0=",
-        "owner": "goodlyrottenapple",
+        "lastModified": 1643802645,
+        "narHash": "sha256-BynM25iwp/l3FyrcHqiNJdDxvN6IxSM3/zkFR6PD3B0=",
+        "owner": "nix-community",
         "repo": "mavenix",
-        "rev": "153d69e62f87e5dd37d35492cc3e35dd80d2b5fa",
+        "rev": "ce9ddfd7f361190e8e8dcfaf6b8282eebbb3c7cb",
         "type": "github"
       },
       "original": {
-        "owner": "goodlyrottenapple",
+        "owner": "nix-community",
         "repo": "mavenix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     llvm-backend.inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     rv-utils.url = "github:runtimeverification/rv-nix-tools";
-    mavenix.url = "github:goodlyrottenapple/mavenix";
+    mavenix.url = "github:nix-community/mavenix";
     # needed by nix/flake-compat-k-unwrapped.nix
     flake-compat = {
       url = "github:edolstra/flake-compat";

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -9,11 +9,6 @@ let
     infoFile = ./mavenix.lock;
     inherit src;
 
-    # By default, mavenix copies the jars defined in `submodules` of mavenix.lock to `$out/share/java`.
-    # The following flag disables this, since we copy the jars ourselves.
-    # Otherwise, the jars are needlessly duplicated and bloat the cachix cache.
-    copySubmodules = false;
-
     # Add build dependencies
     buildInputs = [ git ];
 
@@ -37,15 +32,6 @@ let
     # as these will be expected/required when compiling other projects, e.g. the evm-semantics repo
     postInstall = ''
       cp -r k-distribution/target/release/k/{bin,include,lib} $out/
-
-      for file in $out/lib/kframework/java/*; do
-        file_name=$(basename $file)
-        found_in_share="$(find -L $out/share/mavenix/repo -maxdepth 20 -name "$file_name")"
-        if [ ! -z "$found_in_share" ]; then
-          rm "$file"
-          ln -sf "$found_in_share" "$file"
-        fi
-      done
 
       mkdir -p $out/lib/cmake/kframework && cp ${llvm-backend.src}/cmake/* $out/lib/cmake/kframework/
       ln -sf ${llvm-backend}/include/kllvm $out/include/


### PR DESCRIPTION
This reverts the change to mavenix from https://github.com/runtimeverification/k/pull/2673 which introduced a custom version of the mavenix build tool. The original mavenix builds a "repo" derivation which symlinks to all the pom and jar files maven needs to build k. The way mavenix assembles this repo is to first copy each pom/jar file into the nix store individually and then symlink them into a single derivation. Once we build using maven, mavenix copies any required runtime jars to the final k derivation. This obviously creates some redundancy, because there are now two copies of some jar/pom files in the store. For the cachix cache, this means unnecessary duplication each time we push to it. The solution in the aforementioned PR was to symlink to the already present jars/poms instead of copying them. 

However, with the new binary cache, the focus is on speed of downloading the pre-compiled binaries and having lot of symlinked paths from the k derivation to each individual pom/jar file introduces a serious bottleneck when we call `nix copy` to download the k binary (see https://github.com/NixOS/nix/issues/2559). Until such time as this issue is resolved, we should revert to the old mavenix which reduces the k closure size (i.e. the number of files the k derivation depends on in the nix store, not necessarily the total size in mb) drastically at the expense of some added duplication of jar files with each build.