### PR TITLE
Apply Java migration: pattern variables

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -201,8 +201,7 @@ public class ModuleToKORE {
         SetMultimap<KLabel, Rule> functionRules = HashMultimap.create();
         for (Rule rule : sortedRules) {
             K left = RewriteToTop.toLeft(rule.body());
-            if (left instanceof KApply) {
-                KApply kapp = (KApply) left;
+            if (left instanceof KApply kapp) {
                 Production prod = production(kapp);
                 if (prod.att().contains(Att.FUNCTION()) || rule.att().contains(Att.ANYWHERE()) || ExpandMacros.isMacro(rule)) {
                     functionRules.put(kapp.klabel(), rule);

--- a/kernel/src/main/java/org/kframework/compile/AddCoolLikeAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/AddCoolLikeAtt.java
@@ -53,8 +53,7 @@ public class AddCoolLikeAtt {
             @Override
             public Boolean apply(KApply k) {
                 if (mod.attributesFor().get(k.klabel()).getOrElse(() -> Att.empty()).contains(Att.MAINCELL())) {
-                    if (k.items().get(0) instanceof KSequence) {
-                        KSequence seq = (KSequence) k.items().get(0);
+                    if (k.items().get(0) instanceof KSequence seq) {
                         if (seq.items().size() > 1 && seq.items().get(0) instanceof KVariable) {
                             return true;
                         }

--- a/kernel/src/main/java/org/kframework/compile/AddImplicitComputationCell.java
+++ b/kernel/src/main/java/org/kframework/compile/AddImplicitComputationCell.java
@@ -48,11 +48,9 @@ public class AddImplicitComputationCell {
             return s;
         }
 
-        if (s instanceof RuleOrClaim) {
-            RuleOrClaim rule = (RuleOrClaim) s;
+        if (s instanceof RuleOrClaim rule) {
             return rule.newInstance(apply(rule.body(), m, rule instanceof Claim), rule.requires(), rule.ensures(), rule.att());
-        } else if (s instanceof Context) {
-            Context context = (Context) s;
+        } else if (s instanceof Context context) {
             return new Context(apply(context.body(), m, false), context.requires(), context.att());
         } else {
             return s;
@@ -74,8 +72,7 @@ public class AddImplicitComputationCell {
             return true;
         } else if (items.size() == 2 && isClaim) {
             K second = items.get(1);
-            if(second instanceof KApply) {
-                KApply app = (KApply) second;
+            if(second instanceof KApply app) {
                 return app.klabel() == KLabels.GENERATED_COUNTER_CELL;
             }
         }
@@ -88,8 +85,7 @@ public class AddImplicitComputationCell {
             return false;
         }
 
-        if (item instanceof KRewrite) {
-            final KRewrite rew = (KRewrite) item;
+        if (item instanceof final KRewrite rew) {
             return Stream.concat(
                             IncompleteCellUtils.flattenCells(rew.left()).stream(),
                             IncompleteCellUtils.flattenCells(rew.right()).stream())

--- a/kernel/src/main/java/org/kframework/compile/AddImplicitCounterCell.java
+++ b/kernel/src/main/java/org/kframework/compile/AddImplicitCounterCell.java
@@ -21,8 +21,7 @@ public class AddImplicitCounterCell {
     public AddImplicitCounterCell() {}
 
     public Sentence apply(Module m, Sentence s) {
-        if(s instanceof Claim) {
-            Claim claim = (Claim) s;
+        if(s instanceof Claim claim) {
             return claim.newInstance(apply(claim.body(), m), claim.requires(), claim.ensures(), claim.att());
         }
         return s;

--- a/kernel/src/main/java/org/kframework/compile/AddParentCells.java
+++ b/kernel/src/main/java/org/kframework/compile/AddParentCells.java
@@ -181,8 +181,7 @@ public class AddParentCells {
                 }
             }
             return Optional.empty();
-        } else if (k instanceof  KRewrite) {
-            KRewrite rew = (KRewrite) k;
+        } else if (k instanceof KRewrite rew) {
             List<K> cells = IncompleteCellUtils.flattenCells(rew.left());
             cells.addAll(IncompleteCellUtils.flattenCells(rew.right()));
             Optional<Integer> level = Optional.empty();
@@ -205,8 +204,7 @@ public class AddParentCells {
     }
 
     Optional<KLabel> getParent(K k) {
-        if (k instanceof KApply) {
-            final KApply app = (KApply) k;
+        if (k instanceof final KApply app) {
             if (KLabels.CELLS.equals(app.klabel())) {
                 List<K> items = app.klist().items();
                 if (items.isEmpty()) {
@@ -246,10 +244,9 @@ public class AddParentCells {
     }
 
     K concretizeCell(K k) {
-        if (!(k instanceof KApply)) {
+        if (!(k instanceof KApply app)) {
             return k;
         } else {
-            KApply app = (KApply) k;
             KLabel target = app.klabel();
             if (cfg.isLeafCell(target)) {
                 return k;
@@ -291,8 +288,7 @@ public class AddParentCells {
     }
 
     K concretize(K term) {
-        if (term instanceof KApply) {
-            KApply app = (KApply) term;
+        if (term instanceof KApply app) {
             KApply newTerm = KApply(app.klabel(), KList(app.klist().stream()
                     .map(this::concretize).collect(Collectors.toList())), app.att());
             if (cfg.isParentCell(newTerm.klabel())) {
@@ -300,8 +296,7 @@ public class AddParentCells {
             } else {
                 return newTerm;
             }
-        } else if (term instanceof KRewrite) {
-            KRewrite rew = (KRewrite) term;
+        } else if (term instanceof KRewrite rew) {
             return KRewrite(concretize(rew.left()), concretize(rew.right()));
         } else if (term instanceof KSequence) {
             return KSequence(((KSequence) term).stream()
@@ -314,11 +309,9 @@ public class AddParentCells {
     }
 
     public Sentence concretize(Sentence m) {
-        if (m instanceof RuleOrClaim) {
-            RuleOrClaim r = (RuleOrClaim) m;
+        if (m instanceof RuleOrClaim r) {
             return r.newInstance(concretize(r.body()), r.requires(), r.ensures(), r.att());
-        } else if (m instanceof Context) {
-            Context c = (Context) m;
+        } else if (m instanceof Context c) {
             return new Context(concretize(c.body()), c.requires(), c.att());
         } else {
             return m;

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -186,8 +186,7 @@ public class AddSortInjections {
         if (actualSort.name().equals(SORTPARAM_NAME)) {
             sortParams.add(actualSort.params().head().name());
         }
-        if (term instanceof KApply) {
-            KApply kapp = (KApply)term;
+        if (term instanceof KApply kapp) {
             if (kapp.klabel().name().equals("inj")) {
                 return term;
             }
@@ -208,8 +207,7 @@ public class AddSortInjections {
                 children.add(internalAddSortInjections(child, expectedSortOfChild));
             }
             return KApply(substituted.klabel().get(), KList(children), att);
-        } else if (term instanceof KRewrite) {
-            KRewrite rew = (KRewrite) term;
+        } else if (term instanceof KRewrite rew) {
             isLHS = true;
             K lhs = internalAddSortInjections(rew.left(), actualSort);
             isLHS = false;
@@ -220,8 +218,7 @@ public class AddSortInjections {
             return KToken(((KToken) term).s(), ((KToken) term).sort(), att);
         } else if (term instanceof InjectedKLabel) {
             return InjectedKLabel(((InjectedKLabel) term).klabel(), att);
-        } else if (term instanceof KSequence) {
-            KSequence kseq = (KSequence)term;
+        } else if (term instanceof KSequence kseq) {
             List<K> children = new ArrayList<>();
             for (int i = 0; i < kseq.size(); i++) {
                 K child = kseq.items().get(i);
@@ -233,8 +230,7 @@ public class AddSortInjections {
                 }
             }
             return KSequence(children, att);
-        } else if (term instanceof KAs) {
-            KAs kas = (KAs)term;
+        } else if (term instanceof KAs kas) {
             return KAs(internalAddSortInjections(kas.pattern(), actualSort), kas.alias(), att);
         } else {
             throw KEMException.internalError("Invalid category of k found.", term);
@@ -323,8 +319,7 @@ public class AddSortInjections {
      * Compute the sort of a term with a particular expected sort.
      */
     public Sort sort(K term, Sort expectedSort) {
-        if (term instanceof KApply) {
-            KApply kapp = (KApply)term;
+        if (term instanceof KApply kapp) {
             if (kapp.klabel().name().equals("inj")) {
                 return kapp.klabel().params().apply(1);
             }
@@ -381,8 +376,7 @@ public class AddSortInjections {
                 substituted = prod.substitute(immutable(args));
             }
             return substituted.sort();
-        } else if (term instanceof KRewrite) {
-            KRewrite rew = (KRewrite)term;
+        } else if (term instanceof KRewrite rew) {
             Sort leftSort = sort(rew.left(), expectedSort);
             Sort rightSort = sort(rew.right(), expectedSort);
             return lubSort(leftSort, rightSort, expectedSort, term, mod);
@@ -394,8 +388,7 @@ public class AddSortInjections {
             return Sorts.K();
         } else if (term instanceof InjectedKLabel) {
             return Sorts.KItem();
-        } else if (term instanceof KAs) {
-            KAs as = (KAs) term;
+        } else if (term instanceof KAs as) {
             Sort patternSort = sort(as.pattern(), expectedSort);
             Sort rightSort = sort(as.alias(), expectedSort);
             return lubSort(patternSort, rightSort, expectedSort, term, mod);

--- a/kernel/src/main/java/org/kframework/compile/AddTopCellToRules.java
+++ b/kernel/src/main/java/org/kframework/compile/AddTopCellToRules.java
@@ -92,8 +92,7 @@ public class AddTopCellToRules {
         }
 
         // KRewrite instance
-        if (term instanceof KRewrite) {
-            KRewrite rew = (KRewrite) term;
+        if (term instanceof KRewrite rew) {
             K left = addRootCell(rew.left());
             if (left == rew.left()) {
                 return KRewrite(rew.left(), rew.right());

--- a/kernel/src/main/java/org/kframework/compile/CloseCells.java
+++ b/kernel/src/main/java/org/kframework/compile/CloseCells.java
@@ -154,8 +154,7 @@ public class CloseCells {
             }
             requiredRight = new HashSet<>(requiredLeft);
             for (K item : contents) {
-                if (item instanceof KRewrite) {
-                    KRewrite rw = (KRewrite) item;
+                if (item instanceof KRewrite rw) {
                     for (K leftItem : IncompleteCellUtils.flattenCells(rw.left())) {
                         filterRequired(requiredLeft, leftItem);
                     }

--- a/kernel/src/main/java/org/kframework/compile/ComputeTransitiveFunctionDependencies.java
+++ b/kernel/src/main/java/org/kframework/compile/ComputeTransitiveFunctionDependencies.java
@@ -31,8 +31,7 @@ public class ComputeTransitiveFunctionDependencies {
         Set<KLabel> anywhereKLabels = new HashSet<>();
         stream(module.rules()).filter(r -> !ExpandMacros.isMacro(r)).forEach(r -> {
             K left = RewriteToTop.toLeft(r.body());
-            if (left instanceof KApply) {
-                KApply kapp = (KApply) left;
+            if (left instanceof KApply kapp) {
                 if (r.att().contains(Att.ANYWHERE())) {
                     if (kapp.klabel().name().equals(KLabels.INJ)) {
                         K k = kapp.items().get(0);

--- a/kernel/src/main/java/org/kframework/compile/ConstantFolding.java
+++ b/kernel/src/main/java/org/kframework/compile/ConstantFolding.java
@@ -41,8 +41,7 @@ public class ConstantFolding {
   }
 
   public Sentence fold(Module module, Sentence sentence) {
-    if (sentence instanceof Rule) {
-      Rule r = (Rule)sentence;
+    if (sentence instanceof Rule r) {
       return Rule(fold(module, r.body(), true), fold(module, r.requires(), false), fold(module, r.ensures(), false), r.att());
     }
     return sentence;

--- a/kernel/src/main/java/org/kframework/compile/ConvertDataStructureToLookup.java
+++ b/kernel/src/main/java/org/kframework/compile/ConvertDataStructureToLookup.java
@@ -354,8 +354,7 @@ public class ConvertDataStructureToLookup {
                             }
                             frame = (KVariable) component;
                             isRight = true;
-                        } else if (component instanceof KApply) {
-                            KApply kapp = (KApply) component;
+                        } else if (component instanceof KApply kapp) {
                             boolean needsWrapper = false;
                             if (kapp.klabel().equals(elementLabel)
                                     || (needsWrapper = kapp.klabel().equals(getWrapElement(collectionLabel)))) {
@@ -444,10 +443,9 @@ public class ConvertDataStructureToLookup {
                                 throw KEMException.internalError("Unsupported associative matching on Map. Found variables " + component + " and " + frame, k);
                             }
                             frame = (KVariable) component;
-                        } else if (component instanceof KApply) {
+                        } else if (component instanceof KApply kapp) {
 
                             boolean needsWrapper = false;
-                            KApply kapp = (KApply) component;
                             if (kapp.klabel().equals(KLabel(m.attributesFor().apply(collectionLabel).get(Att.ELEMENT())))
                                     || (needsWrapper = kapp.klabel().equals(getWrapElement(collectionLabel)))) {
                                 if (kapp.klist().size() != 2 && !needsWrapper) {
@@ -520,8 +518,7 @@ public class ConvertDataStructureToLookup {
                                 throw KEMException.internalError("Unsupported associative matching on Set. Found variables " + component + " and " + frame, k);
                             }
                             frame = (KVariable) component;
-                        } else if (component instanceof KApply) {
-                            KApply kapp = (KApply) component;
+                        } else if (component instanceof KApply kapp) {
 
                             boolean needsWrapper = false;
                             if (kapp.klabel().equals(elementLabel)

--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -315,9 +315,8 @@ public class ExpandMacros {
             return Collections.singleton(k.att().getOptional(Sort.class).orElse(null));
         } else if (k instanceof KToken) {
             return Collections.singleton(((KToken)k).sort());
-        } else if (k instanceof KApply) {
-           KApply kapp = (KApply)k;
-           if (kapp.klabel() instanceof KVariable) {
+        } else if (k instanceof KApply kapp) {
+            if (kapp.klabel() instanceof KVariable) {
                throw KEMException.compilerError("Cannot compute macros with klabel variables.", r);
            }
            Set<Production> prods = new HashSet<>(mutable(mod.productionsFor().apply(kapp.klabel())));
@@ -364,10 +363,8 @@ public class ExpandMacros {
                 }
             }
         }
-        if (pattern instanceof KApply && subject instanceof KApply) {
-           KApply p = (KApply)pattern;
-           KApply s = (KApply)subject;
-           if (p.klabel() instanceof KVariable || s.klabel() instanceof KVariable) {
+        if (pattern instanceof KApply p && subject instanceof KApply s) {
+            if (p.klabel() instanceof KVariable || s.klabel() instanceof KVariable) {
                throw KEMException.compilerError("Cannot compute macros with klabel variables.", r);
            }
            if (!p.klabel().name().equals(s.klabel().name())) {

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -79,16 +79,14 @@ public class GenerateSentencesFromConfigDecl {
      * @return A tuple of the sentences generated, a list of the sorts of the children of the cell, and the body of the initializer.
      */
     private static Tuple4<Set<Sentence>, List<Sort>, K, Boolean> genInternal(K term, K ensures, Att cfgAtt, Module m) {
-        if (term instanceof KApply) {
-            KApply kapp = (KApply) term;
+        if (term instanceof KApply kapp) {
             if (kapp.klabel().name().equals("#configCell")) {
                 // is a single cell
                 if (kapp.klist().size() == 4) {
                     K startLabel = kapp.klist().items().get(0);
                     K endLabel = kapp.klist().items().get(3);
                     if (startLabel.equals(endLabel)) {
-                        if (startLabel instanceof KToken) {
-                            KToken label = (KToken) startLabel;
+                        if (startLabel instanceof KToken label) {
                             if (label.sort().equals(Sort("#CellName"))) {
                                 String cellName = label.s();
                                 Att cellProperties = getCellPropertiesAsAtt(kapp.klist().items().get(1), cellName, ensures);
@@ -115,8 +113,7 @@ public class GenerateSentencesFromConfigDecl {
             } else if (kapp.klabel().name().equals("#externalCell")) {
                 if (kapp.klist().size() == 1) {
                     K startLabel = kapp.klist().items().get(0);
-                    if (startLabel instanceof KToken) {
-                        KToken label = (KToken) startLabel;
+                    if (startLabel instanceof KToken label) {
                         if (label.sort().equals(Sort("#CellName"))) {
                             String cellName = label.s();
                             Sort sort = Sort(getSortOfCell(cellName));
@@ -166,10 +163,9 @@ public class GenerateSentencesFromConfigDecl {
             Sort sort = kapp.att().get(Production.class).sort();
             Tuple2<K, Set<Sentence>> res = getLeafInitializer(term, m);
             return Tuple4.apply(res._2(), Lists.newArrayList(sort), res._1(), true);
-        } else if (term instanceof KToken) {
+        } else if (term instanceof KToken ktoken) {
             // child of a leaf cell. Generate no productions, but inform parent that it has a child of a particular sort.
             // A leaf cell initializes to the value specified in the configuration declaration.
-            KToken ktoken = (KToken) term;
             Tuple2<K, Set<Sentence>> res = getLeafInitializer(term, m);
             return Tuple4.apply(res._2(), Lists.newArrayList(ktoken.sort()), res._1(), true);
         } else if (term instanceof KSequence || term instanceof KVariable || term instanceof InjectedKLabel) {
@@ -217,8 +213,7 @@ public class GenerateSentencesFromConfigDecl {
             if (kapp.klabel().name().equals("#externalCell")) {
                 if (kapp.klist().size() == 1) {
                     K startLabel = kapp.klist().items().get(0);
-                    if (startLabel instanceof KToken) {
-                        KToken label = (KToken) startLabel;
+                    if (startLabel instanceof KToken label) {
                         if (label.sort().equals(Sort("#CellName"))) {
                             String cellName = label.s();
                             Sort sort = Sort(getSortOfCell(cellName));
@@ -580,8 +575,7 @@ public class GenerateSentencesFromConfigDecl {
     }
 
     private static Att getCellPropertiesAsAtt(K k) {
-        if (k instanceof KApply) {
-            KApply kapp = (KApply) k;
+        if (k instanceof KApply kapp) {
             if (kapp.klabel().name().equals("#cellPropertyListTerminator")) {
                 return Att();
             } else if (kapp.klabel().name().equals("#cellPropertyList")) {
@@ -598,12 +592,10 @@ public class GenerateSentencesFromConfigDecl {
     }
 
     private static Tuple2<Att.Key, String> getCellProperty(K k) {
-        if (k instanceof KApply) {
-            KApply kapp = (KApply) k;
+        if (k instanceof KApply kapp) {
             if (kapp.klabel().name().equals("#cellProperty")) {
                 if (kapp.klist().size() == 2) {
-                    if (kapp.klist().items().get(0) instanceof KToken) {
-                        KToken keyToken = (KToken) kapp.klist().items().get(0);
+                    if (kapp.klist().items().get(0) instanceof KToken keyToken) {
                         if (keyToken.sort().equals(Sort("#CellName"))) {
                             Att.Key key = Att.getBuiltinKeyOptional(keyToken.s())
                                     .orElseThrow(() ->

--- a/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
+++ b/kernel/src/main/java/org/kframework/compile/MarkExtraConcreteRules.java
@@ -22,8 +22,7 @@ public class MarkExtraConcreteRules {
         }
         HashSet<String> concreteLabelsSet = new HashSet<>(extraConcreteRuleLabels);
         Definition result = DefinitionTransformer.fromSentenceTransformer((mod, s) -> {
-            if (s instanceof Rule) {
-                Rule r = (Rule) s;
+            if (s instanceof Rule r) {
                 String label = r.att().getOption(Att.LABEL()).getOrElse(() -> null);
                 if (label != null && concreteLabelsSet.contains(label)) {
                     // rule labels must be unique, so it's safe to remove from the set as we iterate

--- a/kernel/src/main/java/org/kframework/compile/RemoveUnit.java
+++ b/kernel/src/main/java/org/kframework/compile/RemoveUnit.java
@@ -29,10 +29,9 @@ public class RemoveUnit {
   }
 
   private Stream<Sentence> gen(Sentence s) {
-    if (!(s instanceof Rule)) {
+    if (!(s instanceof Rule r)) {
       return Stream.of(s);
     }
-    Rule r = (Rule)s;
     K body = flattenLists(r.body());
     K requires = flattenLists(r.requires());
     K ensures = flattenLists(r.ensures());

--- a/kernel/src/main/java/org/kframework/compile/ResolveContexts.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveContexts.java
@@ -184,8 +184,7 @@ public class ResolveContexts {
         // TODO(dwightguth): generate freezers better for pretty-printing purposes
         List<ProductionItem> items = new ArrayList<>();
         KLabel freezerLabel;
-        if (cooled instanceof KApply) {
-            KApply kApply = (KApply)cooled;
+        if (cooled instanceof KApply kApply) {
             String name = kApply.klabel().name();
             if (name.equals("#SemanticCastToK")) {
                 K firstArg = kApply.klist().items().get(0);
@@ -309,8 +308,7 @@ public class ResolveContexts {
 
             // return true when k is either HOLE or #SemanticCastToX(HOLE)
             private boolean isHOLE(K k) {
-                if (k instanceof KApply) {
-                    KApply kapp = (KApply) k;
+                if (k instanceof KApply kapp) {
                     return kapp.klabel().name().startsWith("#SemanticCastTo") &&
                             kapp.klist().size() == 1 &&
                             isHOLEVar(kapp.klist().items().get(0));

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConfigConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConfigConstants.java
@@ -37,11 +37,10 @@ public class ResolveFreshConfigConstants {
      *         fresh constant
      */
     private K transform(RuleOrClaim r, K body) {
-        if (!(r instanceof Rule)) {
+        if (!(r instanceof Rule rule)) {
             return body;
         }
 
-        Rule rule = (Rule) r;
         if (!rule.att().contains(Att.INITIALIZER())) {
             return body;
         }

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
@@ -72,8 +72,7 @@ public class ResolveFreshConstants {
                 rule.att());
         if (rule.att().contains(Att.INITIALIZER())) {
             K left = RewriteToTop.toLeft(withFresh.body());
-            if (left instanceof KApply) {
-                KApply kapp = (KApply) left;
+            if (left instanceof KApply kapp) {
                 if (kapp.klabel().equals(KLabels.INIT_GENERATED_TOP_CELL)) {
                     KApply right = (KApply)RewriteToTop.toRight(withFresh.body());
                     KApply cells = (KApply)right.items().get(1);
@@ -91,8 +90,7 @@ public class ResolveFreshConstants {
             }
         }
         K left = RewriteToTop.toLeft(rule.body());
-        if (left instanceof KApply) {
-            KApply kapp = (KApply)left;
+        if (left instanceof KApply kapp) {
             if (kapp.klabel().name().equals("#withConfig")) {
                 left = kapp.items().get(0);
             }
@@ -255,8 +253,7 @@ public class ResolveFreshConstants {
             List<Integer> cellPositions = new ArrayList<Integer>();
             int i = 1;
             for (ProductionItem p: JavaConverters.seqAsJavaList(prod.items())) {
-                if (p instanceof NonTerminal) {
-                    NonTerminal nt = (NonTerminal) p;
+                if (p instanceof NonTerminal nt) {
                     if (! nt.sort().equals(Sorts.GeneratedCounterCell())) {
                         cellPositions.add(i);
                     }

--- a/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
@@ -122,9 +122,8 @@ public class ResolveFunctionWithConfig {
     }
 
     private K resolve(K body, Module module) {
-      if (body instanceof KApply) {
-        KApply kapp = (KApply) body;
-        if (kapp.klabel().name().equals("#withConfig")) {
+      if (body instanceof KApply kapp) {
+          if (kapp.klabel().name().equals("#withConfig")) {
           K fun = kapp.items().get(0);
           K cell = kapp.items().get(1);
           K rhs = null;
@@ -134,18 +133,16 @@ public class ResolveFunctionWithConfig {
             fun = rew.left();
             rhs = rew.right();
           }
-          if (!(fun instanceof KApply)) {
+          if (!(fun instanceof KApply funKApp)) {
             throw KEMException.compilerError("Found term that is not a cell or a function at the top of a rule.", fun);
           }
-          KApply funKApp = (KApply)fun;
-          if (!module.attributesFor().apply(funKApp.klabel()).contains(Att.FUNCTION())) {
+              if (!module.attributesFor().apply(funKApp.klabel()).contains(Att.FUNCTION())) {
             throw KEMException.compilerError("Found term that is not a cell or a function at the top of a rule.", fun);
           }
-          if (!(cell instanceof KApply)) {
+          if (!(cell instanceof KApply cellKApp)) {
             throw KEMException.compilerError("Found term that is not a cell in the context of a function rule.", cell);
           }
-          KApply cellKApp = (KApply)cell;
-          K secondChild;
+              K secondChild;
           if (cellKApp.klabel().equals(topCellLabel)) {
             secondChild = cell;
           } else {
@@ -213,9 +210,8 @@ public class ResolveFunctionWithConfig {
     }
 
     public Sentence resolveConfigVar(Sentence s) {
-      if (s instanceof RuleOrClaim) {
-        RuleOrClaim r = (RuleOrClaim)s;
-        return r.newInstance(resolveConfigVar(r.body(), r.requires(), r.ensures()), r.requires(), r.ensures(), r.att());
+      if (s instanceof RuleOrClaim r) {
+          return r.newInstance(resolveConfigVar(r.body(), r.requires(), r.ensures()), r.requires(), r.ensures(), r.att());
       }
       return s;
     }

--- a/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
@@ -94,8 +94,7 @@ public class ResolveIOStreams {
     private java.util.Set<Production> getStreamProductions(Set<Sentence> sentences) {
         java.util.Set<Production> productions = new HashSet<>();
         for (Sentence s : mutable(sentences)) {
-            if (s instanceof Production) {
-                Production p = (Production) s;
+            if (s instanceof Production p) {
                 if (p.att().getOption(Att.STREAM()).isDefined()) {
                     checkStreamName(p.att().get(Att.STREAM()));
                     productions.add(p);
@@ -187,8 +186,7 @@ public class ResolveIOStreams {
 
         java.util.Set<Sentence> sentences = new HashSet<>();
         for (Sentence s : mutable(getStreamModule(streamName).localSentences())) {
-            if (s instanceof Rule) {
-                Rule rule = (Rule) s;
+            if (s instanceof Rule rule) {
                 if (rule.att().contains(Att.STREAM())) {
                     // Update cell names
                     K body = new TransformK() {
@@ -212,8 +210,7 @@ public class ResolveIOStreams {
                 } else if (rule.att().contains(Att.PROJECTION())) {
                     sentences.add(rule);
                 }
-            } else if (s instanceof Production) {
-                Production production = (Production) s;
+            } else if (s instanceof Production production) {
                 if (production.sort().toString().equals("Stream") || production.att().contains(Att.PROJECTION())) {
                     sentences.add(production);
                 }
@@ -257,8 +254,7 @@ public class ResolveIOStreams {
         // find rules with currently supported matching patterns
         java.util.Set<Tuple2<Rule, String>> rules = new HashSet<>();
         for (Sentence s : sentences) {
-            if (s instanceof Rule) {
-                Rule rule = (Rule) s;
+            if (s instanceof Rule rule) {
                 java.util.List<String> sorts = isSupportingRulePatternAndGetSortNameOfCast(streamProduction, rule);
                 assert sorts.size() <= 1;
                 if (sorts.size() == 1) {
@@ -402,8 +398,7 @@ public class ResolveIOStreams {
             public K apply(KApply k) {
                 if (k.klabel().name().equals("#SemanticCastToString") && k.klist().size() == 1) {
                     K i = k.klist().items().get(0);
-                    if (i instanceof KVariable) {
-                        KVariable x = (KVariable) i;
+                    if (i instanceof KVariable x) {
                         switch (x.name()) {
                         case "?Sort":
                             return KToken("\"" + sort + "\"", Sorts.String());

--- a/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
@@ -105,8 +105,7 @@ public class ResolveSemanticCasts {
                 if (v.klabel().name().startsWith("#SemanticCastTo")) {
                     casts.add(v);
                     K child = v.klist().items().get(0);
-                    if (child instanceof KVariable) {
-                        KVariable var = (KVariable) child;
+                    if (child instanceof KVariable var) {
                         varToTypedVar.put(var, KVariable(var.name(), var.att().contains(Sort.class) ? var.att() : var.att().add(Sort.class, Outer.parseSort(getSortNameOfCast(v)))));
                     }
                 }

--- a/kernel/src/main/java/org/kframework/compile/SortCells.java
+++ b/kernel/src/main/java/org/kframework/compile/SortCells.java
@@ -146,8 +146,7 @@ public class SortCells {
                 }
             }
             for (K item : items) {
-                if (item instanceof KApply) {
-                    KApply kApply = (KApply) item;
+                if (item instanceof KApply kApply) {
                     Sort s = cfg.getCellSort(kApply.klabel());
                     if (s != null && cfg.getMultiplicity(s) != Multiplicity.STAR) {
                         remainingCells.remove(s);
@@ -275,8 +274,7 @@ public class SortCells {
             private void processSide(KApply parentCell, boolean allowRhs, List<K> items) {
                 List<KVariable> bagVars = new ArrayList<>();
                 for (K item : items) {
-                    if (item instanceof KVariable) {
-                        KVariable var = (KVariable) item;
+                    if (item instanceof KVariable var) {
                         if (var.att().contains(Sort.class)) {
                             Sort sort = var.att().get(Sort.class);
                             if (cfg.cfg.isCell(sort)) {
@@ -382,8 +380,7 @@ public class SortCells {
                                 .reduce(BooleanUtils.TRUE, BooleanUtils::and);
                     } else if(k.klabel().name().equals("isBag")
                             && k.klist().size() == 1
-                            && k.klist().items().get(0) instanceof KVariable) {
-                        KVariable var = (KVariable)k.klist().items().get(0);
+                            && k.klist().items().get(0) instanceof KVariable var) {
                         VarInfo info = variables.get(var);
                         if (info != null) {
                             return info.getSplit(var).entrySet().stream()
@@ -454,8 +451,7 @@ public class SortCells {
                             return concatenateStarCells(e.getKey(), e.getValue());
                         }
                     }));
-                } else if (item instanceof KRewrite) {
-                    KRewrite rw = (KRewrite) item;
+                } else if (item instanceof KRewrite rw) {
                     Map<Sort, K> splitLeft = new HashMap<>(getSplit(rw.left()));
                     Map<Sort, K> splitRight = new HashMap<>(getSplit(rw.right()));
                     addDefaultCells(item, splitLeft, splitRight);
@@ -573,8 +569,7 @@ public class SortCells {
             for (int idx = 0; idx < k0.klist().size(); idx++) {
                 K item0 = k0.klist().items().get(idx);
                 klist0.set(idx, item0);
-                if (item0 instanceof KApply) {
-                    KApply k = (KApply) item0;
+                if (item0 instanceof KApply k) {
 
                     // incomplete cells remain as #cells(...) after processVars
                     if (k.klabel().name().equals("#cells")) {
@@ -612,8 +607,7 @@ public class SortCells {
                             KApply cellFragment = null;
                             ArrayList<K> klist = new ArrayList<K>(Collections.nCopies(subcellSorts.size(), null));
                             for (K item : IncompleteCellUtils.flattenCells(k)) { // #cells(#cells(x,y),z) => [x,y,z]
-                                if (item instanceof KApply) {
-                                    KApply kapp = (KApply) item;
+                                if (item instanceof KApply kapp) {
                                     if (cfg.cfg.isCellLabel(kapp.klabel())) {
                                         Sort sort = cfg.getCellSort(kapp.klabel());
                                         if (!subcellSorts.contains(sort)) {
@@ -627,8 +621,7 @@ public class SortCells {
                                     } else {
                                         throw KEMException.compilerError("Unsupported cell fragment element.", item);
                                     }
-                                } else if (item instanceof KVariable) {
-                                    KVariable var = (KVariable) item;
+                                } else if (item instanceof KVariable var) {
                                     VarInfo varinfo = null;
                                     if (variables.containsKey(var)) {
                                         varinfo = variables.get(var);
@@ -747,8 +740,7 @@ public class SortCells {
                 if (k.klabel().name().equals("#cells")) {
                     for (int i = 0; i < k.klist().size(); i++) {
                         K item = k.klist().items().get(i);
-                        if (item instanceof KVariable) {
-                            KVariable var = (KVariable) item;
+                        if (item instanceof KVariable var) {
                             if (var.att().contains(Sort.class)) {
                                 Sort sort = var.att().get(Sort.class);
                                 if (!cfg.cfg.isCell(sort)) {
@@ -817,8 +809,7 @@ public class SortCells {
                     for (int idx = 0; idx < k0.klist().size(); idx++) {
                         K item0 = k0.klist().items().get(idx);
                         klist0.set(idx, item0);
-                        if (item0 instanceof KApply) {
-                            KApply k = (KApply) item0;
+                        if (item0 instanceof KApply k) {
                             if (k.klabel().name().equals("#cells")) {
                                 if (cellFragmentVarsCell.contains(k)) {
                                     Sort cellFragmentSort = nthArgSort(k0.klabel(), idx);

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAnonymous.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAnonymous.java
@@ -75,17 +75,14 @@ public class CheckAnonymous {
             return;
         }
         resetVars();
-        if (s instanceof RuleOrClaim) {
-            RuleOrClaim r = (RuleOrClaim) s;
+        if (s instanceof RuleOrClaim r) {
             gatherVars(r.body());
             gatherVars(r.requires());
             gatherVars(r.ensures());
-        } else if (s instanceof Context) {
-            Context c = (Context)s;
+        } else if (s instanceof Context c) {
             gatherVars(c.body());
             gatherVars(c.requires());
-        } else if (s instanceof ContextAlias) {
-            ContextAlias c = (ContextAlias)s;
+        } else if (s instanceof ContextAlias c) {
             gatherVars(c.body());
             gatherVars(c.requires());
         }

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAssoc.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAssoc.java
@@ -28,8 +28,7 @@ public class CheckAssoc {
     }
 
     public void check(Sentence s) {
-        if (s instanceof Production) {
-            Production p = (Production) s;
+        if (s instanceof Production p) {
             if (p.arity() != 2) {
                 return;
             }

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckBracket.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckBracket.java
@@ -21,8 +21,7 @@ public class CheckBracket {
     }
 
     private static void check(ModuleItem i) {
-        if (i instanceof Syntax) {
-            Syntax s = (Syntax) i;
+        if (i instanceof Syntax s) {
             for (PriorityBlock b : s.getPriorityBlocks()) {
                 for (Production p : b.getProductions()) {
                     if (p.containsAttribute(Att.BRACKET())) {

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckFunctions.java
@@ -29,30 +29,26 @@ public class CheckFunctions {
     }
 
     public void check(Sentence sentence) {
-        if (sentence instanceof Rule) {
-            Rule rl = (Rule) sentence;
+        if (sentence instanceof Rule rl) {
             checkFuncAtt(rl);
             if (!rl.att().contains(Att.SIMPLIFICATION()))
                 // functions are allowed on the LHS of simplification rules
                 check(rl.body());
-        } else if (sentence instanceof Claim) {
+        } else if (sentence instanceof Claim c) {
             // functions are allowed on LHS of claims
-            Claim c = (Claim) sentence;
             if (c.att().contains(Att.MACRO()) || c.att().contains(Att.MACRO_REC())
                     || c.att().contains(Att.ALIAS()) || c.att().contains(Att.ALIAS_REC()))
                 errors.add(KEMException.compilerError(
                         "Attributes " + Att.MACRO() + "|" + Att.MACRO_REC() + "|"
                                 + Att.ALIAS() + "|" + Att.ALIAS_REC() + " are not allowed on claims.", c));
-        } else if (sentence instanceof Context) {
-            Context ctx = (Context) sentence;
+        } else if (sentence instanceof Context ctx) {
             check(ctx.body());
             if (ctx.att().contains(Att.MACRO()) || ctx.att().contains(Att.MACRO_REC())
                     || ctx.att().contains(Att.ALIAS()) || ctx.att().contains(Att.ALIAS_REC()))
                 errors.add(KEMException.compilerError(
                         "Attributes " + Att.MACRO() + "|" + Att.MACRO_REC() + "|"
                                 + Att.ALIAS() + "|" + Att.ALIAS_REC() + " are not allowed on contexts.", ctx));
-        } else if (sentence instanceof ContextAlias) {
-            ContextAlias ctx = (ContextAlias) sentence;
+        } else if (sentence instanceof ContextAlias ctx) {
             check(ctx.body());
             if (ctx.att().contains(Att.MACRO()) || ctx.att().contains(Att.MACRO_REC())
                     || ctx.att().contains(Att.ALIAS()) || ctx.att().contains(Att.ALIAS_REC()))

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckK.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckK.java
@@ -29,8 +29,7 @@ public class CheckK {
                 boolean error = false;
                 if (!(as.alias() instanceof KVariable)) {
                     error = true;
-                    if (as.alias() instanceof KApply) {
-                        KApply app = (KApply)as.alias();
+                    if (as.alias() instanceof KApply app) {
                         if (app.klabel().name().startsWith("#SemanticCastTo") && app.items().size() == 1 && app.items().get(0) instanceof KVariable) {
                             error = false;
                         }
@@ -45,17 +44,14 @@ public class CheckK {
     }
 
     public void check(Sentence s) {
-        if (s instanceof RuleOrClaim) {
-            RuleOrClaim r = (RuleOrClaim)s;
+        if (s instanceof RuleOrClaim r) {
             check(r.body());
             check(r.requires());
             check(r.ensures());
-        } else if (s instanceof Context) {
-            Context c = (Context)s;
+        } else if (s instanceof Context c) {
             check(c.body());
             check(c.requires());
-        } else if (s instanceof ContextAlias) {
-            ContextAlias c = (ContextAlias)s;
+        } else if (s instanceof ContextAlias c) {
             check(c.body());
             check(c.requires());
         }

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
@@ -87,21 +87,17 @@ public class CheckKLabels {
                 }
             }
         };
-        if (sentence instanceof Rule) {
-            Rule rl = (Rule) sentence;
+        if (sentence instanceof Rule rl) {
             checkKLabels.apply(rl.body());
             checkKLabels.apply(rl.requires());
             checkKLabels.apply(rl.ensures());
-        } else if (sentence instanceof Context) {
-            Context ctx = (Context) sentence;
+        } else if (sentence instanceof Context ctx) {
             checkKLabels.apply(ctx.body());
             checkKLabels.apply(ctx.requires());
-        } else if (sentence instanceof ContextAlias) {
-            ContextAlias ctx = (ContextAlias) sentence;
+        } else if (sentence instanceof ContextAlias ctx) {
             checkKLabels.apply(ctx.body());
             checkKLabels.apply(ctx.requires());
-        } else if (sentence instanceof Production) {
-            Production prod = (Production) sentence;
+        } else if (sentence instanceof Production prod) {
             if (prod.klabel().isDefined()) {
                 KLabel klabel = prod.klabel().get();
                 if (klabelProds.containsKey(klabel.name()) && !internalDuplicates.contains(klabel.name())) {

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckListDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckListDecl.java
@@ -37,8 +37,7 @@ public class CheckListDecl {
 
 
     private static void check(ModuleItem i) {
-        if (i instanceof Syntax) {
-            Syntax s = (Syntax) i;
+        if (i instanceof Syntax s) {
             for (PriorityBlock b : s.getPriorityBlocks()) {
                 for (Production p : b.getProductions()) {
                     if (p.getItems().size() == 1 && p.getItems().get(0) instanceof UserList) { // Syntax Es ::= List{E,""}

--- a/kernel/src/main/java/org/kframework/kil/Lexical.java
+++ b/kernel/src/main/java/org/kframework/kil/Lexical.java
@@ -27,10 +27,8 @@ public class Lexical extends ProductionItem {
             return false;
         if (obj == this)
             return true;
-        if (!(obj instanceof Lexical))
+        if (!(obj instanceof Lexical trm))
             return false;
-
-        Lexical trm = (Lexical) obj;
 
         if (!trm.lexicalRule.equals(this.lexicalRule))
             return false;

--- a/kernel/src/main/java/org/kframework/kil/NonTerminal.java
+++ b/kernel/src/main/java/org/kframework/kil/NonTerminal.java
@@ -52,10 +52,8 @@ public class NonTerminal extends ProductionItem {
             return false;
         if (obj == this)
             return true;
-        if (!(obj instanceof NonTerminal))
+        if (!(obj instanceof NonTerminal nt))
             return false;
-
-        NonTerminal nt = (NonTerminal) obj;
 
         if (!sort.equals(nt.sort))
             return false;

--- a/kernel/src/main/java/org/kframework/kil/PriorityBlock.java
+++ b/kernel/src/main/java/org/kframework/kil/PriorityBlock.java
@@ -66,9 +66,8 @@ public class PriorityBlock extends ASTNode {
             return false;
         if (this == obj)
             return true;
-        if (!(obj instanceof PriorityBlock))
+        if (!(obj instanceof PriorityBlock pb))
             return false;
-        PriorityBlock pb = (PriorityBlock) obj;
 
         if (!pb.getAssoc().equals(this.assoc))
             return false;

--- a/kernel/src/main/java/org/kframework/kil/PriorityBlockExtended.java
+++ b/kernel/src/main/java/org/kframework/kil/PriorityBlockExtended.java
@@ -38,9 +38,8 @@ public class PriorityBlockExtended extends ASTNode {
             return false;
         if (this == obj)
             return true;
-        if (!(obj instanceof PriorityBlockExtended))
+        if (!(obj instanceof PriorityBlockExtended pb))
             return false;
-        PriorityBlockExtended pb = (PriorityBlockExtended) obj;
 
         if (pb.productions.size() != productions.size())
             return false;

--- a/kernel/src/main/java/org/kframework/kil/PriorityExtended.java
+++ b/kernel/src/main/java/org/kframework/kil/PriorityExtended.java
@@ -36,9 +36,8 @@ public class PriorityExtended extends ModuleItem {
             return false;
         if (this == obj)
             return true;
-        if (!(obj instanceof PriorityExtended))
+        if (!(obj instanceof PriorityExtended syn))
             return false;
-        PriorityExtended syn = (PriorityExtended) obj;
 
         if (syn.priorityBlocks.size() != priorityBlocks.size())
             return false;

--- a/kernel/src/main/java/org/kframework/kil/PriorityExtendedAssoc.java
+++ b/kernel/src/main/java/org/kframework/kil/PriorityExtendedAssoc.java
@@ -49,9 +49,8 @@ public class PriorityExtendedAssoc extends ModuleItem {
             return false;
         if (this == obj)
             return true;
-        if (!(obj instanceof PriorityExtendedAssoc))
+        if (!(obj instanceof PriorityExtendedAssoc syn))
             return false;
-        PriorityExtendedAssoc syn = (PriorityExtendedAssoc) obj;
 
         if (syn.tags.size() != tags.size())
             return false;

--- a/kernel/src/main/java/org/kframework/kil/Syntax.java
+++ b/kernel/src/main/java/org/kframework/kil/Syntax.java
@@ -82,9 +82,8 @@ public class Syntax extends ModuleItem {
             return false;
         if (this == obj)
             return true;
-        if (!(obj instanceof Syntax))
+        if (!(obj instanceof Syntax syn))
             return false;
-        Syntax syn = (Syntax) obj;
 
         if (!syn.getDeclaredSort().equals(this.sort))
             return false;

--- a/kernel/src/main/java/org/kframework/kil/Terminal.java
+++ b/kernel/src/main/java/org/kframework/kil/Terminal.java
@@ -32,10 +32,8 @@ public class Terminal extends ProductionItem {
             return false;
         if (obj == this)
             return true;
-        if (!(obj instanceof Terminal))
+        if (!(obj instanceof Terminal trm))
             return false;
-
-        Terminal trm = (Terminal) obj;
 
         if (!trm.terminal.equals(this.terminal))
             return false;

--- a/kernel/src/main/java/org/kframework/kil/UserList.java
+++ b/kernel/src/main/java/org/kframework/kil/UserList.java
@@ -58,10 +58,8 @@ public class UserList extends ProductionItem {
             return false;
         if (obj == this)
             return true;
-        if (!(obj instanceof UserList))
+        if (!(obj instanceof UserList srt))
             return false;
-
-        UserList srt = (UserList) obj;
 
         if (!sort.equals(srt.getSort()))
             return false;

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -100,11 +100,9 @@ public class CompiledDefinition implements Serializable {
                         @Override
                         public void apply(KApply k) {
                             if (k.klabel().name().startsWith("project:")
-                                    && k.items().size() == 1 && k.items().get(0) instanceof KApply) {
-                                KApply theMapLookup = (KApply) k.items().get(0);
+                                    && k.items().size() == 1 && k.items().get(0) instanceof KApply theMapLookup) {
                                 if (KLabels.MAP_LOOKUP.equals(theMapLookup.klabel())
-                                        && theMapLookup.size() == 2 && theMapLookup.items().get(1) instanceof KToken) {
-                                    KToken t = (KToken) theMapLookup.items().get(1);
+                                        && theMapLookup.size() == 2 && theMapLookup.items().get(1) instanceof KToken t) {
                                     if (t.sort().equals(Sorts.KConfigVar())) {
                                         Sort sort = Outer.parseSort(k.klabel().name().substring("project:".length()));
                                         configurationVariableDefaultSorts.put(t.s(), sort);

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -338,9 +338,8 @@ public class Kompile {
     }
 
     public static Sentence removePolyKLabels(Sentence s) {
-      if (s instanceof Production) {
-        Production p = (Production)s;
-        if (!p.isSyntacticSubsort() && p.params().nonEmpty()) {
+      if (s instanceof Production p) {
+          if (!p.isSyntacticSubsort() && p.params().nonEmpty()) {
             p = p.substitute(immutable(Collections.nCopies(p.params().size(), Sorts.K())));
             return Production(p.klabel().map(KLabel::head), Seq(), p.sort(), p.items(), p.att());
         }

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -205,8 +205,7 @@ public class KILtoKORE extends KILTransformation<Object> {
                 } else {
                     List<ProductionItem> items = new ArrayList<>();
                     for (org.kframework.kil.ProductionItem it : p.getItems()) {
-                        if (it instanceof NonTerminal) {
-                            NonTerminal nt = (NonTerminal)it;
+                        if (it instanceof NonTerminal nt) {
                             items.add(NonTerminal(nt.getSort(), nt.getName()));
                         } else if (it instanceof UserList) {
                             throw new AssertionError("Lists should have applied before.");

--- a/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
+++ b/kernel/src/main/java/org/kframework/kprove/ProofDefinitionBuilder.java
@@ -92,9 +92,8 @@ public class ProofDefinitionBuilder {
             }
             specModule = new ModuleTransformer((m -> {
                 Set<Sentence> filtered = stream(m.localSentences()).flatMap(s -> {
-                    if (s instanceof Claim && s.att().getOptional(Att.LABEL()).isPresent()) {
+                    if (s instanceof Claim c && s.att().getOptional(Att.LABEL()).isPresent()) {
                         String label = s.att().getOptional(Att.LABEL()).get();
-                        Claim c = (Claim) s;
                         if (proveOptions.trusted != null && proveOptions.trusted.contains(label)) {
                             s = c.newInstance(c.body(), c.requires(), c.ensures(), c.att().add(Att.TRUSTED()));
                             unused.remove(label);

--- a/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
+++ b/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
@@ -228,13 +228,11 @@ public class TextDocumentSyncHandler {
                                     loc2range(loc)));
                             break;
                         }
-                    } else if (di instanceof Module) {
-                        Module m = (Module) di;
+                    } else if (di instanceof Module m) {
                         for (ModuleItem mi : m.getItems()) {
                             org.kframework.attributes.Location loc = getSafeLoc(mi);
                             if (isPositionOverLocation(pos, loc)) {
-                                if (mi instanceof Import) { // goto module definition
-                                    Import imp = (Import) mi;
+                                if (mi instanceof Import imp) { // goto module definition
                                     List<DefinitionItem> allDi = slurp(params.getTextDocument().getUri());
                                     allDi.stream().filter(ddi -> ddi instanceof Module)
                                             .map(ddi -> ((Module) ddi))
@@ -243,8 +241,7 @@ public class TextDocumentSyncHandler {
                                                     loc2range(getSafeLoc(m3)),
                                                     loc2range(getSafeLoc(m3)),
                                                     loc2range(getSafeLoc(imp)))));
-                                } else if (mi instanceof StringSentence) { // goto syntax of term inside rule
-                                    StringSentence ss = (StringSentence) mi;
+                                } else if (mi instanceof StringSentence ss) { // goto syntax of term inside rule
                                     String suffix = ss.getType().equals(DefinitionParsing.configuration) ? "-" + RuleGrammarGenerator.CONFIG_CELLS : "-" + RuleGrammarGenerator.RULE_CELLS;
                                     Optional<Map.Entry<String, ParseCache>> ch = caches.entrySet().stream().filter(elm -> elm.getKey().startsWith(m.getName() + suffix)).findFirst();
                                     if (ch.isPresent()) {
@@ -461,22 +458,19 @@ public class TextDocumentSyncHandler {
                 KPos pos = new KPos(ppos);
                 for (DefinitionItem di : dis) {
                     if (isPositionOverLocation(pos, getSafeLoc(di))) {
-                        if (di instanceof Module) {
-                            Module m = (Module) di;
+                        if (di instanceof Module m) {
                             SelectionRange msr = new SelectionRange(loc2range(m.getLocation()), topsr);
                             for (ModuleItem mi : m.getItems()) {
                                 if (isPositionOverLocation(pos, getSafeLoc(mi))) {
                                     SelectionRange sentsr = new SelectionRange(loc2range(getSafeLoc(mi)), msr);
-                                    if (mi instanceof org.kframework.kil.Syntax) {
-                                        Syntax stx = (org.kframework.kil.Syntax) mi;
+                                    if (mi instanceof Syntax stx) {
                                         for (PriorityBlock pb : stx.getPriorityBlocks()) {
                                             SelectionRange pbsr = new SelectionRange(loc2range(getSafeLoc(pb)), sentsr);
                                             for (Production prd : pb.getProductions())
                                                 if (isPositionOverLocation(pos, getSafeLoc(prd)))
                                                     lloc.add(new SelectionRange(loc2range(getSafeLoc(prd)), pbsr));
                                         }
-                                    } else if (mi instanceof StringSentence) { // if we have caches, find the deepest term
-                                        StringSentence ss = (StringSentence) mi;
+                                    } else if (mi instanceof StringSentence ss) { // if we have caches, find the deepest term
                                         String suffix = ss.getType().equals(DefinitionParsing.configuration) ? "-" + RuleGrammarGenerator.CONFIG_CELLS : "-" + RuleGrammarGenerator.RULE_CELLS;
                                         Optional<Map.Entry<String, ParseCache>> ch = caches.entrySet().stream().filter(elm -> elm.getKey().startsWith(m.getName() + suffix)).findFirst();
                                         AtomicReference<SelectionRange> x = new AtomicReference<>(sentsr);

--- a/kernel/src/main/java/org/kframework/main/Main.java
+++ b/kernel/src/main/java/org/kframework/main/Main.java
@@ -127,10 +127,9 @@ public class Main {
             return retval;
         } catch (ProvisionException e) {
             for (Message m : e.getErrorMessages()) {
-                if (!(m.getCause() instanceof KEMException)) {
+                if (!(m.getCause() instanceof KEMException ex)) {
                     throw e;
                 } else {
-                    KEMException ex = (KEMException) m.getCause();
                     kem.registerThrown(ex);
                 }
             }

--- a/kernel/src/main/java/org/kframework/parser/inner/ApplySynonyms.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ApplySynonyms.java
@@ -20,9 +20,8 @@ public class ApplySynonyms {
       Sort returnSort = m.sortSynonymMap().applyOrElse(p.sort(), s -> p.sort());
       List<ProductionItem> pis = new ArrayList<>();
       for (ProductionItem pi : iterable(p.items())) {
-          if (pi instanceof NonTerminal) {
-            NonTerminal nt = (NonTerminal)pi;
-            pis.add(NonTerminal(m.sortSynonymMap().applyOrElse(nt.sort(), s -> nt.sort()), nt.name()));
+          if (pi instanceof NonTerminal nt) {
+              pis.add(NonTerminal(m.sortSynonymMap().applyOrElse(nt.sort(), s -> nt.sort()), nt.name()));
           } else {
             pis.add(pi);
           }

--- a/kernel/src/main/java/org/kframework/parser/inner/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/RuleGrammarGenerator.java
@@ -395,8 +395,7 @@ public class RuleGrammarGenerator {
                 if (s instanceof Production && s.att().contains(Att.CELL_COLLECTION())) {
                     return Stream.empty();
                 }
-                if (s instanceof Production && (s.att().contains(Att.CELL()))) {
-                    Production p = (Production) s;
+                if (s instanceof Production p && (s.att().contains(Att.CELL()))) {
                     // assuming that productions tagged with 'cell' start and end with terminals, and only have non-terminals in the middle
                     assert p.items().head() instanceof Terminal || p.items().head() instanceof RegexTerminal;
                     assert p.items().last() instanceof Terminal || p.items().last() instanceof RegexTerminal;
@@ -412,8 +411,7 @@ public class RuleGrammarGenerator {
                     Production p2 = Production(Seq(), Sorts.Cell(), Seq(NonTerminal(p.sort())));
                     return Stream.of(p1, p2);
                 }
-                if (s instanceof Production && (s.att().contains(Att.CELL_FRAGMENT(), Sort.class))) {
-                    Production p = (Production) s;
+                if (s instanceof Production p && (s.att().contains(Att.CELL_FRAGMENT(), Sort.class))) {
                     Production p1 = Production(Seq(), Sorts.Cell(), Seq(NonTerminal(p.sort())));
                     return Stream.of(p, p1);
                 }
@@ -442,8 +440,7 @@ public class RuleGrammarGenerator {
                 if (i instanceof Terminal) terminals.put(((Terminal) i).value(), PRESENT);
             }));
             parseProds = parseProds.stream().map(s -> {
-                if (s instanceof Production) {
-                    Production p = (Production) s;
+                if (s instanceof Production p) {
                     if (p.sort().name().startsWith("#"))
                         return p; // don't do anything for such productions since they are advanced features
                     // rewrite productions to contain follow restrictions for prefix terminals
@@ -551,9 +548,8 @@ public class RuleGrammarGenerator {
     private static void addCellNameProd(Set<Sentence> prods, Sentence prod) {
         if (prod instanceof Production) {
           for (ProductionItem pi : iterable(((Production)prod).items())) {
-            if (pi instanceof Terminal) {
-              Terminal t = (Terminal)pi;
-              if (alphaNum.matcher(t.value()).matches()) {
+            if (pi instanceof Terminal t) {
+                if (alphaNum.matcher(t.value()).matches()) {
                 prods.add(Production(Seq(), Sorts.CellName(), Seq(t), Att().add(Att.TOKEN())));
               }
             }

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AddEmptyLists.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AddEmptyLists.java
@@ -222,8 +222,7 @@ public class AddEmptyLists extends SetsGeneralTransformer<KEMException, KEMExcep
     }
 
     private Optional<KLabel> klabelFromTerm(Term labelTerm) {
-        if (labelTerm instanceof Constant) {
-            Constant labelCon = (Constant) labelTerm;
+        if (labelTerm instanceof Constant labelCon) {
             if (labelCon.production().sort().equals(Sorts.KLabel())) {
                 String labelVal = labelCon.value();
                 if (labelVal.charAt(0) == '`') {
@@ -243,8 +242,7 @@ public class AddEmptyLists extends SetsGeneralTransformer<KEMException, KEMExcep
     }
 
     private void lowerKListAcc(Term term, List<Term> items) {
-        if (term instanceof TermCons) {
-            TermCons cons = (TermCons) term;
+        if (term instanceof TermCons cons) {
             if (cons.production().klabel().isDefined()) {
                 String labelName = cons.production().klabel().get().name();
                 if (labelName.equals("#KList")) {

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AmbFilter.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AmbFilter.java
@@ -52,8 +52,7 @@ public class AmbFilter extends SetsGeneralTransformer<KEMException, KEMException
         for (int i = 0; i < amb.items().size(); i++) {
             msg += "\n" + (i + 1) + ": ";
             Term elem = (Term) amb.items().toArray()[i];
-            if (elem instanceof ProductionReference) {
-                ProductionReference tc = (ProductionReference) elem;
+            if (elem instanceof ProductionReference tc) {
                 msg += tc.production().toString();
             }
             // TODO: use the unparser

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AmbFilterError.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AmbFilterError.java
@@ -55,8 +55,7 @@ public class AmbFilterError extends SetsTransformerWithErrors<KEMException> {
         for (int i = 0; i < amb.items().size(); i++) {
             msg += "\n" + (i + 1) + ": ";
             Term elem = (Term) amb.items().toArray()[i];
-            if (elem instanceof ProductionReference) {
-                ProductionReference tc = (ProductionReference) elem;
+            if (elem instanceof ProductionReference tc) {
                 msg += tc.production().toString();
             }
             // TODO: use the unparser

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/KAppToTermConsVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/KAppToTermConsVisitor.java
@@ -50,10 +50,9 @@ public class KAppToTermConsVisitor extends SetsTransformerWithErrors<KEMExceptio
     public Either<java.util.Set<KEMException>, Term> apply(TermCons tc) {
         assert tc.production() != null : this.getClass() + ":" + " production not found." + tc;
         if (tc.production().klabel().isDefined() && tc.production().klabel().get().equals(KLabels.KAPP)) {
-            if (!(tc.get(0) instanceof Constant) || !((Constant) tc.get(0)).production().sort().equals(Sorts.KLabel()))
+            if (!(tc.get(0) instanceof Constant kl) || !((Constant) tc.get(0)).production().sort().equals(Sorts.KLabel()))
                 // TODO: remove check once the java backend is no longer supported.
                 return super.apply(tc); // don't do anything if the label is not a token KLabel (in case of variable or casted variable)
-            Constant kl = (Constant) tc.get(0);
             String klvalue = kl.value();
             try { klvalue = StringUtil.unescapeKoreKLabel(kl.value()); } catch (IllegalArgumentException e) { /* ignore */ } // if possible, unescape
             Set<Production> prods = mutable(mod.productionsFor().get(KLabel(klvalue))
@@ -85,8 +84,7 @@ public class KAppToTermConsVisitor extends SetsTransformerWithErrors<KEMExceptio
             assert false : KAppToTermConsVisitor.class + " expected all ambiguities to already be pushed to the top:\n" +
                     "   Source: " + ((Ambiguity) t).items().iterator().next().source().orElse(null) + "\n" +
                     "   Location: " + ((Ambiguity) t).items().iterator().next().location().orElse(null);
-        } else if (t instanceof TermCons) {
-            TermCons tc = (TermCons) t;
+        } else if (t instanceof TermCons tc) {
             if (tc.production().klabel().isDefined() && tc.production().klabel().get().equals(KLabels.KLIST))
                 return flattenKList(tc.get(0)).plusAll(Lists.reverse(Lists.newArrayList(flattenKList(tc.get(1)))));
             else if (tc.production().klabel().isDefined() && tc.production().klabel().get().equals(KLabels.EMPTYKLIST))

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/PushAmbiguitiesDownAndPreferAvoid.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/PushAmbiguitiesDownAndPreferAvoid.java
@@ -84,10 +84,9 @@ public class PushAmbiguitiesDownAndPreferAvoid extends SafeTransformer {
 
         a = (Ambiguity)super.apply(a);
         for (Term t : a.items()) {
-            if (!(t instanceof ProductionReference)) {
+            if (!(t instanceof ProductionReference ref)) {
                 return a;
             }
-            ProductionReference ref = (ProductionReference)t;
             if (prod == null) {
                 prod = ref.production();
                 if (ref instanceof TermCons) {

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/PushTopAmbiguityUp.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/PushTopAmbiguityUp.java
@@ -16,8 +16,7 @@ public class PushTopAmbiguityUp extends SafeTransformer {
     public Term apply(TermCons tc) {
         if (tc.production().sort().equals(Sorts.RuleContent())) {
             Term t = new PushTopAmbiguityUp2().apply(tc.get(0));
-            if (t instanceof Ambiguity) {
-                Ambiguity old = (Ambiguity)t;
+            if (t instanceof Ambiguity old) {
                 Set<Term> newTerms = new HashSet<>();
                 for (Term child : old.items()) {
                     Term newTerm = tc.with(0, child);
@@ -34,8 +33,7 @@ public class PushTopAmbiguityUp extends SafeTransformer {
         public Term apply(TermCons tc) {
             if (tc.production().klabel().isDefined() && tc.production().klabel().get().head().equals(KLabels.KREWRITE)) {
                 Term t = tc.get(0);
-                if (t instanceof Ambiguity) {
-                    Ambiguity old = (Ambiguity)t;
+                if (t instanceof Ambiguity old) {
                     Set<Term> newTerms = new HashSet<>();
                     for (Term child : old.items()) {
                         Term newTerm = tc.with(0, child);

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/RemoveOverloads.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/RemoveOverloads.java
@@ -22,8 +22,7 @@ public class RemoveOverloads {
     public Term apply(Ambiguity a) {
         Set<Production> productions = new HashSet<>();
         for (Term t : a.items()) {
-            if (t instanceof TermCons) {
-                TermCons tc = (TermCons)t;
+            if (t instanceof TermCons tc) {
                 productions.add(tc.production());
             } else {
                 return a;

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TreeCleanerVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TreeCleanerVisitor.java
@@ -13,8 +13,7 @@ public class TreeCleanerVisitor extends SafeTransformer {
     @Override
     public Term apply(Ambiguity amb) {
         Term newTerm = super.apply(amb);
-        if (newTerm instanceof Ambiguity) {
-            Ambiguity newAmb = (Ambiguity)newTerm;
+        if (newTerm instanceof Ambiguity newAmb) {
             if (newAmb.items().size() == 1) {
                 return newAmb.items().iterator().next();
             }

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
@@ -208,8 +208,7 @@ public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException
 
     @Override
     public Either<Set<KEMException>, Term> apply(Term term) {
-      if (term instanceof Ambiguity) {
-        Ambiguity amb = (Ambiguity)term;
+      if (term instanceof Ambiguity amb) {
         return super.apply(amb);
       }
       ProductionReference pr = (ProductionReference)term;
@@ -233,8 +232,7 @@ public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException
         return typeError(pr, expectedSort, actualSort);
       }
       // check types of children
-      if (pr instanceof TermCons) {
-        TermCons tc = (TermCons)pr;
+      if (pr instanceof TermCons tc) {
         for (int i = 0, j = 0; i < substituted.items().size(); i++) {
           if (substituted.items().apply(i) instanceof NonTerminal) {
             // save prior value of variables

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
@@ -354,10 +354,9 @@ public class TypeInferencer implements AutoCloseable {
    * @return
    */
   private static Optional<ProductionReference> getFunction(Term t) {
-    if (!(t instanceof ProductionReference)) {
+    if (!(t instanceof ProductionReference child)) {
       return Optional.empty();
     }
-    ProductionReference child = (ProductionReference)t;
     while (child.production().att().contains(Att.BRACKET())) {
       if (((TermCons)child).get(0) instanceof Ambiguity) {
         return Optional.empty();
@@ -514,8 +513,7 @@ public class TypeInferencer implements AutoCloseable {
      * this term.
      */
     public String apply(Term t) {
-      if (t instanceof Ambiguity) {
-        Ambiguity amb = (Ambiguity)t;
+      if (t instanceof Ambiguity amb) {
         if (isIncremental) {
           // we are error checking an ill typed term, so we pick just one branch of the ambiguity and explain why it is
           // ill typed.
@@ -567,15 +565,13 @@ public class TypeInferencer implements AutoCloseable {
         // get cached id
         id = pr.id().get();
       }
-      if (pr instanceof TermCons) {
+      if (pr instanceof TermCons tc) {
         boolean wasStrict = isStrictEquality;
         Sort oldExpectedSort = expectedSort;
         Optional<ProductionReference> oldExpectedParams = expectedParams;
-        TermCons tc = (TermCons)pr;
         // traverse children
         for (int i = 0, j = 0; i < tc.production().items().size(); i++) {
-          if (tc.production().items().apply(i) instanceof NonTerminal) {
-            NonTerminal nt = (NonTerminal)tc.production().items().apply(i);
+          if (tc.production().items().apply(i) instanceof NonTerminal nt) {
             expectedParams = Optional.of(tc);
             isStrictEquality = false;
             // compute expected sort and whether this is a cast
@@ -586,8 +582,7 @@ public class TypeInferencer implements AutoCloseable {
               expectedSort = getSortOfCast(tc);
               isStrictEquality = tc.production().klabel().get().name().equals("#SyntacticCast")
                   || tc.production().klabel().get().name().equals("#InnerCast");
-              if (tc.get(0) instanceof Constant) {
-                Constant child = (Constant)tc.get(0);
+              if (tc.get(0) instanceof Constant child) {
                 if (child.production().sort().equals(Sorts.KVariable()) || child.production().sort().equals(Sorts.KConfigVar())) {
                   isStrictEquality = true;
                 }
@@ -619,8 +614,7 @@ public class TypeInferencer implements AutoCloseable {
       if (isIncremental || !shared || !cached) {
         // if we are in incremental mode or this is the first time reaching this term under this expected sort,
         // compute the local constraints of this term and add them to the current constraint.
-        if (pr instanceof Constant && (pr.production().sort().equals(Sorts.KVariable()) || pr.production().sort().equals(Sorts.KConfigVar()))) {
-          Constant c = (Constant) pr;
+        if (pr instanceof Constant c && (pr.production().sort().equals(Sorts.KVariable()) || pr.production().sort().equals(Sorts.KConfigVar()))) {
           String name;
           boolean oldStrictEquality = isStrictEquality;
           if (!shared) {

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/EarleyParser.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/EarleyParser.java
@@ -658,8 +658,7 @@ public class EarleyParser {
       }
       List<EarleyProductionItem> items = new ArrayList<>(prod.items().size());
       for (ProductionItem item : iterable(prod.items())) {
-        if (item instanceof Terminal) {
-          Terminal t = (Terminal) item;
+        if (item instanceof Terminal t) {
           if (t.value().isEmpty()) {
             continue;
           }

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/KSyntax2Bison.java
@@ -79,8 +79,7 @@ public class KSyntax2Bison {
     Set<Sentence> sentences = new HashSet<>();
     Set<Tuple2<Sort, Set<Tag>>> nts = new HashSet<>();
     for (Sentence s : iterable(module.sentences())) {
-      if (s instanceof Production) {
-        Production prod = (Production)s;
+      if (s instanceof Production prod) {
         if (prod.klabel().isDefined() && prod.params().isEmpty()) {
           List<ProductionItem> items = new ArrayList<>(mutable(prod.items()));
           if (items.get(0) instanceof NonTerminal) {
@@ -332,8 +331,7 @@ public class KSyntax2Bison {
     int i = 1;
     List<Integer> nts = new ArrayList<>();
     for (ProductionItem item : iterable(prod.items())) {
-      if (item instanceof NonTerminal) {
-        NonTerminal nt = (NonTerminal)item;
+      if (item instanceof NonTerminal nt) {
         encode(nt.sort(), bison);
         bison.append(" ");
         nts.add(i);

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
@@ -59,8 +59,7 @@ public class Scanner implements AutoCloseable {
         Set<String> terminals = new HashSet<>();
         for (Production p : iterable(module.productions())) {
             for (ProductionItem pi : iterable(p.items())) {
-                if (pi instanceof TerminalLike) {
-                    TerminalLike lx = (TerminalLike) pi;
+                if (pi instanceof TerminalLike lx) {
                     if (tokens.containsKey(lx)) {
                         int prec;
                         if (p.att().contains(Att.PREC())) {
@@ -151,8 +150,7 @@ public class Scanner implements AutoCloseable {
         }
         List<TerminalLike> ordered = tokens.keySet().stream().sorted((t1, t2) -> tokens.get(t2)._2() - tokens.get(t1)._2()).collect(Collectors.toList());
         for (TerminalLike key : ordered) {
-            if (key instanceof Terminal) {
-                Terminal t = (Terminal) key;
+            if (key instanceof Terminal t) {
                 flex.append(StringUtil.enquoteCString(t.value()));
             } else {
                 RegexTerminal t = (RegexTerminal) key;
@@ -191,11 +189,10 @@ public class Scanner implements AutoCloseable {
         flex.append("%%\n\n");
         if (module.productionsForSort().contains(Sorts.LineMarker().head())) {
           stream(module.productionsForSort().apply(Sorts.LineMarker().head())).forEach(prod -> {
-            if (prod.items().size() != 1 || !(prod.items().apply(0) instanceof RegexTerminal)) {
+            if (prod.items().size() != 1 || !(prod.items().apply(0) instanceof RegexTerminal terminal)) {
               throw KEMException.compilerError("Productions of sort `#LineMarker` must be exactly one `RegexTerminal`.", prod);
             }
-            RegexTerminal terminal = (RegexTerminal)prod.items().apply(0);
-            String regex = terminal.regex();
+              String regex = terminal.regex();
             flex.append(regex).append(" line_marker(yytext, yyscanner);\n");
           });
         }

--- a/kernel/src/main/java/org/kframework/unparser/Formatter.java
+++ b/kernel/src/main/java/org/kframework/unparser/Formatter.java
@@ -33,13 +33,11 @@ public class Formatter {
     public static void format(Term term, Indenter indenter, ColorSetting colorize) {
         int indent = 0;
         int localColor = 0;
-        if (term instanceof Constant) {
-            Constant c = (Constant) term;
+        if (term instanceof Constant c) {
             color(indenter, c.production(), 0, colorize);
             indenter.append(c.value());
             resetColor(indenter, c.production(), colorize);
-        } else if (term instanceof TermCons) {
-            TermCons tc = (TermCons) term;
+        } else if (term instanceof TermCons tc) {
             String format = tc.production().att().getOptional(Att.FORMAT()).orElse(defaultFormat(tc.production().items().size()));
             for (int i = 0; i < format.length(); i++) {
                 char c = format.charAt(i);
@@ -84,8 +82,7 @@ public class Formatter {
                             assert tc.production().nonterminal(nt) == item;
                             Term inner = tc.get(nt);
                             boolean assoc = false;
-                            if (inner instanceof TermCons) {
-                                TermCons innerTc = (TermCons) inner;
+                            if (inner instanceof TermCons innerTc) {
                                 Production origProd = tc.production().att().getOptional(Att.ORIGINAL_PRD(), Production.class).orElse(tc.production());
                                 Production innerOrigProd = innerTc.production().att().getOptional(Att.ORIGINAL_PRD(), Production.class).orElse(innerTc.production());
                                 if (innerOrigProd.equals(origProd) && origProd.att().contains(Att.ASSOC())) {

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -221,11 +221,10 @@ public class KPrint {
     }
 
     private K filterSubst(K term, Module mod) {
-      if (!(term instanceof KApply)) {
+      if (!(term instanceof KApply kapp)) {
         return term;
       }
-      KApply kapp = (KApply)term;
-      if (kapp.klabel().head().equals(KLabels.ML_AND)) {
+        if (kapp.klabel().head().equals(KLabels.ML_AND)) {
         return filterConjunction(kapp, mod);
       } else if (kapp.klabel().head().equals(KLabels.ML_OR)) {
         KLabel unit = KLabel(KLabels.ML_FALSE.name(), kapp.klabel().params().apply(0));
@@ -244,11 +243,10 @@ public class KPrint {
     }
 
     private K filterConjunction(K term, Module mod) {
-      if (!(term instanceof KApply)) {
+      if (!(term instanceof KApply kapp)) {
         return term;
       }
-      KApply kapp = (KApply)term;
-      if (kapp.klabel().head().equals(KLabels.ML_AND)) {
+        if (kapp.klabel().head().equals(KLabels.ML_AND)) {
         KLabel unit = KLabel(KLabels.ML_TRUE.name(), kapp.klabel().params().apply(0));
         List<K> conjuncts = Assoc.flatten(kapp.klabel(), kapp.items(), unit);
         return conjuncts.stream()
@@ -266,11 +264,10 @@ public class KPrint {
     }
 
     public Optional<K> filterEquality(K term, Multiset<KVariable> vars, Module mod) {
-      if (!(term instanceof KApply)) {
+      if (!(term instanceof KApply kapp)) {
         return Optional.of(term);
       }
-      KApply kapp = (KApply)term;
-      if (kapp.klabel().head().equals(KLabels.ML_EQUALS)) {
+        if (kapp.klabel().head().equals(KLabels.ML_EQUALS)) {
         if (!(kapp.items().get(0) instanceof KVariable) &&
             (!(kapp.items().get(0) instanceof KApply) ||
              !mod.attributesFor().apply(((KApply)kapp.items().get(0)).klabel()).contains(Att.FUNCTION()))) {
@@ -391,10 +388,9 @@ public class KPrint {
             @Override
             public K apply(KApply orig) {
                 K newK = super.apply(orig);
-                if (! (newK instanceof KApply)) {
+                if (! (newK instanceof KApply kapp)) {
                     return newK;
                 }
-                KApply kapp = (KApply) newK;
                 String name = orig.klabel().name();
                 return options.flattenedKLabels.contains(name) ? flattenTerm(mod, kapp)
                      : kapp ;

--- a/kernel/src/main/java/org/kframework/unparser/ToBinary.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToBinary.java
@@ -64,16 +64,14 @@ public class ToBinary {
             add_intern(k);
             return;
         }
-        if (k instanceof KToken) {
-            KToken tok = (KToken) k;
+        if (k instanceof KToken tok) {
 
             data.writeByte(BinaryParser.KTOKEN);
             add_intern(k);
             writeString(tok.s());
             writeString(tok.sort().toString());
 
-        } else if (k instanceof KApply) {
-            KApply app = (KApply) k;
+        } else if (k instanceof KApply app) {
 
             for (K item : app.asIterable()) {
                 traverse(item);
@@ -84,8 +82,7 @@ public class ToBinary {
             data.writeBoolean(app.klabel() instanceof KVariable);
             data.writeInt(app.size());
 
-        } else if (k instanceof KSequence) {
-            KSequence seq = (KSequence) k;
+        } else if (k instanceof KSequence seq) {
 
             for (K item : seq.asIterable()) {
                 traverse(item);
@@ -94,23 +91,20 @@ public class ToBinary {
             add_intern(k);
             data.writeInt(seq.size());
 
-        } else if (k instanceof KVariable) {
-            KVariable var = (KVariable) k;
+        } else if (k instanceof KVariable var) {
 
             data.writeByte(BinaryParser.KVARIABLE);
             add_intern(k);
             writeString(var.name());
 
-        } else if (k instanceof KRewrite) {
-            KRewrite rew = (KRewrite) k;
+        } else if (k instanceof KRewrite rew) {
 
             traverse(rew.left());
             traverse(rew.right());
             data.writeByte(BinaryParser.KREWRITE);
             add_intern(k);
 
-        } else if (k instanceof InjectedKLabel) {
-            InjectedKLabel inj = (InjectedKLabel) k;
+        } else if (k instanceof InjectedKLabel inj) {
 
             data.writeByte(BinaryParser.INJECTEDKLABEL);
             add_intern(k);

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -369,21 +369,18 @@ public class ToJson {
     public static JsonObject toJson(ProductionItem prod) {
         JsonObjectBuilder jsonProduction = factory.createObjectBuilder();
 
-        if (prod instanceof NonTerminal) {
-            NonTerminal t = (NonTerminal) prod;
+        if (prod instanceof NonTerminal t) {
             jsonProduction.add("node", JsonParser.KNONTERMINAL);
             jsonProduction.add("sort", toJson(t.sort()));
             Option<String> name = t.name();
             if (! name.isEmpty())
                 jsonProduction.add("name", name.get());
-        } else if (prod instanceof RegexTerminal) {
-            RegexTerminal t = (RegexTerminal) prod;
+        } else if (prod instanceof RegexTerminal t) {
             jsonProduction.add("node", JsonParser.KREGEXTERMINAL);
             jsonProduction.add("precedeRegex", t.precedeRegex());
             jsonProduction.add("regex", t.regex());
             jsonProduction.add("followRegex", t.followRegex());
-        } else if (prod instanceof Terminal) {
-            Terminal t = (Terminal) prod;
+        } else if (prod instanceof Terminal t) {
             jsonProduction.add("node", JsonParser.KTERMINAL);
             jsonProduction.add("value", t.value());
         }
@@ -431,15 +428,13 @@ public class ToJson {
 
     public static JsonStructure toJson(K k) {
         JsonObjectBuilder knode = factory.createObjectBuilder();
-        if (k instanceof KToken) {
-            KToken tok = (KToken) k;
+        if (k instanceof KToken tok) {
 
             knode.add("node", JsonParser.KTOKEN);
             knode.add("sort", toJson(tok.sort()));
             knode.add("token", tok.s());
 
-        } else if (k instanceof KApply) {
-            KApply app = (KApply) k;
+        } else if (k instanceof KApply app) {
 
             knode.add("node", JsonParser.KAPPLY);
             knode.add("label", toJson(((KApply) k).klabel()));
@@ -452,8 +447,7 @@ public class ToJson {
             knode.add("arity", app.klist().size());
             knode.add("args", args.build());
 
-        } else if (k instanceof KSequence) {
-            KSequence seq = (KSequence) k;
+        } else if (k instanceof KSequence seq) {
 
             knode.add("node", JsonParser.KSEQUENCE);
 
@@ -465,8 +459,7 @@ public class ToJson {
             knode.add("arity", seq.size());
             knode.add("items", items.build());
 
-        } else if (k instanceof KVariable) {
-            KVariable var = (KVariable) k;
+        } else if (k instanceof KVariable var) {
 
             knode.add("node", JsonParser.KVARIABLE);
             knode.add("name", var.name());
@@ -474,22 +467,19 @@ public class ToJson {
                 knode.add("sort", toJson(k.att().get(Sort.class)));
             }
 
-        } else if (k instanceof KRewrite) {
-            KRewrite rew = (KRewrite) k;
+        } else if (k instanceof KRewrite rew) {
 
             knode.add("node", JsonParser.KREWRITE);
             knode.add("lhs", toJson(rew.left()));
             knode.add("rhs", toJson(rew.right()));
 
-        } else if (k instanceof KAs) {
-            KAs alias = (KAs) k;
+        } else if (k instanceof KAs alias) {
 
             knode.add("node", JsonParser.KAS);
             knode.add("pattern", toJson(alias.pattern()));
             knode.add("alias",   toJson(alias.alias()));
 
-        } else if (k instanceof InjectedKLabel) {
-            InjectedKLabel inj = (InjectedKLabel) k;
+        } else if (k instanceof InjectedKLabel inj) {
 
             knode.add("node", JsonParser.INJECTEDKLABEL);
             knode.add("label", toJson(inj.klabel()));

--- a/kernel/src/main/java/org/kframework/unparser/ToLatex.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToLatex.java
@@ -71,13 +71,11 @@ public class ToLatex {
     }
 
     public static void apply(DataOutputStream out, K k) throws IOException {
-        if (k instanceof KToken) {
-            KToken tok = (KToken) k;
+        if (k instanceof KToken tok) {
 
             writeString(out, ("\\texttt{ " + tok.s() + " }"));
 
-        } else if (k instanceof KApply) {
-            KApply app = (KApply) k;
+        } else if (k instanceof KApply app) {
 
             writeString(out, ("\\" + latexedKLabel(app.klabel().name())));
 
@@ -87,8 +85,7 @@ public class ToLatex {
                 writeString(out, "}");
             }
 
-        } else if (k instanceof KSequence) {
-            KSequence kseq = (KSequence) k;
+        } else if (k instanceof KSequence kseq) {
 
             writeString(out, "\\kseq{");
 
@@ -99,8 +96,7 @@ public class ToLatex {
 
             writeString(out, "}{\\dotk{}}");
 
-        } else if (k instanceof KVariable) {
-            KVariable var = (KVariable) k;
+        } else if (k instanceof KVariable var) {
 
             Optional<String> origName = var.att().getOptional(Att.ORIGINAL_NAME());
             if (origName.isPresent()) {
@@ -109,8 +105,7 @@ public class ToLatex {
                 writeString(out, var.name());
             }
 
-        } else if (k instanceof KRewrite) {
-            KRewrite rew = (KRewrite) k;
+        } else if (k instanceof KRewrite rew) {
 
             writeString(out, "\\krewrites{");
             apply(out, rew.left());
@@ -120,8 +115,7 @@ public class ToLatex {
             apply(out, rew.att());
             writeString(out, "}");
 
-        } else if (k instanceof KAs) {
-            KAs alias = (KAs) k;
+        } else if (k instanceof KAs alias) {
 
             writeString(out, "\\kas{");
             apply(out, alias.pattern());
@@ -131,8 +125,7 @@ public class ToLatex {
             apply(out, alias.att());
             writeString(out, "}");
 
-        } else if (k instanceof InjectedKLabel) {
-            InjectedKLabel inj = (InjectedKLabel) k;
+        } else if (k instanceof InjectedKLabel inj) {
 
             writeString(out, "\\injectedklabel{");
             writeString(out, inj.klabel().name());

--- a/kernel/src/main/java/org/kframework/utils/inject/Annotations.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/Annotations.java
@@ -24,10 +24,9 @@ public class Annotations {
             }
 
             public boolean equals(Object o) {
-                if (!(o instanceof Main)) {
+                if (!(o instanceof Main other)) {
                     return false;
                 }
-                Main other = (Main) o;
                 return annotation.equals(other.value());
             }
 
@@ -53,10 +52,9 @@ public class Annotations {
             }
 
             public boolean equals(Object o) {
-                if (!(o instanceof Spec1)) {
+                if (!(o instanceof Spec1 other)) {
                     return false;
                 }
-                Spec1 other = (Spec1) o;
                 return annotation.equals(other.value());
             }
 
@@ -82,10 +80,9 @@ public class Annotations {
             }
 
             public boolean equals(Object o) {
-                if (!(o instanceof Spec2)) {
+                if (!(o instanceof Spec2 other)) {
                     return false;
                 }
-                Spec2 other = (Spec2) o;
                 return annotation.equals(other.value());
             }
 

--- a/kore/src/main/java/org/kframework/kore/AttCompare.java
+++ b/kore/src/main/java/org/kframework/kore/AttCompare.java
@@ -39,15 +39,11 @@ public class AttCompare {
                 || (thisK instanceof KVariable && thatK instanceof KVariable)
                 || (thisK instanceof InjectedKLabel && thatK instanceof InjectedKLabel)) {
             return thisK.equals(thatK);
-        } else if (thisK instanceof KApply && thatK instanceof KApply) {
-            KApply thisKItem = (KApply) thisK;
-            KApply thatKItem = (KApply) thatK;
+        } else if (thisK instanceof KApply thisKItem && thatK instanceof KApply thatKItem) {
             return thisKItem.klabel().equals(thatKItem.klabel()) && attEquals(thisKItem.klist().items(), thatKItem.klist().items());
         } else if (thisK instanceof KSequence && thatK instanceof KSequence) {
             return attEquals(((KSequence) thisK).items(), ((KSequence) thatK).items());
-        } else if (thisK instanceof KRewrite && thatK instanceof KRewrite) {
-            KRewrite thisKR = (KRewrite) thisK;
-            KRewrite thatKR = (KRewrite) thatK;
+        } else if (thisK instanceof KRewrite thisKR && thatK instanceof KRewrite thatKR) {
             return attEquals(thisKR.left(), thatKR.left()) && attEquals(thisKR.right(), thatKR.right());
         } else {
             return false;


### PR DESCRIPTION
This is a fully-mechanical PR that uses IntelliJ to migrate to using the new Java feature for pattern variables in `instanceof` checks. For example, this code:
```java
            if (left instanceof KApply) {
                KApply kapp = (KApply) left;
                Production prod = production(kapp);
```
becomes:
```java
            if (left instanceof KApply kapp) {
                Production prod = production(kapp);
```
which saves a lot of boilerplate code.

There are **no manual changes or decisions** in this PR; it's push-button only.