### PR TITLE
Pin nixpkgs to haskell-backend

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,13 +2,14 @@
   "nodes": {
     "booster-backend": {
       "inputs": {
-        "haskell-backend": "haskell-backend",
+        "haskell-backend": [
+          "haskell-backend"
+        ],
         "nixpkgs": [
           "haskell-backend",
           "nixpkgs"
         ],
         "stacklock2nix": [
-          "booster-backend",
           "haskell-backend",
           "stacklock2nix"
         ]
@@ -100,27 +101,6 @@
         "type": "github"
       }
     },
-    "haskell-backend_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_2",
-        "stacklock2nix": "stacklock2nix_2",
-        "z3": "z3_2"
-      },
-      "locked": {
-        "lastModified": 1697702407,
-        "narHash": "sha256-r9c5qpgoejKJePbxqq01QkHx/wZNypY/fUSugsapF8w=",
-        "owner": "runtimeverification",
-        "repo": "haskell-backend",
-        "rev": "03a6228f78d7f4805fee4b9d9c45208dcbe0c9fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "runtimeverification",
-        "repo": "haskell-backend",
-        "rev": "03a6228f78d7f4805fee4b9d9c45208dcbe0c9fb",
-        "type": "github"
-      }
-    },
     "immer-src": {
       "flake": false,
       "locked": {
@@ -142,14 +122,18 @@
       "inputs": {
         "fmt-src": "fmt-src",
         "immer-src": "immer-src",
-        "mavenix": "mavenix",
+        "mavenix": [
+          "mavenix"
+        ],
         "nixpkgs": [
           "haskell-backend",
           "nixpkgs"
         ],
         "pybind11-src": "pybind11-src",
         "rapidjson-src": "rapidjson-src",
-        "utils": "utils_2"
+        "utils": [
+          "flake-utils"
+        ]
       },
       "locked": {
         "lastModified": 1697808331,
@@ -167,27 +151,13 @@
     },
     "mavenix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3",
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1643802645,
-        "narHash": "sha256-BynM25iwp/l3FyrcHqiNJdDxvN6IxSM3/zkFR6PD3B0=",
-        "owner": "nix-community",
-        "repo": "mavenix",
-        "rev": "ce9ddfd7f361190e8e8dcfaf6b8282eebbb3c7cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "mavenix",
-        "type": "github"
-      }
-    },
-    "mavenix_2": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_4",
-        "utils": "utils_3"
+        "nixpkgs": [
+          "haskell-backend",
+          "nixpkgs"
+        ],
+        "utils": [
+          "flake-utils"
+        ]
       },
       "locked": {
         "lastModified": 1643802645,
@@ -215,49 +185,6 @@
       "original": {
         "id": "nixpkgs",
         "ref": "nixos-23.05",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1696983906,
-        "narHash": "sha256-L7GyeErguS7Pg4h8nK0wGlcUTbfUMDu+HMf1UcyP72k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "bd1cde45c77891214131cbbea5b1203e485a9d51",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-23.05",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1621552131,
-        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "type": "indirect"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1621552131,
-        "narHash": "sha256-AD/AEXv+QOYAg0PIqMYv2nbGOGTIwfOGKtz3rE+y+Tc=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d42cd445dde587e9a993cd9434cb43da07c4c5de",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
         "type": "indirect"
       }
     },
@@ -300,9 +227,9 @@
         "booster-backend": "booster-backend",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "haskell-backend": "haskell-backend_2",
+        "haskell-backend": "haskell-backend",
         "llvm-backend": "llvm-backend",
-        "mavenix": "mavenix_2",
+        "mavenix": "mavenix",
         "nixpkgs": [
           "haskell-backend",
           "nixpkgs"
@@ -340,21 +267,6 @@
         "type": "github"
       }
     },
-    "stacklock2nix_2": {
-      "locked": {
-        "lastModified": 1696895532,
-        "narHash": "sha256-QXQ7frsy7D8V81oE6HQBZhlL48Vr7iPR5fSZfNaTdg0=",
-        "owner": "cdepillabout",
-        "repo": "stacklock2nix",
-        "rev": "10d531672cada2e02ac49b1b18293e7a94938a38",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cdepillabout",
-        "repo": "stacklock2nix",
-        "type": "github"
-      }
-    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,
@@ -370,87 +282,7 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_2": {
-      "inputs": {
-        "systems": "systems_2"
-      },
-      "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "utils_3": {
-      "locked": {
-        "lastModified": 1620759905,
-        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "z3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1674011426,
-        "narHash": "sha256-7cuUf29TMpX62PwO1ab3ZuzmzlcrRjTKB1CyXnYgYus=",
-        "owner": "Z3Prover",
-        "repo": "z3",
-        "rev": "3012293c35eadbfd73e5b94adbe50b0cc44ffb83",
-        "type": "github"
-      },
-      "original": {
-        "owner": "Z3Prover",
-        "ref": "z3-4.12.1",
-        "repo": "z3",
-        "type": "github"
-      }
-    },
-    "z3_2": {
       "flake": false,
       "locked": {
         "lastModified": 1674011426,

--- a/flake.lock
+++ b/flake.lock
@@ -261,21 +261,6 @@
         "type": "indirect"
       }
     },
-    "nixpkgs_5": {
-      "locked": {
-        "lastModified": 1697851979,
-        "narHash": "sha256-lJ8k4qkkwdvi+t/Xc6Fn74kUuobpu9ynPGxNZR6OwoA=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "5550a85a087c04ddcace7f892b0bdc9d8bb080c8",
-        "type": "github"
-      },
-      "original": {
-        "id": "nixpkgs",
-        "ref": "nixos-23.05",
-        "type": "indirect"
-      }
-    },
     "pybind11-src": {
       "flake": false,
       "locked": {
@@ -318,7 +303,10 @@
         "haskell-backend": "haskell-backend_2",
         "llvm-backend": "llvm-backend",
         "mavenix": "mavenix_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": [
+          "haskell-backend",
+          "nixpkgs"
+        ],
         "rv-utils": "rv-utils"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "K Framework";
   inputs = {
-    nixpkgs.url = "nixpkgs/nixos-23.05";
+    nixpkgs.follows = "haskell-backend/nixpkgs";
     haskell-backend.url = "github:runtimeverification/haskell-backend/03a6228f78d7f4805fee4b9d9c45208dcbe0c9fb";
     booster-backend = {
       url = "github:runtimeverification/hs-backend-booster/66439eba81e7311698cb3647b22bb840529ac524";

--- a/flake.nix
+++ b/flake.nix
@@ -5,16 +5,19 @@
     haskell-backend.url = "github:runtimeverification/haskell-backend/03a6228f78d7f4805fee4b9d9c45208dcbe0c9fb";
     booster-backend = {
       url = "github:runtimeverification/hs-backend-booster/66439eba81e7311698cb3647b22bb840529ac524";
-      # NB booster-backend will bring in another dependency on haskell-backend,
-      # but the two are not necessarily the same (different more often than not).
-      # We get two transitive dependencies on haskell-nix.
       inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
+      inputs.haskell-backend.follows = "haskell-backend";
+      inputs.stacklock2nix.follows = "haskell-backend/stacklock2nix";
     };
+    flake-utils.url = "github:numtide/flake-utils";
+    mavenix.url = "github:nix-community/mavenix";
+    mavenix.inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
+    mavenix.inputs.utils.follows = "flake-utils";
     llvm-backend.url = "github:runtimeverification/llvm-backend";
     llvm-backend.inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
-    flake-utils.url = "github:numtide/flake-utils";
+    llvm-backend.inputs.mavenix.follows = "mavenix";
+    llvm-backend.inputs.utils.follows = "flake-utils";
     rv-utils.url = "github:runtimeverification/rv-nix-tools";
-    mavenix.url = "github:nix-community/mavenix";
     # needed by nix/flake-compat-k-unwrapped.nix
     flake-compat = {
       url = "github:edolstra/flake-compat";

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,6 @@
 {
   description = "K Framework";
   inputs = {
-    nixpkgs.follows = "haskell-backend/nixpkgs";
     haskell-backend.url = "github:runtimeverification/haskell-backend/03a6228f78d7f4805fee4b9d9c45208dcbe0c9fb";
     booster-backend = {
       url = "github:runtimeverification/hs-backend-booster/66439eba81e7311698cb3647b22bb840529ac524";
@@ -9,14 +8,19 @@
       inputs.haskell-backend.follows = "haskell-backend";
       inputs.stacklock2nix.follows = "haskell-backend/stacklock2nix";
     };
+    nixpkgs.follows = "haskell-backend/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
-    mavenix.url = "github:nix-community/mavenix";
-    mavenix.inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
-    mavenix.inputs.utils.follows = "flake-utils";
-    llvm-backend.url = "github:runtimeverification/llvm-backend";
-    llvm-backend.inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
-    llvm-backend.inputs.mavenix.follows = "mavenix";
-    llvm-backend.inputs.utils.follows = "flake-utils";
+    mavenix = {
+      url = "github:nix-community/mavenix";
+      inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
+      inputs.utils.follows = "flake-utils";
+    };
+    llvm-backend = {
+      url = "github:runtimeverification/llvm-backend";
+      inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
+      inputs.mavenix.follows = "mavenix";
+      inputs.utils.follows = "flake-utils";
+    };
     rv-utils.url = "github:runtimeverification/rv-nix-tools";
     # needed by nix/flake-compat-k-unwrapped.nix
     flake-compat = {


### PR DESCRIPTION
We are having issues with downstream packages overriding nixpkgs version of upstream packages. We should try to invert this and instead pick up nixpkgs from the upstream dependencies. Since haskell-backend is the deepest dependency and also the most sensitive to nixpkgs version, i have picked it to be the source of pinned nixpkgs for everything downstream.