### PR TITLE
Temporary hotfixes for release flakiness

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,29 +142,36 @@ jobs:
           cp kframework_amd64_debian_bookworm.deb kframework_${version}_amd64_debian_bookworm.deb
           gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_amd64_debian_bookworm.deb
 
-  arch:
-    name: 'Arch Linux Package'
-    runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Build and Test Package'
-        uses: ./.github/actions/test-package
-        with:
-          dockerfile: package/arch/Dockerfile
-          os: archlinux
-          distro: base
-          build-package: package/arch/build-package
-          test-package: package/arch/test-package
-          pkg-name: kframework_arch_x86_64.pkg.tar.zst
-      - name: 'Upload Package to Release'
-        env:
-          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
-        run: |
-          set -x
-          version=$(cat package/version)
-          cp kframework_arch_x86_64.pkg.tar.zst kframework_${version}_arch_x86_64.pkg.tar.zst
-          gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_arch_x86_64.pkg.tar.zst
+  # The arch linux packaging step is disabled because of recurrent flakiness on
+  # the runners we use:
+  #   - https://github.com/runtimeverification/k/issues/3723
+  #   - https://github.com/runtimeverification/k/issues/3731
+  # We may wish to consider reinstating this step when these issues have been
+  # resolved.
+  #
+  # arch:
+  #   name: 'Arch Linux Package'
+  #   runs-on: [self-hosted, linux, normal]
+  #   timeout-minutes: 90
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - name: 'Build and Test Package'
+  #       uses: ./.github/actions/test-package
+  #       with:
+  #         dockerfile: package/arch/Dockerfile
+  #         os: archlinux
+  #         distro: base
+  #         build-package: package/arch/build-package
+  #         test-package: package/arch/test-package
+  #         pkg-name: kframework_arch_x86_64.pkg.tar.zst
+  #     - name: 'Upload Package to Release'
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
+  #       run: |
+  #         set -x
+  #         version=$(cat package/version)
+  #         cp kframework_arch_x86_64.pkg.tar.zst kframework_${version}_arch_x86_64.pkg.tar.zst
+  #         gh release upload --repo runtimeverification/k --clobber v${version} kframework_${version}_arch_x86_64.pkg.tar.zst
 
   macos-build:
     name: 'Build MacOS Package'
@@ -284,9 +291,9 @@ jobs:
         env:
           # github actions sets the JAVA_HOME variable to Java 8 explicitly for
           # some reason. There doesn't seem to be a way to tell it to unset the
-          # variable, so instead we just have to tell it to use Java 11
-          # explicitly intead.
-          JAVA_HOME: ${{ env.JAVA_HOME_11_X64 }}
+          # variable, so instead we just have to tell it to use Java 17
+          # explicitly instead.
+          JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
           cd homebrew-k-old
@@ -299,7 +306,14 @@ jobs:
           spawn-kserver $WD/kserver.log
           cd pl-tutorial
           echo 'Testing tutorial in user environment...'
-          make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+          # The macOS public runners are prone to flakiness when running this
+          # test suite with high parallelism:
+          #   - https://github.com/runtimeverification/k/issues/3705
+          # We know that there are 4 CPUs on macos-13 runners, so rather than
+          # using them all, we use only 2 to reduce load on the machine. Old
+          # command:
+          #   make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+          make -j2 ${MAKE_EXTRA_ARGS}
           cd ~
           echo 'module TEST imports BOOL endmodule' > test.k
           kompile test.k --backend llvm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,7 +362,8 @@ jobs:
     name: 'Publish Release'
     runs-on: [self-hosted, linux, normal]
     environment: production
-    needs: [nix-release, macos-build, macos-test, source-tarball, ubuntu-jammy, debian-bookworm, set-release-id, arch]
+    # Add arch back to this list if we reinstate it as a release platform
+    needs: [nix-release, macos-build, macos-test, source-tarball, ubuntu-jammy, debian-bookworm, set-release-id]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v3


### PR DESCRIPTION
This PR disables the Arch Linux packaging step, and reduces the parallelism being used by the macOS step. Doing so should address the current primary sources of flakiness in the K release job:
- https://github.com/runtimeverification/k/issues/3723
- https://github.com/runtimeverification/k/issues/3731
- https://github.com/runtimeverification/k/issues/3705