### PR TITLE
Drop PL tutorial in macOS release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,25 +296,21 @@ jobs:
           JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
+          # The macOS public runners are prone to flakiness when running this
+          # test suite, so the PL-tutorial is disabled for now.
+          #   - https://github.com/runtimeverification/k/issues/3705
           cd homebrew-k-old
           brew tap kframework/k "file:///$(pwd)"
           brew install ${{ needs.macos-build.outputs.bottle_path }} -v
-          cp -R /usr/local/share/kframework/pl-tutorial ~
-          WD=`pwd`
-          cd
-          echo 'Starting kserver...'
-          spawn-kserver $WD/kserver.log
-          cd pl-tutorial
-          echo 'Testing tutorial in user environment...'
-          # The macOS public runners are prone to flakiness when running this
-          # test suite with high parallelism:
-          #   - https://github.com/runtimeverification/k/issues/3705
-          # We know that there are 4 CPUs on macos-13 runners, so rather than
-          # using them all, we use only 2 to reduce load on the machine. Old
-          # command:
-          #   make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
-          make -j2 ${MAKE_EXTRA_ARGS}
-          cd ~
+          # cp -R /usr/local/share/kframework/pl-tutorial ~
+          # WD=`pwd`
+          # cd
+          # echo 'Starting kserver...'
+          # spawn-kserver $WD/kserver.log
+          # cd pl-tutorial
+          # echo 'Testing tutorial in user environment...'
+          # make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+          # cd ~
           echo 'module TEST imports BOOL endmodule' > test.k
           kompile test.k --backend llvm
           kompile test.k --backend haskell


### PR DESCRIPTION
Reducing the parallelism applied to this job in #2937 does not fix the flakiness, so we should disable the offending part of the test suite for now so that a K release can go through properly. This workflow still smoke-tests K to ensure nothing is *obviously* broken.

Longer term, I think the solution is to run this and related jobs on our own M1/2 machines as we begin to deprecate Intel macOS.

Related to: #3705 