### PR TITLE
Move mac release CI to hosted ARM runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,7 @@ jobs:
 
   macos-build:
     name: 'Build MacOS Package'
-    runs-on: macos-13
+    runs-on: self-macos-13
     timeout-minutes: 120
     environment: production
     needs: [set-release-id, source-tarball]
@@ -257,7 +257,7 @@ jobs:
 
   macos-test:
     name: 'Test MacOS Package'
-    runs-on: macos-13
+    runs-on: self-macos-13
     timeout-minutes: 60
     environment: production
     needs: [macos-build, set-release-id]
@@ -306,14 +306,7 @@ jobs:
           spawn-kserver $WD/kserver.log
           cd pl-tutorial
           echo 'Testing tutorial in user environment...'
-          # The macOS public runners are prone to flakiness when running this
-          # test suite with high parallelism:
-          #   - https://github.com/runtimeverification/k/issues/3705
-          # We know that there are 4 CPUs on macos-13 runners, so rather than
-          # using them all, we use only 2 to reduce load on the machine. Old
-          # command:
-          #   make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
-          make -j2 ${MAKE_EXTRA_ARGS}
+          make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
           cd ~
           echo 'module TEST imports BOOL endmodule' > test.k
           kompile test.k --backend llvm


### PR DESCRIPTION
This PR moves our macOS packaging and release workflow over to use our self-hosted runners, which will hopefully address the recurrent flakiness we've had due to resource exhaustion (#3705).

I have tested these changes by adapting the release workflow to run on PRs, confirming that an `arm64_ventura` bottle gets successfully built. I don't anticipate any changes to the orchestration logic being required, but I will keep an eye on the release that this PR generates just to make sure that it doesn't break the release worse than it already is. In that event, this PR can easily be reverted or hotfixed.