### PR TITLE
Install wget in release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,6 +186,9 @@ jobs:
           submodules: recursive
           path: kframework
 
+      - name: Install script dependencies
+        run: brew install wget
+
       - name: Check out matching homebrew repo branch
         uses: actions/checkout@v3
         id: checkout


### PR DESCRIPTION
https://github.com/runtimeverification/k/actions/runs/6666463392/job/18118970281 is a release job that has failed because `wget` isn't installed on the M2 runner it ran on after the migration in #3764. The solution is to make sure we install it via Homebrew before the bottling job runs.