### PR TITLE
Fix for Homebrew bottle name on arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -187,7 +187,9 @@ jobs:
           path: kframework
 
       - name: Install script dependencies
-        run: brew install wget
+        run: |
+          brew uninstall -f kframework/k/kframework
+          brew install wget
 
       - name: Check out matching homebrew repo branch
         uses: actions/checkout@v3
@@ -231,7 +233,7 @@ jobs:
           git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${VERSION}: part 1"
           ../kframework/package/macos/brew-build-and-update-to-local-bottle ${PACKAGE} ${VERSION} ${ROOT_URL}
           git reset HEAD^
-          LOCAL_BOTTLE_NAME=$(basename $(find . -name "kframework--${VERSION}.ventura.bottle*.tar.gz"))
+          LOCAL_BOTTLE_NAME=$(basename $(find . -name "kframework--${VERSION}.arm64_ventura.bottle*.tar.gz"))
           BOTTLE_NAME=$(echo ${LOCAL_BOTTLE_NAME#./} | sed 's!kframework--!kframework-!')
           ../kframework/package/macos/brew-update-to-final ${PACKAGE} ${VERSION} ${ROOT_URL}
           echo "path=${LOCAL_BOTTLE_NAME}" >> ${GITHUB_OUTPUT}


### PR DESCRIPTION
The Homebrew scripts generate a bottle with a filename prefixed by `arm64` on the M2 runner; this PR updates the release job to expect this. This PR is hopefully one of the last changes needed to iron out Homebrew bottling on these machines.

Fixes broken release: https://github.com/runtimeverification/k/actions/runs/6667962344/job/18122507772