### PR TITLE
Temporary restore of arch PKGBUILD

### DIFF
--- a/package/arch/PKGBUILD
+++ b/package/arch/PKGBUILD
@@ -1,0 +1,44 @@
+# Maintainer: Dwight Guth <dwight.guth@runtimeverification.com>
+pkgname=kframework-git
+pkgver=6.0.0
+pkgrel=1
+epoch=
+pkgdesc="K framework toolchain. Includes K Framework compiler for K language definitions, and K interpreter and prover for programs written in languages defined in K."
+arch=('x86_64')
+url="https://github.com/runtimeverification/k"
+license=('custom')
+groups=()
+depends=( 'bison' 'boost' 'clang' 'diffutils' 'flex' 'fmt' 'gawk' 'gcc' 'gettext' 'gmp' 'grep' 'java-runtime' 'jemalloc' 'libsecp256k1' 'libyaml' 'lld' 'llvm' 'make' 'mpfr' 'patch' 'python' 'tar' 'z3' )
+makedepends=( 'cmake' 'jdk-openjdk' 'maven' 'python' 'zlib' )
+checkdepends=()
+optdepends=()
+provides=()
+conflicts=()
+replaces=()
+backup=()
+options=(!strip)
+install=
+changelog=CHANGELOG.md
+source=()
+noextract=()
+md5sums=()
+validpgpkeys=()
+
+prepare() {
+	true
+}
+
+build() {
+	cd ..
+	mvn --batch-mode package -DskipTests -Dllvm.backend.prefix=/usr -Dllvm.backend.destdir="$srcdir"
+}
+
+check() {
+	true
+}
+
+package() {
+	cd ..
+	DESTDIR="$pkgdir" PREFIX="/usr" package/package
+	install -Dm644 LICENSE.md "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
This PR fixes an issue with the master-branch version bumper introduced in #3765; that PR removed the Arch package definition at the same time as removing it from the version bump script. However, the master branch job still has the old version of the version bumper, which introduces a conflict when trying to modify the package definition.

The fix is to restore the old version of the package definition, allow one master branch bump to go through, then follow up by removing the package definition once the master branch isn't trying to modify it.