### PR TITLE
Revert experimental Homebrew changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -154,9 +154,7 @@ jobs:
           path: kframework
 
       - name: Install script dependencies
-        run: |
-          brew uninstall -f kframework/k/kframework
-          brew install wget
+        run: brew install wget
 
       - name: Check out matching homebrew repo branch
         uses: actions/checkout@v3
@@ -200,7 +198,7 @@ jobs:
           git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${VERSION}: part 1"
           ../kframework/package/macos/brew-build-and-update-to-local-bottle ${PACKAGE} ${VERSION} ${ROOT_URL}
           git reset HEAD^
-          LOCAL_BOTTLE_NAME=$(basename $(find . -name "kframework--${VERSION}.arm64_ventura.bottle*.tar.gz"))
+          LOCAL_BOTTLE_NAME=$(basename $(find . -name "kframework--${VERSION}.ventura.bottle*.tar.gz"))
           BOTTLE_NAME=$(echo ${LOCAL_BOTTLE_NAME#./} | sed 's!kframework--!kframework-!')
           ../kframework/package/macos/brew-update-to-final ${PACKAGE} ${VERSION} ${ROOT_URL}
           echo "path=${LOCAL_BOTTLE_NAME}" >> ${GITHUB_OUTPUT}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,7 +142,7 @@ jobs:
 
   macos-build:
     name: 'Build MacOS Package'
-    runs-on: self-macos-13
+    runs-on: macos-13
     timeout-minutes: 120
     environment: production
     needs: [set-release-id, source-tarball]
@@ -224,7 +224,7 @@ jobs:
 
   macos-test:
     name: 'Test MacOS Package'
-    runs-on: self-macos-13
+    runs-on: macos-13
     timeout-minutes: 60
     environment: production
     needs: [macos-build, set-release-id]
@@ -273,7 +273,14 @@ jobs:
           spawn-kserver $WD/kserver.log
           cd pl-tutorial
           echo 'Testing tutorial in user environment...'
-          make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+          # The macOS public runners are prone to flakiness when running this
+          # test suite with high parallelism:
+          #   - https://github.com/runtimeverification/k/issues/3705
+          # We know that there are 4 CPUs on macos-13 runners, so rather than
+          # using them all, we use only 2 to reduce load on the machine. Old
+          # command:
+          #   make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+          make -j2 ${MAKE_EXTRA_ARGS}
           cd ~
           echo 'module TEST imports BOOL endmodule' > test.k
           kompile test.k --backend llvm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,9 +153,6 @@ jobs:
           submodules: recursive
           path: kframework
 
-      - name: Install script dependencies
-        run: brew install wget
-
       - name: Check out matching homebrew repo branch
         uses: actions/checkout@v3
         id: checkout

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,25 +263,21 @@ jobs:
           JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
         run: |
+          # The macOS public runners are prone to flakiness when running this
+          # test suite, so the PL-tutorial is disabled for now.
+          #   - https://github.com/runtimeverification/k/issues/3705
           cd homebrew-k-old
           brew tap kframework/k "file:///$(pwd)"
           brew install ${{ needs.macos-build.outputs.bottle_path }} -v
-          cp -R /usr/local/share/kframework/pl-tutorial ~
-          WD=`pwd`
-          cd
-          echo 'Starting kserver...'
-          spawn-kserver $WD/kserver.log
-          cd pl-tutorial
-          echo 'Testing tutorial in user environment...'
-          # The macOS public runners are prone to flakiness when running this
-          # test suite with high parallelism:
-          #   - https://github.com/runtimeverification/k/issues/3705
-          # We know that there are 4 CPUs on macos-13 runners, so rather than
-          # using them all, we use only 2 to reduce load on the machine. Old
-          # command:
-          #   make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
-          make -j2 ${MAKE_EXTRA_ARGS}
-          cd ~
+          # cp -R /usr/local/share/kframework/pl-tutorial ~
+          # WD=`pwd`
+          # cd
+          # echo 'Starting kserver...'
+          # spawn-kserver $WD/kserver.log
+          # cd pl-tutorial
+          # echo 'Testing tutorial in user environment...'
+          # make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+          # cd ~
           echo 'module TEST imports BOOL endmodule' > test.k
           kompile test.k --backend llvm
           kompile test.k --backend haskell

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -213,11 +213,6 @@ jobs:
           name: homebrew
           path: homebrew-k
 
-      - name: Clean up Homebrew
-        run: |
-          brew uninstall -f kframework/k/kframework
-          brew untap -f kframework/k 
-
       - name: Delete Release
         if: failure()
         uses: actions/github-script@v6.0.0
@@ -318,11 +313,6 @@ jobs:
           git commit -m 'Update brew package version' Formula/kframework.rb
           git remote set-url origin git@github.com:kframework/homebrew-k.git
           git push origin master
-
-      - name: Clean up Homebrew
-        run: |
-          brew uninstall -f kframework/k/kframework
-          brew untap -f kframework/k 
 
       - name: 'Delete Release'
         if: failure()


### PR DESCRIPTION
This PR reverts a series of experimental changes I made last week to attempt a fix for the flakiness of the macOS Homebrew job; the required implementation turned out to be substantially trickier than I'd thought and so this PR undoes the changes in the interest of returning the release job to a better state. The PRs reverted are:
* https://github.com/runtimeverification/k/pull/3764
* https://github.com/runtimeverification/k/pull/3766
* https://github.com/runtimeverification/k/pull/3767
* https://github.com/runtimeverification/k/pull/3768

Additionally, I have temporarily disabled the PL-tutorial tests on Intel macOS to avoid a common source of release flakiness.

Future changes to the Homebrew code should review and adapt the changes made and reverted here.