### PR TITLE
Fix release cachix action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,6 +73,8 @@ jobs:
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
         uses: cachix/cachix-action@v12
+        with:
+          name: k-framework-binary
 
       - name: 'Publish K to k-framework-binary cache'
         uses: workflow/nix-shell-action@v3


### PR DESCRIPTION
The cachix action requires a cache name, even though we aren't using the action for pushing to the cache, instead using kup.