### PR TITLE
Update README to address missing dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ sudo apt-get install    \
     build-essential     \
     clang-15            \
     cmake               \
+    curl                \
     flex                \
     g++                 \
     gcc                 \
@@ -147,8 +148,9 @@ The following dependencies are needed either at build time or runtime:
 *   [gmp](https://gmplib.org/)
 *   [jdk](https://openjdk.java.net/) (version 17 or greater)
 *   [libjemalloc](https://github.com/jemalloc/jemalloc)
+*   [libsecp256k1](https://github.com/bitcoin-core/secp256k1)
 *   [libyaml](https://pyyaml.org/wiki/LibYAML)
-*   [llvm](https://llvm.org/) (We require version 14 or greater for clang, lld, and llvm-tools. On some distributions, the utilities below are also needed and packaged separately.)
+*   [llvm](https://llvm.org/) (We require version 15 or greater for clang, lld, and llvm-tools. On some distributions, the utilities below are also needed and packaged separately.)
     * [clang](http://clang.llvm.org/)
     * [lld](https://lld.llvm.org/)
 *   [make](https://www.gnu.org/software/make/)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,32 @@ On Ubuntu Linux 22.04 (Jammy):
 
 ```shell
 git submodule update --init --recursive
-sudo apt-get install build-essential m4 openjdk-17-jdk libfmt-dev libgmp-dev libmpfr-dev pkg-config flex bison z3 libz3-dev maven python3 python3-dev cmake gcc g++ clang-14 lld-14 llvm-14-tools zlib1g-dev libboost-test-dev libyaml-dev libjemalloc-dev
+sudo apt-get install    \
+    bison               \
+    build-essential     \
+    clang-15            \
+    cmake               \
+    flex                \
+    g++                 \
+    gcc                 \
+    libboost-test-dev   \
+    libfmt-dev          \
+    libgmp-dev          \
+    libjemalloc-dev     \
+    libmpfr-dev         \
+    libsecp256k1-dev    \
+    libyaml-dev         \
+    libz3-dev           \
+    lld-15              \
+    llvm-15-tools       \
+    m4                  \
+    maven               \
+    openjdk-17-jdk      \
+    pkg-config          \
+    python3             \
+    python3-dev         \
+    z3                  \
+    zlib1g-dev
 curl -sSL https://get.haskellstack.org/ | sh
 ```
 
@@ -86,7 +111,27 @@ On macOS using [Homebrew](https://brew.sh/):
 
 ```shell
 git submodule update --init --recursive
-brew install bison boost cmake flex fmt gcc gmp openjdk jemalloc libyaml llvm make maven mpfr pkg-config python secp256k1 stack zlib z3
+brew install    \
+    bison       \
+    boost       \
+    cmake       \
+    flex        \
+    fmt         \
+    gcc         \
+    gmp         \
+    openjdk     \
+    jemalloc    \
+    libyaml     \
+    llvm        \
+    make        \
+    maven       \
+    mpfr        \
+    pkg-config  \
+    python      \
+    secp256k1   \
+    stack       \
+    zlib        \
+    z3
 ```
 
 ## The Long Version


### PR DESCRIPTION
@MirceaS identified that `libsecp256k1-dev` was a missing dependency for building K from source; this PR adds it to the README in the appropriate places.

The dependency lists in the README are also reformatted to make it more obvious when things are changed or go missing.

Finally, in anticipation of https://github.com/runtimeverification/llvm-backend/pull/874, K's LLVM dependency is bumped to 15 in this documentation.