### PR TITLE
delete jung dependency

### DIFF
--- a/kernel/pom.xml
+++ b/kernel/pom.xml
@@ -79,11 +79,6 @@
       <version>1.0.4</version>
     </dependency>
     <dependency>
-      <groupId>net.sf.jung</groupId>
-      <artifactId>jung-api</artifactId>
-      <version>2.1.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.3.2</version>
@@ -97,11 +92,6 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.10</version>
-    </dependency>
-    <dependency>
-      <groupId>net.sf.jung</groupId>
-      <artifactId>jung-graph-impl</artifactId>
-      <version>2.1.1</version>
     </dependency>
     <dependency>
       <groupId>dk.brics.automaton</groupId>


### PR DESCRIPTION
I'm removing this dependency because it was barely used and I want to tinker with using a different graph library in the Maude backend, but it doesn't make sense to have two different graph libraries on the classpath.