### PR TITLE
Apply more automatic Java refactoring

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -2034,9 +2034,7 @@ public class ModuleToKORE {
 
     for (Tuple2<Tuple2<Att.Key, String>, ?> attribute :
         // Sort to stabilize error messages
-        stream(att.att())
-            .sorted(Comparator.comparing(Tuple2::toString))
-            .collect(Collectors.toList())) {
+        stream(att.att()).sorted(Comparator.comparing(Tuple2::toString)).toList()) {
       Att.Key key = attribute._1._1;
       String strKey = key.key();
       String clsName = attribute._1._2;
@@ -2095,7 +2093,7 @@ public class ModuleToKORE {
                   else
                     throw KEMException.criticalError("No free variable found for " + s, location);
                 })
-            .collect(Collectors.toList());
+            .toList();
     String conn = "";
     for (KVariable var : variables) {
       sb.append(conn);

--- a/kernel/src/main/java/org/kframework/compile/AddParentCells.java
+++ b/kernel/src/main/java/org/kframework/compile/AddParentCells.java
@@ -200,10 +200,10 @@ public class AddParentCells {
       Optional<Integer> level = Optional.empty();
       for (K item : cells) {
         Optional<Integer> level2 = getLevel(item);
-        if (item instanceof KVariable && !level2.isPresent()) {
+        if (item instanceof KVariable && level2.isEmpty()) {
           continue;
         }
-        if (!level.isPresent()) {
+        if (level.isEmpty()) {
           level = level2;
         } else if (!level.equals(level2)) {
           throw KEMException.criticalError("Can't mix cells at different levels under a rewrite");
@@ -247,10 +247,10 @@ public class AddParentCells {
     } else {
       Optional<KLabel> leftParent = getParent(((KRewrite) k).left());
       Optional<KLabel> rightParent = getParent(((KRewrite) k).right());
-      if (!leftParent.isPresent()) {
+      if (leftParent.isEmpty()) {
         return rightParent;
       }
-      if (!rightParent.isPresent()) {
+      if (rightParent.isEmpty()) {
         return leftParent;
       }
       if (leftParent.equals(rightParent)) {

--- a/kernel/src/main/java/org/kframework/compile/AddParentCells.java
+++ b/kernel/src/main/java/org/kframework/compile/AddParentCells.java
@@ -60,10 +60,7 @@ public class AddParentCells {
     List<K> children =
         allChildren.stream().filter(t -> !(t instanceof KRewrite)).collect(Collectors.toList());
     List<KRewrite> rewrites =
-        allChildren.stream()
-            .filter(t -> t instanceof KRewrite)
-            .map(t -> (KRewrite) t)
-            .collect(Collectors.toList());
+        allChildren.stream().filter(t -> t instanceof KRewrite).map(t -> (KRewrite) t).toList();
 
     // see if all children can fit together
     Set<Sort> usedCells = Sets.newHashSet();

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -503,9 +503,7 @@ public class AddSortInjections {
     assert !entries.isEmpty();
     entries = new HashSet<>(entries);
     Collection<Sort> filteredEntries =
-        entries.stream()
-            .filter(s -> s != null && !s.name().equals(SORTPARAM_NAME))
-            .collect(Collectors.toList());
+        entries.stream().filter(s -> s != null && !s.name().equals(SORTPARAM_NAME)).toList();
     if (filteredEntries.isEmpty()) { // if all sorts are parameters, take the first
       return entries.iterator().next();
     }

--- a/kernel/src/main/java/org/kframework/compile/ConvertDataStructureToLookup.java
+++ b/kernel/src/main/java/org/kframework/compile/ConvertDataStructureToLookup.java
@@ -121,7 +121,6 @@ public class ConvertDataStructureToLookup {
     return stream(m.productions())
         .filter(p -> p.att().contains(Att.ASSOC()) && p.att().contains(Att.FILTER_ELEMENT()))
         .map(p -> p.klabel().get())
-        .distinct()
         .collect(Collectors.toSet());
   }
 

--- a/kernel/src/main/java/org/kframework/compile/ConvertDataStructureToLookup.java
+++ b/kernel/src/main/java/org/kframework/compile/ConvertDataStructureToLookup.java
@@ -163,7 +163,7 @@ public class ConvertDataStructureToLookup {
    */
   K addSideCondition(K requires) {
     Optional<KApply> sideCondition = getSortedLookups().reduce(BooleanUtils::and);
-    if (!sideCondition.isPresent()) {
+    if (sideCondition.isEmpty()) {
       return requires;
     } else if (requires.equals(BooleanUtils.TRUE) && sideCondition.isPresent()) {
       return sideCondition.get();

--- a/kernel/src/main/java/org/kframework/compile/DeconstructIntegerAndFloatLiterals.java
+++ b/kernel/src/main/java/org/kframework/compile/DeconstructIntegerAndFloatLiterals.java
@@ -92,7 +92,7 @@ public class DeconstructIntegerAndFloatLiterals {
 
   K addSideCondition(K requires) {
     Optional<KApply> sideCondition = state.stream().reduce(BooleanUtils::and);
-    if (!sideCondition.isPresent()) {
+    if (sideCondition.isEmpty()) {
       return requires;
     } else if (requires.equals(BooleanUtils.TRUE) && sideCondition.isPresent()) {
       return sideCondition.get();

--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -117,7 +117,7 @@ public class ExpandMacros {
         stream(mod.rules())
             .filter(r -> isMacro(r.att(), reverse))
             .sorted(Comparator.comparingInt(r -> ModuleToKORE.getPriority(r.att())))
-            .collect(Collectors.toList());
+            .toList();
     macros =
         allMacros.stream()
             .filter(r -> getLeft(r, reverse) instanceof KApply)

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
@@ -130,7 +130,7 @@ public class ResolveFreshConstants {
       public K apply(KVariable k) {
         if (freshVars.contains(k)) {
           Optional<Sort> s = k.att().getOptional(Sort.class);
-          if (!s.isPresent()) {
+          if (s.isEmpty()) {
             throw KEMException.compilerError("Fresh constant used without a declared sort.", k);
           }
           Option<KLabel> lbl = m.freshFunctionFor().get(s.get());

--- a/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
@@ -84,7 +84,7 @@ public class ResolveSemanticCasts {
                       }.apply(k))
               .map(k -> KApply(KLabel("is" + getSortNameOfCast((KApply) k)), transform(k)))
               .reduce(BooleanUtils::and);
-      if (!sideCondition.isPresent()) {
+      if (sideCondition.isEmpty()) {
         return requires;
       } else if (requires.equals(BooleanUtils.TRUE) && sideCondition.isPresent()) {
         return sideCondition.get();

--- a/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
@@ -72,17 +72,16 @@ public class ResolveSemanticCasts {
       Optional<KApply> sideCondition =
           casts.stream()
               .map(
-                  k -> {
-                    return new TransformK() {
-                      @Override
-                      public K apply(KVariable k) {
-                        if (varToTypedVar.containsKey(k)) {
-                          return varToTypedVar.get(k);
+                  k ->
+                      new TransformK() {
+                        @Override
+                        public K apply(KVariable k) {
+                          if (varToTypedVar.containsKey(k)) {
+                            return varToTypedVar.get(k);
+                          }
+                          return k;
                         }
-                        return k;
-                      }
-                    }.apply(k);
-                  })
+                      }.apply(k))
               .map(k -> KApply(KLabel("is" + getSortNameOfCast((KApply) k)), transform(k)))
               .reduce(BooleanUtils::and);
       if (!sideCondition.isPresent()) {

--- a/kernel/src/main/java/org/kframework/compile/ResolveStrict.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveStrict.java
@@ -167,7 +167,7 @@ public class ResolveStrict {
                 .map(j -> KApply(KLabel("is" + result.toString()), KVariable("K" + (j - 1))))
                 .reduce(BooleanUtils::and);
         K requires;
-        if (!sideCondition.isPresent() || !sequential) {
+        if (sideCondition.isEmpty() || !sequential) {
           requires = BooleanUtils.TRUE;
         } else {
           requires = sideCondition.get();
@@ -261,7 +261,7 @@ public class ResolveStrict {
                 .map(j -> KApply(result, KVariable("K" + (j - 1))))
                 .reduce(BooleanUtils::and);
         K requires;
-        if (!sideCondition.isPresent()) {
+        if (sideCondition.isEmpty()) {
           requires = BooleanUtils.TRUE;
         } else {
           requires = sideCondition.get();

--- a/kernel/src/main/java/org/kframework/compile/SortInfo.java
+++ b/kernel/src/main/java/org/kframework/compile/SortInfo.java
@@ -57,9 +57,8 @@ public class SortInfo {
     joinOps
         .asMap()
         .forEach(
-            (sort, labels) -> {
-              info.closeOperators.put(sort, Iterators.getNext(labels.iterator(), null));
-            });
+            (sort, labels) ->
+                info.closeOperators.put(sort, Iterators.getNext(labels.iterator(), null)));
     return info;
   }
 }

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -46,10 +46,7 @@ public class CheckAtt {
               "Unrecognized attributes on module "
                   + m.name()
                   + ": "
-                  + stream(m.att().unrecognizedKeys())
-                      .map(Key::toString)
-                      .sorted()
-                      .collect(Collectors.toList())
+                  + stream(m.att().unrecognizedKeys()).map(Key::toString).sorted().toList()
                   + "\nHint: User-defined groups can be added with the group(_) attribute."));
     }
   }
@@ -84,10 +81,7 @@ public class CheckAtt {
       errors.add(
           KEMException.compilerError(
               "Unrecognized attributes: "
-                  + stream(sentence.att().unrecognizedKeys())
-                      .map(Key::toString)
-                      .sorted()
-                      .collect(Collectors.toList())
+                  + stream(sentence.att().unrecognizedKeys()).map(Key::toString).sorted().toList()
                   + "\nHint: User-defined groups can be added with the group(_) attribute.",
               sentence));
     }
@@ -99,8 +93,7 @@ public class CheckAtt {
     Set<Key> keys = stream(att.att().keySet()).map(k -> k._1()).collect(Collectors.toSet());
     keys.removeIf(k -> k.allowedSentences().exists(c -> c.isAssignableFrom(cls)));
     if (!keys.isEmpty()) {
-      List<String> sortedKeys =
-          keys.stream().map(k -> k.toString()).sorted().collect(Collectors.toList());
+      List<String> sortedKeys = keys.stream().map(k -> k.toString()).sorted().toList();
       errors.add(
           KEMException.compilerError(
               cls.getSimpleName()

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckBracket.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckBracket.java
@@ -2,7 +2,6 @@
 package org.kframework.compile.checks;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import org.kframework.attributes.Att;
 import org.kframework.kil.Module;
 import org.kframework.kil.ModuleItem;
@@ -25,14 +24,12 @@ public class CheckBracket {
         for (Production p : b.getProductions()) {
           if (p.containsAttribute(Att.BRACKET())) {
             List<ProductionItem> nts =
-                p.getItems().stream()
-                    .filter(x -> x instanceof NonTerminal)
-                    .collect(Collectors.toList());
+                p.getItems().stream().filter(x -> x instanceof NonTerminal).toList();
             if (nts.size() != 1
                 || !((NonTerminal) nts.get(0)).getSort().equals(s.getDeclaredSort().getSort()))
               throw KEMException.outerParserError(
-                  "bracket productions should have exactly one non-terminal of the same sort as the"
-                      + " production.",
+                  "bracket productions should have exactly one non-terminal "
+                      + "of the same sort as the production.",
                   p.getSource(),
                   p.getLocation());
           }

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
@@ -164,7 +164,7 @@ public class CheckKLabels {
       if (prod.att().contains(Att.MAINCELL())
           || prod.att().contains(Att.UNUSED())
           || symbol.equals("<generatedTop>")
-          || !s.isPresent()
+          || s.isEmpty()
           || (prod.att().contains(Att.CELL())
               && stream(prod.nonterminals())
                   .filter(

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
@@ -167,16 +167,14 @@ public class CheckKLabels {
           || s.isEmpty()
           || (prod.att().contains(Att.CELL())
               && stream(prod.nonterminals())
-                  .filter(
+                  .anyMatch(
                       nt ->
                           klabels
                               .get(symbol)
                               .sortAttributesFor()
                               .get(nt.sort().head())
                               .getOrElse(() -> Att.empty())
-                              .contains(Att.CELL_COLLECTION()))
-                  .findAny()
-                  .isPresent())) {
+                              .contains(Att.CELL_COLLECTION())))) {
         continue;
       }
       if (canonicalPath == null || !s.get().source().contains(canonicalPath)) {

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckListDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckListDecl.java
@@ -21,7 +21,7 @@ import org.kframework.utils.errorsystem.KEMException;
 public class CheckListDecl {
 
   public static void check(Module m) {
-    m.getItems().stream().forEach(CheckListDecl::check); // i -> check(i)
+    m.getItems().forEach(CheckListDecl::check); // i -> check(i)
   }
 
   private static final Set<Sort> BASE_SORTS =

--- a/kernel/src/main/java/org/kframework/kdep/KDepFrontEnd.java
+++ b/kernel/src/main/java/org/kframework/kdep/KDepFrontEnd.java
@@ -126,10 +126,7 @@ public class KDepFrontEnd extends FrontEnd {
 
     List<File> sortedFiles = new ArrayList<File>(allFiles);
     Collections.sort(
-        sortedFiles,
-        (File a, File b) -> {
-          return a.getAbsolutePath().compareTo(b.getAbsolutePath());
-        });
+        sortedFiles, (File a, File b) -> a.getAbsolutePath().compareTo(b.getAbsolutePath()));
 
     for (File file : sortedFiles) {
       System.out.println("    " + file.getAbsolutePath() + " \\");

--- a/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
+++ b/kernel/src/main/java/org/kframework/kompile/CompiledDefinition.java
@@ -116,39 +116,38 @@ public class CompiledDefinition implements Serializable {
     // searching for #SemanticCastTo<Sort>(Map:lookup(_, #token(<VarName>, KConfigVar)))
     Collections.stream(kompiledDefinition.mainModule().rules())
         .forEach(
-            r -> {
-              new VisitK() {
-                @Override
-                public void apply(KApply k) {
-                  if (k.klabel().name().startsWith("project:")
-                      && k.items().size() == 1
-                      && k.items().get(0) instanceof KApply theMapLookup) {
-                    if (KLabels.MAP_LOOKUP.equals(theMapLookup.klabel())
-                        && theMapLookup.size() == 2
-                        && theMapLookup.items().get(1) instanceof KToken t) {
-                      if (t.sort().equals(Sorts.KConfigVar())) {
-                        Sort sort =
-                            Outer.parseSort(k.klabel().name().substring("project:".length()));
-                        configurationVariableDefaultSorts.put(t.s(), sort);
-                        if (sort.equals(Sorts.K())) {
-                          sort = Sorts.KItem();
+            r ->
+                new VisitK() {
+                  @Override
+                  public void apply(KApply k) {
+                    if (k.klabel().name().startsWith("project:")
+                        && k.items().size() == 1
+                        && k.items().get(0) instanceof KApply theMapLookup) {
+                      if (KLabels.MAP_LOOKUP.equals(theMapLookup.klabel())
+                          && theMapLookup.size() == 2
+                          && theMapLookup.items().get(1) instanceof KToken t) {
+                        if (t.sort().equals(Sorts.KConfigVar())) {
+                          Sort sort =
+                              Outer.parseSort(k.klabel().name().substring("project:".length()));
+                          configurationVariableDefaultSorts.put(t.s(), sort);
+                          if (sort.equals(Sorts.K())) {
+                            sort = Sorts.KItem();
+                          }
+                          String str =
+                              "declaredConfigVar_"
+                                  + t.s().substring(1)
+                                  + "='"
+                                  + sort.toString()
+                                  + "'\n";
+                          sb.append(str);
+                          String astr = "    '" + t.s().substring(1) + "'\n";
+                          arr.append(astr);
                         }
-                        String str =
-                            "declaredConfigVar_"
-                                + t.s().substring(1)
-                                + "='"
-                                + sort.toString()
-                                + "'\n";
-                        sb.append(str);
-                        String astr = "    '" + t.s().substring(1) + "'\n";
-                        arr.append(astr);
                       }
                     }
+                    super.apply(k);
                   }
-                  super.apply(k);
-                }
-              }.apply(r.body());
-            });
+                }.apply(r.body()));
     sb.append(arr);
     sb.append(")\n");
 

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -736,7 +736,6 @@ public class Kompile {
                     m.productionsForSort()
                         .getOrElse(Sorts.Bool().head(), Set$.MODULE$::<Production>empty)))
         .collect(Collectors.toSet())
-        .stream()
         .forEach(
             prod -> {
               Seq<ProductionItem> items = prod.items();

--- a/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
+++ b/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
@@ -523,9 +523,7 @@ public class TextDocumentSyncHandler {
 
               if (isPositionOverLocation(pos, nameLoc)) {
                 List<DefinitionItem> allDi =
-                    files.values().stream()
-                        .flatMap(doc -> doc.dis.stream())
-                        .collect(Collectors.toList());
+                    files.values().stream().flatMap(doc -> doc.dis.stream()).toList();
                 allDi.stream()
                     .filter(ddi -> ddi instanceof Module)
                     .map(ddi -> ((Module) ddi))
@@ -787,9 +785,7 @@ public class TextDocumentSyncHandler {
                   + " #poss: "
                   + poss
                   + " rezDepth: "
-                  + lloc.stream()
-                      .map(TextDocumentSyncHandler::getSelectionRangeDepth)
-                      .collect(Collectors.toList()));
+                  + lloc.stream().map(TextDocumentSyncHandler::getSelectionRangeDepth).toList());
 
           return lloc;
         });

--- a/kernel/src/main/java/org/kframework/parser/KRead.java
+++ b/kernel/src/main/java/org/kframework/parser/KRead.java
@@ -66,7 +66,6 @@ public record KRead(
           mod, sort, startSymbolLocation, kem, files, stringToParse, source, partialParseDebug);
       case RULE -> throw KEMException.internalError(
           "Should have been handled directly by the kast front end: " + inputMode);
-      default -> throw KEMException.criticalError("Unsupported input mode: " + inputMode);
     };
   }
 

--- a/kernel/src/main/java/org/kframework/parser/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/ParserUtils.java
@@ -415,7 +415,7 @@ public class ParserUtils {
     Optional<Module> opt;
     opt = modules.stream().filter(m -> m.name().equals(syntaxModuleName)).findFirst();
     Module syntaxModule;
-    if (!opt.isPresent()) {
+    if (opt.isEmpty()) {
       kem.registerCompilerWarning(
           ExceptionType.MISSING_SYNTAX_MODULE,
           "Could not find main syntax module with name "
@@ -435,7 +435,7 @@ public class ParserUtils {
   private Module getMainModule(String mainModuleName, Set<Module> modules) {
     Optional<Module> opt =
         modules.stream().filter(m -> m.name().equals(mainModuleName)).findFirst();
-    if (!opt.isPresent()) {
+    if (opt.isEmpty()) {
       throw KEMException.compilerError(
           "Could not find main module with name "
               + mainModuleName

--- a/kernel/src/main/java/org/kframework/parser/ParserUtils.java
+++ b/kernel/src/main/java/org/kframework/parser/ParserUtils.java
@@ -254,7 +254,7 @@ public class ParserUtils {
         groupedModules.entrySet().stream()
             .filter(e -> e.getValue().size() > 1)
             .map(Map.Entry::getKey)
-            .collect(Collectors.toList());
+            .toList();
 
     int errors = 0;
     for (String moduleName : duplicateModules) {

--- a/kernel/src/main/java/org/kframework/parser/inner/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/RuleGrammarGenerator.java
@@ -375,7 +375,7 @@ public record RuleGrammarGenerator(Definition baseK) {
     List<Sort> allSorts =
         stream(mod.allSorts())
             .filter(s -> (!isParserSort(s) || s.equals(Sorts.KItem()) || s.equals(Sorts.K())))
-            .collect(Collectors.toList());
+            .toList();
     for (SortHead sh : mutable(mod.definedInstantiations()).keySet()) {
       for (Sort s : mutable(mod.definedInstantiations().apply(sh))) {
         // syntax MInt{K} ::= MInt{6}
@@ -583,7 +583,7 @@ public record RuleGrammarGenerator(Definition baseK) {
               .collect(Collectors.toSet());
     }
 
-    disambProds = parseProds.stream().collect(Collectors.toSet());
+    disambProds = new HashSet<>(parseProds);
     if (mod.importedModuleNames().contains(PROGRAM_LISTS)) {
       Set<Sentence> prods3 = new HashSet<>();
       // if no start symbol has been defined in the configuration, then use K
@@ -594,7 +594,7 @@ public record RuleGrammarGenerator(Definition baseK) {
         }
       }
       // for each triple, generate a new pattern which works better for parsing lists in programs.
-      prods3.addAll(parseProds.stream().collect(Collectors.toSet()));
+      prods3.addAll(new HashSet<>(parseProds));
       Set<Sentence> res = new HashSet<>();
       for (UserList ul : UserList.getLists(prods3)) {
         Production prod1, prod2, prod3 = null, prod4 = null, prod5 = null;
@@ -714,7 +714,7 @@ public record RuleGrammarGenerator(Definition baseK) {
         stream(mod.importedModules())
             .filter(m -> m.att().contains(Att.NOT_LR1()))
             .map(Module::name)
-            .collect(Collectors.toList());
+            .toList();
     if (!notLrModules.isEmpty()) {
       att = att.add(Att.NOT_LR1_MODULES(), notLrModules.toString());
     }

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AddEmptyLists.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/AddEmptyLists.java
@@ -100,7 +100,7 @@ public class AddEmptyLists extends SetsGeneralTransformer<KEMException, KEMExcep
             orig);
     java.util.Set<KEMException> warnings = new HashSet<>();
 
-    List<Term> reversed = tc.items().stream().collect(Collectors.toList());
+    List<Term> reversed = new ArrayList<>(tc.items());
     Collections.reverse(
         reversed); // TermCons with PStack requires the elements to be in the reverse order
     Iterator<Term> items = reversed.iterator();

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferencer.java
@@ -176,7 +176,7 @@ public class TypeInferencer implements AutoCloseable {
     for (Tuple2<Sort, Set<Sort>> relation :
         stream(relations.relations())
             .sorted(Comparator.comparing(t -> -ordinals.getOrDefault(t._1().head(), 0)))
-            .collect(Collectors.toList())) {
+            .toList()) {
       if (!isRealSort(relation._1().head())) {
         continue;
       }

--- a/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/kernel/Scanner.java
@@ -153,7 +153,7 @@ public class Scanner implements AutoCloseable {
     List<TerminalLike> ordered =
         tokens.keySet().stream()
             .sorted((t1, t2) -> tokens.get(t2)._2() - tokens.get(t1)._2())
-            .collect(Collectors.toList());
+            .toList();
     for (TerminalLike key : ordered) {
       if (key instanceof Terminal t) {
         flex.append(StringUtil.enquoteCString(t.value()));

--- a/kernel/src/main/java/org/kframework/unparser/KPrint.java
+++ b/kernel/src/main/java/org/kframework/unparser/KPrint.java
@@ -312,7 +312,7 @@ public class KPrint {
         return Optional.of(term);
       }
       Set<KVariable> leftVars = vars(kapp.items().get(0));
-      if (leftVars.stream().filter(v -> !v.att().contains(Att.ANONYMOUS())).findAny().isPresent()) {
+      if (leftVars.stream().anyMatch(v -> !v.att().contains(Att.ANONYMOUS()))) {
         return Optional.of(term);
       }
       for (KVariable var : leftVars) {

--- a/kernel/src/main/java/org/kframework/utils/ColorUtil.java
+++ b/kernel/src/main/java/org/kframework/utils/ColorUtil.java
@@ -373,7 +373,6 @@ public final class ColorUtil {
       case OFF -> "";
       case ON -> getClosestTerminalCode(colors.get(rgb), ansiColorsToTerminalCodes);
       case EXTENDED -> getClosestTerminalCode(colors.get(rgb), eightBitColorsToTerminalCodes);
-      default -> throw new UnsupportedOperationException("colorSettung: " + colorSetting);
     };
   }
 


### PR DESCRIPTION
This PR applies a few small simplifications suggested by IntelliJ:
* [Expression lambdas](https://docs.oracle.com/javase/tutorial/java/javaOO/lambdaexpressions.html)
* Removal of dead-code default cases in switches
* Simplification of stream + optional call chains (removal of redundant calls etc.)