### PR TITLE
Hotfix for release workflow re. macOS / python

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -267,6 +267,18 @@ jobs:
           name: homebrew
           path: homebrew-k-old
 
+      - name: Mac Dependencies
+        run: |
+          # Via: https://github.com/ledger/ledger/commit/1eec9f86667cad3b0bbafb82a83739a0d30ca09f
+          # Unlink and re-link to prevent errors when github mac runner images
+          # install python outside of brew, for example:
+          # https://github.com/orgs/Homebrew/discussions/3895
+          # https://github.com/actions/setup-python/issues/577
+          # https://github.com/actions/runner-images/issues/6459
+          # https://github.com/actions/runner-images/issues/6507
+          # https://github.com/actions/runner-images/issues/2322
+          brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+
       - name: 'Test brew bottle'
         id: test
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -179,6 +179,18 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
 
+      - name: Mac Dependencies
+        run: |
+          # Via: https://github.com/ledger/ledger/commit/1eec9f86667cad3b0bbafb82a83739a0d30ca09f
+          # Unlink and re-link to prevent errors when github mac runner images
+          # install python outside of brew, for example:
+          # https://github.com/orgs/Homebrew/discussions/3895
+          # https://github.com/actions/setup-python/issues/577
+          # https://github.com/actions/runner-images/issues/6459
+          # https://github.com/actions/runner-images/issues/6507
+          # https://github.com/actions/runner-images/issues/2322
+          brew list -1 | grep python | while read formula; do brew unlink $formula; brew link --overwrite $formula; done
+
       - name: Build brew bottle
         id: build
         env:


### PR DESCRIPTION
The K release build has been failing repeatedly with errors regarding Homebrew; I've finally tracked the root cause down to a version upgrade of the runner images that installs Python 3.11. When Homebrew updated some packages between releases, this caused link conflicts between Homebrew Python and the runner-installed version.

There are lots of issue threads discussing this problem; as best I can tell the workaround is to unlink all Homebrew Python packages, then relink them and force an overwrite of the system versions. This PR introduces that change to the macOS workflows we do on release builds.

Example fix: https://github.com/ledger/ledger/commit/1eec9f86667cad3b0bbafb82a83739a0d30ca09f