### PR TITLE
Fix version of mavenix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -160,16 +160,17 @@
         ]
       },
       "locked": {
-        "lastModified": 1689018333,
-        "narHash": "sha256-sthxx50rj0E7gv38oeMj8GZOp7i1776P1qZsM7pVLd0=",
+        "lastModified": 1656435814,
+        "narHash": "sha256-Gx4QoWB9eI437/66iqTr6AUjxGgN6WslqrQ57s+sL6A=",
         "owner": "goodlyrottenapple",
         "repo": "mavenix",
-        "rev": "153d69e62f87e5dd37d35492cc3e35dd80d2b5fa",
+        "rev": "0cbd57b2494d52909b27f57d03580acc66bf0298",
         "type": "github"
       },
       "original": {
         "owner": "goodlyrottenapple",
         "repo": "mavenix",
+        "rev": "0cbd57b2494d52909b27f57d03580acc66bf0298",
         "type": "github"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,7 @@
     nixpkgs.follows = "haskell-backend/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     mavenix = {
-      url = "github:goodlyrottenapple/mavenix";
+      url = "github:goodlyrottenapple/mavenix/0cbd57b2494d52909b27f57d03580acc66bf0298";
       inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
       inputs.utils.follows = "flake-utils";
     };


### PR DESCRIPTION
Fix for a regression in kup binary packages, introduced when we switched back to a custom version of mavenix. This was done because we want to be able to manually specify the path to mavenix.lock (see https://github.com/nix-community/mavenix/commit/0cbd57b2494d52909b27f57d03580acc66bf0298). However, the next commit (https://github.com/nix-community/mavenix/commit/c2f3618ce413ad541027a163a85985760ce1ee75) is what causes the regression, by symlinking to many small nix store paths which take a very long time to download from the binary cache...