### PR TITLE
Clean up cast insertion in `TypeInferenceVisitor`

### DIFF
--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -929,7 +929,6 @@ public class DefinitionParsing {
             source,
             startLine,
             startColumn,
-            true,
             isAnywhere);
     parsedBubbles.getAndIncrement();
     registerWarnings(result._2());

--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -12,7 +12,6 @@ import java.util.stream.Collectors;
 import org.apache.commons.io.FileUtils;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
-import org.kframework.builtin.Sorts;
 import org.kframework.definition.Module;
 import org.kframework.definition.Terminal;
 import org.kframework.definition.TerminalLike;
@@ -420,8 +419,7 @@ public class ParseInModule implements Serializable, AutoCloseable {
       }
 
       rez =
-          new TypeInferenceVisitor(
-                  currentInferencer, startSymbol, inferSortChecks, true, isAnywhere)
+          new TypeInferenceVisitor(currentInferencer, startSymbol, inferSortChecks, isAnywhere)
               .apply(rez3);
       if (rez.isLeft()) return new Tuple2<>(rez, warn);
       endTypeInf = profileRules ? System.currentTimeMillis() : 0;

--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -210,7 +210,7 @@ public class ParseInModule implements Serializable, AutoCloseable {
   public Tuple2<Either<Set<KEMException>, K>, Set<KEMException>> parseString(
       String input, Sort startSymbol, Source source) {
     try (Scanner scanner = getScanner()) {
-      return parseString(input, startSymbol, "unit test", scanner, source, 1, 1, true, false);
+      return parseString(input, startSymbol, "unit test", scanner, source, 1, 1, false);
     }
   }
 
@@ -280,8 +280,7 @@ public class ParseInModule implements Serializable, AutoCloseable {
   public Tuple2<Either<Set<KEMException>, K>, Set<KEMException>> parseString(
       String input, Sort startSymbol, String startSymbolLocation, Source source) {
     try (Scanner scanner = getScanner()) {
-      return parseString(
-          input, startSymbol, startSymbolLocation, scanner, source, 1, 1, true, false);
+      return parseString(input, startSymbol, startSymbolLocation, scanner, source, 1, 1, false);
     }
   }
 
@@ -324,7 +323,6 @@ public class ParseInModule implements Serializable, AutoCloseable {
       Source source,
       int startLine,
       int startColumn,
-      boolean inferSortChecks,
       boolean isAnywhere) {
     final Tuple2<Either<Set<KEMException>, Term>, Set<KEMException>> result =
         parseStringTerm(
@@ -335,7 +333,6 @@ public class ParseInModule implements Serializable, AutoCloseable {
             source,
             startLine,
             startColumn,
-            inferSortChecks,
             isAnywhere);
     Either<Set<KEMException>, K> parseInfo;
     if (result._1().isLeft()) {
@@ -369,7 +366,6 @@ public class ParseInModule implements Serializable, AutoCloseable {
       Source source,
       int startLine,
       int startColumn,
-      boolean inferSortChecks,
       boolean isAnywhere) {
     if (!parsingModule.definedSorts().contains(startSymbol.head()))
       throw KEMException.innerParserError(
@@ -418,9 +414,7 @@ public class ParseInModule implements Serializable, AutoCloseable {
         }
       }
 
-      rez =
-          new TypeInferenceVisitor(currentInferencer, startSymbol, inferSortChecks, isAnywhere)
-              .apply(rez3);
+      rez = new TypeInferenceVisitor(currentInferencer, startSymbol, isAnywhere).apply(rez3);
       if (rez.isLeft()) return new Tuple2<>(rez, warn);
       endTypeInf = profileRules ? System.currentTimeMillis() : 0;
 

--- a/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -482,20 +482,4 @@ public class ParseInModule implements Serializable, AutoCloseable {
     }
     inferencers.clear();
   }
-
-  public static Term disambiguateForUnparse(Module mod, Term ambiguity) {
-    Term rez3 = new PushTopAmbiguityUp().apply(ambiguity);
-    Either<Set<KEMException>, Term> rez;
-    Tuple2<Either<Set<KEMException>, Term>, Set<KEMException>> rez2;
-    try (TypeInferencer inferencer = new TypeInferencer(mod, false)) {
-      rez = new TypeInferenceVisitor(inferencer, Sorts.K(), false, false, false).apply(rez3);
-    }
-    if (rez.isLeft()) {
-      rez2 = new AmbFilter().apply(rez3);
-      return rez2._1().right().get();
-    }
-    rez3 = new PushAmbiguitiesDownAndPreferAvoid(mod.overloads()).apply(rez.right().get());
-    rez2 = new AmbFilter().apply(rez3);
-    return rez2._1().right().get();
-  }
 }

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
@@ -284,32 +284,17 @@ public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException
     }
 
     private Either<Set<KEMException>, Term> wrapTermWithCast(Constant c, Sort declared) {
-      Production cast;
       if (!hasCheckAlready) {
         // strictly typing variables and one does not already exist, so add :Sort
-        cast =
+        Production cast =
             inferencer
                 .module()
                 .productionsFor()
                 .apply(KLabel("#SemanticCastTo" + declared.toString()))
                 .head();
-      } else if (!hasCastAlready
-          && inferencer.module().productionsFor().contains(KLabel("#SyntacticCast"))) {
-        // casting variables and one doeds not already exist, so add ::Sort
-        cast =
-            stream(inferencer.module().productionsFor().apply(KLabel("#SyntacticCast")))
-                .filter(p -> p.sort().equals(declared))
-                .findAny()
-                .get();
-      } else {
-        // unparsing or cast already exists, so do nothing
-        cast = null;
-      }
-      if (cast == null) {
-        return Right.apply(c);
-      } else {
         return Right.apply(TermCons.apply(ConsPStack.singleton(c), cast, c.location(), c.source()));
       }
+      return Right.apply(c);
     }
   }
 }

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
@@ -50,21 +50,17 @@ import scala.util.Right;
  */
 public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException> {
   private final TypeInferencer inferencer;
-  private final boolean inferSortChecks;
   private final boolean isAnywhere;
   private final Sort topSort;
 
   /**
    * @param inferencer
    * @param topSort The expected sort of the top of the term.
-   * @param inferSortChecks true if we should add :Sort to variables
    * @param isAnywhere true if the term is an anywhere rule
    */
-  public TypeInferenceVisitor(
-      TypeInferencer inferencer, Sort topSort, boolean inferSortChecks, boolean isAnywhere) {
+  public TypeInferenceVisitor(TypeInferencer inferencer, Sort topSort, boolean isAnywhere) {
     this.inferencer = inferencer;
     this.topSort = topSort;
-    this.inferSortChecks = inferSortChecks;
     this.isAnywhere = isAnywhere;
   }
 
@@ -289,7 +285,7 @@ public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException
 
     private Either<Set<KEMException>, Term> wrapTermWithCast(Constant c, Sort declared) {
       Production cast;
-      if (inferSortChecks && !hasCheckAlready) {
+      if (!hasCheckAlready) {
         // strictly typing variables and one does not already exist, so add :Sort
         cast =
             inferencer

--- a/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/disambiguation/TypeInferenceVisitor.java
@@ -51,7 +51,6 @@ import scala.util.Right;
 public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException> {
   private final TypeInferencer inferencer;
   private final boolean inferSortChecks;
-  private final boolean inferCasts;
   private final boolean isAnywhere;
   private final Sort topSort;
 
@@ -59,19 +58,13 @@ public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException
    * @param inferencer
    * @param topSort The expected sort of the top of the term.
    * @param inferSortChecks true if we should add :Sort to variables
-   * @param inferCasts true if we should add ::Sort to variables
    * @param isAnywhere true if the term is an anywhere rule
    */
   public TypeInferenceVisitor(
-      TypeInferencer inferencer,
-      Sort topSort,
-      boolean inferSortChecks,
-      boolean inferCasts,
-      boolean isAnywhere) {
+      TypeInferencer inferencer, Sort topSort, boolean inferSortChecks, boolean isAnywhere) {
     this.inferencer = inferencer;
     this.topSort = topSort;
     this.inferSortChecks = inferSortChecks;
-    this.inferCasts = inferCasts;
     this.isAnywhere = isAnywhere;
   }
 
@@ -304,8 +297,7 @@ public class TypeInferenceVisitor extends SetsTransformerWithErrors<KEMException
                 .productionsFor()
                 .apply(KLabel("#SemanticCastTo" + declared.toString()))
                 .head();
-      } else if (inferCasts
-          && !hasCastAlready
+      } else if (!hasCastAlready
           && inferencer.module().productionsFor().contains(KLabel("#SyntacticCast"))) {
         // casting variables and one doeds not already exist, so add ::Sort
         cast =


### PR DESCRIPTION
This PR removes unused fields from `TypeInferenceVisitor` related to cast insertion then simplifies the algorithm accordingly.

The commit history is clean and justifies each step in the clean-up sequentially.