### PR TITLE
Move `id` field out of `ProductionReference` into `TypeInferencer`

### DIFF
--- a/kore/src/main/scala/org/kframework/parser/treeNodes.scala
+++ b/kore/src/main/scala/org/kframework/parser/treeNodes.scala
@@ -11,7 +11,7 @@ import org.pcollections.{ConsPStack, PStack}
 import collection.JavaConverters._
 import org.kframework.utils.StringUtil
 
-import scala.collection.mutable;
+import scala.collection.mutable
 
 trait Term extends HasLocation {
   var location: Optional[Location] = Optional.empty()
@@ -33,37 +33,45 @@ trait HasChildren {
   def replaceChildren(newChildren: Collection[Term]): Term
 }
 
-case class Constant private(value: String, production: Production) extends ProductionReference {
+case class Constant private (value: String, production: Production) extends ProductionReference {
   override def toString = "#token(" + production.sort + "," + StringUtil.enquoteKString(value) + ")"
 
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Constant.this);
 }
 
 // note that items is reversed because it is more efficient to generate it this way during parsing
-case class TermCons private(items: PStack[Term], production: Production)
-  extends ProductionReference with HasChildren {
+case class TermCons private (items: PStack[Term], production: Production)
+    extends ProductionReference
+    with HasChildren {
   def get(i: Int) = items.get(items.size() - 1 - i)
 
-  def `with`(i: Int, e: Term) = TermCons(items.`with`(items.size() - 1 - i, e), production, location, source, id)
+  def `with`(i: Int, e: Term) =
+    TermCons(items.`with`(items.size() - 1 - i, e), production, location, source, id)
 
-  def replaceChildren(newChildren: Collection[Term]) = TermCons(ConsPStack.from(newChildren), production, location, source, id)
+  def replaceChildren(newChildren: Collection[Term]) =
+    TermCons(ConsPStack.from(newChildren), production, location, source, id)
 
   override def toString() = new TreeNodesToKORE(s => Sort(s)).apply(this).toString()
 
   override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(TermCons.this);
 }
 
-case class Ambiguity(items: Set[Term])
-  extends Term with HasChildren {
-  def replaceChildren(newChildren: Collection[Term]) = Ambiguity(new HashSet[Term](newChildren), location, source)
+case class Ambiguity(items: Set[Term]) extends Term with HasChildren {
+  def replaceChildren(newChildren: java.util.Collection[Term]) =
+    Ambiguity(new java.util.HashSet[Term](newChildren), location, source)
 
-  override def toString() = "amb(" + (items.asScala mkString ",") + ")"
+  override def toString: String = "amb(" + (items.asScala mkString ",") + ")"
 
-  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Ambiguity.this);
+  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Ambiguity.this)
 }
 
 object Constant {
-  def apply(value: String, production: Production, location: Optional[Location], source: Optional[Source]): Constant = {
+  def apply(
+      value: String,
+      production: Production,
+      location: Optional[Location],
+      source: Optional[Source]
+  ): Constant = {
     val res = Constant(value, production)
     res.location = location
     res.source = source
@@ -72,7 +80,13 @@ object Constant {
 }
 
 object TermCons {
-  def apply(items: PStack[Term], production: Production, location: Optional[Location], source: Optional[Source], id: Optional[Integer]): TermCons = {
+  def apply(
+      items: PStack[Term],
+      production: Production,
+      location: Optional[Location],
+      source: Optional[Source],
+      id: Optional[Integer]
+  ): TermCons = {
     val res = TermCons(items, production)
     res.location = location
     res.source = source
@@ -80,17 +94,39 @@ object TermCons {
     res
   }
 
-  def apply(items: PStack[Term], production: Production, location: Optional[Location], source: Optional[Source]): TermCons = {
+  def apply(
+      items: PStack[Term],
+      production: Production,
+      location: Optional[Location],
+      source: Optional[Source]
+  ): TermCons = {
     TermCons(items, production, location, source, Optional.empty())
   }
 
-  def apply(items: PStack[Term], production: Production, location: Location, source: Source): TermCons = TermCons(items, production, Optional.of(location), Optional.of(source), Optional.empty())
+  def apply(
+      items: PStack[Term],
+      production: Production,
+      location: Location,
+      source: Source
+  ): TermCons = TermCons(
+    items,
+    production,
+    Optional.of(location),
+    Optional.of(source),
+    Optional
+      .empty()
+  )
 }
 
 object Ambiguity {
-  @annotation.varargs def apply(items: Term*): Ambiguity = Ambiguity(items.to[mutable.Set].asJava)
+  @annotation.varargs
+  def apply(items: Term*): Ambiguity = Ambiguity(items.to[mutable.Set].asJava)
 
-  def apply(items: Set[Term], location: Optional[Location], source: Optional[Source]): Ambiguity = {
+  def apply(
+      items: java.util.Set[Term],
+      location: Optional[Location],
+      source: Optional[Source]
+  ): Ambiguity = {
     val res = Ambiguity(items)
     res.location = location
     res.source = source

--- a/kore/src/main/scala/org/kframework/parser/treeNodes.scala
+++ b/kore/src/main/scala/org/kframework/parser/treeNodes.scala
@@ -2,14 +2,14 @@
 
 package org.kframework.parser
 
-import org.kframework.attributes.{Source, Location, HasLocation}
+import org.kframework.attributes.{HasLocation, Location, Source}
 import org.kframework.definition.Production
 import org.kframework.kore.KORE.Sort
-import java.util._
-import org.pcollections.{ConsPStack, PStack}
-import collection.JavaConverters._
 import org.kframework.utils.StringUtil
+import org.pcollections.{ConsPStack, PStack}
 
+import java.util._
+import scala.collection.JavaConverters._
 import scala.collection.mutable
 
 trait Term extends HasLocation {
@@ -19,11 +19,6 @@ trait Term extends HasLocation {
 
 trait ProductionReference extends Term {
   val production: Production
-  var id: Optional[Integer] = Optional.empty()
-
-  def setId(id: Optional[Integer]): Unit = {
-    this.id = id
-  }
 }
 
 trait HasChildren {
@@ -46,10 +41,10 @@ case class TermCons private (items: PStack[Term], production: Production)
   def get(i: Int): Term = items.get(items.size() - 1 - i)
 
   def `with`(i: Int, e: Term): TermCons =
-    TermCons(items.`with`(items.size() - 1 - i, e), production, location, source, id)
+    TermCons(items.`with`(items.size() - 1 - i, e), production, location, source)
 
   def replaceChildren(newChildren: java.util.Collection[Term]): TermCons =
-    TermCons(ConsPStack.from(newChildren), production, location, source, id)
+    TermCons(ConsPStack.from(newChildren), production, location, source)
 
   override def toString: String = new TreeNodesToKORE(s => Sort(s)).apply(this).toString()
 
@@ -84,23 +79,12 @@ object TermCons {
       items: PStack[Term],
       production: Production,
       location: Optional[Location],
-      source: Optional[Source],
-      id: Optional[Integer]
+      source: Optional[Source]
   ): TermCons = {
     val res = TermCons(items, production)
     res.location = location
     res.source = source
-    res.id = id
     res
-  }
-
-  def apply(
-      items: PStack[Term],
-      production: Production,
-      location: Optional[Location],
-      source: Optional[Source]
-  ): TermCons = {
-    TermCons(items, production, location, source, Optional.empty())
   }
 
   def apply(
@@ -112,9 +96,7 @@ object TermCons {
     items,
     production,
     Optional.of(location),
-    Optional.of(source),
-    Optional
-      .empty()
+    Optional.of(source)
   )
 }
 

--- a/kore/src/main/scala/org/kframework/parser/treeNodes.scala
+++ b/kore/src/main/scala/org/kframework/parser/treeNodes.scala
@@ -6,7 +6,6 @@ import org.kframework.attributes.{Source, Location, HasLocation}
 import org.kframework.definition.Production
 import org.kframework.kore.KORE.Sort
 import java.util._
-import java.lang.Iterable
 import org.pcollections.{ConsPStack, PStack}
 import collection.JavaConverters._
 import org.kframework.utils.StringUtil
@@ -22,42 +21,43 @@ trait ProductionReference extends Term {
   val production: Production
   var id: Optional[Integer] = Optional.empty()
 
-  def setId(id: Optional[Integer]) {
+  def setId(id: Optional[Integer]): Unit = {
     this.id = id
   }
 }
 
 trait HasChildren {
-  def items: Iterable[Term]
+  def items: java.lang.Iterable[Term]
 
-  def replaceChildren(newChildren: Collection[Term]): Term
+  def replaceChildren(newChildren: java.util.Collection[Term]): Term
 }
 
 case class Constant private (value: String, production: Production) extends ProductionReference {
-  override def toString = "#token(" + production.sort + "," + StringUtil.enquoteKString(value) + ")"
+  override def toString: String =
+    "#token(" + production.sort + "," + StringUtil.enquoteKString(value) + ")"
 
-  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Constant.this);
+  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(Constant.this)
 }
 
 // note that items is reversed because it is more efficient to generate it this way during parsing
 case class TermCons private (items: PStack[Term], production: Production)
     extends ProductionReference
     with HasChildren {
-  def get(i: Int) = items.get(items.size() - 1 - i)
+  def get(i: Int): Term = items.get(items.size() - 1 - i)
 
-  def `with`(i: Int, e: Term) =
+  def `with`(i: Int, e: Term): TermCons =
     TermCons(items.`with`(items.size() - 1 - i, e), production, location, source, id)
 
-  def replaceChildren(newChildren: Collection[Term]) =
+  def replaceChildren(newChildren: java.util.Collection[Term]): TermCons =
     TermCons(ConsPStack.from(newChildren), production, location, source, id)
 
-  override def toString() = new TreeNodesToKORE(s => Sort(s)).apply(this).toString()
+  override def toString: String = new TreeNodesToKORE(s => Sort(s)).apply(this).toString()
 
-  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(TermCons.this);
+  override lazy val hashCode: Int = scala.runtime.ScalaRunTime._hashCode(TermCons.this)
 }
 
-case class Ambiguity(items: Set[Term]) extends Term with HasChildren {
-  def replaceChildren(newChildren: java.util.Collection[Term]) =
+case class Ambiguity(items: java.util.Set[Term]) extends Term with HasChildren {
+  def replaceChildren(newChildren: java.util.Collection[Term]): Ambiguity =
     Ambiguity(new java.util.HashSet[Term](newChildren), location, source)
 
   override def toString: String = "amb(" + (items.asScala mkString ",") + ")"


### PR DESCRIPTION
The `id` field of `ProductionReference` is only used by `TypeInferencer`, so this PR removes the field and instead stores it as a `Map<ProductionReference, Integer>` within `TypeInferencer`.

This is useful for testing the new type inference algorithm - both algorithms can be run back-to-back on the same term to compare results, with them each tracking the `id` internally rather than mutating the input and storing conflicting `id`s.

Additionally, I formatted `treeNodes.scala` and fixed all IntelliJ warnings.