### PR TITLE
Update Bencher CLI version

### DIFF
--- a/k-distribution/tests/profiling/setup_profiling.sh
+++ b/k-distribution/tests/profiling/setup_profiling.sh
@@ -3,7 +3,7 @@
 set -euxo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
-export BENCHER_VERSION="0.3.15"
+export BENCHER_VERSION="0.3.23"
 apt-get update
 apt-get upgrade --yes
 apt-get install --yes python3 python3-pip git curl make time sudo wget


### PR DESCRIPTION
Hey guys,
Thanks for using Bencher! 😃
This updates the Bencher CLI version due to breaking changes in the API. The new version of the CLI has some forwards compatibility enhancements to help prevent this from happening as often in the future.