### PR TITLE
Prohibit user-defined parametric sorts

### DIFF
--- a/k-distribution/tests/regression-new/checks/checkParametricSort.k
+++ b/k-distribution/tests/regression-new/checks/checkParametricSort.k
@@ -1,0 +1,8 @@
+// Copyright (c) Runtime Verification, Inc. All Rights Reserved.
+module CHECKPARAMETRICSORT
+imports MINT
+imports INT
+
+syntax MInt{6}
+syntax {S} Foo{S}
+endmodule

--- a/k-distribution/tests/regression-new/checks/checkParametricSort.k.out
+++ b/k-distribution/tests/regression-new/checks/checkParametricSort.k.out
@@ -1,0 +1,5 @@
+[Error] Compiler: User-defined parametric sorts are currently unsupported: Foo{S}
+	Source(checkParametricSort.k)
+	Location(7,1,7,18)
+	7 |	syntax {S} Foo{S}
+	  .	^~~~~~~~~~~~~~~~~


### PR DESCRIPTION
This PR adds a check to error on any non-`MInt` parametric sorts. 

We already assume `MInt` is the only parametric sort internally, so this check just makes that explicit to the user:
https://github.com/runtimeverification/k/blob/0b4353c62f018a46736dc6b512414b77ab81523d/kernel/src/main/java/org/kframework/parser/inner/RuleGrammarGenerator.java#L419

The check has to be done in `Module.checkSorts` so that we error early enough, e.g., before computing the subsort `POSet`.