### PR TITLE
add new classpath dir in ~/.local

### DIFF
--- a/k-distribution/src/main/scripts/lib/checkJava
+++ b/k-distribution/src/main/scripts/lib/checkJava
@@ -42,7 +42,7 @@ else
       TIERED=-XX:+TieredCompilation
     fi
     export K_OPTS="-Xms64m -Xmx4096m -Xss32m $TIERED $K_OPTS"
-    JAVA="java -Dfile.encoding=UTF-8 -Djava.awt.headless=true $K_OPTS -ea -cp \"$(dirname "$BASH_SOURCE")/java/*\""
+    JAVA="java -Dfile.encoding=UTF-8 -Djava.awt.headless=true $K_OPTS -ea -cp \"$(dirname "$BASH_SOURCE")/java/*:$HOME/.local/lib/kframework/java/*\""
   fi
 fi
 


### PR DESCRIPTION
This adds a new directory to search for jars in the K frontend. This directory is located in ~/.local. This allows the user to install extensions to K without modifying their global installation. This is useful if you want to install the Maude backend on a Nix-installed K installation, for example.