### PR TITLE
3926 smoke test llvm booster integration

### DIFF
--- a/.github/workflows/Dockerfile
+++ b/.github/workflows/Dockerfile
@@ -55,6 +55,7 @@ RUN    apt-get update              \
         lld-${LLVM_VERSION}        \
         llvm-${LLVM_VERSION}-tools \
         locales                    \
+        lsof                       \
         maven                      \
         openjdk-${JDK_VERSION}-jdk \
         parallel                   \

--- a/k-distribution/Makefile
+++ b/k-distribution/Makefile
@@ -1,3 +1,3 @@
-SUBDIRS=tests/regression-new tests/builtins/collections
+SUBDIRS=tests/regression-new tests/builtins/collections tests/smoke
 
 include include/kframework/ktest-group.mak

--- a/k-distribution/tests/smoke/krpc-test/Makefile
+++ b/k-distribution/tests/smoke/krpc-test/Makefile
@@ -1,0 +1,52 @@
+# find K_HOME
+include ../find-k.mak
+K_BIN=$(abspath ${K_HOME}/bin)
+
+# used programs
+KOMPILE=$(K_BIN)/kompile
+BOOSTER=$(K_BIN)/kore-rpc-booster
+RPC_CLIENT=$(K_BIN)/kore-rpc-client
+
+# tests
+INPUTS=$(wildcard *-request.json)
+TESTS=$(INPUTS:-request.json=.rpc)
+
+.phony: clean all regenerate $(TEST)
+
+all: $(TESTS)
+
+####################
+KOMPILED_DIR=imp-kompiled
+kompile: $(KOMPILED_DIR)/definition.kore
+
+$(KOMPILED_DIR)/definition.kore: ../imp.k
+	$(KOMPILE) --backend haskell --output-definition $(KOMPILED_DIR) $<
+
+####################
+KOMPILED_LLVM_DIR=imp-llvm-kompiled
+ifeq ($(shell uname -s),Darwin)
+	LIB_SUFFIX=dylib
+else
+	LIB_SUFFIX=so
+endif
+
+kompile-llvm: $(KOMPILED_LLVM_DIR)/interpreter.$(LIB_SUFFIX)
+
+$(KOMPILED_LLVM_DIR)/interpreter.$(LIB_SUFFIX): ../imp.k
+	$(KOMPILE) --backend llvm --llvm-kompile-type c --output-definition $(KOMPILED_LLVM_DIR) $<
+
+clean:
+	rm -rf $(KOMPILED_DIR) $(KOMPILED_LLVM_DIR)
+
+####################
+$(TESTS): %.rpc: %-request.json %-response.json kompile kompile-llvm
+	($(BOOSTER) \
+		$(KOMPILED_DIR)/definition.kore --module IMP \
+		--llvm-backend-library ./$(KOMPILED_LLVM_DIR)/interpreter.$(LIB_SUFFIX) & \
+		echo $$! > server.pid\
+	)
+	@echo "Server running as process $$(cat server.pid)"
+	bash -c "trap 'kill -2 $$(cat server.pid); rm server.pid' ERR EXIT; $(RPC_CLIENT) send $*-request.json --expect $*-response.json $(REGENERATE)"
+
+$(TESTS:.rpc=.regenerate): %.regenerate:
+	$(MAKE) $*.rpc REGENERATE="--regenerate"

--- a/k-distribution/tests/smoke/krpc-test/Makefile
+++ b/k-distribution/tests/smoke/krpc-test/Makefile
@@ -11,9 +11,11 @@ RPC_CLIENT=$(K_BIN)/kore-rpc-client
 INPUTS=$(wildcard *-request.json)
 TESTS=$(INPUTS:-request.json=.rpc)
 
-.phony: clean all regenerate $(TEST)
+.phony: clean all update-results $(TESTS)
 
 all: $(TESTS)
+
+update-results: $(TESTS:.rpc=.update)
 
 ####################
 KOMPILED_DIR=imp-kompiled
@@ -48,5 +50,5 @@ $(TESTS): %.rpc: %-request.json %-response.json kompile kompile-llvm
 	@echo "Server running as process $$(cat server.pid)"
 	bash -c "trap 'kill -2 $$(cat server.pid); rm server.pid' ERR EXIT; $(RPC_CLIENT) send $*-request.json --expect $*-response.json $(REGENERATE)"
 
-$(TESTS:.rpc=.regenerate): %.regenerate:
+$(TESTS:.rpc=.update): %.update:
 	$(MAKE) $*.rpc REGENERATE="--regenerate"

--- a/k-distribution/tests/smoke/krpc-test/Makefile
+++ b/k-distribution/tests/smoke/krpc-test/Makefile
@@ -43,12 +43,14 @@ clean:
 ####################
 $(TESTS): %.rpc: %-request.json %-response.json kompile kompile-llvm
 	($(BOOSTER) \
-		$(KOMPILED_DIR)/definition.kore --module IMP \
+		$(KOMPILED_DIR)/definition.kore --module IMP --server-port 0 \
 		--llvm-backend-library ./$(KOMPILED_LLVM_DIR)/interpreter.$(LIB_SUFFIX) & \
-		echo $$! > server.pid\
-	)
-	@echo "Server running as process $$(cat server.pid)"
-	bash -c "trap 'kill -2 $$(cat server.pid); rm server.pid' ERR EXIT; $(RPC_CLIENT) send $*-request.json --expect $*-response.json $(REGENERATE)"
+		echo $$! > $*.server.pid)
+	bash -c "while ! lsof -a -p$$(cat $*.server.pid) -sTCP:LISTEN -iTCP; do echo .; sleep 1; done"
+	lsof -a -p$$(cat $*.server.pid) -sTCP:LISTEN -iTCP | grep $$(cat $*.server.pid) | sed -e 's/.* TCP \*:\([0-9]*\).*$$/\1/' > $*.server.port
+
+	@echo "Server running as process $$(cat $*.server.pid) on port $$(cat $*.server.port)"
+	bash -c "trap 'kill -2 $$(cat $*.server.pid); rm $*.server.{pid,port}' EXIT; $(RPC_CLIENT) --port $$(cat $*.server.port) send $*-request.json --expect $*-response.json $(REGENERATE)"
 
 $(TESTS:.rpc=.update): %.update:
 	$(MAKE) $*.rpc REGENERATE="--regenerate"

--- a/k-distribution/tests/smoke/krpc-test/Makefile
+++ b/k-distribution/tests/smoke/krpc-test/Makefile
@@ -46,7 +46,7 @@ $(TESTS): %.rpc: %-request.json %-response.json kompile kompile-llvm
 		$(KOMPILED_DIR)/definition.kore --module IMP --server-port 0 \
 		--llvm-backend-library ./$(KOMPILED_LLVM_DIR)/interpreter.$(LIB_SUFFIX) & \
 		echo $$! > $*.server.pid)
-	bash -c "while ! lsof -a -p$$(cat $*.server.pid) -sTCP:LISTEN -iTCP; do echo .; sleep 1; done"
+	timeout 10 bash -c "while ! lsof -a -p$$(cat $*.server.pid) -sTCP:LISTEN -iTCP; do echo .; sleep 1; done"
 	lsof -a -p$$(cat $*.server.pid) -sTCP:LISTEN -iTCP | grep $$(cat $*.server.pid) | sed -e 's/.* TCP \*:\([0-9]*\).*$$/\1/' > $*.server.port
 
 	@echo "Server running as process $$(cat $*.server.pid) on port $$(cat $*.server.port)"

--- a/k-distribution/tests/smoke/krpc-test/plus-request.json
+++ b/k-distribution/tests/smoke/krpc-test/plus-request.json
@@ -1,0 +1,198 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "execute",
+    "params": {
+        "state": {
+            "format": "KORE",
+            "version": 1,
+            "term": {
+                "tag": "App",
+                "name": "Lbl'-LT-'generatedTop'-GT-'",
+                "sorts": [],
+                "args": [
+                    {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'T'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'k'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "kseq",
+                                        "sorts": [],
+                                        "args": [
+                                            {
+                                                "tag": "App",
+                                                "name": "inj",
+                                                "sorts": [
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortPgm",
+                                                        "args": []
+                                                    },
+                                                    {
+                                                        "tag": "SortApp",
+                                                        "name": "SortKItem",
+                                                        "args": []
+                                                    }
+                                                ],
+                                                "args": [
+                                                    {
+                                                        "tag": "App",
+                                                        "name": "Lblint'UndsSClnUndsUnds'IMP-SYNTAX'Unds'Pgm'Unds'Ids'Unds'Stmt",
+                                                        "sorts": [],
+                                                        "args": [
+                                                            {
+                                                                "tag": "App",
+                                                                "name": "Lbl'UndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids",
+                                                                "sorts": [],
+                                                                "args": [
+                                                                    {
+                                                                        "tag": "DV",
+                                                                        "sort": {
+                                                                            "tag": "SortApp",
+                                                                            "name": "SortId",
+                                                                            "args": []
+                                                                        },
+                                                                        "value": "i"
+                                                                    },
+                                                                    {
+                                                                        "tag": "App",
+                                                                        "name": "Lbl'Stop'List'LBraQuotUndsCommUndsUnds'IMP-SYNTAX'Unds'Ids'Unds'Id'Unds'Ids'QuotRBraUnds'Ids",
+                                                                        "sorts": [],
+                                                                        "args": []
+                                                                    }
+                                                                ]
+                                                            },
+                                                            {
+                                                                "tag": "App",
+                                                                "name": "Lbl'UndsEqlsUndsSClnUnds'IMP-SYNTAX'Unds'Stmt'Unds'Id'Unds'AExp",
+                                                                "sorts": [],
+                                                                "args": [
+                                                                    {
+                                                                        "tag": "DV",
+                                                                        "sort": {
+                                                                            "tag": "SortApp",
+                                                                            "name": "SortId",
+                                                                            "args": []
+                                                                        },
+                                                                        "value": "i"
+                                                                    },
+                                                                    {
+                                                                        "tag": "App",
+                                                                        "name": "Lbl'UndsPlusUndsUnds'IMP-SYNTAX'Unds'AExp'Unds'AExp'Unds'AExp",
+                                                                        "sorts": [],
+                                                                        "args": [
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "inj",
+                                                                                "sorts": [
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortAExp",
+                                                                                        "args": []
+                                                                                    }
+                                                                                ],
+                                                                                "args": [
+                                                                                    {
+                                                                                        "tag": "DV",
+                                                                                        "sort": {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortInt",
+                                                                                            "args": []
+                                                                                        },
+                                                                                        "value": "42"
+                                                                                    }
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "tag": "App",
+                                                                                "name": "inj",
+                                                                                "sorts": [
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortInt",
+                                                                                        "args": []
+                                                                                    },
+                                                                                    {
+                                                                                        "tag": "SortApp",
+                                                                                        "name": "SortAExp",
+                                                                                        "args": []
+                                                                                    }
+                                                                                ],
+                                                                                "args": [
+                                                                                    {
+                                                                                        "tag": "DV",
+                                                                                        "sort": {
+                                                                                            "tag": "SortApp",
+                                                                                            "name": "SortInt",
+                                                                                            "args": []
+                                                                                        },
+                                                                                        "value": "1"
+                                                                                    }
+                                                                                ]
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                ]
+                                                            }
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "tag": "App",
+                                                "name": "dotk",
+                                                "sorts": [],
+                                                "args": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            },
+                            {
+                                "tag": "App",
+                                "name": "Lbl'-LT-'state'-GT-'",
+                                "sorts": [],
+                                "args": [
+                                    {
+                                        "tag": "App",
+                                        "name": "Lbl'Stop'Map",
+                                        "sorts": [],
+                                        "args": []
+                                    }
+                                ]
+                            }
+                        ]
+                    },
+                    {
+                        "tag": "App",
+                        "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                        "sorts": [],
+                        "args": [
+                            {
+                                "tag": "DV",
+                                "sort": {
+                                    "tag": "SortApp",
+                                    "name": "SortInt",
+                                    "args": []
+                                },
+                                "value": "0"
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/k-distribution/tests/smoke/krpc-test/plus-response.json
+++ b/k-distribution/tests/smoke/krpc-test/plus-response.json
@@ -1,0 +1,125 @@
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "result": {
+        "reason": "stuck",
+        "depth": 6,
+        "state": {
+            "term": {
+                "format": "KORE",
+                "version": 1,
+                "term": {
+                    "tag": "App",
+                    "name": "Lbl'-LT-'generatedTop'-GT-'",
+                    "sorts": [],
+                    "args": [
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'T'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'k'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "dotk",
+                                            "sorts": [],
+                                            "args": []
+                                        }
+                                    ]
+                                },
+                                {
+                                    "tag": "App",
+                                    "name": "Lbl'-LT-'state'-GT-'",
+                                    "sorts": [],
+                                    "args": [
+                                        {
+                                            "tag": "App",
+                                            "name": "Lbl'UndsPipe'-'-GT-Unds'",
+                                            "sorts": [],
+                                            "args": [
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortId",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "DV",
+                                                            "sort": {
+                                                                "tag": "SortApp",
+                                                                "name": "SortId",
+                                                                "args": []
+                                                            },
+                                                            "value": "i"
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "tag": "App",
+                                                    "name": "inj",
+                                                    "sorts": [
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortInt",
+                                                            "args": []
+                                                        },
+                                                        {
+                                                            "tag": "SortApp",
+                                                            "name": "SortKItem",
+                                                            "args": []
+                                                        }
+                                                    ],
+                                                    "args": [
+                                                        {
+                                                            "tag": "DV",
+                                                            "sort": {
+                                                                "tag": "SortApp",
+                                                                "name": "SortInt",
+                                                                "args": []
+                                                            },
+                                                            "value": "43"
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "tag": "App",
+                            "name": "Lbl'-LT-'generatedCounter'-GT-'",
+                            "sorts": [],
+                            "args": [
+                                {
+                                    "tag": "DV",
+                                    "sort": {
+                                        "tag": "SortApp",
+                                        "name": "SortInt",
+                                        "args": []
+                                    },
+                                    "value": "0"
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/k-distribution/tests/smoke/krpc-test/rubbish-request.json
+++ b/k-distribution/tests/smoke/krpc-test/rubbish-request.json
@@ -1,0 +1,1 @@
+rubbish

--- a/k-distribution/tests/smoke/krpc-test/rubbish-response.json
+++ b/k-distribution/tests/smoke/krpc-test/rubbish-response.json
@@ -1,0 +1,9 @@
+{
+    "jsonrpc": "2.0",
+    "id": null,
+    "error": {
+        "code": -32700,
+        "data": "rubbish\n",
+        "message": "Parse error"
+    }
+}

--- a/package/debian/test-package
+++ b/package/debian/test-package
@@ -9,7 +9,7 @@ cp "${pkg}" kframework.deb
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get upgrade --yes
-apt-get install --yes make
+apt-get install --yes make lsof
 apt-get install --yes ./kframework.deb
 
 package/test-package


### PR DESCRIPTION
As a smoke test, compile the `IMP` semantics from `tests/smoke/imp.k` and run two basic tests with `kore-rpc-booster` to check that LLVM backend and booster server work together.

Fixes #3926 

This also enables the tests in `tests/smoke` as these were previously not executed by `mvn verify`.