### PR TITLE
Base64-encode module digests

### DIFF
--- a/kernel/src/main/java/org/kframework/kil/Module.java
+++ b/kernel/src/main/java/org/kframework/kil/Module.java
@@ -4,6 +4,7 @@ package org.kframework.kil;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 import java.util.Set;
 import org.kframework.kore.Sort;
@@ -73,7 +74,9 @@ public class Module extends DefinitionItem {
       toString(mod);
       MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
       messageDigest.update(mod.toString().getBytes());
-      return new String(messageDigest.digest());
+
+      var textDigest = Base64.getEncoder().encode(messageDigest.digest());
+      return new String(textDigest);
     } catch (NoSuchAlgorithmException e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
Previously, the content generated for module digest attributes was an arbitrary sequence of bytes. This broke outer parsing for `compiled.txt` (i.e. the compiler is generating an intermediate state that it can't re-compile). To fix the issue, we just apply a base 64 encoding to the digest value when it's generated to keep the byte values in printable ASCII range.

Fixes: https://github.com/runtimeverification/k/issues/3945