### PR TITLE
Fix inconsistent symbol naming for syntactic lists

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -373,6 +373,34 @@ the JSON Kast format, building terms using the user-provided pretty
 `symbol, klabel(...)` is easier and less error-prone if the auto-generation
 process for klabels changes.
 
+#### Syntactic Lists
+
+When using K's support for syntactic lists, a production like:
+```k
+syntax Ints ::= List{Int, ","} [klabel(ints), symbol]
+```
+will desugar into two productions:
+```k
+syntax Ints ::= Int "," Ints [klabel(ints), symbol]
+syntax Ints ::= ".Ints"      [klabel(List{"ints"}), symbol]
+```
+
+Note that the label for the _terminator_ of the list has been generated
+automatically from the label on the original production. It is possible to
+control what the terminator's label is using the `terminator-klabel(_)`
+attribute. For example:
+```k
+syntax Ints ::= List{Int, ","} [klabel(ints), terminator-klabel(.ints), symbol]
+```
+will desugar into two productions:
+```k
+syntax Ints ::= Int "," Ints [klabel(ints),  symbol]
+syntax Ints ::= ".Ints"      [klabel(.ints), symbol]
+```
+
+It is an error to apply `terminator-klabel(_)` to a non-production sentence, or
+to a production that does not declare a syntactic list.
+
 ### Parametric productions and `bracket` attributes
 
 Some syntax productions, like the rewrite operator, the bracket operator, and
@@ -2908,76 +2936,77 @@ brief description of each. Note that the same attribute may appear in the index
 multiple times to indicate its effect in different contexts or with/without
 arguments. A legend describing how to interpret the index follows.
 
-| Name                  | Type  | Backend | Reference                                                                                                                                       |
-| --------------------- | ----- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `alias-rec`           | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `alias`               | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `all-path`            | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
-| `anywhere`            | rule  | all     | [`anywhere` rules](#anywhere-rules)                                                                                                             |
-| `applyPriority(_)`    | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `avoid`               | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `binder`              | prod  | all     | No reference yet.                                                                                                                               |
-| `bracket`             | prod  | all     | [Parametric productions and `bracket` attributes](#parametric-productions-and-bracket-attributes)                                               |
-| `color(_)`            | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
-| `colors(_)`           | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
-| `concrete`            | mod   | llvm    | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
-| `concrete(_)`         | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `concrete`            | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `context(_)`          | alias | all     | [Context aliases](#context-aliases)                                                                                                             |
-| `exit = ""`           | cell  | all     | [`exit` attribute](#exit-attribute)                                                                                                             |
-| `format`              | prod  | all     | [`format` attribute](#format-attribute)                                                                                                         |
-| `freshGenerator`      | prod  | all     | [`freshGenerator` attribute](#freshgenerator-attribute)                                                                                         |
-| `function`            | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
-| `group(_)`            | all   | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `hook(_)`             | prod  | all     | No reference yet                                                                                                                                |
-| `hybrid(_)`           | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
-| `hybrid`              | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
-| `klabel(_)`           | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
-| `latex(_)`            | prod  | all     | No reference yet                                                                                                                                |
-| `left`                | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `locations`           | sort  | all     | [Location Information](#location-information)                                                                                                   |
-| `macro-rec`           | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `macro`               | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `memo`                | rule  | haskell | [The `memo` attribute](#the-memo-attribute)                                                                                                     |
-| `multiplicity = "_"`  | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
-| `non-assoc`           | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `one-path`            | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
-| `owise`               | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
-| `prec(_)`             | token | all     | [`prec` attribute](#prec-attribute)                                                                                                             |
-| `prefer`              | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `priority(_)`         | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
-| `private`             | mod   | all     | [`private` attribute](#private-attribute)                                                                                                       |
-| `private`             | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
-| `public`              | mod   | all     | No reference yet.                                                                                                                               |
-| `public`              | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
-| `result(_)`           | ctxt  | all     | [`result` attribute](#result-attribute)                                                                                                         |
-| `result(_)`           | rule  | all     | [`result` attribute](#result-attribute)                                                                                                         |
-| `right`               | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `seqstrict(_)`        | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `seqstrict`           | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `simplification`      | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
-| `simplification(_)`   | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
-| `smt-hook(_)`         | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
-| `smtlib(_)`           | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
-| `smt-lemma`           | rule  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
-| `strict`              | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `strict(_)`           | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `symbolic`            | mod   | haskell | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
-| `symbolic`            | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `symbolic(_)`         | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `symbol`              | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
-| `token`               | prod  | all     | [`token` attribute](#token-attribute)                                                                                                           |
-| `token`               | sort  | all     | [`token` attribute](#token-attribute)                                                                                                           |
-| `total`               | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
-| `trusted`             | claim | haskell | [`trusted` attribute](#trusted-claims)                                                                                                          |
-| `type = "_"`          | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
-| `unboundVariables(_)` | rule  | all     | [The `unboundVariables` attribute](#the-unboundvariables-attribute)                                                                             |
-| `unused`              | prod  | all     | [`unused` attribute](#unused-attribute)                                                                                                         |
-| `kast`                | mod   | all     | Specify that this module should only be included in KAST backends (Java backend).                                                               |
-| `kore`                | mod   | all     | Specify that this module should only be included in Kore backends (Haskell/LLVM backend).                                                       |
-| `concrete`            | mod   | all     | Specify that this module should only be included in concrete backends (LLVM backend).                                                           |
-| `symbolic`            | mod   | all     | Specify that this module should only be included in symbolic backends (Haskell/Java backend).                                                   |
-| `stream = "_"`        | cell  | all     | Specify that this cell should be hooked up to a stream, either `stdin`, `stdout`, or `stderr`.                                                  |
+| Name                   | Type  | Backend | Reference                                                                                                                                       |
+|------------------------|-------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `alias-rec`            | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `alias`                | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `all-path`             | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
+| `anywhere`             | rule  | all     | [`anywhere` rules](#anywhere-rules)                                                                                                             |
+| `applyPriority(_)`     | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `avoid`                | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `binder`               | prod  | all     | No reference yet.                                                                                                                               |
+| `bracket`              | prod  | all     | [Parametric productions and `bracket` attributes](#parametric-productions-and-bracket-attributes)                                               |
+| `color(_)`             | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
+| `colors(_)`            | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
+| `concrete`             | mod   | llvm    | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
+| `concrete(_)`          | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `concrete`             | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `context(_)`           | alias | all     | [Context aliases](#context-aliases)                                                                                                             |
+| `exit = ""`            | cell  | all     | [`exit` attribute](#exit-attribute)                                                                                                             |
+| `format`               | prod  | all     | [`format` attribute](#format-attribute)                                                                                                         |
+| `freshGenerator`       | prod  | all     | [`freshGenerator` attribute](#freshgenerator-attribute)                                                                                         |
+| `function`             | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
+| `group(_)`             | all   | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `hook(_)`              | prod  | all     | No reference yet                                                                                                                                |
+| `hybrid(_)`            | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
+| `hybrid`               | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
+| `klabel(_)`            | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
+| `latex(_)`             | prod  | all     | No reference yet                                                                                                                                |
+| `left`                 | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `locations`            | sort  | all     | [Location Information](#location-information)                                                                                                   |
+| `macro-rec`            | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `macro`                | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `memo`                 | rule  | haskell | [The `memo` attribute](#the-memo-attribute)                                                                                                     |
+| `multiplicity = "_"`   | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
+| `non-assoc`            | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `one-path`             | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
+| `owise`                | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
+| `prec(_)`              | token | all     | [`prec` attribute](#prec-attribute)                                                                                                             |
+| `prefer`               | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `priority(_)`          | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
+| `private`              | mod   | all     | [`private` attribute](#private-attribute)                                                                                                       |
+| `private`              | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
+| `public`               | mod   | all     | No reference yet.                                                                                                                               |
+| `public`               | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
+| `result(_)`            | ctxt  | all     | [`result` attribute](#result-attribute)                                                                                                         |
+| `result(_)`            | rule  | all     | [`result` attribute](#result-attribute)                                                                                                         |
+| `right`                | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `seqstrict(_)`         | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `seqstrict`            | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `simplification`       | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
+| `simplification(_)`    | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
+| `smt-hook(_)`          | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
+| `smtlib(_)`            | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
+| `smt-lemma`            | rule  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
+| `strict`               | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `strict(_)`            | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `symbolic`             | mod   | haskell | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
+| `symbolic`             | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `symbolic(_)`          | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `symbol`               | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
+| `terminator-klabel(_)` | prod  | all     | [`klabel(_)` and `symbol` attributes](...)                                                                                                      |
+| `token`                | prod  | all     | [`token` attribute](#token-attribute)                                                                                                           |
+| `token`                | sort  | all     | [`token` attribute](#token-attribute)                                                                                                           |
+| `total`                | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
+| `trusted`              | claim | haskell | [`trusted` attribute](#trusted-claims)                                                                                                          |
+| `type = "_"`           | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
+| `unboundVariables(_)`  | rule  | all     | [The `unboundVariables` attribute](#the-unboundvariables-attribute)                                                                             |
+| `unused`               | prod  | all     | [`unused` attribute](#unused-attribute)                                                                                                         |
+| `kast`                 | mod   | all     | Specify that this module should only be included in KAST backends (Java backend).                                                               |
+| `kore`                 | mod   | all     | Specify that this module should only be included in Kore backends (Haskell/LLVM backend).                                                       |
+| `concrete`             | mod   | all     | Specify that this module should only be included in concrete backends (LLVM backend).                                                           |
+| `symbolic`             | mod   | all     | Specify that this module should only be included in symbolic backends (Haskell/Java backend).                                                   |
+| `stream = "_"`         | cell  | all     | Specify that this cell should be hooked up to a stream, either `stdin`, `stdout`, or `stderr`.                                                  |
 
 ### Internal Attribute Index
 

--- a/k-distribution/tests/regression-new/checks/checkTerminatorKLabel.k
+++ b/k-distribution/tests/regression-new/checks/checkTerminatorKLabel.k
@@ -1,0 +1,7 @@
+module CHECKTERMINATORKLABEL
+  imports INT
+  syntax KItem ::= foo()
+                 | bar() [terminator-klabel(bar)]
+
+  syntax Ints ::= List{Int, ","} [klabel(ints), terminator-klabel(.ints), symbol]
+endmodule

--- a/k-distribution/tests/regression-new/checks/checkTerminatorKLabel.k.out
+++ b/k-distribution/tests/regression-new/checks/checkTerminatorKLabel.k.out
@@ -1,0 +1,6 @@
+[Error] Compiler: The attribute 'terminator-klabel' cannot be applied to a production that does not declare a syntactic list.
+	Source(checkTerminatorKLabel.k)
+	Location(4,20,4,50)
+	4 |	                 | bar() [terminator-klabel(bar)]
+	  .	                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Had 1 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -69,6 +69,7 @@ public class CheckAtt {
     checkFormat(prod);
     checkFunctional(prod);
     checkTotal(prod);
+    checkTerminatorKLabel(prod);
   }
 
   private <T extends HasAtt & HasLocation> void checkUnrecognizedAtts(T term) {
@@ -327,6 +328,15 @@ public class CheckAtt {
           KEMException.compilerError(
               "The attribute 'total' cannot be applied to a production which does not have the"
                   + " 'function' attribute.",
+              prod));
+    }
+  }
+
+  private void checkTerminatorKLabel(Production prod) {
+    if (!prod.att().contains(Att.USER_LIST()) && prod.att().contains(Att.TERMINATOR_KLABEL())) {
+      errors.add(
+          KEMException.compilerError(
+              "The attribute 'terminator-klabel' cannot be applied to a production that does not declare a syntactic list.",
               prod));
     }
   }

--- a/kernel/src/main/java/org/kframework/kil/Production.java
+++ b/kernel/src/main/java/org/kframework/kil/Production.java
@@ -36,10 +36,11 @@ public class Production extends ASTNode {
    */
   public String getTerminatorKLabel(boolean kore) {
     assert isListDecl();
+    boolean isSymbol = getAttribute(Att.SYMBOL()) != null;
     return ".List{"
         + StringUtil.enquoteCString(getKLabel(kore))
         + "}"
-        + (kore ? "_" + getSort().name() : "");
+        + (kore && !isSymbol ? "_" + getSort().name() : "");
   }
 
   /**

--- a/kernel/src/main/java/org/kframework/kil/Production.java
+++ b/kernel/src/main/java/org/kframework/kil/Production.java
@@ -29,18 +29,27 @@ public class Production extends ASTNode {
   }
 
   /**
-   * Returns the KLabel for the list terminator. Constructed as '.List{"<list_klabel>"} Should be
-   * called only if isListDecl is true.
+   * Returns the KLabel for the list terminator.
    *
-   * @return String representation of the separator KLabel.
+   * <p>If a label has been specified using `terminator-klabel(...)` then use that; otherwise
+   * construct a new label based on the label for the non-terminator production. This new label is
+   * constructed as `.List{"<list_klabel>"}`. Should be called only if `isListDecl()` returns true.
+   *
+   * @return String representation of the terminator KLabel.
    */
   public String getTerminatorKLabel(boolean kore) {
     assert isListDecl();
-    boolean isSymbol = getAttribute(Att.SYMBOL()) != null;
-    return ".List{"
-        + StringUtil.enquoteCString(getKLabel(kore))
-        + "}"
-        + (kore && !isSymbol ? "_" + getSort().name() : "");
+
+    String terminatorLabel = getAttribute(Att.TERMINATOR_KLABEL());
+    if (terminatorLabel == null) {
+      boolean isSymbol = getAttribute(Att.SYMBOL()) != null;
+      return ".List{"
+          + StringUtil.enquoteCString(getKLabel(kore))
+          + "}"
+          + (kore && !isSymbol ? "_" + getSort().name() : "");
+    }
+
+    return terminatorLabel.replace(" ", "");
   }
 
   /**

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -287,6 +287,8 @@ object Att {
   final val INTERNAL  = Key.builtin("internal", KeyParameter.Forbidden, onlyon[Production])
   final val KAST      = Key.builtin("kast", KeyParameter.Forbidden, onlyon[Module])
   final val KLABEL    = Key.builtin("klabel", KeyParameter.Required, onlyon[Production])
+  final val TERMINATOR_KLABEL =
+    Key.builtin("terminator-klabel", KeyParameter.Required, onlyon[Production])
   final val KORE      = Key.builtin("kore", KeyParameter.Forbidden, onlyon2[RuleOrClaim, Module])
   final val LABEL     = Key.builtin("label", KeyParameter.Required, onlyon[Sentence])
   final val LATEX     = Key.builtin("latex", KeyParameter.Required, onlyon[Production])


### PR DESCRIPTION
This PR makes a small refactoring to the way that we generate symbol names from syntactic list declarations. Specifically, it:
* Respects the `symbol` attribute when generating a label for the terminator element.
* Adds a new attribute `terminator-klabel(_)` by which the actual label for the terminator can be specified.

Documentation, attribute checks and a test for the new attribute are updated.

Fixes https://github.com/runtimeverification/k/issues/3940