### PR TITLE
add back "dead" code that was actually live

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackend.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackend.java
@@ -44,7 +44,7 @@ public class HaskellBackend extends KoreBackend {
   @Override
   public void accept(Backend.Holder h) {
     Stopwatch sw = new Stopwatch(globalOptions);
-    String kore = getKompiledString(h.def);
+    String kore = getKompiledString(h.def, true);
     h.def = null;
     files.saveToKompiled("definition.kore", kore);
     sw.printIntermediate("  Print definition.kore");

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -365,7 +365,7 @@ public record HaskellRewriter(
 
       @Override
       public RewriterResult prove(Module rules, Boolean reuseDef) {
-        Module kompiledModule = KoreBackend.getKompiledModule(module);
+        Module kompiledModule = KoreBackend.getKompiledModule(module, true);
         ModuleToKORE converter =
             new ModuleToKORE(
                 kompiledModule,

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -57,16 +57,21 @@ public class KoreBackend implements Backend {
   @Override
   public void accept(Backend.Holder h) {
     CompiledDefinition def = h.def;
-    String kore = getKompiledString(def);
+    String kore = getKompiledString(def, true);
     File defFile = kompileOptions.outerParsing.mainDefinitionFile(files);
     String name = defFile.getName();
     String basename = FilenameUtils.removeExtension(name);
     files.saveToDefinitionDirectory(basename + ".kore", kore);
   }
 
-  /** Convert a CompiledDefinition to a String of a KORE definition. */
-  protected String getKompiledString(CompiledDefinition def) {
-    Module mainModule = getKompiledModule(def.kompiledDefinition.mainModule());
+  /**
+   * Convert a CompiledDefinition to a String of a KORE definition.
+   *
+   * @param hasAnd whether the backend in question supports and-patterns during pattern matching.
+   */
+  protected String getKompiledString(
+      CompiledDefinition def, @SuppressWarnings("unused") boolean hasAnd) {
+    Module mainModule = getKompiledModule(def.kompiledDefinition.mainModule(), hasAnd);
     ModuleToKORE converter =
         new ModuleToKORE(mainModule, def.topCellInitializer, def.kompileOptions);
     return getKompiledString(converter, files, heatCoolEquations, tool);
@@ -94,7 +99,7 @@ public class KoreBackend implements Backend {
     return semantics.toString();
   }
 
-  public static Module getKompiledModule(Module mainModule) {
+  public static Module getKompiledModule(Module mainModule, boolean hasAnd) {
     mainModule =
         ModuleTransformer.fromSentenceTransformer(
                 new AddSortInjections(mainModule)::addInjections, "Add sort injections")
@@ -102,10 +107,12 @@ public class KoreBackend implements Backend {
     mainModule =
         ModuleTransformer.from(new RemoveUnit()::apply, "Remove unit applications for collections")
             .apply(mainModule);
-    mainModule =
-        ModuleTransformer.fromSentenceTransformer(
-                new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction")
-            .apply(mainModule);
+    if (hasAnd) {
+      mainModule =
+          ModuleTransformer.fromSentenceTransformer(
+                  new MinimizeTermConstruction(mainModule)::resolve, "Minimize term construction")
+              .apply(mainModule);
+    }
     return mainModule;
   }
 

--- a/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
+++ b/kernel/src/main/java/org/kframework/utils/errorsystem/KExceptionManager.java
@@ -91,6 +91,11 @@ public class KExceptionManager {
     register(type, KExceptionGroup.CRITICAL, message, e, null, null);
   }
 
+  @SuppressWarnings("unused")
+  public void registerInternalWarning(ExceptionType type, String message) {
+    register(type, KExceptionGroup.INTERNAL, message, null, null, null);
+  }
+
   public void registerInternalWarning(ExceptionType type, String message, Throwable e) {
     register(type, KExceptionGroup.INTERNAL, message, e, null, null);
   }

--- a/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
+++ b/llvm-backend/src/main/java/org/kframework/backend/llvm/LLVMBackend.java
@@ -49,7 +49,7 @@ public class LLVMBackend extends KoreBackend {
   @Override
   public void accept(Backend.Holder h) {
     Stopwatch sw = new Stopwatch(globalOptions);
-    String kore = getKompiledString(h.def);
+    String kore = getKompiledString(h.def, true);
     h.def = null;
     files.saveToKompiled("definition.kore", kore);
     sw.printIntermediate("  Print definition.kore");


### PR DESCRIPTION
There were a couple methods recently deleted from the K frontend that were actually being used by the Maude backend. I have added them back and annotated them so that they will not be automatically deleted by further dead code elimination in the future.