### PR TITLE
Disable implicit addition of klabels

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -2617,7 +2617,7 @@ containing `name` in its name. The file is only flushed to disk when rewriting
 finishes.
 
 ```k
-  syntax K ::= #logToFile(name: String, value: String) [function, total, hook(IO.log), impure, returnsUnit, symbol]
+  syntax K ::= #logToFile(name: String, value: String) [function, total, hook(IO.log), impure, returnsUnit, klabel(#logToFile), symbol]
 ```
 
 Strings can also be logged via the logging mechanisms available to the backend.
@@ -2626,7 +2626,7 @@ Haskell backend, a log message of type InfoUserLog is created with the
 specified text.
 
 ```k
-  syntax K ::= #log(value: String) [function, total, hook(IO.logString), impure, returnsUnit, symbol]
+  syntax K ::= #log(value: String) [function, total, hook(IO.logString), impure, returnsUnit, klabel(#log), symbol]
 ```
 
 Terms can also be logged to standard error in _surface syntax_, rather than as
@@ -2637,8 +2637,8 @@ logged, which requires re-parsing the underlying K definition. Subsequent calls
 do not incur this overhead again; the definition is cached.
 
 ```k
-  syntax K ::= #trace(value: KItem) [function, total, hook(IO.traceTerm), impure, returnsUnit, symbol]
-             | #traceK(value: K)    [function, total, hook(IO.traceTerm), impure, returnsUnit, symbol]
+  syntax K ::= #trace(value: KItem) [function, total, hook(IO.traceTerm), impure, returnsUnit, klabel(#trace), symbol]
+             | #traceK(value: K)    [function, total, hook(IO.traceTerm), impure, returnsUnit, klabel(#traceK), symbol]
 ```
 
 ### Implementation of high-level I/O streams in K
@@ -3037,7 +3037,7 @@ module STRATEGY
 
     syntax #RuleTag ::= #KVariable
 
-    syntax Strategy ::= #STUCK()    [symbol]
+    syntax Strategy ::= #STUCK()    [symbol, klabel(#STUCK)]
                       | "^" #RuleTag [symbol, klabel(#applyRule)]
                       | "~" #RuleTag [symbol, klabel(#appliedRule)]
 

--- a/k-distribution/include/kframework/builtin/kast.md
+++ b/k-distribution/include/kframework/builtin/kast.md
@@ -552,7 +552,7 @@ regular K rules to disambiguate as necessary.
 ```k
 module K-AMBIGUITIES
 
-  syntax {Sort} Sort ::= amb(Sort, Sort) [symbol]
+  syntax {Sort} Sort ::= amb(Sort, Sort) [klabel(amb), symbol]
 
 endmodule
 ```
@@ -572,7 +572,7 @@ module K-LOCATIONS
   imports INT-SYNTAX
 
   // filename, startLine, startCol, endLine, endCol
-  syntax {Sort} Sort ::= #location(Sort, String, Int, Int, Int, Int) [symbol, format(%3)]
+  syntax {Sort} Sort ::= #location(Sort, String, Int, Int, Int, Int) [klabel(#location), symbol, format(%3)]
 
 endmodule
 ```

--- a/k-distribution/tests/regression-new/context-alias-2/test.k
+++ b/k-distribution/tests/regression-new/context-alias-2/test.k
@@ -8,7 +8,7 @@ module TEST
                | Id "=" Int
                | Id
                | Int
-               | l(Exp) [symbol] | m(Exp) [symbol] | r(Exp) [symbol]
+               | l(Exp) [klabel(l), symbol] | m(Exp) [klabel(m), symbol] | r(Exp) [klabel(r), symbol]
   syntax KResult ::= Int
 
   context alias [left]: HERE [context(l)]

--- a/k-distribution/tests/regression-new/glr2/test.k
+++ b/k-distribution/tests/regression-new/glr2/test.k
@@ -4,8 +4,8 @@ module TEST-SYNTAX
 
   syntax Exp ::= Val
                | Exp "+" Exp
-               | foo(Exp)
-  syntax Val ::= foo(Val)
+               | foo(Exp) [klabel(foo)]
+  syntax Val ::= foo(Val) [klabel(foo)]
                | Int
 
 endmodule

--- a/k-distribution/tests/regression-new/glr3/test.k
+++ b/k-distribution/tests/regression-new/glr3/test.k
@@ -4,8 +4,8 @@ module TEST-SYNTAX
 
   syntax Exp ::= Val
                | Exp "+" Exp
-               | foo(Exp, Exp, Int)
-  syntax Val ::= foo(Val, Val, Int)
+               | foo(Exp, Exp, Int) [klabel(foo)]
+  syntax Val ::= foo(Val, Val, Int) [klabel(foo)]
                | Int
 
 endmodule

--- a/k-distribution/tests/regression-new/glr4/test.k
+++ b/k-distribution/tests/regression-new/glr4/test.k
@@ -2,14 +2,14 @@
 module TEST-SYNTAX
   imports INT-SYNTAX
 
-  syntax Exp5 ::= Exp4 | Exp5 "-" Exp5 | foo(Exp5)
-  syntax Exp4 ::= Exp3 | Exp4 "-" Exp4 | foo(Exp4)
-  syntax Exp3 ::= Exp2 | Exp3 "-" Exp3 | foo(Exp3)
-  syntax Exp2 ::= Exp | Exp2 "-" Exp2 | foo(Exp2)
+  syntax Exp5 ::= Exp4 | Exp5 "-" Exp5 | foo(Exp5) [klabel(foo)]
+  syntax Exp4 ::= Exp3 | Exp4 "-" Exp4 | foo(Exp4) [klabel(foo)]
+  syntax Exp3 ::= Exp2 | Exp3 "-" Exp3 | foo(Exp3) [klabel(foo)]
+  syntax Exp2 ::= Exp | Exp2 "-" Exp2 | foo(Exp2) [klabel(foo)]
   syntax Exp ::= Val
                | Exp "+" Exp
-               | foo(Exp)
-  syntax Val ::= foo(Val)
+               | foo(Exp) [klabel(foo)]
+  syntax Val ::= foo(Val) [klabel(foo)]
                | Int
 
 endmodule

--- a/kernel/src/main/javacc/Outer.jj
+++ b/kernel/src/main/javacc/Outer.jj
@@ -788,12 +788,11 @@ void PriorityBlock(List<PriorityBlock> pblocks) :
 /** Parses a Production and adds it to 'prods' */
 void Production(List<Production> prods) :
 { Location loc = startLoc(); NonTerminal nonTerminal;
-  List<ProductionItem> items = new ArrayList<ProductionItem>();
-  String klabel = null; }
+  List<ProductionItem> items = new ArrayList<ProductionItem>(); }
 {
 ( LOOKAHEAD((UpperId() | <LOWER_ID>) "(")
   (UpperId() | <LOWER_ID>)
-  { items.add(tokenLoc(new Terminal(image()))); klabel = image(); }
+  { items.add(tokenLoc(new Terminal(image()))); }
   "("              { items.add(tokenLoc(new Terminal(image()))); }
   (nonTerminal = SortID()  { items.add(nonTerminal); }
   (","             { items.add(tokenLoc(new Terminal(image()))); }
@@ -809,10 +808,7 @@ void Production(List<Production> prods) :
 | (ProductionItem(items))+
 ) { Production prod = new Production(new NonTerminal(Sort(""), Optional.empty()), items); }
   (Attributes(prod))?
-  { if (klabel != null && prod.getAttribute(Att.KLABEL()) == null) {
-      prod.addAttribute(Att.KLABEL(), klabel);
-    }
-    prods.add(markLoc(loc, prod)); }
+  { prods.add(markLoc(loc, prod)); }
 }
 
 /** Parses a ProductionItem and adds it to 'items' */

--- a/kernel/src/test/java/org/kframework/parser/inner/disambiguation/AddEmptyListsTest.java
+++ b/kernel/src/test/java/org/kframework/parser/inner/disambiguation/AddEmptyListsTest.java
@@ -97,7 +97,7 @@ public class AddEmptyListsTest {
           + "syntax As ::= List{A,\",\"} [klabel(as)]\n"
           + "syntax Bs ::= List{B,\",\"} [klabel(as)]\n"
           + "syntax As ::= Bs\n"
-          + "syntax K ::= f(As) [symbol] | g(A) [symbol] | h(Bs) [symbol]"
+          + "syntax K ::= f(As) [klabel(f), symbol] | g(A) [klabel(g), symbol] | h(Bs) [klabel(h), symbol]"
           + "endmodule\n";
 
   public static final KApply NIL = KApply(KLabel(".List{\"_,__TEST_Bs_B_Bs\"}_Bs"));


### PR DESCRIPTION
Currently, the _outer parser_ automatically adds the `klabel` attribute to _unquoted_ productions. For example:
```k
syntax Foo ::= foo()
```
becomes
```k
syntax Foo ::= "foo" "(" ")" [klabel(foo)]
```
in the compiled output.

However, if we instead wrote:
```k
syntax Foo ::= "foo" "(" ")"
```
we would get output:
```k
syntax Foo ::= "foo" "(" ")"
```

This behaviour is unintuitive, and makes it harder to perform the work specified in #3966 re. overhauling the overloading mechanism of K. The changes required are small:
* Remove the parser code that adds the attribute.
* Fix a few places in the standard library and test suite that rely on this implicit label for their `symbol` attribute to be valid.