### PR TITLE
Implement check for uses of deprecated symbols

### DIFF
--- a/docs/user_manual.md
+++ b/docs/user_manual.md
@@ -679,6 +679,18 @@ syntax Foo ::= foo() [unused]
 configuration <foo unused=""> .K </foo>
 ```
 
+### `deprecated` attribute
+
+Symbols can be marked as deprecated by adding the `deprecated` attribute to
+their declaration. If that symbol subsequently appears in the definition (in a
+rule, context, context alias or configuration), the compiler will issue a
+warning.
+
+```k
+syntax Foo ::= foo() [deprecated]
+rule foo() => . // warning on this line
+```
+
 ### Symbol priority and associativity
 
 Unlike most other parser generators, K combines the task of parsing with AST
@@ -2968,74 +2980,75 @@ brief description of each. Note that the same attribute may appear in the index
 multiple times to indicate its effect in different contexts or with/without
 arguments. A legend describing how to interpret the index follows.
 
-| Name                  | Type  | Backend | Reference                                                                                                                                       |
-| --------------------- | ----- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `alias-rec`           | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `alias`               | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `all-path`            | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
-| `anywhere`            | rule  | all     | [`anywhere` rules](#anywhere-rules)                                                                                                             |
-| `applyPriority(_)`    | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `avoid`               | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `binder`              | prod  | all     | No reference yet.                                                                                                                               |
-| `bracket`             | prod  | all     | [Parametric productions and `bracket` attributes](#parametric-productions-and-bracket-attributes)                                               |
-| `color(_)`            | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
-| `colors(_)`           | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
-| `concrete`            | mod   | llvm    | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
-| `concrete(_)`         | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `concrete`            | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `context(_)`          | alias | all     | [Context aliases](#context-aliases)                                                                                                             |
-| `exit = ""`           | cell  | all     | [`exit` attribute](#exit-attribute)                                                                                                             |
-| `format`              | prod  | all     | [`format` attribute](#format-attribute)                                                                                                         |
-| `freshGenerator`      | prod  | all     | [`freshGenerator` attribute](#freshgenerator-attribute)                                                                                         |
-| `function`            | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
-| `group(_)`            | all   | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `hook(_)`             | prod  | all     | No reference yet                                                                                                                                |
-| `hybrid(_)`           | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
-| `hybrid`              | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
-| `klabel(_)`           | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
-| `left`                | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `locations`           | sort  | all     | [Location Information](#location-information)                                                                                                   |
-| `macro-rec`           | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `macro`               | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
-| `memo`                | rule  | haskell | [The `memo` attribute](#the-memo-attribute)                                                                                                     |
-| `multiplicity = "_"`  | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
-| `non-assoc`           | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `one-path`            | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
-| `owise`               | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
-| `prec(_)`             | token | all     | [`prec` attribute](#prec-attribute)                                                                                                             |
-| `prefer`              | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `priority(_)`         | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
-| `private`             | mod   | all     | [`private` attribute](#private-attribute)                                                                                                       |
-| `private`             | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
-| `public`              | mod   | all     | No reference yet.                                                                                                                               |
-| `public`              | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
-| `result(_)`           | ctxt  | all     | [`result` attribute](#result-attribute)                                                                                                         |
-| `result(_)`           | rule  | all     | [`result` attribute](#result-attribute)                                                                                                         |
-| `right`               | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
-| `seqstrict(_)`        | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `seqstrict`           | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `simplification`      | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
-| `simplification(_)`   | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
-| `smt-hook(_)`         | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
-| `smtlib(_)`           | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
-| `smt-lemma`           | rule  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
-| `strict`              | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `strict(_)`           | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
-| `symbolic`            | mod   | haskell | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
-| `symbolic`            | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `symbolic(_)`         | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
-| `symbol`              | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
+| Name                   | Type  | Backend | Reference                                                                                                                                       |
+|------------------------|-------|---------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `alias-rec`            | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `alias`                | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `all-path`             | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
+| `anywhere`             | rule  | all     | [`anywhere` rules](#anywhere-rules)                                                                                                             |
+| `applyPriority(_)`     | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `avoid`                | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `binder`               | prod  | all     | No reference yet.                                                                                                                               |
+| `bracket`              | prod  | all     | [Parametric productions and `bracket` attributes](#parametric-productions-and-bracket-attributes)                                               |
+| `color(_)`             | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
+| `colors(_)`            | prod  | all     | [`color` and `colors` attributes](#color-and-colors-attributes)                                                                                 |
+| `concrete`             | mod   | llvm    | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
+| `concrete(_)`          | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `concrete`             | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `context(_)`           | alias | all     | [Context aliases](#context-aliases)                                                                                                             |
+| `deprecated`           | prod  | all     | [`deprecated` attribute](#deprecated-attribute)                                                                                                 |
+| `exit = ""`            | cell  | all     | [`exit` attribute](#exit-attribute)                                                                                                             |
+| `format`               | prod  | all     | [`format` attribute](#format-attribute)                                                                                                         |
+| `freshGenerator`       | prod  | all     | [`freshGenerator` attribute](#freshgenerator-attribute)                                                                                         |
+| `function`             | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
+| `group(_)`             | all   | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `hook(_)`              | prod  | all     | No reference yet                                                                                                                                |
+| `hybrid(_)`            | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
+| `hybrid`               | prod  | all     | [`hybrid` attribute](#hybrid-attribute)                                                                                                         |
+| `klabel(_)`            | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
+| `left`                 | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `locations`            | sort  | all     | [Location Information](#location-information)                                                                                                   |
+| `macro-rec`            | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `macro`                | prod  | all     | [Macros and Aliases](#macros-and-aliases)                                                                                                       |
+| `memo`                 | rule  | haskell | [The `memo` attribute](#the-memo-attribute)                                                                                                     |
+| `multiplicity = "_"`   | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
+| `non-assoc`            | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `one-path`             | claim | haskell | [`all-path` and `one-path` attributes to distinguish reachability claims](#all-path-and-one-path-attributes-to-distinguish-reachability-claims) |
+| `owise`                | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
+| `prec(_)`              | token | all     | [`prec` attribute](#prec-attribute)                                                                                                             |
+| `prefer`               | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `priority(_)`          | rule  | all     | [`owise` and `priority` attributes](#owise-and-priority-attributes)                                                                             |
+| `private`              | mod   | all     | [`private` attribute](#private-attribute)                                                                                                       |
+| `private`              | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
+| `public`               | mod   | all     | No reference yet.                                                                                                                               |
+| `public`               | prod  | all     | [`public` and `private` attribute](#public-and-private-attribute)                                                                               |
+| `result(_)`            | ctxt  | all     | [`result` attribute](#result-attribute)                                                                                                         |
+| `result(_)`            | rule  | all     | [`result` attribute](#result-attribute)                                                                                                         |
+| `right`                | prod  | all     | [Symbol priority and associativity](#symbol-priority-and-associativity)                                                                         |
+| `seqstrict(_)`         | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `seqstrict`            | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `simplification`       | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
+| `simplification(_)`    | rule  | haskell | [`simplification` attribute (Haskell backend)](#simplification-attribute-haskell-backend)                                                       |
+| `smt-hook(_)`          | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
+| `smtlib(_)`            | prod  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
+| `smt-lemma`            | rule  | haskell | [SMT Translation](#smt-translation)                                                                                                             |
+| `strict`               | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `strict(_)`            | prod  | all     | [`strict` and `seqstrict` attributes](#strict-and-seqstrict-attributes)                                                                         |
+| `symbolic`             | mod   | haskell | [`symbolic` and `concrete` attribute](#symbolic-and-concrete-attribute)                                                                         |
+| `symbolic`             | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `symbolic(_)`          | rule  | haskell | [`concrete` and `symbolic` attributes (Haskell backend)](#concrete-and-symbolic-attributes-haskell-backend)                                     |
+| `symbol`               | prod  | all     | [`klabel(_)` and `symbol` attributes](#klabel_-and-symbol-attributes)                                                                           |
 | `terminator-klabel(_)` | prod  | all     | [`klabel(_)` and `symbol` attributes](...)                                                                                                      |
-| `token`               | prod  | all     | [`token` attribute](#token-attribute)                                                                                                           |
-| `token`               | sort  | all     | [`token` attribute](#token-attribute)                                                                                                           |
-| `total`               | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
-| `trusted`             | claim | haskell | [`trusted` attribute](#trusted-claims)                                                                                                          |
-| `type = "_"`          | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
-| `unboundVariables(_)` | rule  | all     | [The `unboundVariables` attribute](#the-unboundvariables-attribute)                                                                             |
-| `unused`              | prod  | all     | [`unused` attribute](#unused-attribute)                                                                                                         |
-| `concrete`            | mod   | all     | Specify that this module should only be included in concrete backends (LLVM backend).                                                           |
-| `symbolic`            | mod   | all     | Specify that this module should only be included in symbolic backends (Haskell backend).                                                        |
-| `stream = "_"`        | cell  | all     | Specify that this cell should be hooked up to a stream, either `stdin`, `stdout`, or `stderr`.                                                  |
+| `token`                | prod  | all     | [`token` attribute](#token-attribute)                                                                                                           |
+| `token`                | sort  | all     | [`token` attribute](#token-attribute)                                                                                                           |
+| `total`                | prod  | all     | [`function` and `total` attributes](#function-and-total-attributes)                                                                             |
+| `trusted`              | claim | haskell | [`trusted` attribute](#trusted-claims)                                                                                                          |
+| `type = "_"`           | cell  | all     | [Collection Cells: `multiplicity` and `type` attributes](#collection-cells-multiplicity-and-type-attributes)                                    |
+| `unboundVariables(_)`  | rule  | all     | [The `unboundVariables` attribute](#the-unboundvariables-attribute)                                                                             |
+| `unused`               | prod  | all     | [`unused` attribute](#unused-attribute)                                                                                                         |
+| `concrete`             | mod   | all     | Specify that this module should only be included in concrete backends (LLVM backend).                                                           |
+| `symbolic`             | mod   | all     | Specify that this module should only be included in symbolic backends (Haskell backend).                                                        |
+| `stream = "_"`         | cell  | all     | Specify that this cell should be hooked up to a stream, either `stdin`, `stdout`, or `stderr`.                                                  |
 
 ### Internal Attribute Index
 

--- a/k-distribution/tests/regression-new/checkWarns/deprecated.k
+++ b/k-distribution/tests/regression-new/checkWarns/deprecated.k
@@ -1,0 +1,25 @@
+module DEPRECATED-SYNTAX
+endmodule
+
+module DEPRECATED
+  imports BOOL
+  syntax Foo ::= foo() [deprecated]
+               | bar() [deprecated]
+               | baz(Foo)
+               | qux(Foo) [deprecated]
+
+  syntax Bool ::= f() [function, deprecated]
+  rule f() => true
+
+  rule baz(baz(foo())) => baz(bar())
+    requires f()
+    ensures f()
+
+  context [qux]: qux(HOLE) requires f()
+  context alias [qux2]: baz(qux(HERE)) requires f()
+
+  syntax KResult ::= Foo
+
+  configuration
+    <k> qux(foo()) </k>
+endmodule

--- a/k-distribution/tests/regression-new/checkWarns/deprecated.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/deprecated.k.out
@@ -1,0 +1,56 @@
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(12,8,12,11)
+	12 |	  rule f() => true
+	   .	       ^~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(14,16,14,21)
+	14 |	  rule baz(baz(foo())) => baz(bar())
+	   .	               ^~~~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(14,31,14,36)
+	14 |	  rule baz(baz(foo())) => baz(bar())
+	   .	                              ^~~~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(15,14,15,17)
+	15 |	    requires f()
+	   .	             ^~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(16,13,16,16)
+	16 |	    ensures f()
+	   .	            ^~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(18,18,18,27)
+	18 |	  context [qux]: qux(HOLE) requires f()
+	   .	                 ^~~~~~~~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(18,37,18,40)
+	18 |	  context [qux]: qux(HOLE) requires f()
+	   .	                                    ^~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(19,29,19,38)
+	19 |	  context alias [qux2]: baz(qux(HERE)) requires f()
+	   .	                            ^~~~~~~~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(19,49,19,52)
+	19 |	  context alias [qux2]: baz(qux(HERE)) requires f()
+	   .	                                                ^~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(24,9,24,19)
+	24 |	    <k> qux(foo()) </k>
+	   .	        ^~~~~~~~~~
+[Error] Compiler: Use of deprecated production found; this syntax may be removed in the future.
+	Source(deprecated.k)
+	Location(24,13,24,18)
+	24 |	    <k> qux(foo()) </k>
+	   .	            ^~~~~
+[Error] Compiler: Had 11 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckDeprecated.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckDeprecated.java
@@ -1,0 +1,51 @@
+// Copyright (c) Runtime Verification, Inc. All Rights Reserved.
+package org.kframework.compile.checks;
+
+import java.util.Set;
+import org.kframework.attributes.Att;
+import org.kframework.definition.Context;
+import org.kframework.definition.ContextAlias;
+import org.kframework.definition.Production;
+import org.kframework.definition.RuleOrClaim;
+import org.kframework.definition.Sentence;
+import org.kframework.kore.K;
+import org.kframework.kore.VisitK;
+import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.errorsystem.KException;
+import org.kframework.utils.errorsystem.KExceptionManager;
+
+public record CheckDeprecated(Set<KEMException> errors, KExceptionManager kem) {
+  public void check(Production p, K term) {
+    if (p.att().contains(Att.DEPRECATED())) {
+      kem.registerCompilerWarning(
+          KException.ExceptionType.DEPRECATED_SYMBOL,
+          errors,
+          "Use of deprecated production found; this syntax may be removed in the future.",
+          term);
+    }
+  }
+
+  public void check(K k) {
+    new VisitK() {
+      @Override
+      public void apply(K term) {
+        term.att().getOptional(Att.PRODUCTION(), Production.class).ifPresent(p -> check(p, term));
+        super.apply(term);
+      }
+    }.apply(k);
+  }
+
+  public void check(Sentence s) {
+    if (s instanceof RuleOrClaim r) {
+      check(r.body());
+      check(r.requires());
+      check(r.ensures());
+    } else if (s instanceof Context c) {
+      check(c.body());
+      check(c.requires());
+    } else if (s instanceof ContextAlias c) {
+      check(c.body());
+      check(c.requires());
+    }
+  }
+}

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -36,6 +36,7 @@ import org.kframework.compile.checks.CheckAnonymous;
 import org.kframework.compile.checks.CheckAssoc;
 import org.kframework.compile.checks.CheckAtt;
 import org.kframework.compile.checks.CheckConfigurationCells;
+import org.kframework.compile.checks.CheckDeprecated;
 import org.kframework.compile.checks.CheckFunctions;
 import org.kframework.compile.checks.CheckHOLE;
 import org.kframework.compile.checks.CheckK;
@@ -584,6 +585,9 @@ public class Kompile {
 
     stream(modules)
         .forEach(m -> stream(m.localSentences()).forEach(new CheckAssoc(errors, m)::check));
+
+    stream(modules)
+        .forEach(m -> stream(m.localSentences()).forEach(new CheckDeprecated(errors, kem)::check));
 
     Set<String> moduleNames = new HashSet<>();
     stream(modules)

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -138,6 +138,7 @@ public class KException implements Serializable, HasLocation {
     IGNORED_ATTRIBUTE,
     REMOVED_ANYWHERE,
     DEPRECATED_DIRECTORY_FLAG,
+    DEPRECATED_SYMBOL,
     MISSING_HOOK,
     FIRST_HIDDEN, // warnings below here are hidden by default
     USELESS_RULE,

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -219,6 +219,7 @@ object Att {
   final val CONTEXT     = Key.builtin("context", KeyParameter.Required, onlyon[ContextAlias])
   final val COOL        = Key.builtin("cool", KeyParameter.Forbidden, onlyon[Rule])
   final val DEPENDS     = Key.builtin("depends", KeyParameter.Required, onlyon[Claim])
+  final val DEPRECATED  = Key.builtin("deprecated", KeyParameter.Forbidden, onlyon[Production])
   final val ELEMENT     = Key.builtin("element", KeyParameter.Required, onlyon[Production])
   final val EXIT        = Key.builtin("exit", KeyParameter.Forbidden, onlyon[Production])
   final val FORMAT      = Key.builtin("format", KeyParameter.Required, onlyon[Production])


### PR DESCRIPTION
This PR implements a new `deprecated` attribute that can be applied to productions; if that production is subsequently used in a rule the compiler will emit a warning.

No code uses this feature yet, but I intend to use it to implement the canonicalisation of `.` and `.K` (#3964, #3975) by marking `.` as deprecated and doing some error-driven development.