### PR TITLE
Unpin LLVM backend Nixpkgs to allow an update to go through

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -125,21 +125,23 @@
         "immer-src": "immer-src",
         "mavenix": "mavenix",
         "nixpkgs": [
-          "haskell-backend",
+          "llvm-backend",
+          "rv-utils",
           "nixpkgs"
         ],
         "pybind11-src": "pybind11-src",
         "rapidjson-src": "rapidjson-src",
+        "rv-utils": "rv-utils",
         "utils": [
           "flake-utils"
         ]
       },
       "locked": {
-        "lastModified": 1707214073,
-        "narHash": "sha256-P115n355lWJAdlm9MSo+mK+FdFPRytzZnbOn5bwvr5E=",
+        "lastModified": 1707496962,
+        "narHash": "sha256-padbmy27lfhGbZnKRDHD7O0MNVZg3EzNMflk1JOwxgM=",
         "owner": "runtimeverification",
         "repo": "llvm-backend",
-        "rev": "c96dbb1302774f5e286dc7bd68ed1f0110121034",
+        "rev": "4e6d6ba340b5249db7dbde9d70265e574dcda7e6",
         "type": "github"
       },
       "original": {
@@ -196,6 +198,38 @@
         "type": "indirect"
       }
     },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1707163378,
+        "narHash": "sha256-oz+BzUDwtyircjjxv9aPYOS5gobxLCjD2il+gb/bCRo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1707163378,
+        "narHash": "sha256-oz+BzUDwtyircjjxv9aPYOS5gobxLCjD2il+gb/bCRo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e2ffefe304d941bb98989847944f3b58e0adcdd5",
+        "type": "github"
+      }
+    },
     "pybind11-src": {
       "flake": false,
       "locked": {
@@ -237,19 +271,40 @@
         "haskell-backend": "haskell-backend",
         "llvm-backend": "llvm-backend",
         "nixpkgs": [
-          "haskell-backend",
+          "llvm-backend",
           "nixpkgs"
         ],
-        "rv-utils": "rv-utils"
+        "rv-utils": "rv-utils_2"
       }
     },
     "rv-utils": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_3"
+      },
       "locked": {
-        "lastModified": 1659349707,
-        "narHash": "sha256-+RwJvYwRS4In+pl8R5Uz+R/yZ5yO5SAa7X6UR+eSC2U=",
+        "lastModified": 1707492220,
+        "narHash": "sha256-KRndaUPzUumDlNcKF7KzA8F/EZKLYCvurh7Z13sw2PI=",
         "owner": "runtimeverification",
         "repo": "rv-nix-tools",
-        "rev": "7026604726c5247ceb6e7a1a7532302a58e7e2bf",
+        "rev": "abf86805a623948c941e603e2fc4c26a06ea6eb6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "type": "github"
+      }
+    },
+    "rv-utils_2": {
+      "inputs": {
+        "nixpkgs": "nixpkgs_4"
+      },
+      "locked": {
+        "lastModified": 1707492220,
+        "narHash": "sha256-KRndaUPzUumDlNcKF7KzA8F/EZKLYCvurh7Z13sw2PI=",
+        "owner": "runtimeverification",
+        "repo": "rv-nix-tools",
+        "rev": "abf86805a623948c941e603e2fc4c26a06ea6eb6",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,11 +8,10 @@
       inputs.haskell-backend.follows = "haskell-backend";
       inputs.stacklock2nix.follows = "haskell-backend/stacklock2nix";
     };
-    nixpkgs.follows = "haskell-backend/nixpkgs";
+    nixpkgs.follows = "llvm-backend/nixpkgs";
     flake-utils.url = "github:numtide/flake-utils";
     llvm-backend = {
       url = "github:runtimeverification/llvm-backend";
-      inputs.nixpkgs.follows = "haskell-backend/nixpkgs";
       inputs.utils.follows = "flake-utils";
     };
     rv-utils.url = "github:runtimeverification/rv-nix-tools";

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -1,6 +1,6 @@
 { src, maven, mvnHash, manualMvnArtifacts, clang, stdenv, lib, runCommand
 , makeWrapper, bison, flex, gcc, git, gmp, jdk, jre, jre_minimal, mpfr, ncurses
-, pkgconfig, python3, z3, haskell-backend, booster, prelude-kore, llvm-backend
+, pkg-config, python3, z3, haskell-backend, booster, prelude-kore, llvm-backend
 , debugger, version, llvm-kompile-libs, runtimeShell }:
 
 let
@@ -19,7 +19,7 @@ let
       }))
     mpfr
     ncurses
-    pkgconfig
+    pkg-config
     python3
     z3
     haskell-backend


### PR DESCRIPTION
While we wait for the required changes to Nixpkgs etc. to go through such that we can update the Haskell backend to a newer version, I think it's worth allowing the two backends to diverge briefly such that the LLVM backend update job can go through.

The divergence warning between the two versions of Nixpkgs successfully triggers here.