### PR TITLE
Update regression tests to use `.K` rather than `.`

### DIFF
--- a/k-distribution/tests/regression-new/cell-bag-sort-llvm/test.k
+++ b/k-distribution/tests/regression-new/cell-bag-sort-llvm/test.k
@@ -25,14 +25,14 @@ module TEST
                   </functions>
                   <contracts color="orange">
                     <contract multiplicity = "*">
-                      <cName> . </cName>
+                      <cName> .K </cName>
                       <cFunctions> .Map </cFunctions>
                     </contract>
                   </contracts>
                 </T>
 
   rule
-    <k> addContract(ContractName:Id); => . ... </k>
+    <k> addContract(ContractName:Id); => .K ... </k>
     <contracts>
       ...
       (.Bag =>
@@ -44,7 +44,7 @@ module TEST
     </contracts>
 
 rule
-  <k> addFunction(ContractName:Id, FunctionName:Id); => . ... </k>
+  <k> addFunction(ContractName:Id, FunctionName:Id); => .K ... </k>
     <contracts>
       ...
       <contract>

--- a/k-distribution/tests/regression-new/cell-sort-haskell/test.k
+++ b/k-distribution/tests/regression-new/cell-sort-haskell/test.k
@@ -25,14 +25,14 @@ module TEST
                   </functions>
                   <contracts color="orange">
                     <contract multiplicity = "*" type = "Map">
-                      <cName> . </cName>
+                      <cName> .K </cName>
                       <cFunctions> .Map </cFunctions>
                     </contract>
                   </contracts>
                 </T>
 
   rule
-    <k> addContract(ContractName:Id); => . ... </k>
+    <k> addContract(ContractName:Id); => .K ... </k>
     <contracts>
       ...
       (.Bag =>
@@ -44,7 +44,7 @@ module TEST
     </contracts>
 
 rule
-  <k> addFunction(ContractName:Id, FunctionName:Id); => . ... </k>
+  <k> addFunction(ContractName:Id, FunctionName:Id); => .K ... </k>
     <contracts>
       ...
       <contract>

--- a/k-distribution/tests/regression-new/checkClaimError/errorClaim.k
+++ b/k-distribution/tests/regression-new/checkClaimError/errorClaim.k
@@ -15,7 +15,7 @@ module ERRORCLAIM
 
     configuration <k> $PGM:Pgm </k> <counter> 1 </counter> <sum> 0 </sum>
 
-    rule <k> addCounter(0) => . ... </k>
+    rule <k> addCounter(0) => .K ... </k>
     rule  <k> addCounter(Times:Int => Times -Int 1) ...</k>
           <counter> C:Int => C +Int 1 </counter>
           <sum> S:Int => S +Int C </sum>

--- a/k-distribution/tests/regression-new/configuration-composition/config-comp.k
+++ b/k-distribution/tests/regression-new/configuration-composition/config-comp.k
@@ -42,7 +42,7 @@ module CONFIG-COMP-1
 
     syntax Cmd ::= "Inc"
  // --------------------
-    rule <k> Inc => . ... </k>
+    rule <k> Inc => .K ... </k>
          <accumulator> I => I +Int 1 </accumulator>
 endmodule
 
@@ -57,10 +57,10 @@ module CONFIG-COMP-2
     syntax Cmd ::= "push" Int
                  | "pop"
  // -------------------------
-    rule <k> push I => . ... </k>
+    rule <k> push I => .K ... </k>
          <stack> (.List => ListItem( I )) ... </stack>
 
-    rule <k> pop => . ... </k>
+    rule <k> pop => .K ... </k>
          <output> ... (.List => ListItem( I )) </output>
          <stack> (ListItem( I ) => .List) ... </stack>
 endmodule

--- a/k-distribution/tests/regression-new/context-alias/test.k
+++ b/k-distribution/tests/regression-new/context-alias/test.k
@@ -27,8 +27,8 @@ syntax Expr ::= evalAndStop()
 
 syntax Expr ::= "(" Expr ")" [bracket]
 
-rule <k> enableHeating() => . ...</k> <shouldHeat> _ => true </shouldHeat>
-rule <k> disableHeating() => . ...</k> <shouldHeat> _ => false </shouldHeat>
+rule <k> enableHeating() => .K ...</k> <shouldHeat> _ => true </shouldHeat>
+rule <k> disableHeating() => .K ...</k> <shouldHeat> _ => false </shouldHeat>
 
 rule <k> evalAndStop() => 0 ...</k> <shouldHeat> _ => false </shouldHeat>
 

--- a/k-distribution/tests/regression-new/exit-code-no-gen-top/exitcode.k
+++ b/k-distribution/tests/regression-new/exit-code-no-gen-top/exitcode.k
@@ -15,7 +15,7 @@ module EXITCODE
         <exit-code exit=""> 0 </exit-code>
       </actualTop>
 
-    rule <k> I:Int => . ... </k>
+    rule <k> I:Int => .K ... </k>
          <exit-code> _ => I </exit-code>
 
 endmodule

--- a/k-distribution/tests/regression-new/f32-mul/float-mul.k
+++ b/k-distribution/tests/regression-new/f32-mul/float-mul.k
@@ -14,6 +14,6 @@ module FLOAT-MUL
     configuration <k> $PGM:Pgm </k>
 
     rule <k> f32mul ( F1, F2 ) => roundFloat(F1, 24, 8) *Float roundFloat(F2, 24, 8) ... </k>
-    rule <k> F1:Float ~> checkEqual ( F2 ) => . ... </k> requires F1 ==Float roundFloat(F2, 24, 8)
+    rule <k> F1:Float ~> checkEqual ( F2 ) => .K ... </k> requires F1 ==Float roundFloat(F2, 24, 8)
     rule <k> P1 ; P2 => P1 ~> P2 ... </k>
 endmodule

--- a/k-distribution/tests/regression-new/fresh3/test-ext.k
+++ b/k-distribution/tests/regression-new/fresh3/test-ext.k
@@ -30,5 +30,5 @@ module TEST-EXT
 
     syntax KItem ::= "step"
 
-    rule <k> step => . ... </k>
+    rule <k> step => .K ... </k>
 endmodule

--- a/k-distribution/tests/regression-new/imp++-llvm/imp.md
+++ b/k-distribution/tests/regression-new/imp++-llvm/imp.md
@@ -340,7 +340,7 @@ this syntactic restructuring has been explained in Lesson 7. Here is the
 semantics of the two constructs:
 
 ```k
-  rule _:Int; => .
+  rule _:Int; => .K
   rule <k> X = I:Int => I ...</k>
        <env>... X |-> N ...</env>
        <store>... N |-> (_ => I) ...</store>  [group(assignment)]
@@ -354,7 +354,7 @@ sequentialize a syntactic list of statements `s1 s2 ... sn..` into the
 corresponding computation `s1 ~> s2 ~> ... ~> sn`.
 
 ```k
-   rule .Stmts => .
+   rule .Stmts => .K
    rule S:Stmt Ss:Stmts => S ~> Ss
 ```
 
@@ -444,7 +444,7 @@ all behaviors.
 
   rule <k> print(P:Printable,AEs => AEs); ...</k>
        <output>... .List => ListItem(P) </output>  [group(print)]
-  rule print(.AExps); => .
+  rule print(.AExps); => .K
 ```
 
 ### Halt
@@ -458,7 +458,7 @@ terminates the entire program, no matter how many concurrent threads it has,
 because there is nothing else to rewrite.
 
 ```k
-  rule <k> halt; ~> _ => . </k>
+  rule <k> halt; ~> _ => .K </k>
 ```
 
 ### Spawn thread
@@ -502,7 +502,7 @@ join statement is simply dissolved. The terminated thread is not removed,
 because we want to allow possible other join statements to also dissolve.
 
 ```k
-  rule <k> join(T); => . ...</k> <thread>... <k>.</k> <id>T</id> ...</thread>
+  rule <k> join(T); => .K ...</k> <thread>... <k> .K </k> <id>T</id> ...</thread>
 ```
 
 ### Blocks
@@ -541,7 +541,7 @@ initialize it with 0.
   rule <k> int (X,Xs => Xs); ...</k>
        <env> Rho => Rho[X <- !N:Int] </env>
        <store>... .Map => !N |-> 0 ...</store>
-  rule int .Ids; => .
+  rule int .Ids; => .K
 ```
 
 ### Auxiliary operations
@@ -552,7 +552,7 @@ This rule is structural: we do not want them to count as computational
 steps in the transition system of a program.
 
 ```k
-  rule <k> Rho => . ...</k> <env> _ => Rho </env>
+  rule <k> Rho => .K ...</k> <env> _ => Rho </env>
 ```
 
 If you want to avoid useless environment recovery steps and keep the size

--- a/k-distribution/tests/regression-new/imp-haskell/imp.k
+++ b/k-distribution/tests/regression-new/imp-haskell/imp.k
@@ -51,10 +51,10 @@ module IMP
   rule true && B => B
   rule false && _ => false
 // Block
-  rule {} => .
+  rule {} => .K
   rule {S} => S
 // Stmt
-  rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
+  rule <k> X = I:Int; => .K ...</k> <state>... X |-> (_ => I) ...</state>
   rule S1:Stmt S2:Stmt => S1 ~> S2
   rule if (true)  S else _ => S
   rule if (false) _ else S => S

--- a/k-distribution/tests/regression-new/imp-json/imp.k
+++ b/k-distribution/tests/regression-new/imp-json/imp.k
@@ -51,10 +51,10 @@ module IMP
   rule true && B => B
   rule false && _ => false
 
-  rule {} => .
+  rule {} => .K
   rule {S} => S
 
-  rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
+  rule <k> X = I:Int; => .K ...</k> <state>... X |-> (_ => I) ...</state>
 
   rule S1:Stmt S2:Stmt => S1 ~> S2
 

--- a/k-distribution/tests/regression-new/imp-kore/imp.k
+++ b/k-distribution/tests/regression-new/imp-kore/imp.k
@@ -143,7 +143,7 @@ Similarly, the non-empty blocks are dissolved and replaced by their statement
 contents, thus effectively giving them a bracket semantics; we can afford to
 do this only because we have no block-local variable declarations yet in IMP. */
 
-  rule {} => .
+  rule {} => .K
   rule {S} => S
 
 /*@ \subsubsection{Assignment}
@@ -151,7 +151,7 @@ The assigned variable is updated in the state.  The variable is expected
 to be declared, otherwise the semantics will get stuck.  At the same time,
 the assignment is dissolved. */
 
-  rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
+  rule <k> X = I:Int; => .K ...</k> <state>... X |-> (_ => I) ...</state>
 
 /*@ \subsubsection{Sequential composition}
 Sequential composition is simply structurally translated into \K's

--- a/k-distribution/tests/regression-new/imp-llvm/imp.k
+++ b/k-distribution/tests/regression-new/imp-llvm/imp.k
@@ -53,10 +53,10 @@ module IMP
   rule true && B => B
   rule false && _ => false
 
-  rule {} => .
+  rule {} => .K
   rule {S} => S
 
-  rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
+  rule <k> X = I:Int; => .K ...</k> <state>... X |-> (_ => I) ...</state>
 
   rule S1:Stmt S2:Stmt => S1 ~> S2
 

--- a/k-distribution/tests/regression-new/issue-1263/test.k
+++ b/k-distribution/tests/regression-new/issue-1263/test.k
@@ -25,5 +25,5 @@ module TEST
     syntax Pgm ::= "go" FInt | Pgm ";" Pgm [left]
  // ---------------------------------------------
     rule <k> P ; Q => P ~> Q ... </k>
-    rule <k> go wad(0) => . ... </k>
+    rule <k> go wad(0) => .K ... </k>
 endmodule

--- a/k-distribution/tests/regression-new/issue-1384/test.k
+++ b/k-distribution/tests/regression-new/issue-1384/test.k
@@ -33,13 +33,13 @@ imports DOMAINS
                | sequenceDefns  ( Defns  ) [function]
                | sequenceInstrs ( Instrs ) [function]
  // -------------------------------------------------
-    rule sequenceStmts(.Stmts) => .
+    rule sequenceStmts(.Stmts) => .K
     rule sequenceStmts(S SS  ) => S ~> sequenceStmts(SS)
 
-    rule sequenceDefns(.Defns) => .
+    rule sequenceDefns(.Defns) => .K
     rule sequenceDefns(D DS  ) => D ~> sequenceDefns(DS)
 
-    rule sequenceInstrs(.Instrs) => .
+    rule sequenceInstrs(.Instrs) => .K
     rule sequenceInstrs(I IS   ) => I ~> sequenceInstrs(IS)
 
 endmodule

--- a/k-distribution/tests/regression-new/issue-2321-kprovexCrash/test-spec.k
+++ b/k-distribution/tests/regression-new/issue-2321-kprovexCrash/test-spec.k
@@ -6,7 +6,7 @@ module TEST-SPEC
     imports TEST
 
   claim
-    <k> #assert i ( 1 , 0 ) ==Int 0 => . </k>
+    <k> #assert i ( 1 , 0 ) ==Int 0 => .K </k>
       requires true #And ( #Forall X. { i ( X, 0 ) #Equals 0 } )
 
 endmodule

--- a/k-distribution/tests/regression-new/issue-3450-kprove-fresh/explicit-spec.k
+++ b/k-distribution/tests/regression-new/issue-3450-kprove-fresh/explicit-spec.k
@@ -5,8 +5,8 @@ require "test.k"
 module EXPLICIT-SPEC
     imports TEST
 
-    claim <k> quux => . </k>
-        <c1> . => ?C </c1>
-        <c2> . => ?C </c2>
+    claim <k> quux => .K </k>
+        <c1> .K => ?C </c1>
+        <c2> .K => ?C </c2>
         <generatedCounter> GC => GC +Int 1 </generatedCounter>
 endmodule

--- a/k-distribution/tests/regression-new/issue-3450-kprove-fresh/implicit-spec.k
+++ b/k-distribution/tests/regression-new/issue-3450-kprove-fresh/implicit-spec.k
@@ -5,7 +5,7 @@ require "test.k"
 module IMPLICIT-SPEC
     imports TEST
 
-    claim <k> quux => . </k>
-        <c1> . => ?C </c1>
-        <c2> . => ?C </c2>
+    claim <k> quux => .K </k>
+        <c1> .K => ?C </c1>
+        <c2> .K => ?C </c2>
 endmodule

--- a/k-distribution/tests/regression-new/issue-3450-kprove-fresh/test.k
+++ b/k-distribution/tests/regression-new/issue-3450-kprove-fresh/test.k
@@ -9,10 +9,10 @@ module TEST
     imports INT
 
     configuration <k> $PGM:Pgm </k>
-        <c1> . </c1>
-        <c2> . </c2>
+        <c1> .K </c1>
+        <c2> .K </c2>
 
-    rule <k> quux => . </k>
-        <c1> . => !C:Int </c1>
-        <c2> . => !C:Int </c2>
+    rule <k> quux => .K </k>
+        <c1> .K => !C:Int </c1>
+        <c2> .K => !C:Int </c2>
 endmodule

--- a/k-distribution/tests/regression-new/issue-3520-freshConfig/test.k
+++ b/k-distribution/tests/regression-new/issue-3520-freshConfig/test.k
@@ -36,16 +36,16 @@ module TEST
                  | assertNotEqual( List )
                  | assertNotEqual( Int, List )
 
-  rule assertEqual( .List ) => .
+  rule assertEqual( .List ) => .K
   rule assertEqual( ListItem(X:Int) REST )  => assertEqual( X, REST ) ~> assertEqual( REST )
 
-  rule assertEqual( _, .List ) => .
+  rule assertEqual( _, .List ) => .K
   rule assertEqual( X, ListItem( X ) REST ) => assertEqual( X, REST )
 
-  rule assertNotEqual( .List ) => .
+  rule assertNotEqual( .List ) => .K
   rule assertNotEqual( ListItem(X:Int) REST )  => assertNotEqual( X, REST ) ~> assertNotEqual( REST )
 
-  rule assertNotEqual( _, .List ) => .
+  rule assertNotEqual( _, .List ) => .K
   rule assertNotEqual( X, ListItem( Y ) REST ) => assertNotEqual( X, REST ) requires X =/=Int Y
 
   rule start => !_A:Int

--- a/k-distribution/tests/regression-new/ite-bug/failing-1-spec.k
+++ b/k-distribution/tests/regression-new/ite-bug/failing-1-spec.k
@@ -1,6 +1,6 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 module FAILING-1-SPEC
     imports ITE-BUG
-    claim <k> JUMPI 2 bool2Word(_X <Int 0) => . </k>
+    claim <k> JUMPI 2 bool2Word(_X <Int 0) => .K </k>
           <pc> 0 => 1 </pc>
 endmodule

--- a/k-distribution/tests/regression-new/ite-bug/failing-2-spec.k
+++ b/k-distribution/tests/regression-new/ite-bug/failing-2-spec.k
@@ -1,6 +1,6 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 module FAILING-2-SPEC
     imports ITE-BUG
-    claim <k> JUMPI 2 bool2Word(_X <Int 0) => . </k>
+    claim <k> JUMPI 2 bool2Word(_X <Int 0) => .K </k>
           <pc> 0 => 2 </pc>
 endmodule

--- a/k-distribution/tests/regression-new/ite-bug/ite-bug.k
+++ b/k-distribution/tests/regression-new/ite-bug/ite-bug.k
@@ -18,11 +18,11 @@ module ITE-BUG
       <k> $PGM:Pgm </k>
       <pc> 0 </pc>
 
-    rule <k> JUMPI _DEST I => . ... </k>
+    rule <k> JUMPI _DEST I => .K ... </k>
          <pc> PCOUNT => PCOUNT +Int 1 </pc>
       requires I ==Int 0
 
-    rule <k> JUMPI DEST I => . ... </k>
+    rule <k> JUMPI DEST I => .K ... </k>
          <pc> _PCOUNT => DEST </pc>
       requires I =/=Int 0
 

--- a/k-distribution/tests/regression-new/ite-bug/passing-spec.k
+++ b/k-distribution/tests/regression-new/ite-bug/passing-spec.k
@@ -1,6 +1,6 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 module PASSING-SPEC
     imports ITE-BUG
-    claim <k> JUMPI 2 bool2Word(X <Int 0) => . </k>
+    claim <k> JUMPI 2 bool2Word(X <Int 0) => .K </k>
           <pc> 0 => #if (X <Int 0) #then 2 #else 1 #fi </pc>
 endmodule

--- a/k-distribution/tests/regression-new/itp/nth-ancestor/chain.k
+++ b/k-distribution/tests/regression-new/itp/nth-ancestor/chain.k
@@ -47,11 +47,11 @@ module CHAIN
                   | Int "<~*" Int
 
     rule
-    <k> apply("<~*.i") => . ... </k>
+    <k> apply("<~*.i") => .K ... </k>
     <g> B1 <~ B2 => B1 <~* B2 </g>
 
     rule
-    <k> apply("<~*.i") => . ... </k>
+    <k> apply("<~*.i") => .K ... </k>
     <g> B1 <~ B2 and B2 <~* B3 => B1 <~* B3 </g>
 
     /*
@@ -68,20 +68,20 @@ module CHAIN
                   | Int "==" Int
 
     rule
-    <k> apply("nth.i") => . ... </k>
+    <k> apply("nth.i") => .K ... </k>
     <g> block(B) => nth(0, B, B) </g>
 
     rule
-    <k> apply("nth.i") => . ... </k>
+    <k> apply("nth.i") => .K ... </k>
     <g> nth(N, B1, B2) and B2 <~ B3
      => nth(N +Int 1, B1, B3) </g>
 
     rule
-    <k> apply("nth.e") => . ... </k>
+    <k> apply("nth.e") => .K ... </k>
     <g> nth(0, B1, B2) => B1 == B2 </g>
 
     rule
-    <k> apply("nth.e") => . ... </k>
+    <k> apply("nth.e") => .K ... </k>
     <g> nth(N, B1, B3)
      => nth(N -Int 1, B1, ?B2:Int) and ?B2 <~ B3 </g>
         requires N >Int 0

--- a/k-distribution/tests/regression-new/itp/nth-ancestor/nth1-spec.k
+++ b/k-distribution/tests/regression-new/itp/nth-ancestor/nth1-spec.k
@@ -38,10 +38,10 @@ module NTH1-SPEC
      ~> load("p2")
      ~> apply("lemma")
      ~> apply("<~*.i")
-     => . </k>
+     => .K </k>
 
     claim
-    <k> apply("lemma") => . ... </k>
+    <k> apply("lemma") => .K ... </k>
     <g> B1 == B2 and B2 <~ B3 => B1 <~ B3 </g>
         [trusted]
 endmodule

--- a/k-distribution/tests/regression-new/itp/nth-ancestor/nth2-spec.k
+++ b/k-distribution/tests/regression-new/itp/nth-ancestor/nth2-spec.k
@@ -37,12 +37,12 @@ module NTH2-SPEC
      ~> apply("ih")
      ~> load("p2")
      ~> apply("lemma")
-     => . </k>
+     => .K </k>
         requires k(N) >Int 0 andBool const(N)
 
     // induction hypothesis
     claim
-    <k> apply("ih") => . ... </k>
+    <k> apply("ih") => .K ... </k>
     <g> nth(k(N), B1, B2) => B1 <~* B2 </g>
         requires k(N) >Int 0 andBool const(N)
         [trusted]
@@ -57,7 +57,7 @@ module NTH2-SPEC
         Qed.
     */
     claim
-    <k> apply("lemma") => . ... </k>
+    <k> apply("lemma") => .K ... </k>
     <g> B1 <~* B2 and B2 <~ B3 => B1 <~* B3 </g>
         [trusted]
 endmodule

--- a/k-distribution/tests/regression-new/itp/nth-ancestor/proof-script.k
+++ b/k-distribution/tests/regression-new/itp/nth-ancestor/proof-script.k
@@ -23,7 +23,7 @@ module PROOF-SCRIPT
                     | store2(String, String)
 
     rule [load]:
-    <k> load(N) => . ... </k>
+    <k> load(N) => .K ... </k>
     <g> X => #if X ==K none
              #then         M [ N ]
              #else X and { M [ N ] }:>Pred
@@ -31,12 +31,12 @@ module PROOF-SCRIPT
     <p> M </p>
 
     rule [store1]:
-    <k> store1(N) => . ... </k>
+    <k> store1(N) => .K ... </k>
     <g> X => none </g>
     <p> M => M [ N <- X ] </p>
 
     rule [store2]:
-    <k> store2(N1,N2) => . ... </k>
+    <k> store2(N1,N2) => .K ... </k>
     <g> X1 and X2 => none </g>
     <p> M => M [ N1 <- X1 ]
                [ N2 <- X2 ] </p>

--- a/k-distribution/tests/regression-new/kprove-append/def-spec.k
+++ b/k-distribution/tests/regression-new/kprove-append/def-spec.k
@@ -1,5 +1,5 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 module DEF-SPEC
     imports DEF
-    claim <k> (a ~> _ => .) ... </k>
+    claim <k> (a ~> _ => .K) ... </k>
 endmodule

--- a/k-distribution/tests/regression-new/kprove-error-status/verif.k
+++ b/k-distribution/tests/regression-new/kprove-error-status/verif.k
@@ -17,7 +17,7 @@ module VERIF
 
     configuration <k> $PGM:Pgm </k> <counter> 1 </counter> <sum> 0 </sum>
 
-    rule <k> addCounter(0) => . ... </k>
+    rule <k> addCounter(0) => .K ... </k>
     rule  <k> addCounter(Times:Int => Times -Int 1) ...</k>
           <counter> C:Int => C +Int 1 </counter>
           <sum> S:Int => S +Int C </sum>

--- a/k-distribution/tests/regression-new/kprove-haskell/sum-spec.k
+++ b/k-distribution/tests/regression-new/kprove-haskell/sum-spec.k
@@ -6,7 +6,7 @@ endmodule
 module SUM-SPEC
   import VERIFICATION
 
-  claim  <k> addCounter(N:Int) => . ...</k>
+  claim  <k> addCounter(N:Int) => .K ...</k>
          <counter> C:Int => ?_ </counter>
          <sum> S:Int => ?S:Int </sum>
     requires

--- a/k-distribution/tests/regression-new/kprove-haskell/verif.k
+++ b/k-distribution/tests/regression-new/kprove-haskell/verif.k
@@ -15,7 +15,7 @@ module VERIF
 
     configuration <k> $PGM:Pgm </k> <counter> 1 </counter> <sum> 0 </sum>
 
-    rule <k> addCounter(0) => . ... </k>
+    rule <k> addCounter(0) => .K ... </k>
     rule  <k> addCounter(Times:Int => Times -Int 1) ...</k>
           <counter> C:Int => C +Int 1 </counter>
           <sum> S:Int => S +Int C </sum>

--- a/k-distribution/tests/regression-new/kprove-markdown/set-balance-spec.md
+++ b/k-distribution/tests/regression-new/kprove-markdown/set-balance-spec.md
@@ -49,7 +49,7 @@ This property shows that `set_balance` will not result in a zero-balance attack.
 ```
 
 ```keep
-    claim <k> set_balance_reserved ( WHO , RESERVED_BALANCE' ) => . ... </k>
+    claim <k> set_balance_reserved ( WHO , RESERVED_BALANCE' ) => .K ... </k>
           <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
           <totalIssuance> TOTAL_ISSUANCE +Int ( FREE_BALANCE' -Int FREE_BALANCE ) => TOTAL_ISSUANCE +Int ( FREE_BALANCE' -Int FREE_BALANCE ) +Int ( RESERVED_BALANCE' -Int RESERVED_BALANCE ) </totalIssuance>
           <account>

--- a/k-distribution/tests/regression-new/kprove-markdown/set-balance.md
+++ b/k-distribution/tests/regression-new/kprove-markdown/set-balance.md
@@ -210,7 +210,7 @@ A `Result` is considered an `Action`, as is an `EntryAction`.
 ```k
     syntax Action ::= "create_account" "(" AccountId ")"
  // ----------------------------------------------------
-    rule <k> create_account(WHO) => . ... </k>
+    rule <k> create_account(WHO) => .K ... </k>
          <accounts> ( .Bag => <account> <accountID> WHO </accountID> ... </account> ) ... </accounts>
 ```
 
@@ -223,11 +223,11 @@ A `Result` is considered an `Action`, as is an `EntryAction`.
 ```k
     syntax Action ::= "set_free_balance" "(" AccountId "," Int ")"
  // --------------------------------------------------------------
-    rule <k> (. => create_account(WHO)) ~> set_free_balance(WHO, _) ... </k>
+    rule <k> (.K => create_account(WHO)) ~> set_free_balance(WHO, _) ... </k>
       requires notBool account_exists(WHO)
 
     rule [free-account-updated]:
-         <k> set_free_balance(WHO, BALANCE) => . ... </k>
+         <k> set_free_balance(WHO, BALANCE) => .K ... </k>
          <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
          <account>
            <accountID> WHO </accountID>
@@ -237,7 +237,7 @@ A `Result` is considered an `Action`, as is an `EntryAction`.
       requires EXISTENTIAL_DEPOSIT <=Int BALANCE
 
     rule [free-account-killed]:
-         <k> set_free_balance(WHO, BALANCE) => . ... </k>
+         <k> set_free_balance(WHO, BALANCE) => .K ... </k>
          <events> ... (.List => ListItem(DustEvent(FREE_BALANCE))) </events>
          <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
          <totalIssuance> TOTAL_ISSUANCE => TOTAL_ISSUANCE -Int BALANCE </totalIssuance>
@@ -252,7 +252,7 @@ A `Result` is considered an `Action`, as is an `EntryAction`.
        andBool 0 <Int RESERVED_BALANCE
 
     rule [free-account-reaped]:
-         <k> set_free_balance(WHO, BALANCE) => . ... </k>
+         <k> set_free_balance(WHO, BALANCE) => .K ... </k>
          <events> ... (.List => ListItem(DustEvent(FREE_BALANCE))) </events>
          <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
          <totalIssuance> TOTAL_ISSUANCE => TOTAL_ISSUANCE -Int BALANCE </totalIssuance>
@@ -279,11 +279,11 @@ A `Result` is considered an `Action`, as is an `EntryAction`.
 ```k
     syntax Action ::= "set_reserved_balance" "(" AccountId "," Int ")"
  // ------------------------------------------------------------------
-    rule <k> (. => create_account(WHO)) ~> set_reserved_balance(WHO, _) ... </k>
+    rule <k> (.K => create_account(WHO)) ~> set_reserved_balance(WHO, _) ... </k>
       requires notBool account_exists(WHO)
 
     rule [reserved-account-updated]:
-         <k> set_reserved_balance(WHO, BALANCE) => . ... </k>
+         <k> set_reserved_balance(WHO, BALANCE) => .K ... </k>
          <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
          <account>
            <accountID> WHO </accountID>
@@ -293,7 +293,7 @@ A `Result` is considered an `Action`, as is an `EntryAction`.
       requires EXISTENTIAL_DEPOSIT <=Int BALANCE
 
     rule [reserved-account-killed]:
-         <k> set_reserved_balance(WHO, BALANCE) => . ... </k>
+         <k> set_reserved_balance(WHO, BALANCE) => .K ... </k>
          <events> ... (.List => ListItem(DustEvent(RESERVED_BALANCE))) </events>
          <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
          <totalIssuance> TOTAL_ISSUANCE => TOTAL_ISSUANCE -Int BALANCE </totalIssuance>
@@ -308,7 +308,7 @@ A `Result` is considered an `Action`, as is an `EntryAction`.
        andBool 0 <Int FREE_BALANCE
 
     rule [reserved-account-reaped]:
-         <k> set_reserved_balance(WHO, BALANCE) => . ... </k>
+         <k> set_reserved_balance(WHO, BALANCE) => .K ... </k>
          <events> ... (.List => ListItem(DustEvent(RESERVED_BALANCE))) </events>
          <existentialDeposit> EXISTENTIAL_DEPOSIT </existentialDeposit>
          <totalIssuance> TOTAL_ISSUANCE => TOTAL_ISSUANCE -Int BALANCE </totalIssuance>
@@ -398,12 +398,12 @@ The dispatch origin for this call must be `Signed` by the transactor.
          ...
          </k>
 
-    rule <k> (. => create_account(DESTINATION)) ~> rawTransfer(ORIGIN, DESTINATION, _, _) ... </k>
+    rule <k> (.K => create_account(DESTINATION)) ~> rawTransfer(ORIGIN, DESTINATION, _, _) ... </k>
       requires         account_exists(ORIGIN)
        andBool notBool account_exists(DESTINATION)
 
     rule [transfer-self]:
-         <k> rawTransfer(ORIGIN:AccountId, ORIGIN, _, _) => . ... </k>
+         <k> rawTransfer(ORIGIN:AccountId, ORIGIN, _, _) => .K ... </k>
       requires account_exists(ORIGIN)
 
     rule [transfer-existing-account]:
@@ -521,7 +521,7 @@ Function call and return.
          <call-stack> ListItem(frame(CONT)) => .List ... </call-stack>
 
     rule [return-unit]:
-         <k> . => CONT </k>
+         <k> .K => CONT </k>
          <return-value> _ => .Result </return-value>
          <call-stack> ListItem(frame(CONT)) => .List ... </call-stack>
 ```
@@ -751,7 +751,7 @@ Deposit into an existing account.
     syntax EntryAction ::= "deposit_into_existing" "(" AccountId "," Int ")"
  // ------------------------------------------------------------------------
     rule [deposit-into-existing]:
-         <k> deposit_into_existing(WHO, AMOUNT) => . ... </k>
+         <k> deposit_into_existing(WHO, AMOUNT) => .K ... </k>
          <totalIssuance> TOTAL_ISSUANCE => TOTAL_ISSUANCE +Int AMOUNT </totalIssuance>
          <account>
            <accountID> WHO </accountID>

--- a/k-distribution/tests/regression-new/krun-deserialize/imp.k
+++ b/k-distribution/tests/regression-new/krun-deserialize/imp.k
@@ -48,10 +48,10 @@ module IMP
   rule true && B => B
   rule false && _ => false
 
-  rule {} => .
+  rule {} => .K
   rule {S} => S
 
-  rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
+  rule <k> X = I:Int; => .K ...</k> <state>... X |-> (_ => I) ...</state>
 
   rule S1:Stmt S2:Stmt => S1 ~> S2
 

--- a/k-distribution/tests/regression-new/parseNonPgm/test.k
+++ b/k-distribution/tests/regression-new/parseNonPgm/test.k
@@ -28,7 +28,7 @@ module TEST
 
   syntax KResult ::= Int
 
-  rule <k> _I:Int ; => . ...</k> <mode> noprint </mode>
+  rule <k> _I:Int ; => .K ...</k> <mode> noprint </mode>
   rule <k> I:Int ; => #write(1, Int2String(I)) ...</k> <mode> print </mode>
 
   rule I + I2 => I +Int I2

--- a/k-distribution/tests/regression-new/pl-tutorial/1_k/2_imp/lesson_4/imp.k
+++ b/k-distribution/tests/regression-new/pl-tutorial/1_k/2_imp/lesson_4/imp.k
@@ -46,10 +46,10 @@ module IMP
   rule true && B => B
   rule false && _ => false
 // Block
-  rule {} => .
+  rule {} => .K
   rule {S} => S
 // Stmt
-  rule <k> X = I:Int; => . ...</k> <state>... X |-> (_ => I) ...</state>
+  rule <k> X = I:Int; => .K ...</k> <state>... X |-> (_ => I) ...</state>
   rule S1:Stmt S2:Stmt => S1 ~> S2
   rule if (true)  S else _ => S
   rule if (false) _ else S => S

--- a/k-distribution/tests/regression-new/pl-tutorial/1_k/3_lambda++/lesson_5/lambda.k
+++ b/k-distribution/tests/regression-new/pl-tutorial/1_k/3_lambda++/lesson_5/lambda.k
@@ -26,7 +26,7 @@ module LAMBDA
   rule <k> X => V ...</k>
        <env>... X |-> N ...</env>
        <store>... N |-> V ...</store>
-  rule <k> _:Val ~> (Rho => .) ...</k> <env> _ => Rho </env>
+  rule <k> _:Val ~> (Rho => .K) ...</k> <env> _ => Rho </env>
 
   syntax Val ::= Int | Bool
   syntax Exp ::= Exp "*" Exp          [strict, left]

--- a/k-distribution/tests/regression-new/pl-tutorial/1_k/4_imp++/lesson_7/imp.k
+++ b/k-distribution/tests/regression-new/pl-tutorial/1_k/4_imp++/lesson_7/imp.k
@@ -72,9 +72,9 @@ module IMP
   rule false && _ => false
 // Block
   rule <k> {Ss} => Ss ~> Rho ...</k> <env> Rho </env>
-  rule <k> Rho => . ...</k> <env> _ => Rho </env>
+  rule <k> Rho => .K ...</k> <env> _ => Rho </env>
 // Stmt
-  rule _:Int; => .
+  rule _:Int; => .K
   rule <k> X = I:Int => I ...</k>
        <env>... X |-> N ...</env>
        <store>... N |-> (_ => I) ...</store>  [group(assignment)]
@@ -85,7 +85,7 @@ module IMP
   rule <k> int (X,Xs => Xs); ...</k>
        <env> Rho => Rho[X <- !N:Int] </env>
        <store>... .Map => !N |-> 0 ...</store>
-  rule int .Ids; => .
+  rule int .Ids; => .K
 
   syntax Printable ::= Int | String
 /* currently it is necessary to subsort Printable to AExp,
@@ -94,17 +94,17 @@ module IMP
   context print(HOLE:AExp, _AEs:AExps);
   rule <k> print(P:Printable,AEs => AEs); ...</k>
        <output>... .List => ListItem(P) </output>  [group(print)]
-  rule print(.AExps); => .
+  rule print(.AExps); => .K
 
-  rule <k> halt; ~> _ => . </k>
+  rule <k> halt; ~> _ => .K </k>
 
   rule <k> spawn S => !T:Int +Int 1 ...</k> <env> Rho </env>
        (.Bag => <thread>... <k> S </k> <env> Rho </env> <id> !T +Int 1 </id> ...</thread>)
-  rule <k> join(T:Int); => . ...</k>
-       <thread>... <k> . </k> <id> T </id> ...</thread>
+  rule <k> join(T:Int); => .K ...</k>
+       <thread>... <k> .K </k> <id> T </id> ...</thread>
 
 // Stmts
-  rule .Stmts => .
+  rule .Stmts => .K
   rule S:Stmt Ss:Stmts => S ~> Ss
 
 // verification ids

--- a/k-distribution/tests/regression-new/pl-tutorial/1_k/5_types/lesson_6/lambda.k
+++ b/k-distribution/tests/regression-new/pl-tutorial/1_k/5_types/lesson_6/lambda.k
@@ -65,7 +65,7 @@ module LAMBDA
        (.Bag => <task> <k> E = ?T </k> <tenv> TEnv[X <- ?T] </tenv> </task>)
 
   syntax KItem ::= Exp "=" Exp  [seqstrict]
-  rule <k> T:Type = T:Type => . ...</k>
+  rule <k> T:Type = T:Type => .K ...</k>
 
-  rule <task>... <k> . </k> ...</task> => .Bag
+  rule <task>... <k> .K </k> ...</task> => .Bag
 endmodule

--- a/k-distribution/tests/regression-new/pl-tutorial/2_languages/1_simple/1_untyped/simple-untyped.md
+++ b/k-distribution/tests/regression-new/pl-tutorial/2_languages/1_simple/1_untyped/simple-untyped.md
@@ -440,7 +440,7 @@ structure.
 ```k
   syntax KItem ::= "undefined"
 
-  rule <k> var X:Id; => . ...</k>
+  rule <k> var X:Id; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> undefined ...</store>
        <nextLoc> L => L +Int 1 </nextLoc>
@@ -467,7 +467,7 @@ declarations.
 ```k
   context var _:Id[HOLE];
 
-  rule <k> var X:Id[N:Int]; => . ...</k>
+  rule <k> var X:Id[N:Int]; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> array(L +Int 1, N)
                           (L +Int 1) ... (L +Int N) |-> undefined ...</store>
@@ -528,7 +528,7 @@ SIMPLE, also defined in **K** (see `examples/simple/typed/static`),
 discards programs which do not respect this requirement.
 
 ```k
-  rule <k> function F(Xs) S => . ...</k>
+  rule <k> function F(Xs) S => .K ...</k>
        <env> Env => Env[F <- L] </env>
        <store>... .Map => L |-> lambda(Xs, S) ...</store>
        <nextLoc> L => L +Int 1 </nextLoc>
@@ -775,7 +775,7 @@ for variable declarations, as we did above.  One can make the two rules below
 computational if one wants them to count as computational steps.
 
 ```k
-  rule {} => .
+  rule {} => .K
   rule <k> { S } => S ~> setEnv(Env) ...</k>  <env> Env </env>
 ```
 The basic definition of environment recovery is straightforward and
@@ -835,7 +835,7 @@ Expression statements are only used for their side effects, so their result
 value is simply discarded.  Common examples of expression statements are ones
 of the form `++x;`, `x=e;`, `e1[e2]=e3;`, etc.
 ```k
-  rule _:Val; => .
+  rule _:Val; => .K
 ```
 
 ## Conditional
@@ -870,7 +870,7 @@ its evaluated arguments to the output buffer, and discard the residual
 ```k
   rule <k> print(V:Val, Es => Es); ...</k> <output>... .List => ListItem(V) </output>
     [group(print)]
-  rule print(.Vals); => .
+  rule print(.Vals); => .K
 ```
 
 ## Exceptions
@@ -911,7 +911,7 @@ exception stack.  The three rules below modularly do precisely the above.
        </control>
        <env> Env </env>
 
-  rule <k> popx => . ...</k>
+  rule <k> popx => .K ...</k>
        <xstack> ListItem(_) => .List ...</xstack>
 
   rule <k> throw V:Val; ~> _ => { var X = V; S2 } ~> K </k>
@@ -973,7 +973,7 @@ by a thread.  The unique identifier of the terminated thread is also collected
 into the `terminated` cell, so the `join` construct knows which
 threads have terminated.
 ```k
-  rule (<thread>... <k>.</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
+  rule (<thread>... <k>.K</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
        <busy> Busy => Busy -Set keys(H) </busy>
        <terminated>... .Set => SetItem(T) ...</terminated>
 ```
@@ -985,7 +985,7 @@ the identifier of the thread to be joined is in the `terminated` cell.
 If yes, then the `join` statement dissolves and the joining thread
 continues normally; if not, then the joining thread gets stuck.
 ```k
-  rule <k> join T:Int; => . ...</k>
+  rule <k> join T:Int; => .K ...</k>
        <terminated>... SetItem(T) ...</terminated>
 ```
 
@@ -1000,12 +1000,12 @@ the side condition of the first rule).
 counter for the lock (the locks are re-entrant).  These two cases are captured
 by the two rules below:
 ```k
-  rule <k> acquire V:Val; => . ...</k>
+  rule <k> acquire V:Val; => .K ...</k>
        <holds>... .Map => V |-> 0 ...</holds>
        <busy> Busy (.Set => SetItem(V)) </busy>
     requires (notBool(V in Busy))  [group(acquire)]
 
-  rule <k> acquire V; => . ...</k>
+  rule <k> acquire V; => .K ...</k>
        <holds>... V:Val |-> (N => N +Int 1) ...</holds>
 ```
 
@@ -1019,11 +1019,11 @@ is to decrement the lock counter.
 from its `holds` cell and also from the the shared `busy` cell,
 so other threads can acquire it if they need to.
 ```k
-  rule <k> release V:Val; => . ...</k>
+  rule <k> release V:Val; => .K ...</k>
        <holds>... V |-> (N => N -Int 1) ...</holds>
     requires N >Int 0
 
-  rule <k> release V; => . ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
+  rule <k> release V; => .K ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
        <busy>... SetItem(V) => .Set ...</busy>
 ```
 
@@ -1044,8 +1044,8 @@ the `thread` cell, the only way to concretize the rule below to the
 actual configuration of SIMPLE is to include each `k` cell in a
 `thread` cell.
 ```k
-  rule <k> rendezvous V:Val; => . ...</k>
-       <k> rendezvous V; => . ...</k>  [group(rendezvous)]
+  rule <k> rendezvous V:Val; => .K ...</k>
+       <k> rendezvous V; => .K ...</k>  [group(rendezvous)]
 ```
 
 ## Auxiliary declarations and operations
@@ -1083,7 +1083,7 @@ IMP++ tutorial:
 // TODO: eliminate the env wrapper, like we did in IMP++
 
   syntax KItem ::= setEnv(Map)
-  rule <k> setEnv(Env) => . ...</k> <env> _ => Env </env>
+  rule <k> setEnv(Env) => .K ...</k> <env> _ => Env </env>
 ```
 While theoretically sufficient, the basic definition for environment
 recovery alone is suboptimal.  Consider a loop `while (E)S`,
@@ -1098,7 +1098,7 @@ recovery tasks, we only need to keep the last one.  The elegant rule below
 does precisely that, thus avoiding the unnecessary computation explosion
 problem:
 ```k
-  rule (setEnv(_) => .) ~> setEnv(_)
+  rule (setEnv(_) => .K) ~> setEnv(_)
 ```
 In fact, the above follows a common convention in **K** for recovery
 operations of cell contents: the meaning of a computation task of the form

--- a/k-distribution/tests/regression-new/pl-tutorial/2_languages/1_simple/2_typed/2_dynamic/simple-typed-dynamic.md
+++ b/k-distribution/tests/regression-new/pl-tutorial/2_languages/1_simple/2_typed/2_dynamic/simple-typed-dynamic.md
@@ -224,7 +224,7 @@ to a location.
 ```k
   syntax KItem ::= undefined(Type)
 
-  rule <k> T:Type X:Id; => . ...</k>
+  rule <k> T:Type X:Id; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> undefined(T) ...</store>
        <nextLoc> L:Int => L +Int 1 </nextLoc>
@@ -236,7 +236,7 @@ The dynamic semantics of typed array declarations is similar to that
 in untyped SIMPLE, but we have to make sure that we associate the
 right type to the allocated locations.
 ```k
-  rule <k> T:Type X:Id[N:Int]; => . ...</k>
+  rule <k> T:Type X:Id[N:Int]; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> array(T, L +Int 1, N)
                           (L +Int 1)...(L +Int N) |-> undefined(T) ...</store>
@@ -271,7 +271,7 @@ Store all function parameters, as well as the return type, as part
 of the lambda abstraction.  In the spirit of dynamic typing, we will
 make sure that parameters are well typed when the function is invoked.
 ```k
-  rule <k> T:Type F:Id(Ps:Params) S => . ...</k>
+  rule <k> T:Type F:Id(Ps:Params) S => .K ...</k>
        <env> Env => Env[F <- L] </env>
        <store>... .Map => L |-> lambda(T, Ps, S) ...</store>
        <nextLoc> L => L +Int 1 </nextLoc>
@@ -404,7 +404,7 @@ preserved:
 ### Blocks
 
 ```k
-  rule {} => .
+  rule {} => .K
   rule <k> { S } => S ~> setEnv(Env) ...</k>  <env> Env </env>
 ```
 
@@ -417,7 +417,7 @@ preserved:
 ### Expression statements
 
 ```k
-  rule _:Val; => .
+  rule _:Val; => .K
 ```
 
 ### Conditional
@@ -439,7 +439,7 @@ We only allow printing integers and strings:
 ```k
   rule <k> print(V:Val, Es => Es); ...</k> <output>... .List => ListItem(V) </output>
     requires typeOf(V) ==K int orBool typeOf(V) ==K string  [group(print)]
-  rule print(.Vals); => .
+  rule print(.Vals); => .K
 ```
 
 ### Exceptions
@@ -461,7 +461,7 @@ values, in which case our semantics below works fine:
        </control>
        <env> Env </env>
 
-  rule <k> popx => . ...</k>
+  rule <k> popx => .K ...</k>
        <xstack> ListItem(_) => .List ...</xstack>
 
   rule <k> throw V:Val; ~> _ => { T X = V; S2 } ~> K </k>
@@ -491,7 +491,7 @@ values, in which case our semantics below works fine:
 ### Thread termination
 
 ```k
-   rule (<thread>... <k>.</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
+   rule (<thread>... <k>.K</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
         <busy> Busy => Busy -Set keys(H) </busy>
         <terminated>... .Set => SetItem(T) ...</terminated>
 ```
@@ -499,38 +499,38 @@ values, in which case our semantics below works fine:
 ### Thread joining
 
 ```k
-   rule <k> join T:Int; => . ...</k>
+   rule <k> join T:Int; => .K ...</k>
         <terminated>... SetItem(T) ...</terminated>
 ```
 
 ### Acquire lock
 
 ```k
-   rule <k> acquire V:Val; => . ...</k>
+   rule <k> acquire V:Val; => .K ...</k>
         <holds>... .Map => V |-> 0 ...</holds>
         <busy> Busy (.Set => SetItem(V)) </busy>
      requires (notBool(V in Busy:Set))  [group(acquire)]
 
-   rule <k> acquire V; => . ...</k>
+   rule <k> acquire V; => .K ...</k>
         <holds>... V:Val |-> (N:Int => N +Int 1) ...</holds>
 ```
 
 ### Release lock
 
 ```k
-   rule <k> release V:Val; => . ...</k>
+   rule <k> release V:Val; => .K ...</k>
         <holds>... V |-> (N => N:Int -Int 1) ...</holds>
       requires N >Int 0
 
-   rule <k> release V; => . ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
+   rule <k> release V; => .K ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
         <busy>... SetItem(V) => .Set ...</busy>
 ```
 
 ### Rendezvous synchronization
 
 ```k
-   rule <k> rendezvous V:Val; => . ...</k>
-        <k> rendezvous V; => . ...</k>  [group(rendezvous)]
+   rule <k> rendezvous V:Val; => .K ...</k>
+        <k> rendezvous V; => .K ...</k>  [group(rendezvous)]
 ```
 
 ### Auxiliary declarations and operations
@@ -553,8 +553,8 @@ Environment recovery.
 // TODO: same comment regarding setEnv(...) as for simple untyped
 
   syntax KItem ::= setEnv(Map)
-  rule <k> setEnv(Env) => . ...</k>  <env> _ => Env </env>
-  rule (setEnv(_) => .) ~> setEnv(_)
+  rule <k> setEnv(Env) => .K ...</k>  <env> _ => Env </env>
+  rule (setEnv(_) => .K) ~> setEnv(_)
 ```
 lvalue and loc
 ```k

--- a/k-distribution/tests/regression-new/pl-tutorial/2_languages/2_kool/1_untyped/kool-untyped.md
+++ b/k-distribution/tests/regression-new/pl-tutorial/2_languages/2_kool/1_untyped/kool-untyped.md
@@ -383,7 +383,7 @@ definition.
 ```k
   syntax KItem ::= "undefined"
 
-  rule <k> var X:Id; => . ...</k>
+  rule <k> var X:Id; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> undefined ...</store>
        <nextLoc> L:Int => L +Int 1 </nextLoc>
@@ -391,7 +391,7 @@ definition.
 
   context var _:Id[HOLE];
 
-  rule <k> var X:Id[N:Int]; => . ...</k>
+  rule <k> var X:Id[N:Int]; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> array(L +Int 1, N)
                           (L +Int 1) ... (L +Int N) |-> undefined ...</store>
@@ -477,13 +477,13 @@ interestingly, the semantics of return stays unchanged.
     [group(assignment)]
 
 
-  rule {} => .
+  rule {} => .K
   rule <k> { S } => S ~> setEnv(Env) ...</k>  <env> Env </env>
 
 
   rule S1::Stmt S2::Stmt => S1 ~> S2
 
-  rule _:Val; => .
+  rule _:Val; => .K
 
   rule if ( true) S else _ => S
   rule if (false) _ else S => S
@@ -492,7 +492,7 @@ interestingly, the semantics of return stays unchanged.
 
   rule <k> print(V:Val, Es => Es); ...</k> <output>... .List => ListItem(V) </output>
     [group(print)]
-  rule print(.Vals); => .
+  rule print(.Vals); => .K
 
 
   syntax KItem ::= xstackFrame(Id,Stmt,K,Map,K)
@@ -508,7 +508,7 @@ interestingly, the semantics of return stays unchanged.
        </control>
        <env> Env </env>
 
-  rule <k> popx => . ...</k>
+  rule <k> popx => .K ...</k>
        <xstack> ListItem(_) => .List ...</xstack>
 
   rule <k> throw V:Val; ~> _ => { var X = V; S2 } ~> K </k>
@@ -525,33 +525,33 @@ interestingly, the other concurrency constructs keep their semantics
 from SIMPLE unchanged.
 ```k
   // TODO(KORE): ..Bag should be . throughout this definition #1772
-  rule (<thread>... <k>.</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
+  rule (<thread>... <k>.K</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
   /*
   rule (<thread>... <k>.</k> <holds>H</holds> <id>T</id> ...</thread> => .)
   */
        <busy> Busy => Busy -Set keys(H) </busy>
        <terminated>... .Set => SetItem(T) ...</terminated>
 
-  rule <k> join T:Int; => . ...</k>
+  rule <k> join T:Int; => .K ...</k>
        <terminated>... SetItem(T) ...</terminated>
 
-  rule <k> acquire V:Val; => . ...</k>
+  rule <k> acquire V:Val; => .K ...</k>
        <holds>... .Map => V |-> 0 ...</holds>
        <busy> Busy (.Set => SetItem(V)) </busy>
     requires (notBool(V in Busy:Set))  [group(acquire)]
 
-  rule <k> acquire V; => . ...</k>
+  rule <k> acquire V; => .K ...</k>
        <holds>... V:Val |-> (N:Int => N +Int 1) ...</holds>
 
-  rule <k> release V:Val; => . ...</k>
+  rule <k> release V:Val; => .K ...</k>
        <holds>... V |-> (N => N:Int -Int 1) ...</holds>
     requires N >Int 0
 
-  rule <k> release V; => . ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
+  rule <k> release V; => .K ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
        <busy>... SetItem(V) => .Set ...</busy>
 
-  rule <k> rendezvous V:Val; => . ...</k>
-       <k> rendezvous V; => . ...</k>  [group(rendezvous)]
+  rule <k> rendezvous V:Val; => .K ...</k>
+       <k> rendezvous V; => .K ...</k>  [group(rendezvous)]
 ```
 
 ## Unchanged auxiliary operations from untyped SIMPLE
@@ -569,8 +569,8 @@ from SIMPLE unchanged.
   rule <k> lookup(L) => V ...</k> <store>... L |-> V:Val ...</store>  [group(lookup)]
 
   syntax KItem ::= setEnv(Map)
-  rule <k> setEnv(Env) => . ...</k>  <env> _ => Env </env>
-  rule (setEnv(_) => .) ~> setEnv(_)
+  rule <k> setEnv(Env) => .K ...</k>  <env> _ => Env </env>
+  rule (setEnv(_) => .K) ~> setEnv(_)
   // TODO: How can we make sure that the second rule above applies before the first one?
   //       Probably we'll deal with this using strategies, eventually.
 
@@ -705,7 +705,7 @@ environment.
 Initially, the classes forming the program are moved into their
 corresponding cells:
 ```k
-  rule <k> class Class1 extends Class2 { S } => . ...</k>
+  rule <k> class Class1 extends Class2 { S } => .K ...</k>
        <classes>... (.Bag => <classData>
                             <className> Class1 </className>
                             <baseClass> Class2 </baseClass>
@@ -731,7 +731,7 @@ This gives the KOOL programmer a lot of power; one should use this
 power wisely, though, because programs can become easily hard to
 understand and reason about if one overuses these features.
 ```k
-  rule <k> method F:Id(Xs:Ids) S => . ...</k>
+  rule <k> method F:Id(Xs:Ids) S => .K ...</k>
        <crntClass> Class:Id </crntClass>
        <location> OL:Int </location>
        <env> Env => Env[F <- L] </env>
@@ -790,7 +790,7 @@ members (both fields and methods) of that class.
        <baseClass> Class1:Id </baseClass>
        <declarations> S </declarations>
 
-  rule <k> create(Object) => . ...</k>
+  rule <k> create(Object) => .K ...</k>
 ```
 The next operation sets the current class of the current object.
 This is necessary to be done at each layer, because the current class
@@ -799,7 +799,7 @@ semantics of method declarations above).
 ```k
   syntax KItem ::= setCrntClass(Id)
 
-  rule <k> setCrntClass(C) => . ...</k>
+  rule <k> setCrntClass(C) => .K ...</k>
        <crntClass> _ => C </crntClass>
 ```
 The next operation adds a new tagged environment layer to the
@@ -809,7 +809,7 @@ empty).
 ```k
   syntax KItem ::= "addEnvLayer"
 
-  rule <k> addEnvLayer => . ...</k>
+  rule <k> addEnvLayer => .K ...</k>
        <env> Env => .Map </env>
        <crntClass> Class:Id </crntClass>
        <envStack> .List => ListItem(envStackFrame(Class, Env)) ...</envStack>
@@ -824,7 +824,7 @@ the location is unnecessary and thus we delete it from the
 ```k
   syntax KItem ::= "storeObj"
 
-  rule <k> storeObj => . ...</k>
+  rule <k> storeObj => .K ...</k>
        <crntObj> <crntClass> CC </crntClass> <envStack> ES </envStack> (<location> L:Int </location> => .Bag) </crntObj>
        <store>... .Map => L |-> objectClosure(CC, ES) ...</store>
 ```

--- a/k-distribution/tests/regression-new/pl-tutorial/2_languages/2_kool/2_typed/1_dynamic/kool-typed-dynamic.md
+++ b/k-distribution/tests/regression-new/pl-tutorial/2_languages/2_kool/2_typed/1_dynamic/kool-typed-dynamic.md
@@ -249,13 +249,13 @@ KOOL).
 
   syntax KItem ::= undefined(Type)
 
-  rule <k> T:Type X:Id; => . ...</k>
+  rule <k> T:Type X:Id; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> undefined(T) ...</store>
        <nextLoc> L:Int => L +Int 1 </nextLoc>
 
 
-  rule <k> T:Type X:Id[N:Int]; => . ...</k>
+  rule <k> T:Type X:Id[N:Int]; => .K ...</k>
        <env> Env => Env[X <- L] </env>
        <store>... .Map => L |-> array(T, L +Int 1, N)
                           (L +Int 1)...(L +Int N) |-> undefined(T) ...</store>
@@ -326,14 +326,14 @@ KOOL).
   context (HOLE => lvalue(HOLE)) = _
 
 
-  rule {} => .
+  rule {} => .K
   rule <k> { S } => S ~> setEnv(Env) ...</k>  <env> Env </env>
 
 
   rule S1:Stmt S2:Stmt => S1 ~> S2
 
 
-  rule _:Val; => .
+  rule _:Val; => .K
 
 
   rule if ( true) S else _ => S
@@ -345,33 +345,33 @@ KOOL).
 
   rule <k> print(V:Val, Es => Es); ...</k> <output>... .List => ListItem(V) </output>
     requires typeOf(V) ==K int orBool typeOf(V) ==K string  [group(print)]
-  rule print(.Vals); => .
+  rule print(.Vals); => .K
 
 
-  rule (<thread>... <k>.</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
+  rule (<thread>... <k>.K</k> <holds>H</holds> <id>T</id> ...</thread> => .Bag)
        <busy> Busy => Busy -Set keys(H) </busy>
        <terminated>... .Set => SetItem(T) ...</terminated>
 
-  rule <k> join T:Int; => . ...</k>
+  rule <k> join T:Int; => .K ...</k>
        <terminated>... SetItem(T) ...</terminated>
 
-  rule <k> acquire V:Val; => . ...</k>
+  rule <k> acquire V:Val; => .K ...</k>
        <holds>... .Map => V |-> 0 ...</holds>
        <busy> Busy (.Set => SetItem(V)) </busy>
     requires (notBool(V in Busy:Set))  [group(acquire)]
 
-  rule <k> acquire V; => . ...</k>
+  rule <k> acquire V; => .K ...</k>
        <holds>... V:Val |-> (N:Int => N +Int 1) ...</holds>
 
-  rule <k> release V:Val; => . ...</k>
+  rule <k> release V:Val; => .K ...</k>
        <holds>... V |-> (N => N:Int -Int 1) ...</holds>
     requires N >Int 0
 
-  rule <k> release V; => . ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
+  rule <k> release V; => .K ...</k> <holds>... V:Val |-> 0 => .Map ...</holds>
        <busy>... SetItem(V) => .Set ...</busy>
 
-  rule <k> rendezvous V:Val; => . ...</k>
-       <k> rendezvous V; => . ...</k>  [group(rendezvous)]
+  rule <k> rendezvous V:Val; => .K ...</k>
+       <k> rendezvous V; => .K ...</k>  [group(rendezvous)]
 ```
 
 ## Unchanged auxiliary operations from dynamically typed SIMPLE
@@ -386,8 +386,8 @@ KOOL).
   rule <k> lookup(L) => V ...</k> <store>... L |-> V:Val ...</store>  [group(lookup)]
 
   syntax KItem ::= setEnv(Map)
-  rule <k> setEnv(Env) => . ...</k>  <env> _ => Env </env>
-  rule (setEnv(_) => .) ~> setEnv(_)
+  rule <k> setEnv(Env) => .K ...</k>  <env> _ => Env </env>
+  rule (setEnv(_) => .K) ~> setEnv(_)
 
   syntax Exp ::= lvalue(K)
   syntax Val ::= loc(Int)
@@ -532,7 +532,7 @@ encountered.
        </control>
        <env> Env </env>
 
-  rule <k> popx => . ...</k>
+  rule <k> popx => .K ...</k>
        <xstack> ListItem(_) => .List ...</xstack>
 
   rule <k> throw V:Val; ~> _
@@ -568,7 +568,7 @@ Like in untyped KOOL.
 
 Like in untyped KOOL.
 ```k
-  rule <k> class Class1 extends Class2 { S } => . ...</k>
+  rule <k> class Class1 extends Class2 { S } => .K ...</k>
        <classes>... (.Bag => <classData>
                             <className> Class1 </className>
                             <baseClass> Class2 </baseClass>
@@ -584,7 +584,7 @@ closures, so that their type contract can be checked at invocation
 time.  The rule below is conceptually similar to that of untyped KOOL;
 the only difference is the addition of the types.
 ```k
-  rule <k> T:Type F:Id(Ps:Params) S => . ...</k>
+  rule <k> T:Type F:Id(Ps:Params) S => .K ...</k>
        <crntClass> C </crntClass>
        <location> OL </location>
        <env> Env => Env[F <- L] </env>
@@ -628,23 +628,23 @@ those in untyped KOOL.
        <baseClass> Class1:Id </baseClass>
        <declarations> S </declarations>
 
-  rule <k> create(Object) => . ...</k>
+  rule <k> create(Object) => .K ...</k>
 
   syntax KItem ::= setCrntClass(Id)
 
-  rule <k> setCrntClass(C) => . ...</k>
+  rule <k> setCrntClass(C) => .K ...</k>
        <crntClass> _ => C </crntClass>
 
   syntax KItem ::= "addEnvLayer"
 
-  rule <k> addEnvLayer => . ...</k>
+  rule <k> addEnvLayer => .K ...</k>
        <env> Env => .Map </env>
        <crntClass> Class:Id </crntClass>
        <envStack> .List => ListItem(envStackFrame(Class, Env)) ...</envStack>
 
   syntax KItem ::= "storeObj"
 
-  rule <k> storeObj => . ...</k>
+  rule <k> storeObj => .K ...</k>
        <crntObj>
          <crntClass> Class </crntClass>
          <envStack> EStack </envStack>
@@ -864,7 +864,7 @@ A generic computational guard: it allows the computation to continue
 only if a prefix guard evaluates to true.
 ```k
   syntax KItem ::= "true?"
-  rule true ~> true? => .
+  rule true ~> true? => .K
 
 endmodule
 ```

--- a/k-distribution/tests/regression-new/pl-tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.md
+++ b/k-distribution/tests/regression-new/pl-tutorial/2_languages/2_kool/2_typed/2_static/kool-typed-static.md
@@ -823,9 +823,9 @@ The subclass relation introduces a subtyping relation.
 ```k
   syntax KItem ::= checkSubtype(Types,Types)
 
-  rule checkSubtype(T:Type, T) => .
+  rule checkSubtype(T:Type, T) => .K
 
-  rule <k> checkSubtype(`class`(C:Id), `class`(C':Id)) => . ...</k>
+  rule <k> checkSubtype(`class`(C:Id), `class`(C':Id)) => .K ...</k>
        <className> C </className>
        <baseClasses>... SetItem(C') ...</baseClasses>
 
@@ -839,8 +839,8 @@ The subclass relation introduces a subtyping relation.
     => checkSubtype(T,T') ~> checkSubtype(Ts,Ts')
     requires Ts =/=K .Types
 
-  rule checkSubtype(.Types,.Types) => .
-  rule checkSubtype(.Types,void) => .
+  rule checkSubtype(.Types,.Types) => .K
+  rule checkSubtype(.Types,void) => .K
 ```
 
 ## Checking well-formedness of types
@@ -852,13 +852,13 @@ check that the types used in the program actually exists
 
   rule checkType(T:Type,Ts:Types) => checkType(T) ~> checkType(Ts)
     requires Ts =/=K .Types
-  rule checkType(.Types) => .
-  rule checkType(int) => .
-  rule checkType(bool) => .
-  rule checkType(string) => .
-  rule checkType(void) => .
-  rule <k> checkType(`class`(C:Id)) => . ...</k> <className> C </className>
-  rule checkType(`class`(Object)) => .
+  rule checkType(.Types) => .K
+  rule checkType(int) => .K
+  rule checkType(bool) => .K
+  rule checkType(string) => .K
+  rule checkType(void) => .K
+  rule <k> checkType(`class`(C:Id)) => .K ...</k> <className> C </className>
+  rule checkType(`class`(Object)) => .K
   rule checkType(Ts:Types -> T:Type) => checkType(T,Ts)
   rule checkType(T:Type[]) => checkType(T)
 ```
@@ -885,7 +885,7 @@ is co-variant in the codomain and contra-variant in the domain).
        <ctenv> Rho </ctenv>
     requires notBool(F in keys(Rho))
 
-  rule checkMethod(_:Id,_,Object) => .
+  rule checkMethod(_:Id,_,Object) => .K
 ```
 
 ## Generic operations which could be part of the **K** framework
@@ -894,7 +894,7 @@ is co-variant in the codomain and contra-variant in the domain).
   syntax KItem ::= stuck(K)
 
   syntax KItem ::= "discard"
-  rule _:KResult ~> discard => .
+  rule _:KResult ~> discard => .K
 
 endmodule
 ```

--- a/k-distribution/tests/regression-new/pl-tutorial/2_languages/3_fun/1_untyped/1_environment/fun-untyped.md
+++ b/k-distribution/tests/regression-new/pl-tutorial/2_languages/3_fun/1_untyped/1_environment/fun-untyped.md
@@ -563,11 +563,11 @@ making sure that the environment is properly recovered afterwards.
 If the first pattern does not match, then we drop it and thus move on
 to the next one.
 ```k
-  rule (. => getMatching(P, V)) ~> closure(_, P->_ | _) V:Val
+  rule (.K => getMatching(P, V)) ~> closure(_, P->_ | _) V:Val
   rule <k> matchResult(M:Map) ~> closure(Rho, _->E | _) _
            => bindMap(M) ~> E ~> setEnv(Rho') ...</k>
        <env> Rho' => Rho </env>
-  rule (matchFailure => .) ~> closure(_, (_->_ | Cs:Cases => Cs)) _
+  rule (matchFailure => .K) ~> closure(_, (_->_ | Cs:Cases => Cs)) _
 //  rule <k> closure(Rho, P->E | _) V:Val
 //           => bindMap(getMatching(P,V)) ~> E ~> setEnv(Rho') ...</k>
 //       <env> Rho' => Rho </env>  requires isMatching(P,V)
@@ -694,7 +694,7 @@ way to achieve the benefits of tail recursion in **K**.
 ```k
   syntax KItem ::= setEnv(Map)  // TODO: get rid of env
   //rule (setEnv(_) => .) ~> setEnv(_)  [anywhere]
-  rule <k> _:Val ~> (setEnv(Rho) => .) ...</k> <env> _ => Rho </env>
+  rule <k> _:Val ~> (setEnv(Rho) => .K) ...</k> <env> _ => Rho </env>
 ```
 
 ## `bindTo`, `bind` and `assignTo`
@@ -707,21 +707,21 @@ above.
                  | bindMap(Map)
                  | bind(Names)
 
-  rule (. => getMatchingAux(Xs,Vs)) ~> bindTo(Xs:Names,Vs:Vals)
+  rule (.K => getMatchingAux(Xs,Vs)) ~> bindTo(Xs:Names,Vs:Vals)
   rule matchResult(M:Map) ~> bindTo(_:Names, _:Vals) => bindMap(M)
 
-  rule bindMap(.Map) => .
+  rule bindMap(.Map) => .K
   rule <k> bindMap((X:Name |-> V:Val => .Map) _:Map) ...</k>
        <env> Rho => Rho[X <- !L:Int] </env>
        <store>... .Map => !L |-> V ...</store>
 
-  rule bind(.Names) => .
+  rule bind(.Names) => .K
   rule <k> bind(X:Name,Xs => Xs) ...</k>
        <env> Rho => Rho[X <- !_L:Int] </env>
 
   syntax KItem ::= assignTo(Names,Exps)  [strict(2)]
 
-  rule <k> assignTo(.Names,.Vals) => . ...</k>
+  rule <k> assignTo(.Names,.Vals) => .K ...</k>
   rule <k> assignTo((X:Name,Xs => Xs),(V:Val,Vs:Vals => Vs)) ...</k>
        <env>... X |-> L ...</env>
        <store>... .Map => L |-> V ...</store>

--- a/k-distribution/tests/regression-new/proof-tests/deposit/test/deposit.k
+++ b/k-distribution/tests/regression-new/proof-tests/deposit/test/deposit.k
@@ -49,7 +49,7 @@ rule <k> initConfigLoop(I, N) => initConfigLoop(I +Int 1, N) ... </k>
      <branch>     B => B[I <- 0] </branch>
      requires I <Int N
 
-rule initConfigLoop(I, N) => . requires I >=Int N
+rule initConfigLoop(I, N) => .K requires I >=Int N
 
 
 /*
@@ -68,7 +68,7 @@ rule <k> initLoop(I,        N)
      <zerohashes> Z => Z[I +Int 1 <- hash(Z[I], Z[I])] </zerohashes>
      requires I <Int N
 
-rule initLoop(I, N) => . requires I >=Int N
+rule initLoop(I, N) => .K requires I >=Int N
 
 
 /*
@@ -97,12 +97,12 @@ rule <k> depositLoop(I,        N, Size,        Value)
      requires I <Int N
       andBool Size %Int 2 =/=Int 1
 
-rule <k> depositLoop(I, N, Size, Value) => . ... </k>
+rule <k> depositLoop(I, N, Size, Value) => .K ... </k>
      <branch> B => B[I <- Value] </branch>
      requires I <Int N
       andBool Size %Int 2 ==Int 1
 
-rule <k> depositLoop(I, N, _Size, Value) => . ... </k>
+rule <k> depositLoop(I, N, _Size, Value) => .K ... </k>
      <branch> B => B[I <- Value] </branch>
      requires I >=Int N
 //     orBool Size %Int 2 ==Int 1

--- a/k-distribution/tests/regression-new/rand/rand.k
+++ b/k-distribution/tests/regression-new/rand/rand.k
@@ -16,6 +16,6 @@ module RAND
 
   rule <k> I ; P => srandInt(I) ~> runRand() ~> P ... </k>
 
-  rule <k> runRand() => . ... </k>
+  rule <k> runRand() => .K ... </k>
        <rands> ... .List => ListItem(randInt(1000)) </rands>
 endmodule

--- a/k-distribution/tests/regression-new/star-multiplicity/test.k
+++ b/k-distribution/tests/regression-new/star-multiplicity/test.k
@@ -17,7 +17,7 @@ module TEST
 
     syntax KItem ::= "#putCells"
  // ----------------------------
-    rule <k> #putCells => . ... </k>
+    rule <k> #putCells => .K ... </k>
          <cells>
            (.Bag => #makeCell(0, 1))
            (.Bag => <cell> <num> 5 </num> <data> 6 </data> </cell>)


### PR DESCRIPTION
This is an initial change to minimise any fallout from making `.` a deprecated symbol; it's a bulk change of uses of the unadorned `.` in the K regression test suite to instead use `.K`.

Once this is merged, we can start to think about doing a similar change for downstream semantics, then finally deprecating and removing the symbol.

Part of: https://github.com/runtimeverification/k/issues/3964