### PR TITLE
Remove `Att` methods based on `Class` rather than `Att.Key`

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellRewriter.java
@@ -151,7 +151,8 @@ public record HaskellRewriter(
         if (patternTerm instanceof KVariable) {
           patternTerm =
               KORE.KVariable(
-                  ((KVariable) patternTerm).name(), Att.empty().add(Sort.class, initializerSort));
+                  ((KVariable) patternTerm).name(),
+                  Att.empty().add(Att.SORT(), Sort.class, initializerSort));
         }
         K patternCondition = pattern.requires();
         String patternTermKore =

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -161,7 +161,7 @@ public class ModuleToKORE {
     // insert the location of the main module so the backend can provide better error location
     convert(
         considerSource,
-        Att.empty().add(Source.class, module.att().get(Source.class)),
+        Att.empty().add(Att.SOURCE(), Source.class, module.att().get(Source.class)),
         sb,
         null,
         null);
@@ -671,7 +671,7 @@ public class ModuleToKORE {
     // #Ceil(@K1) and #Ceil(@Rest).
     // [simplification]
 
-    K restMapSet = KVariable("@Rest", Att.empty().add(Sort.class, mapSort));
+    K restMapSet = KVariable("@Rest", Att.empty().add(Att.SORT(), Sort.class, mapSort));
     KLabel ceilMapLabel = KLabel(KLabels.ML_CEIL.name(), mapSort, sortParam);
     KLabel andLabel = KLabel(KLabels.ML_AND.name(), sortParam);
 
@@ -680,7 +680,7 @@ public class ModuleToKORE {
     K setArgsCeil = KApply(KLabel(KLabels.ML_TRUE.name(), sortParam));
     for (int i = 0; i < nonterminals.length(); i++) {
       Sort sort = nonterminals.apply(i).sort();
-      KVariable setVar = KVariable("@K" + i, Att.empty().add(Sort.class, sort));
+      KVariable setVar = KVariable("@K" + i, Att.empty().add(Att.SORT(), Sort.class, sort));
       setArgs.add(setVar);
       if (i > 0) {
         KLabel ceil = KLabel(KLabels.ML_CEIL.name(), sort, sortParam);
@@ -959,7 +959,7 @@ public class ModuleToKORE {
     considerSource.put(Att.SOURCE(), true);
     convert(
         considerSource,
-        Att.empty().add(Source.class, spec.att().get(Source.class)),
+        Att.empty().add(Att.SOURCE(), Source.class, spec.att().get(Source.class)),
         sb,
         null,
         null);

--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -161,7 +161,7 @@ public class ModuleToKORE {
     // insert the location of the main module so the backend can provide better error location
     convert(
         considerSource,
-        Att.empty().add(Att.SOURCE(), Source.class, module.att().get(Source.class)),
+        Att.empty().add(Att.SOURCE(), Source.class, module.att().get(Att.SOURCE(), Source.class)),
         sb,
         null,
         null);
@@ -959,7 +959,7 @@ public class ModuleToKORE {
     considerSource.put(Att.SOURCE(), true);
     convert(
         considerSource,
-        Att.empty().add(Att.SOURCE(), Source.class, spec.att().get(Source.class)),
+        Att.empty().add(Att.SOURCE(), Source.class, spec.att().get(Att.SOURCE(), Source.class)),
         sb,
         null,
         null);
@@ -1454,7 +1454,7 @@ public class ModuleToKORE {
     String conn = "";
     for (KVariable var : freeVars) {
       sb.append(conn);
-      convert(var.att().getOptional(Sort.class).orElse(Sorts.K()), sb);
+      convert(var.att().getOptional(Att.SORT(), Sort.class).orElse(Sorts.K()), sb);
       conn = ",";
     }
     sb.append(") : ");
@@ -2218,7 +2218,7 @@ public class ModuleToKORE {
       public void apply(KSequence k) {
         for (int i = 0; i < k.items().size(); i++) {
           K item = k.items().get(i);
-          boolean isList = item.att().get(Sort.class).equals(Sorts.K());
+          boolean isList = item.att().get(Att.SORT(), Sort.class).equals(Sorts.K());
           if (i == k.items().size() - 1) {
             if (isList) {
               apply(item);
@@ -2228,7 +2228,7 @@ public class ModuleToKORE {
               sb.append(",dotk{}())");
             }
           } else {
-            if (item.att().get(Sort.class).equals(Sorts.K())) {
+            if (item.att().get(Att.SORT(), Sort.class).equals(Sorts.K())) {
               sb.append("append{}(");
             } else {
               sb.append("kseq{}(");
@@ -2255,13 +2255,13 @@ public class ModuleToKORE {
         String name = setVar ? k.name().substring(1) : k.name();
         convert(name, sb);
         sb.append(":");
-        convert(k.att().getOptional(Sort.class).orElse(Sorts.K()), sb);
+        convert(k.att().getOptional(Att.SORT(), Sort.class).orElse(Sorts.K()), sb);
       }
 
       @Override
       public void apply(KRewrite k) {
         sb.append("\\rewrites{");
-        convert(k.att().get(Sort.class), sb);
+        convert(k.att().get(Att.SORT(), Sort.class), sb);
         sb.append("}(");
         apply(k.left());
         sb.append(",");
@@ -2271,7 +2271,7 @@ public class ModuleToKORE {
 
       @Override
       public void apply(KAs k) {
-        Sort sort = k.att().get(Sort.class);
+        Sort sort = k.att().get(Att.SORT(), Sort.class);
         sb.append("\\and{");
         convert(sort, sb);
         sb.append("}(");

--- a/kernel/src/main/java/org/kframework/compile/AddParentCells.java
+++ b/kernel/src/main/java/org/kframework/compile/AddParentCells.java
@@ -19,6 +19,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.kframework.attributes.Att;
 import org.kframework.builtin.KLabels;
 import org.kframework.definition.Context;
 import org.kframework.definition.RuleOrClaim;
@@ -184,7 +185,7 @@ public class AddParentCells {
       return getLevel((KApply) k);
     } else if (k instanceof KVariable) {
       if (k.att().contains(Sort.class)) {
-        Sort sort = k.att().get(Sort.class);
+        Sort sort = k.att().get(Att.SORT(), Sort.class);
         int level = cfg.cfg().getLevel(sort);
         if (level >= 0) {
           return Optional.of(level);
@@ -239,7 +240,7 @@ public class AddParentCells {
         return Optional.empty();
       }
     } else if (k instanceof KVariable) {
-      Sort sort = k.att().get(Sort.class);
+      Sort sort = k.att().get(Att.SORT(), Sort.class);
       return Optional.of(cfg.getParent(sort));
     } else {
       Optional<KLabel> leftParent = getParent(((KRewrite) k).left());

--- a/kernel/src/main/java/org/kframework/compile/AddParentCells.java
+++ b/kernel/src/main/java/org/kframework/compile/AddParentCells.java
@@ -184,7 +184,7 @@ public class AddParentCells {
     if (k instanceof KApply) {
       return getLevel((KApply) k);
     } else if (k instanceof KVariable) {
-      if (k.att().contains(Sort.class)) {
+      if (k.att().contains(Att.SORT(), Sort.class)) {
         Sort sort = k.att().get(Att.SORT(), Sort.class);
         int level = cfg.cfg().getLevel(sort);
         if (level >= 0) {

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -135,7 +135,7 @@ public class AddSortInjections {
             KApply(
                 KLabel("inj", actualSort, Sorts.KItem()),
                 KList(visitChildren(term, actualSort, expectedSort)),
-                Att.empty().add(Sort.class, Sorts.KItem())));
+                Att.empty().add(Att.SORT(), Sort.class, Sorts.KItem())));
       }
     } else {
       String hookAtt =
@@ -184,12 +184,12 @@ public class AddSortInjections {
                     KList(
                         visitChildren(key, actualKeySort, expectedKeySort),
                         visitChildren(k, actualSort, expectedSort)),
-                    Att.empty().add(Sort.class, expectedSort));
+                    Att.empty().add(Att.SORT(), Sort.class, expectedSort));
               } else {
                 return KApply(
                     elementLabel,
                     KList(visitChildren(k, actualSort, expectedSort)),
-                    Att.empty().add(Sort.class, expectedSort));
+                    Att.empty().add(Att.SORT(), Sort.class, expectedSort));
               }
             }
           }
@@ -198,7 +198,7 @@ public class AddSortInjections {
       return KApply(
           KLabel("inj", actualSort, expectedSort),
           KList(visitChildren(term, actualSort, expectedSort)),
-          Att.empty().add(Sort.class, expectedSort));
+          Att.empty().add(Att.SORT(), Sort.class, expectedSort));
     }
   }
 
@@ -208,7 +208,7 @@ public class AddSortInjections {
   }
 
   private K visitChildren(K term, Sort actualSort, Sort expectedSort) {
-    Att att = term.att().add(Sort.class, actualSort);
+    Att att = term.att().add(Att.SORT(), Sort.class, actualSort);
     if (actualSort.name().equals(SORTPARAM_NAME)) {
       sortParams.add(actualSort.params().head().name());
     }

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -168,7 +168,7 @@ public class AddSortInjections {
                 }
                 Sort adjustedExpectedSort = expectedSort;
                 if (k.att().contains(Sort.class)) {
-                  adjustedExpectedSort = k.att().get(Sort.class);
+                  adjustedExpectedSort = k.att().get(Att.SORT(), Sort.class);
                 }
                 Production prod = production(k);
                 Production substituted =
@@ -217,7 +217,7 @@ public class AddSortInjections {
         return term;
       }
       if (kapp.att().contains(Sort.class)) {
-        expectedSort = kapp.att().get(Sort.class);
+        expectedSort = kapp.att().get(Att.SORT(), Sort.class);
       }
       Production prod = production(kapp);
       List<K> children = new ArrayList<>();
@@ -377,7 +377,7 @@ public class AddSortInjections {
         return Sorts.Bool();
       }
       if (kapp.att().contains(Sort.class)) {
-        expectedSort = kapp.att().get(Sort.class);
+        expectedSort = kapp.att().get(Att.SORT(), Sort.class);
       }
       Production prod = production(kapp);
       Production substituted = prod;
@@ -418,7 +418,7 @@ public class AddSortInjections {
     } else if (term instanceof KToken) {
       return ((KToken) term).sort();
     } else if (term instanceof KVariable) {
-      return term.att().getOptional(Sort.class).orElse(Sorts.K());
+      return term.att().getOptional(Att.SORT(), Sort.class).orElse(Sorts.K());
     } else if (term instanceof KSequence) {
       return Sorts.K();
     } else if (term instanceof InjectedKLabel) {

--- a/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/kernel/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -167,7 +167,7 @@ public class AddSortInjections {
                           KList(visitChildren(k, actualSort, expectedSort)));
                 }
                 Sort adjustedExpectedSort = expectedSort;
-                if (k.att().contains(Sort.class)) {
+                if (k.att().contains(Att.SORT(), Sort.class)) {
                   adjustedExpectedSort = k.att().get(Att.SORT(), Sort.class);
                 }
                 Production prod = production(k);
@@ -216,7 +216,7 @@ public class AddSortInjections {
       if (kapp.klabel().name().equals("inj")) {
         return term;
       }
-      if (kapp.att().contains(Sort.class)) {
+      if (kapp.att().contains(Att.SORT(), Sort.class)) {
         expectedSort = kapp.att().get(Att.SORT(), Sort.class);
       }
       Production prod = production(kapp);
@@ -376,7 +376,7 @@ public class AddSortInjections {
       if (kapp.klabel().name().equals("_:/=K_")) {
         return Sorts.Bool();
       }
-      if (kapp.att().contains(Sort.class)) {
+      if (kapp.att().contains(Att.SORT(), Sort.class)) {
         expectedSort = kapp.att().get(Att.SORT(), Sort.class);
       }
       Production prod = production(kapp);

--- a/kernel/src/main/java/org/kframework/compile/CloseCells.java
+++ b/kernel/src/main/java/org/kframework/compile/CloseCells.java
@@ -291,7 +291,7 @@ public class CloseCells {
     if (item instanceof KApply) {
       required.remove(labelInfo.getCodomain(((KApply) item).klabel()));
     } else if (item instanceof KVariable) {
-      if (item.att().contains(Sort.class)) {
+      if (item.att().contains(Att.SORT(), Sort.class)) {
         Sort sort = item.att().get(Att.SORT(), Sort.class);
         if (cfg.cfg().isCell(sort)) {
           required.remove(sort);

--- a/kernel/src/main/java/org/kframework/compile/CloseCells.java
+++ b/kernel/src/main/java/org/kframework/compile/CloseCells.java
@@ -86,7 +86,8 @@ public class CloseCells {
         newLabel = KVariable("_DotVar" + (counter++), Att().add(Att.ANONYMOUS()));
       } else {
         newLabel =
-            KVariable("_DotVar" + (counter++), Att().add(Att.ANONYMOUS()).add(Sort.class, s));
+            KVariable(
+                "_DotVar" + (counter++), Att().add(Att.ANONYMOUS()).add(Att.SORT(), Sort.class, s));
       }
     } while (vars.contains(newLabel));
     vars.add(newLabel);

--- a/kernel/src/main/java/org/kframework/compile/CloseCells.java
+++ b/kernel/src/main/java/org/kframework/compile/CloseCells.java
@@ -292,7 +292,7 @@ public class CloseCells {
       required.remove(labelInfo.getCodomain(((KApply) item).klabel()));
     } else if (item instanceof KVariable) {
       if (item.att().contains(Sort.class)) {
-        Sort sort = item.att().get(Sort.class);
+        Sort sort = item.att().get(Att.SORT(), Sort.class);
         if (cfg.cfg().isCell(sort)) {
           required.remove(sort);
         } else {

--- a/kernel/src/main/java/org/kframework/compile/ConcretizationInfo.java
+++ b/kernel/src/main/java/org/kframework/compile/ConcretizationInfo.java
@@ -4,6 +4,7 @@ package org.kframework.compile;
 import static org.kframework.kore.KORE.*;
 
 import java.util.List;
+import org.kframework.attributes.Att;
 import org.kframework.kore.K;
 import org.kframework.kore.KApply;
 import org.kframework.kore.KLabel;
@@ -18,7 +19,7 @@ public record ConcretizationInfo(ConfigurationInfo cfg, LabelInfo labels) {
     if (k instanceof KApply) {
       return labels.getCodomain(((KApply) k).klabel());
     } else if (k instanceof KVariable) {
-      return k.att().get(Sort.class);
+      return k.att().get(Att.SORT(), Sort.class);
     } else {
       throw new AssertionError(
           "expected KApply or KVariable, found " + k.getClass().getSimpleName());

--- a/kernel/src/main/java/org/kframework/compile/ConcretizeCells.java
+++ b/kernel/src/main/java/org/kframework/compile/ConcretizeCells.java
@@ -69,7 +69,8 @@ public class ConcretizeCells {
 
   public static boolean hasCells(K item) {
     if (IncompleteCellUtils.flattenCells(item).stream()
-        .anyMatch(k -> k.att().get(Production.class).att().contains(Att.CELL()))) {
+        .anyMatch(
+            k -> k.att().get(Att.PRODUCTION(), Production.class).att().contains(Att.CELL()))) {
       return true;
     }
 

--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -389,7 +389,7 @@ public class ExpandMacros {
       if (subst.containsKey(pattern)) {
         return subst.get(pattern).equals(subject);
       } else {
-        if (pattern.att().contains(Sort.class)) {
+        if (pattern.att().contains(Att.SORT(), Sort.class)) {
           Sort patternSort = pattern.att().get(Att.SORT(), Sort.class);
           if (sort(subject, r).stream()
               .anyMatch(s -> s == null || mod.subsorts().lessThanEq(s, patternSort))) {

--- a/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
+++ b/kernel/src/main/java/org/kframework/compile/ExpandMacros.java
@@ -345,7 +345,7 @@ public class ExpandMacros {
 
   private Set<Sort> sort(K k, RuleOrClaim r) {
     if (k instanceof KVariable) {
-      return Collections.singleton(k.att().getOptional(Sort.class).orElse(null));
+      return Collections.singleton(k.att().getOptional(Att.SORT(), Sort.class).orElse(null));
     } else if (k instanceof KToken) {
       return Collections.singleton(((KToken) k).sort());
     } else if (k instanceof KApply kapp) {
@@ -390,7 +390,7 @@ public class ExpandMacros {
         return subst.get(pattern).equals(subject);
       } else {
         if (pattern.att().contains(Sort.class)) {
-          Sort patternSort = pattern.att().get(Sort.class);
+          Sort patternSort = pattern.att().get(Att.SORT(), Sort.class);
           if (sort(subject, r).stream()
               .anyMatch(s -> s == null || mod.subsorts().lessThanEq(s, patternSort))) {
             subst.put((KVariable) pattern, subject);

--- a/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateCoverage.java
@@ -16,7 +16,7 @@ import org.kframework.utils.file.FileUtil;
 public record GenerateCoverage(boolean cover, FileUtil files) {
 
   public K gen(RuleOrClaim r, K body, Module mod) {
-    if (!cover || r.att().getOptional(Source.class).isEmpty()) {
+    if (!cover || r.att().getOptional(Att.SOURCE(), Source.class).isEmpty()) {
       return body;
     }
     K left = RewriteToTop.toLeft(body);

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -106,7 +106,7 @@ public class GenerateSentencesFromConfigDecl {
                 K cellContents = kapp.klist().items().get(2);
                 Att att = cfgAtt;
                 if (kapp.att().contains(Location.class))
-                  att = cfgAtt.add(Location.class, kapp.att().get(Location.class));
+                  att = cfgAtt.add(Att.LOCATION(), Location.class, kapp.att().get(Location.class));
                 Tuple4<Set<Sentence>, List<Sort>, K, Boolean> childResult =
                     genInternal(cellContents, null, att, m);
 
@@ -335,7 +335,8 @@ public class GenerateSentencesFromConfigDecl {
         h.sentences);
   }
 
-  private static final KVariable INIT = KVariable("Init", Att.empty().add(Sort.class, Sorts.Map()));
+  private static final KVariable INIT =
+      KVariable("Init", Att.empty().add(Att.SORT(), Sort.class, Sorts.Map()));
 
   /**
    * Generates the sentences associated with a particular cell.
@@ -659,7 +660,8 @@ public class GenerateSentencesFromConfigDecl {
                     NonTerminal(sort),
                     Terminal(")")),
                 Att().add(Att.FUNCTION()).add(Att.TOTAL()));
-        KVariable key = KVariable("Key", Att.empty().add(Sort.class, childSorts.get(0)));
+        KVariable key =
+            KVariable("Key", Att.empty().add(Att.SORT(), Sort.class, childSorts.get(0)));
         Rule cellMapKeyRule =
             Rule(
                 KRewrite(
@@ -721,7 +723,7 @@ public class GenerateSentencesFromConfigDecl {
                   Terminal(")")),
               Att.empty().add(Att.FUNCTION()));
       sentences.add(getExitCode);
-      KVariable var = KVariable("Exit", Att.empty().add(Sort.class, Sorts.Int()));
+      KVariable var = KVariable("Exit", Att.empty().add(Att.SORT(), Sort.class, Sorts.Int()));
       Rule getExitCodeRule =
           Rule(
               KRewrite(

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -106,7 +106,11 @@ public class GenerateSentencesFromConfigDecl {
                 K cellContents = kapp.klist().items().get(2);
                 Att att = cfgAtt;
                 if (kapp.att().contains(Location.class))
-                  att = cfgAtt.add(Att.LOCATION(), Location.class, kapp.att().get(Location.class));
+                  att =
+                      cfgAtt.add(
+                          Att.LOCATION(),
+                          Location.class,
+                          kapp.att().get(Att.LOCATION(), Location.class));
                 Tuple4<Set<Sentence>, List<Sort>, K, Boolean> childResult =
                     genInternal(cellContents, null, att, m);
 
@@ -201,7 +205,7 @@ public class GenerateSentencesFromConfigDecl {
       // child of a leaf cell. Generate no productions, but inform parent that it has a child of a
       // particular sort.
       // A leaf cell initializes to the value specified in the configuration declaration.
-      Sort sort = kapp.att().get(Production.class).sort();
+      Sort sort = kapp.att().get(Att.PRODUCTION(), Production.class).sort();
       Tuple2<K, Set<Sentence>> res = getLeafInitializer(term);
       return Tuple4.apply(res._2(), Lists.newArrayList(sort), res._1(), true);
     } else if (term instanceof KToken ktoken) {
@@ -311,7 +315,7 @@ public class GenerateSentencesFromConfigDecl {
           @Override
           public K apply(KApply k) {
             if (k.klabel().name().startsWith("#SemanticCastTo")) {
-              sort = k.att().get(Production.class).sort();
+              sort = k.att().get(Att.PRODUCTION(), Production.class).sort();
             }
             return super.apply(k);
           }

--- a/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSentencesFromConfigDecl.java
@@ -105,7 +105,7 @@ public class GenerateSentencesFromConfigDecl {
 
                 K cellContents = kapp.klist().items().get(2);
                 Att att = cfgAtt;
-                if (kapp.att().contains(Location.class))
+                if (kapp.att().contains(Att.LOCATION(), Location.class))
                   att =
                       cfgAtt.add(
                           Att.LOCATION(),

--- a/kernel/src/main/java/org/kframework/compile/GenerateSortPredicateRules.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSortPredicateRules.java
@@ -59,7 +59,9 @@ public class GenerateSortPredicateRules {
       res.add(
           Rule(
               KRewrite(
-                  KApply(KLabel("is" + sort), KVariable(sort.name(), Att().add(Sort.class, sort))),
+                  KApply(
+                      KLabel("is" + sort),
+                      KVariable(sort.name(), Att().add(Att.SORT(), Sort.class, sort))),
                   BooleanUtils.TRUE),
               BooleanUtils.TRUE,
               BooleanUtils.TRUE));

--- a/kernel/src/main/java/org/kframework/compile/GenerateSortProjections.java
+++ b/kernel/src/main/java/org/kframework/compile/GenerateSortProjections.java
@@ -71,7 +71,7 @@ public class GenerateSortProjections {
       return Stream.empty();
     }
     KLabel lbl = getProjectLbl(sort);
-    KVariable var = KVariable("K", Att.empty().add(Sort.class, sort));
+    KVariable var = KVariable("K", Att.empty().add(Att.SORT(), Sort.class, sort));
     Rule r =
         Rule(
             KRewrite(KApply(lbl, var), var),
@@ -105,7 +105,9 @@ public class GenerateSortProjections {
           Rule(
               KRewrite(
                   KApply(
-                      sideEffectLbl, KVariable("K2", Att.empty().add(Sort.class, Sorts.K())), var),
+                      sideEffectLbl,
+                      KVariable("K2", Att.empty().add(Att.SORT(), Sort.class, Sorts.K())),
+                      var),
                   var),
               BooleanUtils.TRUE,
               BooleanUtils.TRUE);
@@ -125,7 +127,7 @@ public class GenerateSortProjections {
     int i = 0;
     boolean hasName = false;
     for (NonTerminal nt : iterable(prod.nonterminals())) {
-      vars.add(KVariable("K" + i++, Att.empty().add(Sort.class, nt.sort())));
+      vars.add(KVariable("K" + i++, Att.empty().add(Att.SORT(), Sort.class, nt.sort())));
       hasName = hasName || nt.name().isDefined();
     }
     if (!hasName) {

--- a/kernel/src/main/java/org/kframework/compile/GuardOrPatterns.java
+++ b/kernel/src/main/java/org/kframework/compile/GuardOrPatterns.java
@@ -93,7 +93,9 @@ public class GuardOrPatterns {
     }
     KVariable newLabel;
     do {
-      newLabel = KVariable("_Gen" + (counter++), Att().add(Att.ANONYMOUS()).add(Sort.class, s));
+      newLabel =
+          KVariable(
+              "_Gen" + (counter++), Att().add(Att.ANONYMOUS()).add(Att.SORT(), Sort.class, s));
     } while (vars.contains(newLabel));
     vars.add(newLabel);
     return newLabel;

--- a/kernel/src/main/java/org/kframework/compile/MinimizeTermConstruction.java
+++ b/kernel/src/main/java/org/kframework/compile/MinimizeTermConstruction.java
@@ -171,7 +171,7 @@ public class MinimizeTermConstruction {
             return KAs(
                 super.apply(k),
                 cache.get(k),
-                Att.empty().add(Sort.class, cache.get(k).att().get(Sort.class)));
+                Att.empty().add(Att.SORT(), Sort.class, cache.get(k).att().get(Sort.class)));
           }
         }
         return super.apply(k);
@@ -218,7 +218,7 @@ public class MinimizeTermConstruction {
   KVariable newDotVariable(Sort sort) {
     KVariable newLabel;
     do {
-      newLabel = KVariable("_Gen" + (counter++), Att().add(Sort.class, sort));
+      newLabel = KVariable("_Gen" + (counter++), Att().add(Att.SORT(), Sort.class, sort));
     } while (vars.contains(newLabel));
     vars.add(newLabel);
     return newLabel;

--- a/kernel/src/main/java/org/kframework/compile/MinimizeTermConstruction.java
+++ b/kernel/src/main/java/org/kframework/compile/MinimizeTermConstruction.java
@@ -171,7 +171,8 @@ public class MinimizeTermConstruction {
             return KAs(
                 super.apply(k),
                 cache.get(k),
-                Att.empty().add(Att.SORT(), Sort.class, cache.get(k).att().get(Sort.class)));
+                Att.empty()
+                    .add(Att.SORT(), Sort.class, cache.get(k).att().get(Att.SORT(), Sort.class)));
           }
         }
         return super.apply(k);

--- a/kernel/src/main/java/org/kframework/compile/ResolveAnonVar.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveAnonVar.java
@@ -122,9 +122,16 @@ public class ResolveAnonVar {
     KVariable newLabel;
     Att locInfo =
         Optional.of(Att())
-            .flatMap(att -> k.att().getOptional(Source.class).map(s -> att.add(Source.class, s)))
             .flatMap(
-                att -> k.att().getOptional(Location.class).map(l -> att.add(Location.class, l)))
+                att ->
+                    k.att()
+                        .getOptional(Source.class)
+                        .map(s -> att.add(Att.SOURCE(), Source.class, s)))
+            .flatMap(
+                att ->
+                    k.att()
+                        .getOptional(Location.class)
+                        .map(l -> att.add(Att.LOCATION(), Location.class, l)))
             .orElse(Att());
     Att att = Att().add(Att.ANONYMOUS()).addAll(locInfo);
     if (prefix.equals("?")) {

--- a/kernel/src/main/java/org/kframework/compile/ResolveAnonVar.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveAnonVar.java
@@ -125,12 +125,12 @@ public class ResolveAnonVar {
             .flatMap(
                 att ->
                     k.att()
-                        .getOptional(Source.class)
+                        .getOptional(Att.SOURCE(), Source.class)
                         .map(s -> att.add(Att.SOURCE(), Source.class, s)))
             .flatMap(
                 att ->
                     k.att()
-                        .getOptional(Location.class)
+                        .getOptional(Att.LOCATION(), Location.class)
                         .map(l -> att.add(Att.LOCATION(), Location.class, l)))
             .orElse(Att());
     Att att = Att().add(Att.ANONYMOUS()).addAll(locInfo);

--- a/kernel/src/main/java/org/kframework/compile/ResolveComm.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveComm.java
@@ -87,8 +87,8 @@ public record ResolveComm(KExceptionManager kem) {
                   "Used 'comm' attribute on simplification rule but "
                       + k.klabel().name()
                       + " is not comm.",
-                  k.att().getOptional(Source.class).orElse(null),
-                  k.att().getOptional(Location.class).orElse(null)));
+                  k.att().getOptional(Att.SOURCE(), Source.class).orElse(null),
+                  k.att().getOptional(Att.LOCATION(), Location.class).orElse(null)));
         return k;
       }
     }.apply(body);

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConfigConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConfigConstants.java
@@ -47,7 +47,7 @@ public class ResolveFreshConfigConstants {
       @Override
       public K apply(KVariable k) {
         if (k.name().startsWith("!")) {
-          if (!k.att().get(Sort.class).equals(Sorts.Int())) {
+          if (!k.att().get(Att.SORT(), Sort.class).equals(Sorts.Int())) {
             throw KEMException.compilerError(
                 "Can't resolve fresh configuration variable not of sort Int", k);
           }

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
@@ -133,7 +133,7 @@ public class ResolveFreshConstants {
       @Override
       public K apply(KVariable k) {
         if (freshVars.contains(k)) {
-          Optional<Sort> s = k.att().getOptional(Sort.class);
+          Optional<Sort> s = k.att().getOptional(Att.SORT(), Sort.class);
           if (s.isEmpty()) {
             throw KEMException.compilerError("Fresh constant used without a declared sort.", k);
           }

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
@@ -126,7 +126,7 @@ public class ResolveFreshConstants {
   }
 
   private static final KVariable FRESH =
-      KVariable("#Fresh", Att.empty().add(Sort.class, Sorts.Int()));
+      KVariable("#Fresh", Att.empty().add(Att.SORT(), Sort.class, Sorts.Int()));
 
   private K transform(K term) {
     return new TransformK() {
@@ -244,9 +244,11 @@ public class ResolveFreshConstants {
                         KLabels.GENERATED_TOP_CELL,
                         true,
                         KVariable(
-                            "Cell", Att.empty().add(Sort.class, Sorts.GeneratedCounterCell())),
+                            "Cell",
+                            Att.empty().add(Att.SORT(), Sort.class, Sorts.GeneratedCounterCell())),
                         true)),
-                KVariable("Cell", Att.empty().add(Sort.class, Sorts.GeneratedCounterCell()))),
+                KVariable(
+                    "Cell", Att.empty().add(Att.SORT(), Sort.class, Sorts.GeneratedCounterCell()))),
             BooleanUtils.TRUE,
             BooleanUtils.TRUE));
 

--- a/kernel/src/main/java/org/kframework/compile/ResolveFun.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFun.java
@@ -237,7 +237,7 @@ public class ResolveFun {
     pis.add(NonTerminal(arg));
     for (KVariable var : closure(k)) {
       pis.add(Terminal(","));
-      pis.add(NonTerminal(var.att().getOptional(Sort.class).orElse(Sorts.K())));
+      pis.add(NonTerminal(var.att().getOptional(Att.SORT(), Sort.class).orElse(Sorts.K())));
     }
     pis.add(Terminal(")"));
     return Production(fun, rhs, immutable(pis), att.add(Att.FUNCTION()));

--- a/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFunctionWithConfig.java
@@ -61,7 +61,9 @@ public class ResolveFunctionWithConfig {
     new ConfigurationInfoFromModule(mod);
     topCell = Sorts.GeneratedTopCell();
     topCellLabel = KLabels.GENERATED_TOP_CELL;
-    CONFIG_VAR = KVariable("#Configuration", Att().add(Sort.class, topCell).add(Att.WITH_CONFIG()));
+    CONFIG_VAR =
+        KVariable(
+            "#Configuration", Att().add(Att.SORT(), Sort.class, topCell).add(Att.WITH_CONFIG()));
   }
 
   private boolean ruleNeedsConfig(RuleOrClaim r) {

--- a/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveIOStreams.java
@@ -324,7 +324,7 @@ public record ResolveIOStreams(Definition definition, KExceptionManager kem) {
             sorts.add(sort);
           } else {
             if (k.att()
-                .getOption(Location.class)
+                .getOption(Att.LOCATION(), Location.class)
                 .isDefined()) { // warning only for user-provided rules
               throw KEMException.compilerError(
                   "Unsupported matching pattern in stdin stream cell.\n"

--- a/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.kframework.attributes.Att;
 import org.kframework.builtin.BooleanUtils;
 import org.kframework.definition.Context;
 import org.kframework.definition.RuleOrClaim;
@@ -112,7 +113,8 @@ public class ResolveSemanticCasts {
                     var.name(),
                     var.att().contains(Sort.class)
                         ? var.att()
-                        : var.att().add(Sort.class, Outer.parseSort(getSortNameOfCast(v)))));
+                        : var.att()
+                            .add(Att.SORT(), Sort.class, Outer.parseSort(getSortNameOfCast(v)))));
           }
         }
         super.apply(v);
@@ -137,7 +139,7 @@ public class ResolveSemanticCasts {
           applied = super.apply(k);
         }
         if (oldSort != null) {
-          return new AddAtt(a -> a.add(Sort.class, oldSort)).apply(applied);
+          return new AddAtt(a -> a.add(Att.SORT(), Sort.class, oldSort)).apply(applied);
         }
         if (varToTypedVar.containsKey(applied)) {
           return varToTypedVar.get(applied);

--- a/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveSemanticCasts.java
@@ -111,7 +111,7 @@ public class ResolveSemanticCasts {
                 var,
                 KVariable(
                     var.name(),
-                    var.att().contains(Sort.class)
+                    var.att().contains(Att.SORT(), Sort.class)
                         ? var.att()
                         : var.att()
                             .add(Att.SORT(), Sort.class, Outer.parseSort(getSortNameOfCast(v)))));

--- a/kernel/src/main/java/org/kframework/compile/SortCells.java
+++ b/kernel/src/main/java/org/kframework/compile/SortCells.java
@@ -191,16 +191,22 @@ public class SortCells {
         if (cfg.getMultiplicity(s) == Multiplicity.STAR) {
           split =
               ImmutableMap.of(
-                  s, KVariable(var.name(), var.att().add(Sort.class, getPredicateSort(s))));
+                  s,
+                  KVariable(
+                      var.name(), var.att().add(Att.SORT(), Sort.class, getPredicateSort(s))));
         } else {
           split =
               ImmutableMap.of(
-                  s, KVariable(var.name(), var.att().add(Sort.class, s).add(Att.CELL_SORT())));
+                  s,
+                  KVariable(
+                      var.name(), var.att().add(Att.SORT(), Sort.class, s).add(Att.CELL_SORT())));
         }
       } else {
         split = new HashMap<>();
         for (Sort cell : remainingCells) {
-          split.put(cell, newDotVariable(var.att().add(Sort.class, cell).add(Att.CELL_SORT())));
+          split.put(
+              cell,
+              newDotVariable(var.att().add(Att.SORT(), Sort.class, cell).add(Att.CELL_SORT())));
         }
       }
       return split;

--- a/kernel/src/main/java/org/kframework/compile/SortCells.java
+++ b/kernel/src/main/java/org/kframework/compile/SortCells.java
@@ -136,7 +136,7 @@ public class SortCells {
         remainingCells = new LinkedHashSet<>(cfg.getChildren(cell));
       }
       if (var.att().contains(Sort.class)) {
-        Sort sort = var.att().get(Sort.class);
+        Sort sort = var.att().get(Att.SORT(), Sort.class);
         if (cfg.cfg().isCell(sort)) {
           remainingCells.removeIf(s -> !s.equals(sort));
         }
@@ -149,7 +149,7 @@ public class SortCells {
           }
         } else if (item instanceof KVariable && !item.equals(var)) {
           if (item.att().contains(Sort.class)) {
-            Sort sort = item.att().get(Sort.class);
+            Sort sort = item.att().get(Att.SORT(), Sort.class);
             remainingCells.remove(sort);
           }
         }
@@ -296,7 +296,7 @@ public class SortCells {
         for (K item : items) {
           if (item instanceof KVariable var) {
             if (var.att().contains(Sort.class)) {
-              Sort sort = var.att().get(Sort.class);
+              Sort sort = var.att().get(Att.SORT(), Sort.class);
               if (cfg.cfg().isCell(sort)) {
                 if (!cellVariables.getOrDefault(var, sort).equals(sort)) {
                   Sort prevSort = cellVariables.get(var);
@@ -694,7 +694,7 @@ public class SortCells {
                       if (varinfo.var != null) var = varinfo.var;
                     }
                     if (var.att().contains(Sort.class)) {
-                      Sort sort = var.att().get(Sort.class);
+                      Sort sort = var.att().get(Att.SORT(), Sort.class);
                       if (cfg.cfg().isCell(sort)) {
                         if (!subcellSorts.contains(sort)) {
                           throw new IllegalArgumentException(
@@ -806,7 +806,7 @@ public class SortCells {
             K item = k.klist().items().get(i);
             if (item instanceof KVariable var) {
               if (var.att().contains(Sort.class)) {
-                Sort sort = var.att().get(Sort.class);
+                Sort sort = var.att().get(Att.SORT(), Sort.class);
                 if (!cfg.cfg().isCell(sort)) {
                   if (!cellFragmentVars.containsKey(var)) {
                     cellFragmentVars.put(var, new HashSet<>());

--- a/kernel/src/main/java/org/kframework/compile/SortCells.java
+++ b/kernel/src/main/java/org/kframework/compile/SortCells.java
@@ -135,7 +135,7 @@ public class SortCells {
       if (remainingCells == null) {
         remainingCells = new LinkedHashSet<>(cfg.getChildren(cell));
       }
-      if (var.att().contains(Sort.class)) {
+      if (var.att().contains(Att.SORT(), Sort.class)) {
         Sort sort = var.att().get(Att.SORT(), Sort.class);
         if (cfg.cfg().isCell(sort)) {
           remainingCells.removeIf(s -> !s.equals(sort));
@@ -148,7 +148,7 @@ public class SortCells {
             remainingCells.remove(s);
           }
         } else if (item instanceof KVariable && !item.equals(var)) {
-          if (item.att().contains(Sort.class)) {
+          if (item.att().contains(Att.SORT(), Sort.class)) {
             Sort sort = item.att().get(Att.SORT(), Sort.class);
             remainingCells.remove(sort);
           }
@@ -295,7 +295,7 @@ public class SortCells {
         List<KVariable> bagVars = new ArrayList<>();
         for (K item : items) {
           if (item instanceof KVariable var) {
-            if (var.att().contains(Sort.class)) {
+            if (var.att().contains(Att.SORT(), Sort.class)) {
               Sort sort = var.att().get(Att.SORT(), Sort.class);
               if (cfg.cfg().isCell(sort)) {
                 if (!cellVariables.getOrDefault(var, sort).equals(sort)) {
@@ -690,10 +690,10 @@ public class SortCells {
                     if (variables.containsKey(var)) {
                       varinfo = variables.get(var);
                     }
-                    if (!var.att().contains(Sort.class) && varinfo != null) {
+                    if (!var.att().contains(Att.SORT(), Sort.class) && varinfo != null) {
                       if (varinfo.var != null) var = varinfo.var;
                     }
-                    if (var.att().contains(Sort.class)) {
+                    if (var.att().contains(Att.SORT(), Sort.class)) {
                       Sort sort = var.att().get(Att.SORT(), Sort.class);
                       if (cfg.cfg().isCell(sort)) {
                         if (!subcellSorts.contains(sort)) {
@@ -805,7 +805,7 @@ public class SortCells {
           for (int i = 0; i < k.klist().size(); i++) {
             K item = k.klist().items().get(i);
             if (item instanceof KVariable var) {
-              if (var.att().contains(Sort.class)) {
+              if (var.att().contains(Att.SORT(), Sort.class)) {
                 Sort sort = var.att().get(Att.SORT(), Sort.class);
                 if (!cfg.cfg().isCell(sort)) {
                   if (!cellFragmentVars.containsKey(var)) {

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
@@ -75,7 +75,7 @@ public class CheckKLabels {
 
           private void apply(KLabel klabel, K k) {
             if (klabel instanceof KVariable) return;
-            Optional<Source> s = k.att().getOptional(Source.class);
+            Optional<Source> s = k.att().getOptional(Att.SOURCE(), Source.class);
             if (s.isPresent()) {
               usedLabels.add(klabel.name());
               if (m.definedKLabels().apply(klabel)) {

--- a/kernel/src/main/java/org/kframework/compile/checks/ComputeUnboundVariables.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/ComputeUnboundVariables.java
@@ -5,6 +5,7 @@ import static org.kframework.kore.KORE.*;
 
 import java.util.Set;
 import java.util.function.Consumer;
+import org.kframework.attributes.Att;
 import org.kframework.builtin.KLabels;
 import org.kframework.compile.ResolveAnonVar;
 import org.kframework.compile.RewriteAwareVisitor;
@@ -38,7 +39,7 @@ public class ComputeUnboundVariables extends RewriteAwareVisitor {
   @Override
   public void apply(KVariable k) {
     if (context != null) {
-      k = KVariable(k.name(), k.att().add(Sort.class, context));
+      k = KVariable(k.name(), k.att().add(Att.SORT(), Sort.class, context));
     }
     if (isRHS() && !isInKLhs) {
       if (!k.name().equals(KLabels.THIS_CONFIGURATION)

--- a/kernel/src/main/java/org/kframework/compile/checks/ComputeUnboundVariables.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/ComputeUnboundVariables.java
@@ -72,7 +72,7 @@ public class ComputeUnboundVariables extends RewriteAwareVisitor {
     }
     if (k.klabel().name().startsWith("#SemanticCastTo")) {
       Sort savedContext = context;
-      context = k.att().get(Production.class).sort();
+      context = k.att().get(Att.PRODUCTION(), Production.class).sort();
       apply(k.items().get(0));
       context = savedContext;
       return;

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -674,13 +674,13 @@ public class DefinitionParsing {
                                   parse
                                       .parse()
                                       .att()
-                                      .remove(Source.class)
-                                      .remove(Location.class)
-                                      .remove(Production.class);
+                                      .remove(Att.SOURCE(), Source.class)
+                                      .remove(Att.LOCATION(), Location.class)
+                                      .remove(Att.PRODUCTION(), Production.class);
                               Att bubbleAtt =
                                   b.att()
-                                      .remove(Source.class)
-                                      .remove(Location.class)
+                                      .remove(Att.SOURCE(), Source.class)
+                                      .remove(Att.LOCATION(), Location.class)
                                       .remove(Att.CONTENT_START_LINE(), Integer.class)
                                       .remove(Att.CONTENT_START_COLUMN(), Integer.class);
                               if (!termAtt.equals(
@@ -728,8 +728,8 @@ public class DefinitionParsing {
                         Location loc = a.get(Att.LOCATION(), Location.class);
                         Location newLoc =
                             updateLocation(oldStartLine, lineOffset, columnOffset, loc);
-                        return a.remove(Source.class)
-                            .remove(Location.class)
+                        return a.remove(Att.SOURCE(), Source.class)
+                            .remove(Att.LOCATION(), Location.class)
                             .add(Att.LOCATION(), Location.class, newLoc)
                             .add(
                                 Att.SOURCE(),
@@ -962,8 +962,8 @@ public class DefinitionParsing {
                       b.att()
                           .remove(Att.CONTENT_START_LINE(), Integer.class)
                           .remove(Att.CONTENT_START_COLUMN(), Integer.class)
-                          .remove(Source.class)
-                          .remove(Location.class)));
+                          .remove(Att.SOURCE(), Source.class)
+                          .remove(Att.LOCATION(), Location.class)));
       cache.put(
           b.contents(),
           new ParsedSentence(

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -725,7 +725,7 @@ public class DefinitionParsing {
           parse.parse() != null
               ? new AddAttRec(
                       a -> {
-                        Location loc = a.get(Location.class);
+                        Location loc = a.get(Att.LOCATION(), Location.class);
                         Location newLoc =
                             updateLocation(oldStartLine, lineOffset, columnOffset, loc);
                         return a.remove(Source.class)
@@ -934,7 +934,7 @@ public class DefinitionParsing {
       ParseInModule pim, Map<String, ParsedSentence> cache, Bubble b) {
     int startLine = b.att().get(Att.CONTENT_START_LINE(), Integer.class);
     int startColumn = b.att().get(Att.CONTENT_START_COLUMN(), Integer.class);
-    Source source = b.att().get(Source.class);
+    Source source = b.att().get(Att.SOURCE(), Source.class);
     boolean isAnywhere =
         b.att().contains(Att.ANYWHERE())
             || b.att().contains(Att.SIMPLIFICATION())

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -730,8 +730,9 @@ public class DefinitionParsing {
                             updateLocation(oldStartLine, lineOffset, columnOffset, loc);
                         return a.remove(Source.class)
                             .remove(Location.class)
-                            .add(Location.class, newLoc)
+                            .add(Att.LOCATION(), Location.class, newLoc)
                             .add(
+                                Att.SOURCE(),
                                 Source.class,
                                 b.source()
                                     .orElseThrow(
@@ -819,7 +820,7 @@ public class DefinitionParsing {
                       Att()
                           .add(Att.CONTENT_START_LINE(), 1)
                           .add(Att.CONTENT_START_COLUMN(), 1)
-                          .add(Source.class, source)))
+                          .add(Att.SOURCE(), Source.class, source)))
               .collect(Collectors.toSet());
       if (!errors.isEmpty()) {
         throw errors.iterator().next();

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -364,9 +364,9 @@ public class Kompile {
     List<String> ruleLocs = new ArrayList<String>();
     for (Sentence s : JavaConverters.setAsJavaSet(def.mainModule().sentences())) {
       if (s instanceof RuleOrClaim) {
-        var optFile = s.att().getOptional(Source.class);
-        var optLine = s.att().getOptional(Location.class);
-        var optCol = s.att().getOptional(Location.class);
+        var optFile = s.att().getOptional(Att.SOURCE(), Source.class);
+        var optLine = s.att().getOptional(Att.LOCATION(), Location.class);
+        var optCol = s.att().getOptional(Att.LOCATION(), Location.class);
         var optId = s.att().getOptional(Att.UNIQUE_ID());
         if (optFile.isPresent() && optLine.isPresent() && optCol.isPresent() && optId.isPresent()) {
           String file = optFile.get().source();

--- a/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
+++ b/kernel/src/main/java/org/kframework/kore/convertors/KILtoKORE.java
@@ -390,14 +390,14 @@ public class KILtoKORE extends KILTransformation<Object> {
 
   private static Att attributesFromSource(Source source) {
     if (source != null) {
-      return Att().add(Source.class, source);
+      return Att().add(Att.SOURCE(), Source.class, source);
     }
     return Att();
   }
 
   private static org.kframework.attributes.Att attributesFromLocation(Location location) {
     if (location != null) {
-      return Att().add(Location.class, location);
+      return Att().add(Att.LOCATION(), Location.class, location);
     } else return Att();
   }
 }

--- a/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
+++ b/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
@@ -303,9 +303,10 @@ public class TextDocumentSyncHandler {
                                   ss.getContent(),
                                   ss.getAttributes()
                                       .add(
+                                          Att.LOCATION(),
                                           org.kframework.attributes.Location.class,
                                           ss.getLocation())
-                                      .add(Source.class, ss.getSource())
+                                      .add(Att.SOURCE(), Source.class, ss.getSource())
                                       .add(Att.CONTENT_START_LINE(), ss.getContentStartLine())
                                       .add(Att.CONTENT_START_COLUMN(), ss.getContentStartColumn()));
                           ParseCache.ParsedSentence parse =
@@ -444,9 +445,10 @@ public class TextDocumentSyncHandler {
                                                 ss.getContent(),
                                                 ss.getAttributes()
                                                     .add(
+                                                        Att.LOCATION(),
                                                         org.kframework.attributes.Location.class,
                                                         ss.getLocation())
-                                                    .add(Source.class, ss.getSource())
+                                                    .add(Att.SOURCE(), Source.class, ss.getSource())
                                                     .add(
                                                         Att.CONTENT_START_LINE(),
                                                         ss.getContentStartLine())
@@ -603,10 +605,14 @@ public class TextDocumentSyncHandler {
                                                           ss.getContent(),
                                                           ss.getAttributes()
                                                               .add(
+                                                                  Att.LOCATION(),
                                                                   org.kframework.attributes.Location
                                                                       .class,
                                                                   ss.getLocation())
-                                                              .add(Source.class, ss.getSource())
+                                                              .add(
+                                                                  Att.SOURCE(),
+                                                                  Source.class,
+                                                                  ss.getSource())
                                                               .add(
                                                                   Att.CONTENT_START_LINE(),
                                                                   ss.getContentStartLine())
@@ -736,9 +742,10 @@ public class TextDocumentSyncHandler {
                                     ss.getContent(),
                                     ss.getAttributes()
                                         .add(
+                                            Att.LOCATION(),
                                             org.kframework.attributes.Location.class,
                                             ss.getLocation())
-                                        .add(Source.class, ss.getSource())
+                                        .add(Att.SOURCE(), Source.class, ss.getSource())
                                         .add(Att.CONTENT_START_LINE(), ss.getContentStartLine())
                                         .add(
                                             Att.CONTENT_START_COLUMN(),

--- a/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
+++ b/kernel/src/main/java/org/kframework/lsp/TextDocumentSyncHandler.java
@@ -75,7 +75,11 @@ public class TextDocumentSyncHandler {
     caches.forEach(
         (key, val) -> {
           String uri =
-              Path.of(val.module().att().get(org.kframework.attributes.Source.class).source())
+              Path.of(
+                      val.module()
+                          .att()
+                          .get(Att.SOURCE(), org.kframework.attributes.Source.class)
+                          .source())
                   .toUri()
                   .toString();
           // load into LSP all the files found in the caches, even if they are not open in the IDE.
@@ -323,11 +327,15 @@ public class TextDocumentSyncHandler {
                           if (x.get() != null
                               && x.get()
                                   .att()
-                                  .get(org.kframework.definition.Production.class)
+                                  .get(Att.PRODUCTION(), org.kframework.definition.Production.class)
                                   .source()
                                   .isPresent()) {
                             org.kframework.definition.Production prd =
-                                x.get().att().get(org.kframework.definition.Production.class);
+                                x.get()
+                                    .att()
+                                    .get(
+                                        Att.PRODUCTION(),
+                                        org.kframework.definition.Production.class);
                             if (prd.source()
                                 .isPresent()) // exclude generated productions like casts
                             lls.add(
@@ -338,14 +346,18 @@ public class TextDocumentSyncHandler {
                                       loc2range(
                                           x.get()
                                               .att()
-                                              .get(org.kframework.attributes.Location.class))));
+                                              .get(
+                                                  Att.LOCATION(),
+                                                  org.kframework.attributes.Location.class))));
                           } else
                             clientLogger.logMessage(
                                 "definition failed no origin for prod: "
                                     + (x.get() != null
                                         ? x.get()
                                             .att()
-                                            .get(org.kframework.definition.Production.class)
+                                            .get(
+                                                Att.PRODUCTION(),
+                                                org.kframework.definition.Production.class)
                                         : null));
                         }
                       } else {
@@ -580,7 +592,7 @@ public class TextDocumentSyncHandler {
                                     parseCache
                                         .module()
                                         .att()
-                                        .get(org.kframework.attributes.Source.class)
+                                        .get(Att.SOURCE(), org.kframework.attributes.Source.class)
                                         .source())
                                 .toUri()
                                 .toString();
@@ -630,6 +642,7 @@ public class TextDocumentSyncHandler {
                                                                 dprd =
                                                                     t.att()
                                                                         .get(
+                                                                            Att.PRODUCTION(),
                                                                             org.kframework
                                                                                 .definition
                                                                                 .Production.class);

--- a/kernel/src/main/java/org/kframework/parser/inner/RuleGrammarGenerator.java
+++ b/kernel/src/main/java/org/kframework/parser/inner/RuleGrammarGenerator.java
@@ -778,7 +778,7 @@ public record RuleGrammarGenerator(Definition baseK) {
 
   private static Set<Sentence> makeCasts(Sort innerSort, Sort castSort, Sort labelSort) {
     Set<Sentence> prods = new HashSet<>();
-    Att attrs1 = Att().add(Sort.class, castSort);
+    Att attrs1 = Att().add(Att.SORT(), Sort.class, castSort);
     prods.add(
         Production(
             KLabel("#SyntacticCast"),

--- a/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
+++ b/kernel/src/main/java/org/kframework/parser/json/JsonParser.java
@@ -323,18 +323,23 @@ public class JsonParser {
     JsonObject attMap = data.getJsonObject("att");
     Att newAtt = Att.empty();
     for (String key : attMap.keySet()) {
-      if (key.equals(Location.class.getName())) {
+      if (key.equals(Att.LOCATION().key())) {
         JsonArray locarr = attMap.getJsonArray(Location.class.getName());
         newAtt =
             newAtt.add(
+                Att.LOCATION(),
                 Location.class,
                 Location(locarr.getInt(0), locarr.getInt(1), locarr.getInt(2), locarr.getInt(3)));
-      } else if (key.equals(Source.class.getName())) {
-        newAtt = newAtt.add(Source.class, Source.apply(attMap.getString(key)));
-      } else if (key.equals(Production.class.getName())) {
-        newAtt = newAtt.add(Production.class, (Production) toSentence(attMap.getJsonObject(key)));
-      } else if (key.equals(Sort.class.getName())) {
-        newAtt = newAtt.add(Sort.class, toSort(attMap.getJsonObject(key)));
+      } else if (key.equals(Att.SOURCE().key())) {
+        newAtt = newAtt.add(Att.SOURCE(), Source.class, Source.apply(attMap.getString(key)));
+      } else if (key.equals(Att.PRODUCTION().key())) {
+        newAtt =
+            newAtt.add(
+                Att.PRODUCTION(),
+                Production.class,
+                (Production) toSentence(attMap.getJsonObject(key)));
+      } else if (key.equals(Att.SORT().key())) {
+        newAtt = newAtt.add(Att.SORT(), Sort.class, toSort(attMap.getJsonObject(key)));
       } else if (key.equals(Att.BRACKET_LABEL().key())) {
         newAtt = newAtt.add(Att.BRACKET_LABEL(), KLabel.class, toKLabel(attMap.getJsonObject(key)));
       } else if (key.equals(Att.PREDICATE().key())) {
@@ -416,7 +421,7 @@ public class JsonParser {
       case KVARIABLE:
         Att varAtt = Att.empty();
         if (data.containsKey("sort")) {
-          varAtt = varAtt.add(Sort.class, toSort(data.getJsonObject("sort")));
+          varAtt = varAtt.add(Att.SORT(), Sort.class, toSort(data.getJsonObject("sort")));
         }
         return KVariable(data.getString("name"), varAtt);
 

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -456,7 +456,7 @@ public class ToJson {
 
       knode.add("node", JsonParser.KVARIABLE);
       knode.add("name", var.name());
-      if (k.att().contains(Sort.class)) {
+      if (k.att().contains(Att.SORT(), Sort.class)) {
         knode.add("sort", toJson(k.att().get(Att.SORT(), Sort.class)));
       }
 

--- a/kernel/src/main/java/org/kframework/unparser/ToJson.java
+++ b/kernel/src/main/java/org/kframework/unparser/ToJson.java
@@ -136,18 +136,18 @@ public class ToJson {
         JavaConverters.seqAsJavaList(att.att().keys().toSeq())) {
       if (attKeyPair._1().key().equals(Location.class.getName())) {
         JsonArrayBuilder locarr = factory.createArrayBuilder();
-        Location loc = att.get(Location.class);
+        Location loc = att.get(Att.LOCATION(), Location.class);
         locarr.add(loc.startLine());
         locarr.add(loc.startColumn());
         locarr.add(loc.endLine());
         locarr.add(loc.endColumn());
         jattKeys.add(attKeyPair._1().key(), locarr.build());
       } else if (attKeyPair._1().key().equals(Source.class.getName())) {
-        jattKeys.add(attKeyPair._1().key(), att.get(Source.class).source());
+        jattKeys.add(attKeyPair._1().key(), att.get(Att.SOURCE(), Source.class).source());
       } else if (attKeyPair._1().key().equals(Production.class.getName())) {
-        jattKeys.add(attKeyPair._1().key(), toJson(att.get(Production.class)));
+        jattKeys.add(attKeyPair._1().key(), toJson(att.get(Att.PRODUCTION(), Production.class)));
       } else if (attKeyPair._1().key().equals(Sort.class.getName())) {
-        jattKeys.add(attKeyPair._1().key(), toJson(att.get(Sort.class)));
+        jattKeys.add(attKeyPair._1().key(), toJson(att.get(Att.SORT(), Sort.class)));
       } else if (attKeyPair._1().equals(Att.BRACKET_LABEL())) {
         jattKeys.add(attKeyPair._1().key(), toJson(att.get(Att.BRACKET_LABEL(), KLabel.class)));
       } else if (attKeyPair._1().equals(Att.PREDICATE())) {
@@ -457,7 +457,7 @@ public class ToJson {
       knode.add("node", JsonParser.KVARIABLE);
       knode.add("name", var.name());
       if (k.att().contains(Sort.class)) {
-        knode.add("sort", toJson(k.att().get(Sort.class)));
+        knode.add("sort", toJson(k.att().get(Att.SORT(), Sort.class)));
       }
 
     } else if (k instanceof KRewrite rew) {

--- a/kernel/src/test/java/org/kframework/compile/AddParentsCellsTest.java
+++ b/kernel/src/test/java/org/kframework/compile/AddParentsCellsTest.java
@@ -11,6 +11,7 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.kframework.attributes.Att;
 import org.kframework.builtin.KLabels;
 import org.kframework.kore.*;
 import org.kframework.utils.errorsystem.KEMException;
@@ -161,7 +162,7 @@ public class AddParentsCellsTest {
         cell(
             "<T>",
             KRewrite(
-                KVariable("KCell", Att().add(Sort.class, Sort("KCell"))),
+                KVariable("KCell", Att().add(Att.SORT(), Sort.class, Sort("KCell"))),
                 cell("<k>", intToToken(1))));
     K expected =
         cell(
@@ -171,7 +172,7 @@ public class AddParentsCellsTest {
                 cell(
                     "<t>",
                     KRewrite(
-                        KVariable("KCell", Att().add(Sort.class, Sort("KCell"))),
+                        KVariable("KCell", Att().add(Att.SORT(), Sort.class, Sort("KCell"))),
                         cell("<k>", intToToken(1))))));
     Assert.assertEquals(expected, pass.concretizeCell(term));
   }

--- a/kernel/src/test/java/org/kframework/compile/GenerateSentencesFromConfigDeclTest.java
+++ b/kernel/src/test/java/org/kframework/compile/GenerateSentencesFromConfigDeclTest.java
@@ -78,12 +78,14 @@ public class GenerateSentencesFromConfigDeclTest {
                         KApply(
                             KLabel("#SemanticCastToKItem"),
                             KList(KToken("$PGM", Sorts.KConfigVar())),
-                            Att.empty().add(Production.class, prod2))),
+                            Att.empty().add(Att.PRODUCTION(), Production.class, prod2))),
                     cell(
                         "opt",
                         Collections.singletonMap("multiplicity", "?"),
                         KApply(
-                            KLabel(".Opt"), KList(), Att.empty().add(Production.class, prod))))));
+                            KLabel(".Opt"),
+                            KList(),
+                            Att.empty().add(Att.PRODUCTION(), Production.class, prod))))));
     Module m1 = Module("CONFIG", Set(Import(def.getModule("KSEQ").get(), true)), Set(prod), Att());
     RuleGrammarGenerator parserGen = new RuleGrammarGenerator(def);
     Module m =

--- a/kernel/src/test/java/org/kframework/compile/SortCellsTest.java
+++ b/kernel/src/test/java/org/kframework/compile/SortCellsTest.java
@@ -5,6 +5,7 @@ import static org.kframework.kore.KORE.*;
 
 import org.junit.Assert;
 import org.junit.Test;
+import org.kframework.attributes.Att;
 import org.kframework.builtin.BooleanUtils;
 import org.kframework.builtin.KLabels;
 import org.kframework.builtin.Sorts;
@@ -51,7 +52,7 @@ public class SortCellsTest {
 
   @Test
   public void testSimpleSplitting() {
-    KVariable Y = KVariable("Y", Att().add(Sort.class, Sort("OptCell")));
+    KVariable Y = KVariable("Y", Att().add(Att.SORT(), Sort.class, Sort("OptCell")));
     K term = KRewrite(cell("<t>", cell("<env>"), KVariable("X"), Y), KVariable("X"));
     K expected =
         KRewrite(
@@ -68,7 +69,7 @@ public class SortCellsTest {
    */
   @Test
   public void testSortedVar() {
-    KVariable Y = KVariable("Y", Att().add(Sort.class, Sort("OptCell")));
+    KVariable Y = KVariable("Y", Att().add(Att.SORT(), Sort.class, Sort("OptCell")));
     K term = KRewrite(cell("<t>", cell("<env>"), KVariable("X"), Y), Y);
     K expected = KRewrite(cell("<t>", KVariable("X"), cell("<env>"), Y), Y);
     KExceptionManager kem = new KExceptionManager(new GlobalOptions());
@@ -432,7 +433,7 @@ public class SortCellsTest {
                     "<t>",
                     cell("<env>"),
                     KVariable("X"),
-                    KVariable("Y", Att().add(Sort.class, Sort("OptCell")))),
+                    KVariable("Y", Att().add(Att.SORT(), Sort.class, Sort("OptCell")))),
                 KVariable("X")),
             app("isThreadCellFragment", KVariable("X")),
             BooleanUtils.TRUE,
@@ -443,7 +444,7 @@ public class SortCellsTest {
                 "<t>",
                 KVariable("X"),
                 cell("<env>"),
-                KVariable("Y", Att().add(Sort.class, Sort("OptCell")))),
+                KVariable("Y", Att().add(Att.SORT(), Sort.class, Sort("OptCell")))),
             cell("<t>-fragment", KVariable("X"), app("noEnvCell"), app(".OptCell")));
     Rule expected =
         new Rule(
@@ -470,7 +471,7 @@ public class SortCellsTest {
                     "<t>",
                     cell("<env>"),
                     KVariable("X"),
-                    KVariable("Y", Att().add(Sort.class, Sort("OptCell")))),
+                    KVariable("Y", Att().add(Att.SORT(), Sort.class, Sort("OptCell")))),
                 KVariable("X")),
             app("isTopCellFragment", KVariable("X")),
             BooleanUtils.TRUE,
@@ -482,7 +483,7 @@ public class SortCellsTest {
                 "<t>",
                 KVariable("X"),
                 cell("<env>"),
-                KVariable("Y", Att().add(Sort.class, Sort("OptCell")))),
+                KVariable("Y", Att().add(Att.SORT(), Sort.class, Sort("OptCell")))),
             replacement);
     Rule expected =
         new Rule(expectedBody, app("isTopCellFragment", replacement), BooleanUtils.TRUE, Att());
@@ -497,8 +498,8 @@ public class SortCellsTest {
    */
   @Test
   public void testMultipleCells() {
-    KVariable T1 = KVariable("T1", Att().add(Sort.class, Sort("ThreadCell")));
-    KVariable T2 = KVariable("T2", Att().add(Sort.class, Sort("ThreadCell")));
+    KVariable T1 = KVariable("T1", Att().add(Att.SORT(), Sort.class, Sort("ThreadCell")));
+    KVariable T2 = KVariable("T2", Att().add(Att.SORT(), Sort.class, Sort("ThreadCell")));
     K term =
         cell("<top>", KVariable("F"), cell("<t>", KVariable("T")), app("_ThreadCellBag_", T1, T2));
     K expected =

--- a/kernel/src/test/java/org/kframework/lsp/LSPTests.java
+++ b/kernel/src/test/java/org/kframework/lsp/LSPTests.java
@@ -17,6 +17,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.kframework.attributes.Att;
 import org.kframework.attributes.Location;
 import org.kframework.definition.KViz;
 import org.kframework.definition.Production;
@@ -161,7 +162,7 @@ public class LSPTests {
                         + " loc: "
                         + t.location()
                         + " trm: "
-                        + t.att().get(Production.class));
+                        + t.att().get(Att.PRODUCTION(), Production.class));
               } else
                 System.out.println(
                     "Pos out loc: "
@@ -169,7 +170,7 @@ public class LSPTests {
                         + " loc: "
                         + t.location()
                         + " trm: "
-                        + t.att().get(Production.class));
+                        + t.att().get(Att.PRODUCTION(), Production.class));
               return t;
             },
             "test find")

--- a/kore/src/main/scala/org/kframework/Strategy.scala
+++ b/kore/src/main/scala/org/kframework/Strategy.scala
@@ -16,7 +16,6 @@ import org.kframework.kore.KApply
 import org.kframework.kore.KORE
 import org.kframework.kore.Sort
 import org.kframework.kore.Unapply.KApply
-import org.kframework.kore.Unapply.KLabel
 
 object Strategy {
   val strategyCellName  = "<s>"
@@ -35,17 +34,17 @@ object Strategy {
               KLabels.STRATEGY_CELL,
               KORE.KApply(KLabels.NO_DOTS),
               KORE.KRewrite(
-                KORE.KVariable("S", Att.empty.add(classOf[Sort], Sorts.KItem)),
+                KORE.KVariable("S", Att.empty.add(Att.SORT, classOf[Sort], Sorts.KItem)),
                 KORE.KSequence(
                   KORE.KApply(KORE.KLabel("#STUCK")),
-                  KORE.KVariable("S", Att.empty.add(classOf[Sort], Sorts.KItem))
+                  KORE.KVariable("S", Att.empty.add(Att.SORT, classOf[Sort], Sorts.KItem))
                 )
               ),
               KORE.KApply(KLabels.DOTS)
             ),
             KORE.KApply(
               KLabels.NOT_EQUALS_K,
-              KORE.KVariable("S", Att.empty.add(classOf[Sort], Sorts.KItem)),
+              KORE.KVariable("S", Att.empty.add(Att.SORT, classOf[Sort], Sorts.KItem)),
               KORE.KApply(KORE.KLabel("#STUCK"))
             ),
             BooleanUtils.TRUE,

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -69,8 +69,6 @@ class Att private (val att: Map[(Att.Key, String), Any])
     None
   }
 
-  def contains(cls: Class[_]): Boolean =
-    att.contains((Att.getInternalKeyOrAssert(cls.getName), cls.getName))
   def contains(key: Att.Key): Boolean                = att.contains((key, Att.stringClassName))
   def contains(key: Att.Key, cls: Class[_]): Boolean = att.contains((key, cls.getName))
 

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -110,9 +110,8 @@ class Att private (val att: Map[(Att.Key, String), Any])
   private def throwForbidden(key: Att.Key) =
     throw KEMException.compilerError("Parameters for the attribute '" + key + "' are forbidden.")
 
-  def addAll(thatAtt: Att): Att  = Att(att ++ thatAtt.att)
-  def remove(key: Att.Key): Att  = remove(key, Att.stringClassName)
-  def remove(key: Class[_]): Att = remove(Att.getInternalKeyOrAssert(key.getName), key.getName)
+  def addAll(thatAtt: Att): Att                         = Att(att ++ thatAtt.att)
+  def remove(key: Att.Key): Att                         = remove(key, Att.stringClassName)
   def remove(key: Att.Key, cls: Class[_]): Att          = remove(key, cls.getName)
   private def remove(key: Att.Key, clsStr: String): Att = Att(att - ((key, clsStr)))
 }

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -95,8 +95,6 @@ class Att private (val att: Map[(Att.Key, String), Any])
   def add(key: Att.Key): Att                = add(key, "")
   def add(key: Att.Key, value: String): Att = add(key, Att.stringClassName, value)
   def add(key: Att.Key, value: Int): Att    = add(key, Att.intClassName, value)
-  def add[T <: AttValue](key: Class[T], value: T): Att =
-    add(Att.getInternalKeyOrAssert(key.getName), key.getName, value)
   def add[T <: AttValue](key: Att.Key, cls: Class[T], value: T): Att = add(key, cls.getName, value)
 
   private def add[T <: AttValue](key: Att.Key, clsStr: String, value: T): Att = key.keyParam match {

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -74,17 +74,13 @@ class Att private (val att: Map[(Att.Key, String), Any])
   def contains(key: Att.Key): Boolean                = att.contains((key, Att.stringClassName))
   def contains(key: Att.Key, cls: Class[_]): Boolean = att.contains((key, cls.getName))
 
-  def get[T](key: Class[T]): T               = getOption(key).get
   def get(key: Att.Key): String              = getOption(key).get
   def get[T](key: Att.Key, cls: Class[T]): T = getOption(key, cls).get
   def getOption(key: Att.Key): Option[String] =
     att.get((key, Att.stringClassName)).asInstanceOf[Option[String]]
-  def getOption[T](key: Class[T]): Option[T] =
-    att.get((Att.getInternalKeyOrAssert(key.getName), key.getName)).asInstanceOf[Option[T]]
   def getOption[T](key: Att.Key, cls: Class[T]): Option[T] =
     att.get((key, cls.getName)).asInstanceOf[Option[T]]
   def getOptional(key: Att.Key): Optional[String] = optionToOptional(getOption(key))
-  def getOptional[T](key: Class[T]): Optional[T]  = optionToOptional(getOption(key))
   def getOptional[T](key: Att.Key, cls: Class[T]): Optional[T] = optionToOptional(
     getOption(key, cls)
   )

--- a/kore/src/main/scala/org/kframework/compile/AssocCommToAssoc.scala
+++ b/kore/src/main/scala/org/kframework/compile/AssocCommToAssoc.scala
@@ -146,9 +146,9 @@ class AssocCommToAssoc extends Function[Module, Module] {
     }
 
   private def anonymousVariable(s: Sort): K =
-    SortedADT.SortedKVariable("THE_VARIABLE", Att.empty.add(classOf[Sort], s))
+    SortedADT.SortedKVariable("THE_VARIABLE", Att.empty.add(Att.SORT, classOf[Sort], s))
 
   private def dotVariable(s: Sort, n: Int): K =
-    SortedADT.SortedKVariable(s.toString + "_DotVar" + n, Att.empty.add(classOf[Sort], s))
+    SortedADT.SortedKVariable(s.toString + "_DotVar" + n, Att.empty.add(Att.SORT, classOf[Sort], s))
 
 }

--- a/kore/src/main/scala/org/kframework/definition/outer-ext.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-ext.scala
@@ -26,8 +26,8 @@ case class Bubble(sentenceType: String, contents: String, att: Att = Att.empty) 
 }
 
 case class FlatImport(name: String, isPublic: Boolean, att: Att = Att.empty) extends HasLocation {
-  override def location(): Optional[Location] = att.getOptional(classOf[Location])
-  override def source(): Optional[Source]     = att.getOptional(classOf[Source])
+  override def location(): Optional[Location] = att.getOptional(Att.LOCATION, classOf[Location])
+  override def source(): Optional[Source]     = att.getOptional(Att.SOURCE, classOf[Source])
 }
 
 case class FlatModule(

--- a/kore/src/main/scala/org/kframework/definition/outer-to-string.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer-to-string.scala
@@ -2,6 +2,7 @@
 package org.kframework.definition
 
 import collection._
+import org.kframework.attributes.Att
 import org.kframework.attributes.Location
 import org.kframework.attributes.Source
 import org.kframework.utils.StringUtil
@@ -39,7 +40,10 @@ trait ProductionToString {
   self: Production =>
   override def toString = "syntax " + (if (params.nonEmpty) { "{" + params.mkString(", ") + "} " }
                                        else "") + sort + " ::= " + items
-    .mkString(" ") + att.remove(classOf[Source]).remove(classOf[Location]).postfixString
+    .mkString(" ") + att
+    .remove(Att.SOURCE, classOf[Source])
+    .remove(Att.LOCATION, classOf[Location])
+    .postfixString
 }
 
 trait SyntaxSortToString {

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -99,8 +99,8 @@ case class Module(
 
   assert(att != null)
 
-  def location: Optional[Location] = att.getOptional(classOf[Location])
-  def source: Optional[Source]     = att.getOptional(classOf[Source])
+  def location: Optional[Location] = att.getOptional(Att.LOCATION, classOf[Location])
+  def source: Optional[Source]     = att.getOptional(Att.SOURCE, classOf[Source])
 
   lazy val fullImports: Set[Module] = imports.map(_.module)
 
@@ -471,8 +471,8 @@ trait Sentence extends HasLocation with HasAtt with AttValue {
   val isNonSyntax: Boolean
   val att: Att
   def withAtt(att: Att): Sentence
-  def location: Optional[Location] = att.getOptional(classOf[Location])
-  def source: Optional[Source]     = att.getOptional(classOf[Source])
+  def location: Optional[Location] = att.getOptional(Att.LOCATION, classOf[Location])
+  def source: Optional[Source]     = att.getOptional(Att.SOURCE, classOf[Source])
   def label: Optional[String]      = att.getOptional(Att.LABEL)
 }
 

--- a/kore/src/main/scala/org/kframework/kore/ADT.scala
+++ b/kore/src/main/scala/org/kframework/kore/ADT.scala
@@ -108,7 +108,11 @@ object SortedADT {
 
   case class SortedKVariable(name: String, att: Att = Att.empty) extends kore.KVariable {
     val sort: Sort =
-      if (att.contains(Att.CELL_SORT)) Sorts.K else att.getOptional(classOf[Sort]).orElse(Sorts.K)
+      if (att.contains(Att.CELL_SORT)) Sorts.K
+      else
+        att
+          .getOptional(Att.SORT, classOf[Sort])
+          .orElse(Sorts.K)
 
     override def equals(other: Any) = other match {
       case v: SortedKVariable => name == v.name && sort == v.sort

--- a/kore/src/main/scala/org/kframework/kore/interface.scala
+++ b/kore/src/main/scala/org/kframework/kore/interface.scala
@@ -22,8 +22,8 @@ trait K extends Serializable with HasLocation with AttValue {
 
   def computeHashCode: Int
 
-  def location: Optional[Location] = att.getOptional(classOf[Location])
-  def source: Optional[Source]     = att.getOptional(classOf[Source])
+  def location: Optional[Location] = att.getOptional(Att.LOCATION, classOf[Location])
+  def source: Optional[Source]     = att.getOptional(Att.SOURCE, classOf[Source])
 }
 
 object K {

--- a/kore/src/main/scala/org/kframework/parser/TreeNodesToKORE.scala
+++ b/kore/src/main/scala/org/kframework/parser/TreeNodesToKORE.scala
@@ -33,6 +33,7 @@ class TreeNodesToKORE(parseSort: java.util.function.Function[String, Sort]) {
         p.sort,
         locationToAtt(c.location, c.source)
           .add(
+            Att.PRODUCTION,
             classOf[Production],
             c.production.att
               .getOption(Att.ORIGINAL_PRD, classOf[Production])
@@ -60,7 +61,7 @@ class TreeNodesToKORE(parseSort: java.util.function.Function[String, Sort]) {
     KApply(
       klabel.head,
       KList(new util.ArrayList(t.items).asScala.reverse.map(apply) asJava),
-      locationToAtt(t.location, t.source).add(classOf[Production], realProd)
+      locationToAtt(t.location, t.source).add(Att.PRODUCTION, classOf[Production], realProd)
     )
   }
 
@@ -123,8 +124,8 @@ class TreeNodesToKORE(parseSort: java.util.function.Function[String, Sort]) {
 
   def locationToAtt(l: Optional[Location], s: Optional[Source]): Att = {
     var a = Att.empty
-    if (l.isPresent) a = a.add(classOf[Location], l.get)
-    if (s.isPresent) a = a.add(classOf[Source], s.get)
+    if (l.isPresent) a = a.add(Att.LOCATION, classOf[Location], l.get)
+    if (s.isPresent) a = a.add(Att.SOURCE, classOf[Source], s.get)
     a
   }
 }

--- a/kore/src/main/scala/org/kframework/parser/kore/parser/KoreToK.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/parser/KoreToK.scala
@@ -111,7 +111,7 @@ class KoreToK(sortAtt: Map[String, String]) {
     case kore.Variable(name, sort) =>
       KORE.KVariable(
         extractVarName(name),
-        Att.empty.add(classOf[org.kframework.kore.Sort], apply(sort))
+        Att.empty.add(Att.SORT, classOf[org.kframework.kore.Sort], apply(sort))
       )
     case kore.Application(head, args) =>
       head.ctr match {

--- a/kore/src/main/scala/org/kframework/unparser/KOREToTreeNodes.scala
+++ b/kore/src/main/scala/org/kframework/unparser/KOREToTreeNodes.scala
@@ -40,14 +40,14 @@ object KOREToTreeNodes {
       Constant(
         t.s,
         mod.tokenProductionFor(t.sort),
-        t.att.getOptional(classOf[Location]),
-        t.att.getOptional(classOf[Source])
+        t.att.getOptional(Att.LOCATION, classOf[Location]),
+        t.att.getOptional(Att.SOURCE, classOf[Source])
       )
     case a: KApply =>
       val scalaChildren = a.klist.items.asScala.map { i: K => apply(i, mod).asInstanceOf[Term] }
       val children      = ConsPStack.from(scalaChildren.reverse asJava)
-      val loc           = t.att.getOptional(classOf[Location])
-      val source        = t.att.getOptional(classOf[Source])
+      val loc           = t.att.getOptional(Att.LOCATION, classOf[Location])
+      val source        = t.att.getOptional(Att.SOURCE, classOf[Source])
       val p =
         mod.productionsFor(KLabel(a.klabel.name)).filter(!_.att.contains(Att.UNPARSE_AVOID)).head
       val subst = if (a.klabel.params.nonEmpty) {
@@ -63,7 +63,7 @@ object KOREToTreeNodes {
     case v: KVariable =>
       if (v.att.contains(Att.PRETTY_PRINT_WITH_SORT_ANNOTATION))
         KORE.KApply(
-          KORE.KLabel("#SemanticCastTo" + v.att.get(classOf[org.kframework.kore.Sort])),
+          KORE.KLabel("#SemanticCastTo" + v.att.get(Att.SORT, classOf[org.kframework.kore.Sort])),
           KToken(v.name, Sorts.KVariable, v.att)
         )
       else


### PR DESCRIPTION
This PR removes all methods from `Att` which refer to attributes by their value type (e.g. `Source.class`, `Location.class`, etc.) rather than by their `Att.Key`.

As a result, we maintain the nice property that usages of an attribute exactly correspond with usages of the whitelisted `Att.Key`.