### PR TITLE
Refactor allowed syntax checks for attributes

### DIFF
--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -87,7 +87,7 @@ public class CheckAtt {
     Set<Key> badKeys =
         stream(term.att().att().keySet())
             .map(Tuple2::_1)
-            .filter(k -> k.visibility().isPermitted(term))
+            .filter(k -> !k.visibility().isPermitted(term))
             .collect(Collectors.toSet());
     if (!badKeys.isEmpty()) {
       List<String> sortedKeys = badKeys.stream().map(Key::toString).sorted().toList();

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -84,15 +84,16 @@ public class CheckAtt {
   }
 
   private <T extends HasAtt & HasLocation> void checkRestrictedAtts(T term) {
-    Class<?> cls = term.getClass();
-    Att att = term.att();
-    Set<Key> keys = stream(att.att().keySet()).map(Tuple2::_1).collect(Collectors.toSet());
-    keys.removeIf(k -> k.allowedSentences().exists(c -> c.isAssignableFrom(cls)));
-    if (!keys.isEmpty()) {
-      List<String> sortedKeys = keys.stream().map(Key::toString).sorted().toList();
+    Set<Key> badKeys =
+        stream(term.att().att().keySet())
+            .map(Tuple2::_1)
+            .filter(k -> k.visibility().isPermitted(term))
+            .collect(Collectors.toSet());
+    if (!badKeys.isEmpty()) {
+      List<String> sortedKeys = badKeys.stream().map(Key::toString).sorted().toList();
       errors.add(
           KEMException.compilerError(
-              cls.getSimpleName() + " cannot have the following attributes: " + sortedKeys, term));
+              "The following attributes are not permitted here: " + sortedKeys, term));
     }
   }
 


### PR DESCRIPTION
Fixes #3982 

Previously, each attribute specified an allowed set of `Class[_]`s where that attribute may occur. However, both a cell and a non-cell are just `Production`s, so no `Class[_]` restriction is sufficient to distinguish cells.

This PR then refactors to instead have an allowed set of `Att.Syntax` types, each with a `isA(term: AnyRef): Boolean` method to check membership.

In process, we also:
- Restrict `label(_)` to rules, claims, contexts, and context aliases rather than allowing it on any sentence
- Restrict `group(_)` to productions
- Restrict `cell`, `cellName`, `exit`, `stream`, `multiplicity`, and `type` to cells