### PR TITLE
No longer emit old overload attribute

### DIFF
--- a/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -931,10 +931,7 @@ public class ModuleToKORE {
     }
     sb.append("))) ");
     final var args = KList(KApply(greater.klabel().get()), KApply(lesser.klabel().get()));
-    final var att =
-        Att.empty()
-            .add(Att.OVERLOAD(), KList.class, args)
-            .add(Att.SYMBOL_OVERLOAD(), KList.class, args);
+    final var att = Att.empty().add(Att.SYMBOL_OVERLOAD(), KList.class, args);
     convert(new HashMap<>(), att, sb, null, null);
     sb.append(" // overloaded production\n");
   }

--- a/kore/src/main/scala/org/kframework/attributes/Att.scala
+++ b/kore/src/main/scala/org/kframework/attributes/Att.scala
@@ -311,7 +311,6 @@ object Att {
   final val NOT_INJECTION        = Key.internal("notInjection")
   final val NOT_LR1_MODULES      = Key.internal("not-lr1-modules")
   final val ORIGINAL_PRD         = Key.internal("originalPrd")
-  final val OVERLOAD             = Key.internal("overload")
   final val PREDICATE            = Key.internal("predicate")
   final val PRETTY_PRINT_WITH_SORT_ANNOTATION =
     Key.internal("prettyPrintWithSortAnnotation")


### PR DESCRIPTION
The backends have now all been changed to accept the new `symbol-overload` KORE attribute (https://github.com/runtimeverification/llvm-backend/pull/984, https://github.com/runtimeverification/haskell-backend/pull/3723) and so we can safely stop the frontend from emitting the old `overload` syntax.

Downstream testing on the C semantics (which makes heavy use of overloading) has passed, so I'm confident this change is correct.