### PR TITLE
Support Java 17 in `kore` submodule

### DIFF
--- a/kore/pom.xml
+++ b/kore/pom.xml
@@ -79,6 +79,12 @@
             <arg>-language:implicitConversions</arg>
             <arg>-language:postfixOps</arg>
           </args>
+          <javacArgs>
+            <javacArg>-source</javacArg>
+            <javacArg>${java.version}</javacArg>
+            <javacArg>-target</javacArg>
+            <javacArg>${java.version}</javacArg>
+          </javacArgs>
         </configuration>
       </plugin>
     </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,7 @@
     <skipCheckstyleOnWindows>true</skipCheckstyleOnWindows>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.build.type>FastBuild</project.build.type>
+    <java.version>17</java.version>
     <scala.majorVersion>2.12</scala.majorVersion>
     <scala.minorVersion>18</scala.minorVersion>
     <scala.version>${scala.majorVersion}.${scala.minorVersion}</scala.version>
@@ -167,8 +168,8 @@
           <artifactId>maven-compiler-plugin</artifactId>
           <version>3.7.0</version>
           <configuration>
-            <source>17</source>
-            <target>17</target>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
           </configuration>
         </plugin>
         <!-- Antrun plugin for running arbitrary shell commands (building subprojects) -->
@@ -248,7 +249,7 @@
         <configuration>
           <rules>
             <requireJavaVersion>
-              <version>[11,)</version>
+              <version>[${java.version},)</version>
             </requireJavaVersion>
           </rules>
         </configuration>


### PR DESCRIPTION
In #3736, we updated to Java 17 by configuring the Java version for `maven-compiler-plugin`. 

However -  after banging my head against a wall for the past hour wondering why none of my code is parsing 🙃  - I realized that the `kore` and `matching` submodules are actually built by `scala-maven-plugin` rather than `maven-compiler-plugin`, and their Java version must be set independently.

This PR sets the version for `kore` to Java 17, and runtimeverification/llvm-backend#993 will do the same for `matching`.