### PR TITLE
Extend cachix timeout on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
           - runner: MacM1
             os: self-macos-12
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v3


### PR DESCRIPTION
The release job has timed out when pushing to cachix because we've done a big nixpkgs upgrade; we should increase the timeout to let the release go through.

https://github.com/runtimeverification/k/actions/runs/8021083565