### PR TITLE
Check for uses of zero-argument `symbol` without `klabel(_)`

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -2380,7 +2380,8 @@ a library function. If the `errno` returned is not one of the below errnos
 known to K, `#unknownIOError` is returned along with the integer errno value.
 
 ```k
-  syntax IOError ::= "#EOF" [klabel(#EOF), symbol] | #unknownIOError(errno: Int) [symbol]
+  syntax IOError ::= "#EOF" [klabel(#EOF), symbol] 
+                   | #unknownIOError(errno: Int) [klabel(#unknownIOError), symbol]
                    | "#E2BIG" [klabel(#E2BIG), symbol]
                    | "#EACCES" [klabel(#EACCES), symbol]
                    | "#EAGAIN" [klabel(#EAGAIN), symbol]

--- a/k-distribution/tests/regression-new/checkWarns/nullarySymbol.k
+++ b/k-distribution/tests/regression-new/checkWarns/nullarySymbol.k
@@ -1,0 +1,6 @@
+module NULLARYSYMBOL-SYNTAX
+endmodule
+
+module NULLARYSYMBOL
+  syntax Foo ::= foo() [symbol, unused]
+endmodule

--- a/k-distribution/tests/regression-new/checkWarns/nullarySymbol.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/nullarySymbol.k.out
@@ -1,0 +1,6 @@
+[Error] Compiler: Zero-argument `symbol` attribute used without a corresponding `klabel(_)`. Either remove `symbol`, or supply an argument.
+	Source(nullarySymbol.k)
+	Location(5,18,5,40)
+	5 |	  syntax Foo ::= foo() [symbol, unused]
+	  .	                 ^~~~~~~~~~~~~~~~~~~~~~
+[Error] Compiler: Had 1 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckAtt.java
@@ -72,6 +72,7 @@ public class CheckAtt {
     checkLatex(prod);
     checkSymbolKLabel(prod);
     checkKLabelOverload(prod);
+    checkNullarySymbol(prod);
   }
 
   private <T extends HasAtt & HasLocation> void checkUnrecognizedAtts(T term) {
@@ -356,6 +357,18 @@ public class CheckAtt {
       errors.add(
           KEMException.compilerError(
               "The attributes `klabel(_)` and `overload(_)` may not occur together.", prod));
+    }
+  }
+
+  private void checkNullarySymbol(Production prod) {
+    if (prod.att().contains(Att.SYMBOL()) && !prod.att().contains(Att.KLABEL())) {
+      if (prod.att().get(Att.SYMBOL()).isEmpty()) {
+        kem.registerCompilerWarning(
+            ExceptionType.FUTURE_ERROR,
+            errors,
+            "Zero-argument `symbol` attribute used without a corresponding `klabel(_)`. Either remove `symbol`, or supply an argument.",
+            prod);
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes: #4043
Related: #4035, #3979  

This PR adds a compiler warning when `symbol` is used without an argument and without a corresponding `klabel(_)` attribute.

I fixed one case in `domains.md` where this was an issue; for consistency I left that production using `klabel(_)` rather than migrating it to `symbol(_)`. We will have to go back and fix these cases anyway in a later PR.