### PR TITLE
Fix strictness warning

### DIFF
--- a/k-distribution/tests/regression-new/checks/missingKResult.k.out
+++ b/k-distribution/tests/regression-new/checks/missingKResult.k.out
@@ -1,4 +1,4 @@
-[Error] Compiler: Definition is missing function isKResult required for strictness. Please either declare sort KResult or declare 'syntax Bool ::= isKResult(K) [symbol, function]'
+[Error] Compiler: Definition is missing function isKResult required for strictness. Please either declare sort KResult or declare 'syntax Bool ::= isKResult(K) [symbol(isKResult), function]'
   while executing phase "resolving heat and cool attributes" on sentence at
 	Source(missingKResult.k)
 	Location(14,18,14,47)

--- a/kernel/src/main/java/org/kframework/compile/ResolveHeatCoolAttribute.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveHeatCoolAttribute.java
@@ -39,7 +39,9 @@ public class ResolveHeatCoolAttribute {
               + sort
               + " or declare 'syntax Bool ::= "
               + lbl.name()
-              + "(K) [symbol, function]'",
+              + "(K) [symbol("
+              + lbl.name()
+              + "), function]'",
           requires);
     }
     KApply predicate = KApply(lbl, KVariable("HOLE"));


### PR DESCRIPTION
This PR amends the error message when a sort predicate required for strictness is missing. The compiler-generated sort predicates are fine and do not need to be amended similarly (i.e. they don't use `klabel(_)` internally).

Fixes: https://github.com/runtimeverification/k/issues/3998