### PR TITLE
Update `maven-compiler-plugin` and `scala-maven-plugin`

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
 
             k-framework = { haskell-backend-bins, llvm-kompile-libs }:
               prev.callPackage ./nix/k.nix {
-                mvnHash = "sha256-AMxXqu1bbpnmsmLTizNw1n2llSdvx6AuNZRGUHqPn14=";
+                mvnHash = "sha256-2QhQ2L6ljDtOHvHQHhz6HT4ATA8ArhlS7wwp6AZfN14=";
                 manualMvnArtifacts = [
                   "org.scala-lang:scala-compiler:2.12.18"
                   "ant-contrib:ant-contrib:1.0b3"

--- a/pom.xml
+++ b/pom.xml
@@ -166,7 +166,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.7.0</version>
+          <version>3.12.1</version>
           <configuration>
             <source>${java.version}</source>
             <target>${java.version}</target>

--- a/pom.xml
+++ b/pom.xml
@@ -152,7 +152,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.6.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>


### PR DESCRIPTION
Part of #4041

This just updates the `maven-compiler-plugin` and `scala-maven-plugin` versions, which in turn also required an update to `maven-dependency-plugin`.