### PR TITLE
Add translation layer from pattern matching exceptions

### DIFF
--- a/kore/src/main/java/org/kframework/utils/errorsystem/KEMException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KEMException.java
@@ -2,6 +2,7 @@
 package org.kframework.utils.errorsystem;
 
 import java.util.Objects;
+import java.util.Optional;
 import org.kframework.attributes.HasLocation;
 import org.kframework.attributes.Location;
 import org.kframework.attributes.Source;
@@ -96,6 +97,17 @@ public class KEMException extends RuntimeException {
         node.source().orElse(null));
   }
 
+  public static KEMException internalError(
+      String message, Throwable e, Optional<Location> location, Optional<Source> source) {
+    return create(
+        ExceptionType.ERROR,
+        KExceptionGroup.INTERNAL,
+        message,
+        e,
+        location.orElse(null),
+        source.orElse(null));
+  }
+
   public static KEMException compilerError(String message) {
     return create(ExceptionType.ERROR, KExceptionGroup.COMPILER, message, null, null, null);
   }
@@ -122,6 +134,17 @@ public class KEMException extends RuntimeException {
         e,
         node.location().orElse(null),
         node.source().orElse(null));
+  }
+
+  public static KEMException compilerError(
+      String message, Throwable e, Optional<Location> location, Optional<Source> source) {
+    return create(
+        ExceptionType.ERROR,
+        KExceptionGroup.COMPILER,
+        message,
+        e,
+        location.orElse(null),
+        source.orElse(null));
   }
 
   public static KEMException innerParserError(String message) {


### PR DESCRIPTION
Related to: https://github.com/runtimeverification/llvm-backend/issues/999

We are working on removing the backwards dependency from the LLVM backend to K; as part of that change we are removing usages of the frontend error handling mechanisms from the backend: https://github.com/runtimeverification/llvm-backend/pull/1001

Doing so requires that we implement a translation layer from the new error types in https://github.com/runtimeverification/llvm-backend/pull/1001 to the frontend infrastructure; by doing so we can recover the frontend's original behaviour in response to errors / warnings thrown or created during pattern matching.

This PR can be reviewed as-is in combination with the backend PR above; I will take care of the required lockstep merging to get both changes landed to the frontend together.