### PR TITLE
add pushList function to LIST module in k prelude

### DIFF
--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -951,7 +951,7 @@ An element can be added to the front of a `List` using the `pushList` operator.
 
 ```k
   syntax List ::= pushList(KItem, List)       [function, total, hook(LIST.push), klabel(pushList), symbol]
-  rule pushList(K, L) => ListItem(K) L
+  rule pushList(K::KItem, L1::List) => ListItem(K) L1
 ```
 
 ### List indexing

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -951,6 +951,7 @@ An element can be added to the front of a `List` using the `pushList` operator.
 
 ```k
   syntax List ::= pushList(KItem, List)       [function, total, hook(LIST.push), klabel(pushList), symbol]
+  rule pushList(K, L) => ListItem(K) L
 ```
 
 ### List indexing

--- a/k-distribution/include/kframework/builtin/domains.md
+++ b/k-distribution/include/kframework/builtin/domains.md
@@ -945,6 +945,14 @@ An element of a `List` is constucted via the `ListItem` operator.
   syntax List ::= ListItem(KItem)             [function, total, hook(LIST.element), klabel(ListItem), symbol, smtlib(smt_seq_elem)]
 ```
 
+### List prepend
+
+An element can be added to the front of a `List` using the `pushList` operator.
+
+```k
+  syntax List ::= pushList(KItem, List)       [function, total, hook(LIST.push), klabel(pushList), symbol]
+```
+
 ### List indexing
 
 You can get an element of a list by its integer offset in O(log(N)) time, or

--- a/k-distribution/tests/builtins/collections/test-set2list-2.col.out
+++ b/k-distribution/tests/builtins/collections/test-set2list-2.col.out
@@ -1,6 +1,6 @@
 <k>
-  ListItem ( 1 )
-  ListItem ( 2 )
+  ListItem ( 4 )
   ListItem ( 3 )
-  ListItem ( 4 ) ~> .K
+  ListItem ( 2 )
+  ListItem ( 1 ) ~> .K
 </k>

--- a/k-distribution/tests/builtins/collections/test-set2list-3.col.out
+++ b/k-distribution/tests/builtins/collections/test-set2list-3.col.out
@@ -1,5 +1,5 @@
 <k>
-  ListItem ( 1 )
+  ListItem ( 4 )
   ListItem ( 3 )
-  ListItem ( 4 ) ~> .K
+  ListItem ( 1 ) ~> .K
 </k>

--- a/llvm-backend/pom.xml
+++ b/llvm-backend/pom.xml
@@ -49,7 +49,7 @@
                   <arg value="-DCMAKE_PREFIX_PATH=${prefix.path}" />
                   <arg value="-DCMAKE_BUILD_TYPE=${project.build.type}" />
                   <arg value="-DCMAKE_INSTALL_PREFIX=${llvm.backend.prefix}" />
-                  <arg value="-DGC_INTERVAL=${llvm.backend.gc.interval}" />
+                  <arg value="-DK_LLVM_BACKEND_LTO=OFF" />
                   <arg value="${project.basedir}/src/main/native/llvm-backend" />
                 </exec>
                 <property environment="env"/>


### PR DESCRIPTION
Adds a function to the k prelude LIST module which prepends an item to a list. This can be implemented more efficiently than the generic list append operator that appends two lists.