### PR TITLE
Restore pretty-printing for exhaustiveness

### DIFF
--- a/kore/pom.xml
+++ b/kore/pom.xml
@@ -16,6 +16,11 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.runtimeverification.k</groupId>
+      <artifactId>scala-kore</artifactId>
+      <version>0.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
       <version>3.3.2</version>

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -363,6 +363,9 @@ case class Module(
     mergeAttributes(_)
   }
 
+  lazy val hookAttributes: Map[String, String] =
+    sortAttributesFor.flatMap(s => s._2.getOption(Att.HOOK).map(att => s._1.name -> att))
+
   private def mergeAttributes[T <: Sentence](p: Set[T]) =
     Att.mergeAttributes(p.map(_.att))
 

--- a/kore/src/main/scala/org/kframework/parser/kore/parser/KoreToK.scala
+++ b/kore/src/main/scala/org/kframework/parser/kore/parser/KoreToK.scala
@@ -1,6 +1,7 @@
 // Copyright (c) Runtime Verification, Inc. All Rights Reserved.
 package org.kframework.parser.kore.parser
 
+import com.runtimeverification.k.kore
 import org.kframework.{ kore => k }
 import org.kframework.attributes.Att
 import org.kframework.builtin.KLabels
@@ -8,7 +9,6 @@ import org.kframework.builtin.Sorts
 import org.kframework.kore.ADT.KVariable
 import org.kframework.kore.Assoc
 import org.kframework.kore.KORE
-import org.kframework.parser.kore
 import org.kframework.utils.StringUtil
 import scala.collection.JavaConverters._
 import scala.collection.Map


### PR DESCRIPTION
Previously, this logic lived in the LLVM backend's matching compiler. When we eliminated the backwards dependency edge between the backend and the frontend, this meant we couldn't use the frontend pretty-printing logic to make the error message in the pattern matcher.

This commit reinstates equivalent pretty-printing logic in the frontend.

Blocked on https://github.com/runtimeverification/llvm-backend/pull/1007 reaching the frontend.