### PR TITLE
Emit better error message for locally-duplicated syntactic lists

### DIFF
--- a/k-distribution/tests/regression-new/checks/localDuplicateList.k
+++ b/k-distribution/tests/regression-new/checks/localDuplicateList.k
@@ -1,0 +1,10 @@
+module LOCALDUPLICATELIST-SYNTAX
+endmodule
+
+module LOCALDUPLICATELIST
+  imports BOOL-SYNTAX
+  imports INT-SYNTAX
+
+  syntax Foo ::= List{Bool, ","}
+  syntax Foo ::= List{Int, ";"}
+endmodule

--- a/k-distribution/tests/regression-new/checks/localDuplicateList.k.out
+++ b/k-distribution/tests/regression-new/checks/localDuplicateList.k.out
@@ -1,0 +1,5 @@
+[Error] Compiler: Sort Foo previously declared as a user list at Source(localDuplicateList.k) and Location(9,18,9,32)
+	Source(localDuplicateList.k)
+	Location(8,18,8,33)
+	8 |	  syntax Foo ::= List{Bool, ","}
+	  .	                 ^~~~~~~~~~~~~~~

--- a/kore/src/main/scala/org/kframework/definition/outer.scala
+++ b/kore/src/main/scala/org/kframework/definition/outer.scala
@@ -481,10 +481,12 @@ case class Module(
   def checkUserLists(): Unit = localSentences.foreach {
     case p @ Production(_, _, srt, _, atts) =>
       if (atts.contains(Att.USER_LIST)) {
-        val prev = importedSentences.find(s =>
+        val prev = sentences.find(s =>
           s.isInstanceOf[Production]
             && s.asInstanceOf[Production].sort.equals(srt)
             && s.att.contains(Att.USER_LIST)
+            && !(s.source.equals(p.source)
+              && s.location.equals(p.location))
         )
         if (prev.isDefined)
           throw KEMException.compilerError(


### PR DESCRIPTION
Previously, we would only inspect _imported_ sentences when looking for duplicated user lists. This means that if you duplicate the production locally, you hit an assertion instead of the existing check.

To fix this, the check needs to ensure that it sees multiple `userList` sentences _with different_ source / location pairs_ for a given sort.

Fixes: #4079