### PR TITLE
Drop support for deprecated `--directory` flag

### DIFF
--- a/k-distribution/src/main/scripts/bin/kore-print
+++ b/k-distribution/src/main/scripts/bin/kore-print
@@ -42,7 +42,7 @@ $KORE_PRINT arguments:
       --color [on|off]     Enable/disable ANSI color codes. Overrides default,
                            which is determined based on whether stdout is a
                            terminal
-      --definition DIR     Exact path to the kompiled directory.
+  -d, --definition DIR     Exact path to the kompiled directory.
   -h, --help               Display this help and exit
       --no-substitution-filtering  Don't filter conjuncts with anonymous
                                    variables from substitution output
@@ -85,7 +85,7 @@ do
       shift
       ;;
 
-      --definition)
+      -d|--definition)
       kompiledDir="$2"
       shift
       ;;

--- a/k-distribution/src/main/scripts/bin/kore-print
+++ b/k-distribution/src/main/scripts/bin/kore-print
@@ -42,8 +42,6 @@ $KORE_PRINT arguments:
       --color [on|off]     Enable/disable ANSI color codes. Overrides default,
                            which is determined based on whether stdout is a
                            terminal
-  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
-                           under the directory DIR
       --definition DIR     Exact path to the kompiled directory.
   -h, --help               Display this help and exit
       --no-substitution-filtering  Don't filter conjuncts with anonymous
@@ -84,12 +82,6 @@ do
         error 1 'Invalid value for --color. Should be "on" or "off".'
         ;;
       esac
-      shift
-      ;;
-
-      -d|--directory)
-      echo "[Warning]: -d/--directory is deprecated. Use --definition instead." >&2
-      dir="$2"
       shift
       ;;
 

--- a/k-distribution/src/main/scripts/bin/kparse
+++ b/k-distribution/src/main/scripts/bin/kparse
@@ -41,7 +41,7 @@ $(k_util_usage)
 $KPARSE options:
 
   -h, --help               Display this help and exit
-      --definition DIR     Exact path to the kompiled directory.
+  -d, --definition DIR     Exact path to the kompiled directory.
   -i, --input MODE         Select input mode to use when parsing. Valid values
                            are program, kast, binary, json, and kore.
   -m, --module MODULE      Module to use to generate grammar
@@ -70,7 +70,7 @@ do
       exit 0
       ;;
 
-      --definition)
+      -d|--definition)
       kompiledDir="$2"
       shift
       ;;

--- a/k-distribution/src/main/scripts/bin/kparse
+++ b/k-distribution/src/main/scripts/bin/kparse
@@ -40,8 +40,8 @@ $(k_util_usage)
 
 $KPARSE options:
 
-  -h, --help               Display this help and exit
   -d, --definition DIR     Exact path to the kompiled directory.
+  -h, --help               Display this help and exit
   -i, --input MODE         Select input mode to use when parsing. Valid values
                            are program, kast, binary, json, and kore.
   -m, --module MODULE      Module to use to generate grammar

--- a/k-distribution/src/main/scripts/bin/kparse
+++ b/k-distribution/src/main/scripts/bin/kparse
@@ -40,8 +40,6 @@ $(k_util_usage)
 
 $KPARSE options:
 
-  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
-                           under the directory DIR
   -h, --help               Display this help and exit
       --definition DIR     Exact path to the kompiled directory.
   -i, --input MODE         Select input mode to use when parsing. Valid values
@@ -67,12 +65,6 @@ do
     ARGV+=("$1")
   else
     case "$arg" in
-      -d|--directory)
-      echo "[Warning]: -d/--directory is deprecated. Use --definition instead." >&2
-      dir="$2"
-      shift
-      ;;
-
       -h|--help)
       print_usage
       exit 0

--- a/k-distribution/src/main/scripts/bin/kparse-gen
+++ b/k-distribution/src/main/scripts/bin/kparse-gen
@@ -42,7 +42,7 @@ $KPARSE_GEN options:
       --bison-file FILE    C file that should be linked into the generated
                            parser
       --bison-stack-max-depth  Maximum size of bison stack. Default: 10000
-      --definition DIR     Exact path to the kompiled directory.
+  -d, --definition DIR     Exact path to the kompiled directory.
   -g, --glr                Generate a GLR parser instead of an LR(1) parser
   -h, --help               Display this help and exit
   -m, --module MODULE      Module to use to generate grammar
@@ -76,7 +76,7 @@ do
       shift
       ;;
 
-      --definition)
+      -d|--definition)
       kompiledDir="$2"
       shift
       ;;

--- a/k-distribution/src/main/scripts/bin/kparse-gen
+++ b/k-distribution/src/main/scripts/bin/kparse-gen
@@ -42,8 +42,6 @@ $KPARSE_GEN options:
       --bison-file FILE    C file that should be linked into the generated
                            parser
       --bison-stack-max-depth  Maximum size of bison stack. Default: 10000
-  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
-                           under the directory DIR
       --definition DIR     Exact path to the kompiled directory.
   -g, --glr                Generate a GLR parser instead of an LR(1) parser
   -h, --help               Display this help and exit
@@ -75,12 +73,6 @@ do
 
       --bison-stack-max-depth)
       stackDepth="$2"
-      shift
-      ;;
-
-      -d|--directory)
-      echo "[Warning]: -d/--directory is deprecated. Use --definition instead."
-      dir="$2"
       shift
       ;;
 

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -125,7 +125,7 @@ $KRUN options:
       --haskell-backend-command CMD  use CMD instead of kore-exec to invoke
                                      Haskell backend
   -h, --help               Display this help and exit
-      --definition DIR     Exact path to the kompiled directory.
+  -d, --definition DIR     Exact path to the kompiled directory.
       --execute-to-branch  Execute until a non-deterministic state is reached, then exit.
                            Requires the --enable-search option to have been passed to kompile
                            on the LLVM backend.
@@ -252,7 +252,7 @@ do
       exit 0
       ;;
 
-      --definition)
+      -d|--definition)
       kompiledDir="$2"
       shift
       ;;

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -101,34 +101,28 @@ $(k_util_usage)
 $KRUN options:
 
       --bound N            Return at most N solutions  with --search
-      --depth N            Execute at most N rewrite steps
-      --color [on|off]     Enable/disable ANSI color codes. Overrides default,
-                           which is determined based on whether stdout is a
-                           terminal.
-  -pNAME=VALUE             Use VALUE as a command to parse \$NAME. For example,
-                           if NAME=PGM and VALUE=cat, and the user also passes
-                           \`-cPGM=foo\`, a temporary file containing the word
-                           "foo" is created and cat is called on it to provide
-                           the value of \$PGM as a KORE term.
-
   -cNAME=VALUE             Use VALUE as the value for \$NAME. By default,
                            \`kparse -m MAINMODULE\` is used as the
                            parser. This can be overridden with -p.
+      --color [on|off]     Enable/disable ANSI color codes. Overrides default,
+                           which is determined based on whether stdout is a
+                           terminal.
       --debugger           Launch the backend in a debugging console.
                            Currently only supported on LLVM backend.
       --debugger-batch     Launch the backend in a debugging console in batch
                            mode. Currently only supported on LLVM backend.
       --debugger-command FILE  Execute GDB commands from FILE to debug program.
                                Currently only supported on LLVM backend.
+  -d, --definition DIR     Exact path to the kompiled directory.
+      --depth N            Execute at most N rewrite steps
       --dry-run            Do not execute backend, but instead print the
                            command that would be executed to stdout.
-      --haskell-backend-command CMD  use CMD instead of kore-exec to invoke
-                                     Haskell backend
-  -h, --help               Display this help and exit
-  -d, --definition DIR     Exact path to the kompiled directory.
       --execute-to-branch  Execute until a non-deterministic state is reached, then exit.
                            Requires the --enable-search option to have been passed to kompile
                            on the LLVM backend.
+      --haskell-backend-command CMD  use CMD instead of kore-exec to invoke
+                                     Haskell backend
+  -h, --help               Display this help and exit
       --io [on|off]        Enable/disable reading/writing to actual
                            stdin/stdout via cells with "stream" attribute.
                            Defaults to enabled when performing concrete
@@ -137,18 +131,23 @@ $KRUN options:
                            This assumes that the initial configuration contains
                            no macro terms. Behavior is undefined if this is not
                            true.
+      --no-pattern         Skip pattern matching the result of searches on the
+                           llvm backend against the default search pattern.
       --no-substitution-filtering  Don't filter conjuncts with anonymous
                                    variables from substitution output
   -o, --output MODE        Select output mode to use when unparsing. Valid
                            values are pretty, program, kast, json,
                            kore, and none.
       --output-file FILE   Print final configuration to FILE
+  -pNAME=VALUE             Use VALUE as a command to parse \$NAME. For example,
+                           if NAME=PGM and VALUE=cat, and the user also passes
+                           \`-cPGM=foo\`, a temporary file containing the word
+                           "foo" is created and cat is called on it to provide
+                           the value of \$PGM as a KORE term.
       --parser VALUE       Use VALUE as parser to parse \$PGM. For example,
                            if the user says "$KRUN --parser cat foo.kore", then
                            \`cat foo.kore\` is invoked and the result on stdout
                            is used as the value of \$PGM as a KORE term.
-      --no-pattern         Skip pattern matching the result of searches on the
-                           llvm backend against the default search pattern.
       --pattern PAT        Use PAT as the search pattern with --search. Can
                            also be used without --search to match the output
                            configuration against a pattern and print the

--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -120,8 +120,6 @@ $KRUN options:
                            mode. Currently only supported on LLVM backend.
       --debugger-command FILE  Execute GDB commands from FILE to debug program.
                                Currently only supported on LLVM backend.
-  -d, --directory DIR      [DEPRECATED] Look for a kompiled directory ending in "-kompiled"
-                           under the directory DIR.
       --dry-run            Do not execute backend, but instead print the
                            command that would be executed to stdout.
       --haskell-backend-command CMD  use CMD instead of kore-exec to invoke
@@ -237,12 +235,6 @@ do
       tempFiles+=("$tempFile")
       printf %s "$val" > "$tempFile"
       printf -v "$var_name" %s "$tempFile"
-      ;;
-
-      -d|--directory)
-      echo "[Warning]: -d/--directory is deprecated. Use --definition instead." >&2
-      dir="$2"
-      shift
       ;;
 
       --dry-run)

--- a/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/DefinitionLoadingModule.java
@@ -10,10 +10,8 @@ import java.io.File;
 import java.util.Map;
 import org.kframework.kompile.CompiledDefinition;
 import org.kframework.kompile.KompileOptions;
-import org.kframework.main.GlobalOptions;
 import org.kframework.utils.BinaryLoader;
 import org.kframework.utils.errorsystem.KEMException;
-import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.Environment;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.KompiledDir;
@@ -49,9 +47,6 @@ public class DefinitionLoadingModule extends AbstractModule {
       @Environment Map<String, String> env) {
     File directory = null;
     if (options.inputDirectory != null) {
-      if (options.directory != null)
-        throw KEMException.criticalError(
-            "Cannot use both --directory and --definition at the same time.");
       File f = new File(options.inputDirectory);
       if (f.isAbsolute()) {
         directory = f;
@@ -67,29 +62,15 @@ public class DefinitionLoadingModule extends AbstractModule {
       }
     } else {
       File whereDir;
-      if (options.directory == null) {
-        if (env.get("KRUN_COMPILED_DEF") != null) {
-          File f = new File(env.get("KRUN_COMPILED_DEF"));
-          if (f.isAbsolute()) {
-            whereDir = f;
-          } else {
-            whereDir = new File(workingDir, env.get("KRUN_COMPILED_DEF"));
-          }
-        } else {
-          whereDir = workingDir;
-        }
-      } else {
-        KExceptionManager kem = new KExceptionManager(new GlobalOptions());
-        kem.registerCriticalWarning(
-            DEPRECATED_DIRECTORY_FLAG,
-            "Using --directory is deprecated. Use --output-definition instead.");
-        kem.print();
-        File f = new File(options.directory);
+      if (env.get("KRUN_COMPILED_DEF") != null) {
+        File f = new File(env.get("KRUN_COMPILED_DEF"));
         if (f.isAbsolute()) {
           whereDir = f;
         } else {
-          whereDir = new File(workingDir, options.directory);
+          whereDir = new File(workingDir, env.get("KRUN_COMPILED_DEF"));
         }
+      } else {
+        whereDir = workingDir;
       }
       File[] dirs = whereDir.listFiles((current, name) -> new File(current, name).isDirectory());
 

--- a/kernel/src/main/java/org/kframework/utils/inject/OuterParsingModule.java
+++ b/kernel/src/main/java/org/kframework/utils/inject/OuterParsingModule.java
@@ -7,9 +7,6 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provides;
 import java.io.File;
 import org.apache.commons.io.FilenameUtils;
-import org.kframework.main.GlobalOptions;
-import org.kframework.utils.errorsystem.KEMException;
-import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.DefinitionDir;
 import org.kframework.utils.file.FileUtil;
 import org.kframework.utils.file.KompiledDir;
@@ -41,28 +38,9 @@ public class OuterParsingModule extends AbstractModule {
   File kompiledDir(
       OuterParsingOptions options, @WorkingDir File workingDir, OutputDirectoryOptions output) {
     if (output.outputDirectory != null) {
-      if (output.directory != null)
-        throw KEMException.criticalError(
-            "Cannot use both --directory and --output-definition at the same time.");
       File f = new File(output.outputDirectory);
       if (f.isAbsolute()) return f;
       return new File(workingDir, output.outputDirectory);
-    } else if (output.directory != null) {
-      KExceptionManager kem = new KExceptionManager(new GlobalOptions());
-      kem.registerCompilerWarning(
-          DEPRECATED_DIRECTORY_FLAG,
-          "The --directory option is deprecated. Please use --output-definition instead.");
-      kem.print();
-      File f = new File(output.directory);
-      if (!f.isAbsolute()) f = new File(workingDir, output.directory).getAbsoluteFile();
-
-      return new File(
-          f,
-          FilenameUtils.removeExtension(
-                  options
-                      .mainDefinitionFile(new FileUtil(null, workingDir, null, null, null))
-                      .getName())
-              + "-kompiled");
     }
     // bootstrap the part of FileUtil we need
     return new File(

--- a/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
@@ -8,22 +8,8 @@ public class DefinitionLoadingOptions {
   public DefinitionLoadingOptions() {}
 
   @Parameter(
-      names = {"--directory", "-d"},
-      description =
-          "[DEPRECATED] Path to the directory in which the kompiled K definition resides. The"
-              + " default is the unique, only directory with the suffix '-kompiled' in the current"
-              + " directory.",
-      descriptionKey = "path",
-      hidden = true)
-  public String directory;
-
-  @Parameter(
       names = {"--definition"},
       description = "Exact path to the kompiled directory.",
       descriptionKey = "path")
   public String inputDirectory;
-
-  public DefinitionLoadingOptions(String dir) {
-    this.directory = dir;
-  }
 }

--- a/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/DefinitionLoadingOptions.java
@@ -8,7 +8,7 @@ public class DefinitionLoadingOptions {
   public DefinitionLoadingOptions() {}
 
   @Parameter(
-      names = {"--definition"},
+      names = {"--definition", "-d"},
       description = "Exact path to the kompiled directory.",
       descriptionKey = "path")
   public String inputDirectory;

--- a/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
+++ b/kernel/src/main/java/org/kframework/utils/options/OutputDirectoryOptions.java
@@ -13,16 +13,6 @@ public class OutputDirectoryOptions implements Serializable {
   public OutputDirectoryOptions(Void v) {}
 
   @Parameter(
-      names = {"--directory", "-d"},
-      description =
-          "[DEPRECATED] Path to the directory in which the output resides. An output can be either"
-              + " a kompiled K definition or a document which depends on the type of backend. The"
-              + " default is the directory containing the main definition file.",
-      descriptionKey = "path",
-      hidden = true)
-  public String directory;
-
-  @Parameter(
       names = {"--output-definition", "-o"},
       description = "Path to the exact directory in which the output resides.",
       descriptionKey = "path")

--- a/kernel/src/main/java/org/kframework/utils/options/StringListConverter.java
+++ b/kernel/src/main/java/org/kframework/utils/options/StringListConverter.java
@@ -10,7 +10,7 @@ import java.util.List;
  * This class is designed to support the specification of a list of strings using a single string in
  * cases where using a list of strings would be infeasible. For example, in krun, simulation options
  * are passed by passing a set of krun options as parameter to a special krun option. We can't use
- * variable arity because then --simulation --directory foo would be interpreted as two options
+ * variable arity because then --simulation --definition foo would be interpreted as two options
  * instead of one with two words.
  *
  * @author dwightguth

--- a/kernel/src/test/java/org/kframework/utils/inject/DefinitionLoadingModuleTest.java
+++ b/kernel/src/test/java/org/kframework/utils/inject/DefinitionLoadingModuleTest.java
@@ -17,19 +17,6 @@ import org.kframework.utils.options.OutputDirectoryOptions;
 public class DefinitionLoadingModuleTest {
 
   @Test
-  public void testReadDefinition() throws IOException {
-    DefinitionLoadingOptions options = new DefinitionLoadingOptions();
-    new JCommander(options, "--directory", "src/test/resources");
-    DefinitionLoadingModule module = new DefinitionLoadingModule();
-    File kompiledDir = module.directory(options, new File("."), System.getenv());
-    assertEquals(
-        new File("src/test/resources/test-kompiled").getCanonicalFile(),
-        kompiledDir.getCanonicalFile());
-    assertTrue(kompiledDir.exists());
-    assertTrue(kompiledDir.isDirectory());
-  }
-
-  @Test
   public void testReadDefinition2() throws IOException {
     DefinitionLoadingOptions options = new DefinitionLoadingOptions();
     new JCommander(options, "--definition", "src/test/resources/test-kompiled");

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -137,7 +137,6 @@ public class KException implements Serializable, HasLocation {
     NON_LR_GRAMMAR,
     IGNORED_ATTRIBUTE,
     REMOVED_ANYWHERE,
-    DEPRECATED_DIRECTORY_FLAG,
     DEPRECATED_SYMBOL,
     MISSING_HOOK,
     SINGLETON_OVERLOAD,


### PR DESCRIPTION
Closes #4083

- Drop support for `--directory` and remove all corresponding logic
- Make `-d` an alias for `--definition`
- Alphabetize all the help options