### PR TITLE
Emit warning if config var occurs in cell collection without `initial` attribute

### DIFF
--- a/k-distribution/tests/regression-new/checkWarns/configVarInitial.k
+++ b/k-distribution/tests/regression-new/checkWarns/configVarInitial.k
@@ -1,0 +1,15 @@
+module CONFIGVARINITIAL-SYNTAX
+endmodule
+
+module CONFIGVARINITIAL
+imports CONFIGVARINITIAL-SYNTAX
+
+configuration <k> $PGM </k>
+              <goods>
+	        <good multiplicity="*" type="Set" initial=""> $FOO </good>
+	      </goods>
+	      <bads>
+	        <bad multiplicity="*" type="Set"> $FOO </bad>
+	      </bads> 
+	      
+endmodule

--- a/k-distribution/tests/regression-new/checkWarns/configVarInitial.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/configVarInitial.k.out
@@ -1,0 +1,2 @@
+[Error] Compiler: Configuration variable found in declaration of collection cell <bad>. Implicitly, this causes the initial configuration to start with one <bad> element instead of zero. Add the `initial=""` attribute to make that behavior explicit.
+[Error] Compiler: Had 1 parsing errors.

--- a/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
+++ b/kernel/src/main/java/org/kframework/backend/kore/KoreBackend.java
@@ -200,6 +200,7 @@ public class KoreBackend implements Backend {
             DefinitionTransformer.from(
                     m ->
                         new ResolveFreshConstants(
+                                kem,
                                 d,
                                 kompileOptions.topCell,
                                 files,
@@ -315,7 +316,7 @@ public class KoreBackend implements Backend {
     Function1<Module, Module> resolveFreshConstants =
         d ->
             ModuleTransformer.from(
-                    new ResolveFreshConstants(def, kompileOptions.topCell, files)::resolve,
+                    new ResolveFreshConstants(kem, def, kompileOptions.topCell, files)::resolve,
                     "resolving !Var variables")
                 .apply(d);
     Function1<Module, Module> addImplicitCounterCell =

--- a/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
+++ b/kernel/src/main/java/org/kframework/compile/ResolveFreshConstants.java
@@ -36,6 +36,7 @@ import org.kframework.parser.inner.ParseInModule;
 import org.kframework.parser.inner.RuleGrammarGenerator;
 import org.kframework.parser.outer.Outer;
 import org.kframework.utils.errorsystem.KEMException;
+import org.kframework.utils.errorsystem.KExceptionManager;
 import org.kframework.utils.file.FileUtil;
 import scala.Option;
 import scala.collection.JavaConverters;
@@ -43,6 +44,7 @@ import scala.collection.Set;
 
 public class ResolveFreshConstants {
 
+  private final KExceptionManager kem;
   private final Definition def;
   private final FileUtil files;
   private Module m;
@@ -200,12 +202,18 @@ public class ResolveFreshConstants {
     return s;
   }
 
-  public ResolveFreshConstants(Definition def, String manualTopCell, FileUtil files) {
-    this(def, manualTopCell, files, 0);
+  public ResolveFreshConstants(
+      KExceptionManager kem, Definition def, String manualTopCell, FileUtil files) {
+    this(kem, def, manualTopCell, files, 0);
   }
 
   public ResolveFreshConstants(
-      Definition def, String manualTopCell, FileUtil files, int initialFresh) {
+      KExceptionManager kem,
+      Definition def,
+      String manualTopCell,
+      FileUtil files,
+      int initialFresh) {
+    this.kem = kem;
     this.def = def;
     this.manualTopCell = manualTopCell;
     this.files = files;
@@ -281,7 +289,7 @@ public class ResolveFreshConstants {
                 topCellToken);
         Set<Sentence> newSentences =
             GenerateSentencesFromConfigDecl.gen(
-                generatedTop, BooleanUtils.TRUE, Att.empty(), mod.getExtensionModule());
+                kem, generatedTop, BooleanUtils.TRUE, Att.empty(), mod.getExtensionModule());
         sentences = (Set<Sentence>) sentences.$bar(newSentences);
         sentences = (Set<Sentence>) sentences.$bar(immutable(counterSentences));
       }
@@ -291,7 +299,7 @@ public class ResolveFreshConstants {
       ParseInModule mod = RuleGrammarGenerator.getCombinedGrammar(gen.getConfigGrammar(m), files);
       Set<Sentence> newSentences =
           GenerateSentencesFromConfigDecl.gen(
-              freshCell, BooleanUtils.TRUE, Att.empty(), mod.getExtensionModule());
+              kem, freshCell, BooleanUtils.TRUE, Att.empty(), mod.getExtensionModule());
       sentences = (Set<Sentence>) sentences.$bar(newSentences);
       sentences = (Set<Sentence>) sentences.$bar(immutable(counterSentences));
     }

--- a/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/kernel/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -513,6 +513,7 @@ public class DefinitionParsing {
                           configDecl ->
                               stream(
                                   GenerateSentencesFromConfigDecl.gen(
+                                      kem,
                                       configDecl.body(),
                                       configDecl.ensures(),
                                       configDecl.att(),

--- a/kernel/src/test/java/org/kframework/compile/GenerateSentencesFromConfigDeclTest.java
+++ b/kernel/src/test/java/org/kframework/compile/GenerateSentencesFromConfigDeclTest.java
@@ -37,12 +37,14 @@ public class GenerateSentencesFromConfigDeclTest {
 
   Definition def;
   FileUtil files;
+  KExceptionManager kem;
 
   @Before
   public void setUp() {
     String definitionText;
     files = FileUtil.testFileUtil();
-    ParserUtils parser = new ParserUtils(files, new KExceptionManager(new GlobalOptions()));
+    kem = new KExceptionManager(new GlobalOptions());
+    ParserUtils parser = new ParserUtils(files, kem);
     File definitionFile = new File(Kompile.BUILTIN_DIRECTORY + "/prelude.md");
     definitionText = files.loadFromWorkingDirectory(definitionFile.getPath());
 
@@ -92,7 +94,7 @@ public class GenerateSentencesFromConfigDeclTest {
         RuleGrammarGenerator.getCombinedGrammar(parserGen.getConfigGrammar(m1), files)
             .getExtensionModule();
     Set<Sentence> gen =
-        GenerateSentencesFromConfigDecl.gen(configuration, BooleanUtils.FALSE, Att(), m);
+        GenerateSentencesFromConfigDecl.gen(kem, configuration, BooleanUtils.FALSE, Att(), m);
     Att initializerAtts = Att().add(Att.INITIALIZER());
     Att productionAtts = initializerAtts.add(Att.FUNCTION());
     Set<Sentence> reference =

--- a/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
+++ b/kore/src/main/java/org/kframework/utils/errorsystem/KException.java
@@ -141,6 +141,7 @@ public class KException implements Serializable, HasLocation {
     DEPRECATED_SYMBOL,
     MISSING_HOOK,
     SINGLETON_OVERLOAD,
+    CELL_COLLECTION_VAR_WITHOUT_INITIAL,
     FIRST_HIDDEN, // warnings below here are hidden by default
     USELESS_RULE,
     UNRESOLVED_FUNCTION_SYMBOL,


### PR DESCRIPTION
Part of #4073

Adds a warning to indicate that the presence of a configuration variable in a cell collection implicitly changes the initialization behavior.

Once all downstream semantics have been patched, we can change this warning to an error.