### PR TITLE
Fix userList edge case from #4117

### DIFF
--- a/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k
+++ b/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k
@@ -1,12 +1,28 @@
 module NONUNIQUEOVERLOAD-SYNTAX
 endmodule
 
+module WARNS
+  syntax Foo1 ::= Foo2
+
+  syntax Foo1 ::= "foo" Foo1 [overload(foo), unused]
+  syntax Foo2 ::= "foo" Foo2 [overload(foo), unused]
+
+  syntax Foo1 ::= "foo" Foo1 Foo1 [overload(foo), unused]
+  syntax Foo2 ::= "foo" Foo2 Foo2 [overload(foo), unused]
+endmodule
+
+module NOWARNS
+  imports DOMAINS
+
+  syntax Exp  ::= Int | Id
+
+  syntax Exps ::= List{Exp, ","} [overload(exps), unused]
+  syntax Ids  ::= List{Id, ","}  [overload(exps), unused]
+
+  syntax Exps ::= Ids
+endmodule
+
 module NONUNIQUEOVERLOAD
-    syntax Foo1 ::= Foo2
-
-    syntax Foo1 ::= "foo" Foo1 [overload(foo), unused]
-    syntax Foo2 ::= "foo" Foo2 [overload(foo), unused]
-
-    syntax Foo1 ::= "foo" Foo1 Foo1 [overload(foo), unused]
-    syntax Foo2 ::= "foo" Foo2 Foo2 [overload(foo), unused]
+  imports WARNS
+  imports NOWARNS
 endmodule

--- a/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k.out
@@ -1,11 +1,11 @@
 [Error] Compiler: Overload `foo` is not unique. Consider renaming one of the overload sets with this key.
 	Source(nonUniqueOverload.k)
-	Location(8,21,8,55)
-	8 |	    syntax Foo2 ::= "foo" Foo2 [overload(foo), unused]
-	  .	                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Location(8,19,8,53)
+	8 |	  syntax Foo2 ::= "foo" Foo2 [overload(foo), unused]
+	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Overload `foo` is not unique. Consider renaming one of the overload sets with this key.
 	Source(nonUniqueOverload.k)
-	Location(11,21,11,60)
-	11 |	    syntax Foo2 ::= "foo" Foo2 Foo2 [overload(foo), unused]
-	   .	                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+	Location(11,19,11,58)
+	11 |	  syntax Foo2 ::= "foo" Foo2 Foo2 [overload(foo), unused]
+	   .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Had 2 structural errors.

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -661,7 +661,9 @@ public class Kompile {
 
     partialOrderHeads.forEach(
         (key, prods) -> {
-          if (prods.size() > 1) {
+          var userList =
+              prods.size() == 2 && prods.stream().allMatch(p -> p.att().contains(Att.USER_LIST()));
+          if (prods.size() > 1 && !userList) {
             for (Production prod : prods) {
               kem.registerCompilerWarning(
                   KException.ExceptionType.DUPLICATE_OVERLOAD,


### PR DESCRIPTION
In #4117, we added a warning when two structurally-different productions share an overload attribute. This produced false-positive warnings on user list productions, as these productions are desugared internally into two separate cons / nil productions that will share an overload attribute based on their original production.

This PR fixes the edge case by checking if precisely 2 productions, all with the `userList` attribute, share an overload key. In this case, we don't emit a warning. The test case from the original PR has been updated with a negative example as a regression test.