### PR TITLE
Refactor "unique overloads" check

### DIFF
--- a/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k
+++ b/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k
@@ -11,8 +11,28 @@ module WARNS
   syntax Foo2 ::= "foo" Foo2 Foo2 [overload(foo), unused]
 endmodule
 
+module WASM-REPRO
+    syntax EmptyStmt
+
+    syntax Instr ::= EmptyStmt
+    syntax Defn  ::= EmptyStmt
+    syntax Stmt  ::= Instr | Defn
+ // -----------------------------
+
+    syntax EmptyStmts ::= List{EmptyStmt , ""} [overload(listStmt), terminator-symbol(".List{\"listStmt\"}"), unused]
+    syntax Instrs     ::= List{Instr     , ""} [overload(listStmt), unused]
+    syntax Defns      ::= List{Defn      , ""} [overload(listStmt), unused]
+    syntax Stmts      ::= List{Stmt      , ""} [overload(listStmt), unused]
+ // -------------------------------------------------------------
+
+    syntax Instrs ::= EmptyStmts
+    syntax Defns  ::= EmptyStmts
+    syntax Stmts  ::= Instrs | Defns
+endmodule
+
 module NOWARNS
   imports DOMAINS
+  imports WASM-REPRO
 
   syntax Exp  ::= Int | Id
 

--- a/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k.out
@@ -1,7 +1,7 @@
 [Error] Compiler: Overload `foo` is not unique. Consider renaming one of the overload sets with this key.
 	Source(nonUniqueOverload.k)
-	Location(8,19,8,53)
-	8 |	  syntax Foo2 ::= "foo" Foo2 [overload(foo), unused]
+	Location(7,19,7,53)
+	7 |	  syntax Foo1 ::= "foo" Foo1 [overload(foo), unused]
 	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Overload `foo` is not unique. Consider renaming one of the overload sets with this key.
 	Source(nonUniqueOverload.k)

--- a/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k.out
+++ b/k-distribution/tests/regression-new/checkWarns/nonUniqueOverload.k.out
@@ -1,7 +1,7 @@
 [Error] Compiler: Overload `foo` is not unique. Consider renaming one of the overload sets with this key.
 	Source(nonUniqueOverload.k)
-	Location(7,19,7,53)
-	7 |	  syntax Foo1 ::= "foo" Foo1 [overload(foo), unused]
+	Location(8,19,8,53)
+	8 |	  syntax Foo2 ::= "foo" Foo2 [overload(foo), unused]
 	  .	                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 [Error] Compiler: Overload `foo` is not unique. Consider renaming one of the overload sets with this key.
 	Source(nonUniqueOverload.k)

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -663,16 +663,13 @@ public class Kompile {
     attributeGroups.forEach(
         ps -> {
           var userList = ps.stream().allMatch(p -> p.att().contains(Att.USER_LIST()));
-          if (userList) {
-            return;
-          }
 
           var groups =
               ps.stream()
                   .collect(
                       Collectors.groupingBy(p -> module.overloads().connectedComponents().get(p)));
 
-          if (groups.size() > 1) {
+          if (groups.size() > (userList ? 2 : 1)) {
             for (var g : groups.values()) {
               assert !g.isEmpty();
               var prod = g.get(0);

--- a/kernel/src/main/java/org/kframework/kompile/Kompile.java
+++ b/kernel/src/main/java/org/kframework/kompile/Kompile.java
@@ -666,8 +666,7 @@ public class Kompile {
 
           var groups =
               ps.stream()
-                  .collect(
-                      Collectors.groupingBy(p -> module.overloads().connectedComponents().get(p)));
+                  .collect(Collectors.groupingBy(module.overloads().connectedComponents()::get));
 
           if (groups.size() > (userList ? 2 : 1)) {
             for (var g : groups.values()) {


### PR DESCRIPTION
Previously, this check relied on identifying when a set of overloads with the same key had multiple greatest / least elements. This is too strong in the presence of Y-shaped overload sets; the solution is instead to check that all the productions that share an overload key are in the same connected component of the overload POSet.[^1]

Fixes an issue in the WASM semantics (https://github.com/runtimeverification/wasm-semantics/blob/master/wasm.md?plain=1#L62-L65) reported by @virgil-serbanuta, where a spurious warning was being generated: https://runtimeverification.slack.com/archives/C7E701MFG/p1711124927666709

The PR includes a reproduction of Virgil's issue, which breaks with K `6.3.58` and is fixed by this change.

[^1]: Except for user lists, which must partition into precisely two connected components: one for the cons case and one for the terminator.