### PR TITLE
Remove old `binary` help text from kast

### DIFF
--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -162,7 +162,7 @@ public final class KastOptions {
       descriptionKey = "mode",
       converter = InputModeConverter.class,
       description =
-          "How to read kast input in. <mode> is either [program|binary|kast|json|kore|rule].")
+          "How to read kast input in. <mode> is either [program|kast|json|kore|rule].")
   public InputModes input = InputModes.PROGRAM;
 
   @Parameter(

--- a/kernel/src/main/java/org/kframework/kast/KastOptions.java
+++ b/kernel/src/main/java/org/kframework/kast/KastOptions.java
@@ -161,8 +161,7 @@ public final class KastOptions {
       names = {"--input", "-i"},
       descriptionKey = "mode",
       converter = InputModeConverter.class,
-      description =
-          "How to read kast input in. <mode> is either [program|kast|json|kore|rule].")
+      description = "How to read kast input in. <mode> is either [program|kast|json|kore|rule].")
   public InputModes input = InputModes.PROGRAM;
 
   @Parameter(


### PR DESCRIPTION
The binary KAST format was removed in #4081, and this usage in the help text was missed.