### PR TITLE
Add secp256k1 to llvm-libs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,7 @@ jobs:
           script: |
             export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
             kup publish k-framework-binary .#k --keep-days 180
-            kup publish k-framework-binary .#k.openssl --keep-days 180
-            kup publish k-framework-binary .#k.procps --keep-days 180
-            kup publish k-framework-binary .#k.openssl.procps --keep-days 180
-            kup publish k-framework-binary .#k.procps.openssl --keep-days 180
+            kup publish k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
 
   ubuntu-jammy:
     name: 'K Ubuntu Jammy Package'

--- a/flake.nix
+++ b/flake.nix
@@ -134,6 +134,7 @@
             llvm-kompile-libs = with pkgs; {
               procps = [ "-I${procps}/include" "-L${procps}/lib" ];
               openssl = [ "-I${openssl.dev}/include" "-L${openssl.out}/lib" ];
+              secp256k1 = [ "-I${secp256k1}/include" "-L${secp256k1}/lib" ];
             };
           };
 

--- a/nix/k.nix
+++ b/nix/k.nix
@@ -85,7 +85,7 @@ let
               lib.optionalString (current-llvm-kompile-libs != [ ]) ''
                 --set NIX_LLVM_KOMPILE_LIBS "${
                   lib.strings.concatStringsSep " "
-                  (lib.lists.unique current-llvm-kompile-libs)
+                  (lib.lists.sort (a: b: a < b) (lib.lists.unique current-llvm-kompile-libs))
                 }"''
             }
         done
@@ -98,7 +98,7 @@ let
             makeWrapper $prog $out/bin/$(basename $prog) \
               --set NIX_LLVM_KOMPILE_LIBS "${
                 lib.strings.concatStringsSep " "
-                (lib.lists.unique current-llvm-kompile-libs)
+                (lib.lists.sort (a: b: a < b) (lib.lists.unique current-llvm-kompile-libs))
               }"
           done''}
       '';


### PR DESCRIPTION
This change also ensures that the package `k.procps.openssl` and `k.openssl.procps` are exactly the same by sorting the list of llvm-lib paths