### PR TITLE
Drop `.` empty K syntax fully and remove special-casing

### DIFF
--- a/k-distribution/include/kframework/builtin/kast.md
+++ b/k-distribution/include/kframework/builtin/kast.md
@@ -97,7 +97,6 @@ module KSEQ
   imports KAST
   imports K-TOP-SORT
   syntax K ::= ".K"      [klabel(#EmptyK), symbol]
-             | "."       [klabel(#EmptyK), symbol, deprecated, unparseAvoid]
   syntax K ::= K "~>" K  [klabel(#KSequence), left, assoc, unit(#EmptyK), symbol]
   syntax left #KSequence
   syntax {Sort} Sort     ::= "(" Sort ")"    [bracket, group(defaultBracket), applyPriority(1)]

--- a/k-distribution/tests/regression-new/checks/claimInDef.k
+++ b/k-distribution/tests/regression-new/checks/claimInDef.k
@@ -2,6 +2,6 @@
 
 module CLAIMINDEF
 
-    claim _ => .
+    claim _ => .K
 
 endmodule

--- a/k-distribution/tests/regression-new/checks/claimInDef.k.out
+++ b/k-distribution/tests/regression-new/checks/claimInDef.k.out
@@ -1,6 +1,6 @@
 [Error] Compiler: Claims are not allowed in the definition.
 	Source(claimInDef.k)
 	Location(5,11,5,17)
-	5 |	    claim _ => .
+	5 |	    claim _ => .K
 	  .	          ^~~~~~
 [Error] Compiler: Had 1 structural errors.

--- a/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
+++ b/kernel/src/main/java/org/kframework/compile/checks/CheckKLabels.java
@@ -107,7 +107,7 @@ public class CheckKLabels {
     } else if (sentence instanceof Production prod) {
       if (prod.klabel().isDefined()) {
         KLabel klabel = prod.klabel().get();
-        if (klabelProds.containsKey(klabel.name()) && !internalDuplicates.contains(klabel.name())) {
+        if (klabelProds.containsKey(klabel.name())) {
           errors.add(
               KEMException.compilerError(
                   "Symbol "
@@ -245,8 +245,6 @@ public class CheckKLabels {
       }
     }
   }
-
-  private static final ImmutableSet<String> internalDuplicates = ImmutableSet.of("#EmptyK");
 
   private static final ImmutableSet<String> internalNames =
       ImmutableSet.of(

--- a/kernel/src/test/java/org/kframework/parser/inner/RuleGrammarTest.java
+++ b/kernel/src/test/java/org/kframework/parser/inner/RuleGrammarTest.java
@@ -256,7 +256,7 @@ public class RuleGrammarTest {
             + "syntax StateCell ::= \"<state>\" K \"</state>\" [klabel(<state>), cell] "
             + "endmodule";
     parseRule(
-        "<T> <k>...1+2*3...</k> (<state> A => .::K ...</state> => .::Bag) ...</T>", def, 0, false);
+        "<T> <k>...1+2*3...</k> (<state> A => .K ...</state> => .::Bag) ...</T>", def, 0, false);
   }
 
   // test rule cells
@@ -286,7 +286,7 @@ public class RuleGrammarTest {
             + "syntax K "
             + "endmodule";
     parseConfig(
-        "<T multiplicity=\"*\"> <k> 1+2*3 </k> (<state> A => .::K </state> => .::Bag) </T>",
+        "<T multiplicity=\"*\"> <k> 1+2*3 </k> (<state> A => .K </state> => .::Bag) </T>",
         def,
         0,
         false);
@@ -309,7 +309,7 @@ public class RuleGrammarTest {
   @Test
   public void test13() {
     String def = "" + "module TEST " + "syntax Bool ::= \"true\" [token] " + "endmodule";
-    parseRule(".::K => .::K requires true", def, 0, false);
+    parseRule(".K => .K requires true", def, 0, false);
   }
 
   // test automatic follow restriction for terminals


### PR DESCRIPTION
Blocked on #4066; we want to use this PR as an example / test case for merging thorny changes that might cause issues with downstream repositories. That process will require a lot more locking / unlocking with K / Pyk being separated.