### PR TITLE
Add test for `no-evaluators` exhaustiveness

### DIFF
--- a/k-distribution/tests/regression-new/checkWarns/noEvaluatorsExhaustive.k
+++ b/k-distribution/tests/regression-new/checkWarns/noEvaluatorsExhaustive.k
@@ -1,0 +1,9 @@
+module NOEVALUATORSEXHAUSTIVE-SYNTAX
+    imports INT-SYNTAX
+    syntax Int ::= foo ( Int ) [function, total, no-evaluators]
+endmodule
+
+module NOEVALUATORSEXHAUSTIVE
+    imports NOEVALUATORSEXHAUSTIVE-SYNTAX
+    rule <k> 0 => foo(0) </k>
+endmodule


### PR DESCRIPTION
Adds a test confirming that the warning in #4148 is no longer present