### PR TITLE
Remove proof field from Prover

### DIFF
--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -317,8 +317,8 @@ class KProve(KPrint):
                 prover = ImpliesProver(proof, kcfg_explore)
             else:
                 proof = APRProof.from_claim(self.definition, claim, {})
-                prover = APRProver(proof, kcfg_explore)
-            prover.advance_proof()
+                prover = APRProver(kcfg_explore)
+            prover.advance_proof(proof)
             if proof.passed:
                 _LOGGER.info(f'Proof passed: {proof.id}')
             elif proof.failed:

--- a/pyk/src/pyk/proof/implies.py
+++ b/pyk/src/pyk/proof/implies.py
@@ -407,7 +407,7 @@ class RefutationSummary(ProofSummary):
         ]
 
 
-class ImpliesProver(Prover[ImpliesProofStep, ImpliesProofResult]):
+class ImpliesProver(Prover[ImpliesProof, ImpliesProofStep, ImpliesProofResult]):
     proof: ImpliesProof
 
     def __init__(self, proof: ImpliesProof, kcfg_explore: KCFGExplore):
@@ -458,6 +458,9 @@ class ImpliesProver(Prover[ImpliesProofStep, ImpliesProofResult]):
             )
         ]
 
-    def failure_info(self) -> FailureInfo:
+    def init_proof(self, proof: ImpliesProof) -> None:
+        pass
+
+    def failure_info(self, proof: ImpliesProof) -> FailureInfo:
         # TODO add implementation
         return FailureInfo()

--- a/pyk/src/tests/integration/proof/test_cell_map.py
+++ b/pyk/src/tests/integration/proof/test_cell_map.py
@@ -137,8 +137,8 @@ class TestCellMapProof(KCFGExploreTest, KProveTest):
         init = proof.kcfg.node(proof.init)
         new_init_term = kcfg_explore.cterm_symbolic.assume_defined(init.cterm)
         proof.kcfg.let_node(init.id, cterm=new_init_term)
-        prover = APRProver(proof, kcfg_explore=kcfg_explore, execute_depth=max_depth)
-        prover.advance_proof(max_iterations=max_iterations)
+        prover = APRProver(kcfg_explore=kcfg_explore, execute_depth=max_depth)
+        prover.advance_proof(proof, max_iterations=max_iterations)
 
         kcfg_show = KCFGShow(kprove, node_printer=APRProofNodePrinter(proof, kprove, full_printer=True))
         cfg_lines = kcfg_show.show(proof.kcfg)

--- a/pyk/src/tests/integration/proof/test_goto.py
+++ b/pyk/src/tests/integration/proof/test_goto.py
@@ -117,13 +117,12 @@ class TestGoToProof(KCFGExploreTest, KProveTest):
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, bmc_depth=bmc_depth)
         kcfg_explore.simplify(proof.kcfg, {})
         prover = APRProver(
-            proof,
             kcfg_explore=kcfg_explore,
             execute_depth=max_depth,
             cut_point_rules=cut_rules,
             terminal_rules=terminal_rules,
         )
-        prover.advance_proof(max_iterations=max_iterations)
+        prover.advance_proof(proof, max_iterations=max_iterations)
 
         kcfg_show = KCFGShow(kprove, node_printer=APRProofNodePrinter(proof, kprove, full_printer=True))
         cfg_lines = kcfg_show.show(proof.kcfg)

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -901,8 +901,8 @@ class TestImpProof(KCFGExploreTest, KProveTest):
                     subproof.admit()
                     subproof.write_proof_data()
 
-            prover = APRProver(proof, kcfg_explore=kcfg_explore, execute_depth=max_depth, cut_point_rules=cut_rules)
-            prover.advance_proof(max_iterations=max_iterations)
+            prover = APRProver(kcfg_explore=kcfg_explore, execute_depth=max_depth, cut_point_rules=cut_rules)
+            prover.advance_proof(proof, max_iterations=max_iterations)
 
             kcfg_show = KCFGShow(kprove, node_printer=APRProofNodePrinter(proof, kprove, full_printer=True))
             cfg_lines = kcfg_show.show(proof.kcfg)
@@ -941,13 +941,12 @@ class TestImpProof(KCFGExploreTest, KProveTest):
 
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, proof_dir=proof_dir)
         prover = APRProver(
-            proof,
             kcfg_explore=kcfg_explore,
             execute_depth=max_depth,
             terminal_rules=terminal_rules,
             cut_point_rules=cut_rules,
         )
-        prover.advance_proof(max_iterations=max_iterations)
+        prover.advance_proof(proof, max_iterations=max_iterations)
 
         assert len(proof.failing) == 1
         path_constraint = proof.path_constraints(proof.failing[0].id)
@@ -982,13 +981,12 @@ class TestImpProof(KCFGExploreTest, KProveTest):
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, bmc_depth=bmc_depth)
         kcfg_explore.simplify(proof.kcfg, {})
         prover = APRProver(
-            proof,
             kcfg_explore=kcfg_explore,
             execute_depth=max_depth,
             terminal_rules=terminal_rules,
             cut_point_rules=cut_rules,
         )
-        prover.advance_proof(max_iterations=max_iterations)
+        prover.advance_proof(proof, max_iterations=max_iterations)
 
         kcfg_show = KCFGShow(kprove, node_printer=APRProofNodePrinter(proof, kprove, full_printer=True))
         cfg_lines = kcfg_show.show(proof.kcfg)
@@ -1021,10 +1019,10 @@ class TestImpProof(KCFGExploreTest, KProveTest):
 
         proof = APRProof.from_claim(kprove.definition, claim, logs={})
         kcfg_explore.simplify(proof.kcfg, {})
-        prover = APRProver(proof, kcfg_explore=kcfg_explore)
-        prover.advance_proof(fail_fast=fail_fast)
+        prover = APRProver(kcfg_explore=kcfg_explore)
+        prover.advance_proof(proof, fail_fast=fail_fast)
 
-        failure_info = prover.failure_info()
+        failure_info = prover.failure_info(proof)
         assert isinstance(failure_info, APRFailureInfo)
 
         actual_pending = len(failure_info.pending_nodes)
@@ -1067,13 +1065,13 @@ class TestImpProof(KCFGExploreTest, KProveTest):
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, proof_dir=proof_dir)
         proof_id = proof.id
         kcfg_explore.simplify(proof.kcfg, {})
-        prover = APRProver(proof, kcfg_explore=kcfg_explore)
-        prover.advance_proof()
+        prover = APRProver(kcfg_explore=kcfg_explore)
+        prover.advance_proof(proof)
 
         # reload proof from disk
         proof = APRProof.read_proof_data(proof_dir, proof_id)
-        prover = APRProver(proof, kcfg_explore=kcfg_explore)
-        prover.advance_proof()
+        prover = APRProver(kcfg_explore=kcfg_explore)
+        prover.advance_proof(proof)
 
         failure_info = proof.failure_info
         assert isinstance(failure_info, APRFailureInfo)
@@ -1106,8 +1104,8 @@ class TestImpProof(KCFGExploreTest, KProveTest):
 
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, proof_dir=proofs_dir)
         kcfg_explore.simplify(proof.kcfg, {})
-        prover = APRProver(proof, kcfg_explore=kcfg_explore, execute_depth=1)
-        prover.advance_proof()
+        prover = APRProver(kcfg_explore=kcfg_explore, execute_depth=1)
+        prover.advance_proof(proof)
 
         proof_from_disk = APRProof.read_proof_data(proof_dir=proofs_dir, id=proof.id)
 
@@ -1131,8 +1129,8 @@ class TestImpProof(KCFGExploreTest, KProveTest):
 
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, proof_dir=proofs_dir, bmc_depth=3)
         kcfg_explore.simplify(proof.kcfg, {})
-        prover = APRProver(proof, kcfg_explore=kcfg_explore, execute_depth=1)
-        prover.advance_proof()
+        prover = APRProver(kcfg_explore=kcfg_explore, execute_depth=1)
+        prover.advance_proof(proof)
 
         proof_from_disk = APRProof.read_proof_data(proof_dir=proofs_dir, id=proof.id)
 
@@ -1154,8 +1152,8 @@ class TestImpProof(KCFGExploreTest, KProveTest):
         )
 
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, proof_dir=proof_dir)
-        prover = APRProver(proof, kcfg_explore=kcfg_explore)
-        prover.advance_proof(fail_fast=False)
+        prover = APRProver(kcfg_explore=kcfg_explore)
+        prover.advance_proof(proof, fail_fast=False)
 
         # Both branches will be checked and fail (fail_fast=False)
         assert len(proof.kcfg.leaves) == 3
@@ -1164,8 +1162,8 @@ class TestImpProof(KCFGExploreTest, KProveTest):
         assert len(proof.failing) == 2
 
         proof = APRProof.from_claim(kprove.definition, claim, logs={}, proof_dir=proof_dir)
-        prover = APRProver(proof, kcfg_explore=kcfg_explore)
-        prover.advance_proof(fail_fast=True)
+        prover = APRProver(kcfg_explore=kcfg_explore)
+        prover.advance_proof(proof, fail_fast=True)
 
         # First branch will be reached first and terminate the proof, leaving the second long branch pending (fail_fast=True)
         assert len(proof.kcfg.leaves) == 3

--- a/pyk/src/tests/integration/proof/test_implies_proof.py
+++ b/pyk/src/tests/integration/proof/test_implies_proof.py
@@ -188,7 +188,7 @@ class TestImpImpliesProof(KCFGExploreTest, KProveTest):
         proof = ImpliesProof(test_id, antecedent, consequent, bind_universally=bind_universally)
         prover = ImpliesProver(proof, kcfg_explore)
 
-        prover.advance_proof()
+        prover.advance_proof(proof)
 
         assert proof.status == expected_proof_status
 
@@ -216,6 +216,6 @@ class TestImpImpliesProof(KCFGExploreTest, KProveTest):
 
         equality_proof = EqualityProof.from_claim(claim, kprove.definition)
         equality_prover = ImpliesProver(equality_proof, kcfg_explore)
-        equality_prover.advance_proof()
+        equality_prover.advance_proof(equality_proof)
 
         assert equality_proof.status == proof_status

--- a/pyk/src/tests/integration/proof/test_mini_kevm.py
+++ b/pyk/src/tests/integration/proof/test_mini_kevm.py
@@ -92,12 +92,11 @@ class TestMiniKEVM(KCFGExploreTest, KProveTest):
             kcfg_explore.simplify(proof.kcfg, {})
 
             prover = APRProver(
-                proof,
                 kcfg_explore=kcfg_explore,
                 execute_depth=max_depth,
                 cut_point_rules=cut_rules,
             )
-            prover.advance_proof(max_iterations=max_iterations)
+            prover.advance_proof(proof, max_iterations=max_iterations)
 
             kcfg_show = KCFGShow(
                 kprove, node_printer=APRProofNodePrinter(proof, kprove, full_printer=True, minimize=False)

--- a/pyk/src/tests/integration/proof/test_non_det.py
+++ b/pyk/src/tests/integration/proof/test_non_det.py
@@ -82,8 +82,8 @@ class TestNonDetProof(KCFGExploreTest, KProveTest):
         )
 
         proof = APRProof.from_claim(kprove.definition, claim, logs={})
-        prover = APRProver(proof, kcfg_explore=kcfg_explore, execute_depth=max_depth)
-        prover.advance_proof(max_iterations=max_iterations)
+        prover = APRProver(kcfg_explore=kcfg_explore, execute_depth=max_depth)
+        prover.advance_proof(proof, max_iterations=max_iterations)
 
         kcfg_show = KCFGShow(kprove, node_printer=APRProofNodePrinter(proof, kprove, full_printer=True))
         cfg_lines = kcfg_show.show(proof.kcfg)

--- a/pyk/src/tests/integration/proof/test_simple.py
+++ b/pyk/src/tests/integration/proof/test_simple.py
@@ -62,11 +62,10 @@ class TestSimpleProof(KCFGExploreTest, KProveTest):
         proof = APRProof.from_claim(kprove.definition, claim, logs={})
         kcfg_explore.simplify(proof.kcfg, {})
         prover = APRProver(
-            proof,
             kcfg_explore=kcfg_explore,
             execute_depth=1,
         )
-        prover.advance_proof()
+        prover.advance_proof(proof)
 
         assert not proof.is_terminal(proof.target)
         for pred in proof.kcfg.predecessors(proof.target):
@@ -78,11 +77,10 @@ class TestSimpleProof(KCFGExploreTest, KProveTest):
         proof = APRProof.from_claim(kprove.definition, claim, logs={})
         kcfg_explore.simplify(proof.kcfg, {})
         prover = APRProver(
-            proof,
             kcfg_explore=kcfg_explore,
             execute_depth=1,
         )
-        prover.advance_proof()
+        prover.advance_proof(proof)
 
         assert proof.is_terminal(proof.target)
         for pred in proof.kcfg.predecessors(proof.target):


### PR DESCRIPTION
Porting https://github.com/runtimeverification/pyk/pull/960 to K repo.

`APRProver.step_proof` currently assumes the proof being passed in the `APRProofStep` it takes as argument is the same as `self.proof`, i.e. when it calls `self.nonzero_depth`, `self._check_subsume`, and `self._checked_for_bounded` assumes the proof being passed in is always the same for a single `APRProver` instance.

This is a problem in itself, but changing this should also move us closer an implementation that can run `step_proof` on different nodes in parallel, by reducing its dependency on external data. A next step could be initializing a new KCFGExplore every `step_proof` instead of using `self.kcfg_explore` to access the `KoreClient`.

- Removes `proof` field from `Prover` and `APRProver`.
- Makes methods that read/write `self.prover` take a prover argument 
- Proof initialization is performed separately in `init_proof` at the beginning of `advance_proof` rather than in the `Prover` constructor.
- Moves `_checked_for_terminal` and `_checked_for_bounded` into `APRProof`, as they refer to nodes of a specific proof.