### PR TITLE
Sort ambiguities generated by GLR Bison parsers

### DIFF
--- a/k-distribution/tests/regression-new/parse-c/test.ref
+++ b/k-distribution/tests/regression-new/parse-c/test.ref
@@ -5,11 +5,11 @@ amb ( .DeclSpecifiers  typedef  int  AA ; , .DeclSpecifiers  typedef  int .InitD
   .BlockItems
   amb ( .DeclSpecifiers  T .InitDecls , ( x ) ; , T ( x ) ; )
   amb ( .DeclSpecifiers  S .InitDecls , ( x ) ; , S ( x ) ; )
-  amb ( T * y ; , .DeclSpecifiers  T .InitDecls , * y ; )
+  amb ( .DeclSpecifiers  T .InitDecls , * y ; , T * y ; )
   .DeclSpecifiers  int .InitDecls , U , z ;
-  amb ( U * z ; , .DeclSpecifiers  U .InitDecls , * z ; )
-  func ( amb ( T * x , ( .SpecifierQuals  T ) * x ) ) ;
-  func ( amb ( U * z , ( .SpecifierQuals  U ) * z ) ) ;
+  amb ( .DeclSpecifiers  U .InitDecls , * z ; , U * z ; )
+  func ( amb ( ( .SpecifierQuals  T ) * x , T * x ) ) ;
+  func ( amb ( ( .SpecifierQuals  U ) * z , U * z ) ) ;
   amb ( .DeclSpecifiers  int  AA ; , .DeclSpecifiers  int .InitDecls , AA ; )
   .DeclSpecifiers  int .InitDecls , BB = AA * 2 ;
   amb ( .DeclSpecifiers  typedef  int  CC ; , .DeclSpecifiers  typedef  int .InitDecls , CC ; )
@@ -27,5 +27,5 @@ amb ( .DeclSpecifiers  typedef  int  AA ; , .DeclSpecifiers  typedef  int .InitD
 amb ( .DeclSpecifiers  typedef  char  C ; , .DeclSpecifiers  typedef  char .InitDecls , C ; )
 .DeclSpecifiers  void baz ( ) {
   .BlockItems
-  .DeclSpecifiers  int .InitDecls , aa = amb ( sizeof C , sizeof ( .SpecifierQuals  C ) ) , C , bb = amb ( sizeof C , sizeof ( .SpecifierQuals  C ) ) ;
+  .DeclSpecifiers  int .InitDecls , aa = amb ( sizeof ( .SpecifierQuals  C ) , sizeof C ) , C , bb = amb ( sizeof ( .SpecifierQuals  C ) , sizeof C ) ;
 }


### PR DESCRIPTION
The order in which the different stanzas in K's Bison parsers are generated depends on the iteration order of a Java set, which is not well defined and may be different across platforms. Normally, this isn't a problem as the location of a grammar action in the file doesn't affect whether it gets run or not for a particular input string.

However, one situation in which this can present an issue is when merging ambiguities. The ordering of the two nodes present under an ambiguity _can_ be changed if the ordering of stanzas in the file changes.

This manifested with https://github.com/runtimeverification/k/pull/4171 causing build failures in the C semantics, and in the subsequent LLVM backend update  PR https://github.com/runtimeverification/k/pull/4257.

The solution is to sort the two nodes that make up an ambiguity when the merge function is called; this PR implements a simple ordering function over parse tree nodes and updates related tests to respect the new consistent ordering of ambiguity nodes.