### PR TITLE
cli/args: remove now redundant spec_module

### DIFF
--- a/pyk/src/pyk/cli/args.py
+++ b/pyk/src/pyk/cli/args.py
@@ -388,7 +388,6 @@ class KCLIArgs:
             type=str,
             help='Code selector expression to use when reading markdown.',
         )
-        args.add_argument('--spec-module', dest='spec_module', type=str, help='Module with claims to be proven.')
         return args
 
     @cached_property


### PR DESCRIPTION
This PR https://github.com/runtimeverification/k/pull/4172 adds `--spec-module` to `definition_args`, but it really belongs in `spec_args` (which this PR adds: https://github.com/runtimeverification/k/pull/4245). But now we have two `--spec-module` arguments present, both included into the KEVM CLI, which causes it to fail to build.

This removes the now redundant `--spec-module` there.