### PR TITLE
Restructure CI dependency graph

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -9,30 +9,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  version-sync:
-    name: 'Version Sync'
-    runs-on: ubuntu-20.04
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.JENKINS_GITHUB_PAT }}
-          # fetch-depth 0 means deep clone the repo
-          fetch-depth: 0
-      - name: 'Update Version'
-        run: |
-          set -x
-          git config user.name devops
-          git config user.email devops@runtimeverification.com
-          ./package/version.sh sub
-          if git add --update && git commit --message "Set Version: $(cat package/version)"; then
-            git push origin HEAD:${GITHUB_HEAD_REF}
-          fi
-
   format-check:
-    name: 'Check code formatting'
+    name: 'Java: Linting'
     runs-on: ubuntu-latest
-    needs: version-sync
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
@@ -48,10 +27,77 @@ jobs:
       - name: 'Check code is formatted correctly'
         run: mvn spotless:check --batch-mode -U
 
+
+  pyk-code-quality-checks:
+    name: 'Pyk: Code Quality'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./pyk
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Set up environment'
+        uses: ./.github/actions/setup-pyk-env
+      - name: 'Run code quality checks'
+        run: make check
+      - name: 'Run pyupgrade'
+        run: make pyupgrade
+
+
+  pyk-unit-tests:
+    name: 'Pyk: Unit Tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.11', '3.12']
+    defaults:
+      run:
+        working-directory: ./pyk
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Set up environment'
+        uses: ./.github/actions/setup-pyk-env
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: 'Run unit tests'
+        run: make cov-unit
+
+
+  pyk-build-docs:
+    name: 'Pyk: Documentation'
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./pyk
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Set up environment'
+        uses: ./.github/actions/setup-pyk-env
+      - name: 'Build documentation'
+        run: make docs
+
+
+  code-quality:
+    name: 'Code Quality Checks'
+    runs-on: ubuntu-latest
+    needs:
+      - format-check
+      - pyk-code-quality-checks
+      - pyk-unit-tests
+      - pyk-build-docs
+    steps:
+      - run: true
+
+
   test-k:
-    name: 'K Tests'
+    name: 'K: Source Build & Test'
     runs-on: [self-hosted, linux, normal]
-    needs: format-check
+    needs: code-quality
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
@@ -72,10 +118,11 @@ jobs:
           docker stop --time=0 k-ci-${GITHUB_SHA}
           docker container rm --force k-ci-${GITHUB_SHA} || true
 
+
   test-package-ubuntu-jammy:
-    name: 'K Ubuntu Jammy Package'
+    name: 'K: Ubuntu Jammy Package'
     runs-on: [self-hosted, linux, normal]
-    needs: format-check
+    needs: code-quality
     steps:
       - uses: actions/checkout@v4
       - name: 'Build and Test'
@@ -102,132 +149,10 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
-  pyk-code-quality-checks:
-    name: 'Pyk Code Quality Checks'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./pyk
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
-      - name: 'Run code quality checks'
-        run: make check
-      - name: 'Run pyupgrade'
-        run: make pyupgrade
-
-  pyk-build-docs:
-    needs: pyk-code-quality-checks
-    name: 'Build Pyk Documentation'
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ./pyk
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
-      - name: 'Build documentation'
-        run: make docs
-
-  pyk-unit-tests:
-    needs: pyk-code-quality-checks
-    name: 'Pyk Unit Tests'
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.11', '3.12']
-    defaults:
-      run:
-        working-directory: ./pyk
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: 'Run unit tests'
-        run: make cov-unit
-
-  pyk-profile:
-    needs: [pyk-code-quality-checks, test-package-ubuntu-jammy]
-    name: 'Pyk Profiling'
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: ./pyk
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-      - name: 'Download K package from the Summary Page'
-        uses: actions/download-artifact@v4
-        with:
-          name: kframework.deb
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
-        with:
-          install-k: true
-          k-deb-path: kframework.deb
-      - name: 'Run profiling'
-        run: |
-          make profile PROF_ARGS=-n2
-          find /tmp/pytest-of-${USER}/pytest-current/ -type f -name '*.prof' | sort | xargs tail -n +1
-  pyk-integration-tests:
-    needs: [pyk-code-quality-checks, test-package-ubuntu-jammy]
-    name: 'Pyk Integration Tests'
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    defaults:
-      run:
-        working-directory: ./pyk
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-      - name: 'Download K package from the Summary Page'
-        uses: actions/download-artifact@v4
-        with:
-          name: kframework.deb
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
-        with:
-          install-k: true
-          k-deb-path: kframework.deb
-      - name: 'Run integration tests'
-        run: make test-integration TEST_ARGS='-n2 --timeout 300'
-
-  pyk-regression-tests:
-    needs: [pyk-code-quality-checks, test-package-ubuntu-jammy]
-    name: 'Pyk K Regression Tests'
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: ./pyk
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-      - name: 'Download K package from the Summary Page'
-        uses: actions/download-artifact@v4
-        with:
-          name: kframework.deb
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
-        with:
-          install-k: true
-          k-deb-path: kframework.deb
-      - name: 'Run K regression tests'
-        run: make test-regression-new -j2
 
   pyk-build-on-nix:
-    needs: pyk-code-quality-checks
-    name: 'Pyk Build on Nix'
+    needs: code-quality
+    name: 'Pyk: Nix Build'
     strategy:
       matrix:
         os: [ubuntu-latest, macos-13]
@@ -258,8 +183,137 @@ jobs:
         run: GC_DONT_GC=1 nix build --print-build-logs .#pyk-python310
 
 
+  compile-nix-flake:
+    needs: code-quality
+    name: 'K: Nix Build & Test'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: [self-hosted, linux, normal]
+          - runner: macos-13
+            os: macos-13
+          - runner: MacM1
+            os: self-macos-12
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Upgrade bash'
+        if: ${{ contains(matrix.os, 'macos') }}
+        run: brew install bash
+      - name: 'Install Nix'
+        if: ${{ !startsWith(matrix.os, 'self') }}
+        uses: cachix/install-nix-action@v22
+        with:
+          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          extra_nix_config: |
+            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+            substituters = http://cache.nixos.org https://hydra.iohk.io
+            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
+      - name: 'Install Cachix'
+        if: ${{ !startsWith(matrix.os, 'self') }}
+        uses: cachix/cachix-action@v14
+        with:
+          name: k-framework
+          authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
+          skipPush: true
+      - name: 'Build K Framework and push build time dependencies to cachix'
+        env:
+          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
+          NIX_PATH: 'nixpkgs=http://nixos.org/channels/nixos-22.05/nixexprs.tar.xz'
+          GC_DONT_GC: '1'
+        run: |
+          nix --version
+          export JQ=$(nix-build '<nixpkgs>' -A jq --no-link)/bin/jq
+          k=$(nix build . --print-build-logs --json | $JQ -r '.[].outputs | to_entries[].value')
+          drv=$(nix-store --query --deriver ${k})
+          nix-store --query --requisites ${drv} | cachix push k-framework
+      - name: 'Smoke test K'
+        run: GC_DONT_GC=1 nix build --print-build-logs .#smoke-test
+      # These tests take a really long time to run on other platforms, so we
+      # skip them unless we're on the M1 runner.
+      - name: 'Test K'
+        if: ${{ matrix.os == 'self-macos-12' }}
+        run: GC_DONT_GC=1 nix build --print-build-logs .#test
+
+
+  pyk-profile:
+    needs: test-package-ubuntu-jammy
+    name: 'Pyk: Profiling'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: ./pyk
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Download K package from the Summary Page'
+        uses: actions/download-artifact@v4
+        with:
+          name: kframework.deb
+      - name: 'Set up environment'
+        uses: ./.github/actions/setup-pyk-env
+        with:
+          install-k: true
+          k-deb-path: kframework.deb
+      - name: 'Run profiling'
+        run: |
+          make profile PROF_ARGS=-n2
+          find /tmp/pytest-of-${USER}/pytest-current/ -type f -name '*.prof' | sort | xargs tail -n +1
+
+
+  pyk-integration-tests:
+    needs: test-package-ubuntu-jammy
+    name: 'Pyk: Integration Tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    defaults:
+      run:
+        working-directory: ./pyk
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Download K package from the Summary Page'
+        uses: actions/download-artifact@v4
+        with:
+          name: kframework.deb
+      - name: 'Set up environment'
+        uses: ./.github/actions/setup-pyk-env
+        with:
+          install-k: true
+          k-deb-path: kframework.deb
+      - name: 'Run integration tests'
+        run: make test-integration TEST_ARGS='-n2 --timeout 300'
+
+
+  pyk-regression-tests:
+    needs: test-package-ubuntu-jammy
+    name: 'Pyk: Regression Tests'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: ./pyk
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Download K package from the Summary Page'
+        uses: actions/download-artifact@v4
+        with:
+          name: kframework.deb
+      - name: 'Set up environment'
+        uses: ./.github/actions/setup-pyk-env
+        with:
+          install-k: true
+          k-deb-path: kframework.deb
+      - name: 'Run K regression tests'
+        run: make test-regression-new -j2
+
+
   performance-tests:
-    name: 'Performance Tests'
+    name: 'K: Profiling'
     runs-on: [self-hosted, linux, performance]
     needs: test-package-ubuntu-jammy
     steps:
@@ -309,62 +363,3 @@ jobs:
         run: |
           docker stop --time=0 k-profiling-tests-${GITHUB_SHA}
           docker container rm --force k-profiling-tests-${GITHUB_SHA} || true
-
-  compile-nix-flake:
-    name: 'Nix flake'
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - runner: [self-hosted, linux, normal]
-          - runner: macos-13
-            os: macos-13
-          - runner: MacM1
-            os: self-macos-12
-    runs-on: ${{ matrix.runner }}
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-
-      - name: 'Upgrade bash'
-        if: ${{ contains(matrix.os, 'macos') }}
-        run: brew install bash
-
-      - name: 'Install Nix'
-        if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v22
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            substituters = http://cache.nixos.org https://hydra.iohk.io
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-      
-      - name: 'Install Cachix'
-        if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v14
-        with:
-          name: k-framework
-          authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
-          skipPush: true
-
-      - name: 'Build K Framework and push build time dependencies to cachix'
-        env:
-          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'
-          NIX_PATH: 'nixpkgs=http://nixos.org/channels/nixos-22.05/nixexprs.tar.xz'
-          GC_DONT_GC: '1'
-        run: |
-          nix --version
-          export JQ=$(nix-build '<nixpkgs>' -A jq --no-link)/bin/jq
-          k=$(nix build . --print-build-logs --json | $JQ -r '.[].outputs | to_entries[].value')
-          drv=$(nix-store --query --deriver ${k})
-          nix-store --query --requisites ${drv} | cachix push k-framework
-
-      - name: 'Smoke test K'
-        run: GC_DONT_GC=1 nix build --print-build-logs .#smoke-test
-
-      # These tests take a really long time to run on other platforms, so we
-      # skip them unless we're on the M1 runner.
-      - name: 'Test K'
-        if: ${{ matrix.os == 'self-macos-12' }}
-        run: GC_DONT_GC=1 nix build --print-build-logs .#test


### PR DESCRIPTION
This PR is an initial attempt to restructure the K CI process and reduce worst-case waiting times; it restructures the dependency graph between workflow stages for clarity and ensures that fast-failing jobs are run at the beginning of CI. The only non-rearrangement changes in this PR are:
- Remove the useless "version sync" job.

## Before

![Screenshot 2024-04-22 at 10 19 52](https://github.com/runtimeverification/k/assets/1329034/87615233-392b-4c3f-ba38-db9af7b6fc46)

## After

![Screenshot 2024-04-22 at 10 17 01](https://github.com/runtimeverification/k/assets/1329034/8e10dcd2-07cc-49cf-95b8-472e7ca83164)

This PR does not make any changes to the way that we supply a K installation to later workflow steps; I plan to implement those changes in a follow-up PR.