### PR TITLE
Temporarily move CI to our runners

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -11,7 +11,7 @@ concurrency:
 jobs:
   format-check:
     name: 'Java: Linting'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, normal]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
This is a temporary fix for an outage in Azure that's preventing us from running jobs on hosted runners; for the time being we can just shift all the affected jobs over to our self-hosted machines.