### PR TITLE
Terminal node subsumption check correction

### DIFF
--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -679,8 +679,9 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         _inject_module(proof.dependencies_module_name, self.main_module_name, dependencies_as_rules)
         _inject_module(proof.circularities_module_name, proof.dependencies_module_name, [circularity_rule])
 
-        if self.kcfg_explore.kcfg_semantics.is_terminal(proof.kcfg.node(proof.target).cterm):
-            proof.add_terminal(proof.target)
+        for node_id in [proof.init, proof.target]:
+            if self.kcfg_explore.kcfg_semantics.is_terminal(proof.kcfg.node(node_id).cterm):
+                proof.add_terminal(node_id)
 
     def nonzero_depth(self, proof: APRProof, node: KCFG.Node) -> bool:
         return not proof.kcfg.zero_depth_between(proof.init, node.id)

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -86,7 +86,6 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
     error_info: Exception | None
     prior_loops_cache: dict[int, list[int]]
 
-    _checked_for_terminal: set[int]
     _checked_for_bounded: set[int]
 
     def __init__(
@@ -124,7 +123,6 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         self._exec_time = _exec_time
         self.error_info = error_info
 
-        self._checked_for_terminal = set()
         self._checked_for_bounded = set()
 
         if self.proof_dir is not None and self.proof_subdir is not None:
@@ -681,25 +679,11 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         _inject_module(proof.dependencies_module_name, self.main_module_name, dependencies_as_rules)
         _inject_module(proof.circularities_module_name, proof.dependencies_module_name, [circularity_rule])
 
-        self._check_all_terminals(proof)
+        if self.kcfg_explore.kcfg_semantics.is_terminal(proof.kcfg.node(proof.target).cterm):
+            proof.add_terminal(proof.target)
 
     def nonzero_depth(self, proof: APRProof, node: KCFG.Node) -> bool:
         return not proof.kcfg.zero_depth_between(proof.init, node.id)
-
-    def _check_terminal(self, proof: APRProof, node: KCFG.Node) -> None:
-        if node.id not in proof._checked_for_terminal:
-            _LOGGER.info(f'Checking terminal: {node.id}')
-            proof._checked_for_terminal.add(node.id)
-            if self.kcfg_explore.kcfg_semantics.is_terminal(node.cterm):
-                _LOGGER.info(f'Terminal node: {node.id}.')
-                proof.add_terminal(node.id)
-            elif self.fast_check_subsumption and self._may_subsume(proof, node):
-                _LOGGER.info(f'Marking node as terminal because of fast may subsume check {proof.id}: {node.id}')
-                proof.add_terminal(node.id)
-
-    def _check_all_terminals(self, proof: APRProof) -> None:
-        for node in proof.kcfg.nodes:
-            self._check_terminal(proof, node)
 
     def _may_subsume(self, proof: APRProof, node: KCFG.Node) -> bool:
         node_k_cell = node.cterm.try_cell('K_CELL')

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -922,11 +922,6 @@ class TestImpProof(KCFGExploreTest, KProveTest):
             prover.advance_proof(proof, max_iterations=1)
             # We have reached a terminal node, but not yet checked subsumption
             assert proof.status != ProofStatus.PASSED
-
-            kcfg_show = KCFGShow(kprove, node_printer=APRProofNodePrinter(proof, kprove, full_printer=True))
-            cfg_lines = kcfg_show.show(proof.kcfg)
-            print('\n'.join(cfg_lines))
-
             # The next advance only checks subsumption
             prover.advance_proof(proof, max_iterations=1)
             assert proof.status == ProofStatus.PASSED

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -896,6 +896,33 @@ class TestImpProof(KCFGExploreTest, KProveTest):
             assert proof.status == proof_status
             assert leaf_number(proof) == expected_leaf_number
 
+    def test_terminal_node_subsumption(
+        self,
+        kprove: KProve,
+        kcfg_explore: KCFGExplore,
+        tmp_path_factory: TempPathFactory,
+    ) -> None:
+        test_id: str = 'imp-simple-addition-1'
+        spec_file: Path = K_FILES / 'imp-simple-spec.k'
+        spec_module: str = 'IMP-SIMPLE-SPEC'
+        claim_id: str = 'addition-1'
+        cut_rules: Iterable[str] = []
+        with tmp_path_factory.mktemp(f'apr_tmp_proofs-{test_id}') as proof_dir:
+            spec_modules = kprove.get_claim_modules(Path(spec_file), spec_module_name=spec_module)
+            spec_label = f'{spec_module}.{claim_id}'
+            proofs = APRProof.from_spec_modules(
+                kprove.definition,
+                spec_modules,
+                spec_labels=[spec_label],
+                logs={},
+                proof_dir=proof_dir,
+            )
+            proof = single([p for p in proofs if p.id == spec_label])
+            prover = APRProver(kcfg_explore=kcfg_explore, execute_depth=1, cut_point_rules=cut_rules)
+            prover.advance_proof(proof, max_iterations=1)
+
+            assert proof.status != ProofStatus.PASSED
+
     @pytest.mark.parametrize(
         'test_id,spec_file,spec_module,claim_id,max_iterations,max_depth,terminal_rules,cut_rules,expected_constraint',
         PATH_CONSTRAINTS_TEST_DATA,

--- a/pyk/src/tests/integration/test-data/k-files/imp-simple-spec.k
+++ b/pyk/src/tests/integration/test-data/k-files/imp-simple-spec.k
@@ -170,4 +170,9 @@ module IMP-SIMPLE-SPEC
       <state> $s |-> (0 => 2) </state>
       [depends(simple-untrue)]
 
+    claim [terminal-node-subsumption]: 
+      <k> $n = $n + 1; => .K </k>
+      <state> $n |-> ( N => N +Int 1 ) </state>
+      requires 0 <=Int N  
+
 endmodule


### PR DESCRIPTION
This PR corrects a bug in which if the execution stopped precisely at a terminal node, that node would never be checked for subsumption. It also adds a test that fails on `master`/`develop` but succeeds in this PR.