### PR TITLE
Revert constraint unsortedness

### DIFF
--- a/pyk/regression-new/kprove-haskell/sum-spec.k.out
+++ b/pyk/regression-new/kprove-haskell/sum-spec.k.out
@@ -89,8 +89,8 @@ Subproofs: 0
 ┃  │       </generatedCounter>
 ┃  │     </generatedTop>
 ┃  │     #And { true #Equals N:Int >Int 0 }
-┃  │     #And { true #Equals N:Int +Int -1 >=Int 0 }
 ┃  │     #And { true #Equals N:Int >=Int 0 }
+┃  │     #And { true #Equals N:Int +Int -1 >=Int 0 }
 ┃  │
 ┃  ┊  constraint: OMITTED CONSTRAINT
 ┃  ┊  subst: OMITTED SUBST

--- a/pyk/regression-new/kprove-haskell/sum-spec.k.out
+++ b/pyk/regression-new/kprove-haskell/sum-spec.k.out
@@ -49,8 +49,8 @@ Subproofs: 0
 ┃  │         GENERATEDCOUNTER_CELL_949ec677:Int
 ┃  │       </generatedCounter>
 ┃  │     </generatedTop>
-┃  │     #And { true #Equals N:Int >=Int 0 }
 ┃  │     #And { true #Equals N:Int >Int 0 }
+┃  │     #And { true #Equals N:Int >=Int 0 }
 ┃  │
 ┃  │  (1 step)
 ┃  ├─ 5
@@ -130,8 +130,8 @@ Subproofs: 0
    │         GENERATEDCOUNTER_CELL_949ec677:Int
    │       </generatedCounter>
    │     </generatedTop>
-   │     #And { true #Equals N:Int >=Int 0 }
    │     #And { N:Int #Equals 0 }
+   │     #And { true #Equals N:Int >=Int 0 }
    │
    │  (1 step)
    ├─ 6

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -14,7 +14,6 @@ from ..kast.manip import (
     flatten_label,
     free_vars,
     ml_pred_to_bool,
-    normalize_constraints,
     push_down_rewrites,
     remove_useless_constraints,
     split_config_and_constraints,
@@ -23,7 +22,7 @@ from ..kast.manip import (
 from ..prelude.k import GENERATED_TOP_CELL
 from ..prelude.kbool import andBool, orBool
 from ..prelude.ml import is_bottom, is_top, mlAnd, mlBottom, mlEqualsTrue, mlImplies, mlTop
-from ..utils import unique
+from ..utils import single, unique
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -47,10 +46,10 @@ class CTerm:
 
     def __init__(self, config: KInner, constraints: Iterable[KInner] = ()) -> None:
         """Instantiate a given `CTerm`, performing basic sanity checks on the `config` and `constraints`."""
-        if is_top(config):
+        if CTerm._is_top(config):
             config = mlTop()
             constraints = ()
-        elif is_bottom(config):
+        elif CTerm._is_bottom(config):
             config = mlBottom()
             constraints = ()
         else:
@@ -62,9 +61,9 @@ class CTerm:
     @staticmethod
     def from_kast(kast: KInner) -> CTerm:
         """Interpret a given `KInner` as a `CTerm` by splitting the `config` and `constraints` (see `CTerm.kast`)."""
-        if is_top(kast):
+        if CTerm._is_top(kast):
             return CTerm.top()
-        elif is_bottom(kast):
+        elif CTerm._is_bottom(kast):
             return CTerm.bottom()
         else:
             config, constraint = split_config_and_constraints(kast)
@@ -94,14 +93,40 @@ class CTerm:
             raise ValueError(f'Expected cell label, found: {config}')
 
     @staticmethod
-    def _normalize_constraints(constraints: Iterable[KInner]) -> tuple[KInner, ...]:
-        constraints = sorted(normalize_constraints(constraints), key=CTerm._constraint_sort_key)
+    def _normalize_constraints(constraints: Iterable[KInner], maintain_order: bool = False) -> tuple[KInner, ...]:
+        constraints = (constraint for _constraint in constraints for constraint in flatten_label('#And', _constraint))
+        constraints = unique(constraints)
+        constraints = (constraint for constraint in constraints if not CTerm._is_spurious_constraint(constraint))
+        if not maintain_order:
+            constraints = sorted(constraints, key=CTerm._constraint_sort_key)
         return tuple(constraints)
+
+    @staticmethod
+    def _is_spurious_constraint(term: KInner) -> bool:
+        if type(term) is KApply and term.label.name == '#Equals' and term.args[0] == term.args[1]:
+            return True
+        if is_top(term):
+            return True
+        return False
+
+    @staticmethod
+    def _is_top(kast: KInner) -> bool:
+        flat = flatten_label('#And', kast)
+        if len(flat) == 1:
+            return is_top(single(flat))
+        return all(CTerm._is_top(term) for term in flat)
+
+    @staticmethod
+    def _is_bottom(kast: KInner) -> bool:
+        flat = flatten_label('#And', kast)
+        if len(flat) == 1:
+            return is_bottom(single(flat))
+        return any(CTerm._is_bottom(term) for term in flat)
 
     @property
     def is_bottom(self) -> bool:
         """Check if a given `CTerm` is trivially empty."""
-        return is_bottom(self.config) or any(is_bottom(constraint) for constraint in self.constraints)
+        return CTerm._is_bottom(self.config) or any(CTerm._is_bottom(cterm) for cterm in self.constraints)
 
     @staticmethod
     def _constraint_sort_key(term: KInner) -> tuple[int, str]:
@@ -293,7 +318,7 @@ class CSubst:
     def __init__(self, subst: Subst | None = None, constraints: Iterable[KInner] = ()) -> None:
         """Construct a new `CSubst` given a `Subst` and set of constraints as `KInner`, performing basic sanity checks."""
         object.__setattr__(self, 'subst', subst if subst is not None else Subst({}))
-        object.__setattr__(self, 'constraints', normalize_constraints(constraints))
+        object.__setattr__(self, 'constraints', CTerm._normalize_constraints(constraints, maintain_order=True))
 
     def __iter__(self) -> Iterator[Subst | KInner]:
         """Return an iterator with the head being the `subst` and the tail being the `constraints`."""

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -315,14 +315,10 @@ class CSubst:
     subst: Subst
     constraints: tuple[KInner, ...]
 
-    def __init__(
-        self, subst: Subst | None = None, constraints: Iterable[KInner] = (), maintain_order: bool = False
-    ) -> None:
+    def __init__(self, subst: Subst | None = None, constraints: Iterable[KInner] = ()) -> None:
         """Construct a new `CSubst` given a `Subst` and set of constraints as `KInner`, performing basic sanity checks."""
         object.__setattr__(self, 'subst', subst if subst is not None else Subst({}))
-        object.__setattr__(
-            self, 'constraints', CTerm._normalize_constraints(constraints, maintain_order=maintain_order)
-        )
+        object.__setattr__(self, 'constraints', CTerm._normalize_constraints(constraints, maintain_order=True))
 
     def __iter__(self) -> Iterator[Subst | KInner]:
         """Return an iterator with the head being the `subst` and the tail being the `constraints`."""
@@ -349,7 +345,7 @@ class CSubst:
 
     def add_constraint(self, constraint: KInner) -> CSubst:
         """Return this `CSubst` with an additional constraint added."""
-        return CSubst(self.subst, list(self.constraints) + [constraint], maintain_order=True)
+        return CSubst(self.subst, list(self.constraints) + [constraint])
 
     def apply(self, cterm: CTerm) -> CTerm:
         """Apply this `CSubst` to the given `CTerm` (instantiating the free variables, and adding the constraints)."""

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -14,6 +14,7 @@ from ..kast.manip import (
     flatten_label,
     free_vars,
     ml_pred_to_bool,
+    normalize_constraints,
     push_down_rewrites,
     remove_useless_constraints,
     split_config_and_constraints,
@@ -22,7 +23,7 @@ from ..kast.manip import (
 from ..prelude.k import GENERATED_TOP_CELL
 from ..prelude.kbool import andBool, orBool
 from ..prelude.ml import is_bottom, is_top, mlAnd, mlBottom, mlEqualsTrue, mlImplies, mlTop
-from ..utils import single, unique
+from ..utils import unique
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -46,10 +47,10 @@ class CTerm:
 
     def __init__(self, config: KInner, constraints: Iterable[KInner] = ()) -> None:
         """Instantiate a given `CTerm`, performing basic sanity checks on the `config` and `constraints`."""
-        if CTerm._is_top(config):
+        if is_top(config):
             config = mlTop()
             constraints = ()
-        elif CTerm._is_bottom(config):
+        elif is_bottom(config):
             config = mlBottom()
             constraints = ()
         else:
@@ -61,9 +62,9 @@ class CTerm:
     @staticmethod
     def from_kast(kast: KInner) -> CTerm:
         """Interpret a given `KInner` as a `CTerm` by splitting the `config` and `constraints` (see `CTerm.kast`)."""
-        if CTerm._is_top(kast):
+        if is_top(kast):
             return CTerm.top()
-        elif CTerm._is_bottom(kast):
+        elif is_bottom(kast):
             return CTerm.bottom()
         else:
             config, constraint = split_config_and_constraints(kast)
@@ -93,40 +94,14 @@ class CTerm:
             raise ValueError(f'Expected cell label, found: {config}')
 
     @staticmethod
-    def _normalize_constraints(constraints: Iterable[KInner], maintain_order: bool = False) -> tuple[KInner, ...]:
-        constraints = (constraint for _constraint in constraints for constraint in flatten_label('#And', _constraint))
-        constraints = unique(constraints)
-        constraints = (constraint for constraint in constraints if not CTerm._is_spurious_constraint(constraint))
-        if not maintain_order:
-            constraints = sorted(constraints, key=CTerm._constraint_sort_key)
+    def _normalize_constraints(constraints: Iterable[KInner]) -> tuple[KInner, ...]:
+        constraints = sorted(normalize_constraints(constraints), key=CTerm._constraint_sort_key)
         return tuple(constraints)
-
-    @staticmethod
-    def _is_spurious_constraint(term: KInner) -> bool:
-        if type(term) is KApply and term.label.name == '#Equals' and term.args[0] == term.args[1]:
-            return True
-        if is_top(term):
-            return True
-        return False
-
-    @staticmethod
-    def _is_top(kast: KInner) -> bool:
-        flat = flatten_label('#And', kast)
-        if len(flat) == 1:
-            return is_top(single(flat))
-        return all(CTerm._is_top(term) for term in flat)
-
-    @staticmethod
-    def _is_bottom(kast: KInner) -> bool:
-        flat = flatten_label('#And', kast)
-        if len(flat) == 1:
-            return is_bottom(single(flat))
-        return any(CTerm._is_bottom(term) for term in flat)
 
     @property
     def is_bottom(self) -> bool:
         """Check if a given `CTerm` is trivially empty."""
-        return CTerm._is_bottom(self.config) or any(CTerm._is_bottom(cterm) for cterm in self.constraints)
+        return is_bottom(self.config) or any(is_bottom(constraint) for constraint in self.constraints)
 
     @staticmethod
     def _constraint_sort_key(term: KInner) -> tuple[int, str]:
@@ -318,7 +293,7 @@ class CSubst:
     def __init__(self, subst: Subst | None = None, constraints: Iterable[KInner] = ()) -> None:
         """Construct a new `CSubst` given a `Subst` and set of constraints as `KInner`, performing basic sanity checks."""
         object.__setattr__(self, 'subst', subst if subst is not None else Subst({}))
-        object.__setattr__(self, 'constraints', CTerm._normalize_constraints(constraints, maintain_order=True))
+        object.__setattr__(self, 'constraints', normalize_constraints(constraints))
 
     def __iter__(self) -> Iterator[Subst | KInner]:
         """Return an iterator with the head being the `subst` and the tail being the `constraints`."""

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -14,6 +14,7 @@ from ..kast.manip import (
     flatten_label,
     free_vars,
     ml_pred_to_bool,
+    normalize_constraints,
     push_down_rewrites,
     remove_useless_constraints,
     split_config_and_constraints,
@@ -22,7 +23,7 @@ from ..kast.manip import (
 from ..prelude.k import GENERATED_TOP_CELL
 from ..prelude.kbool import andBool, orBool
 from ..prelude.ml import is_bottom, is_top, mlAnd, mlBottom, mlEqualsTrue, mlImplies, mlTop
-from ..utils import single, unique
+from ..utils import unique
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
@@ -46,10 +47,10 @@ class CTerm:
 
     def __init__(self, config: KInner, constraints: Iterable[KInner] = ()) -> None:
         """Instantiate a given `CTerm`, performing basic sanity checks on the `config` and `constraints`."""
-        if CTerm._is_top(config):
+        if is_top(config, weak=True):
             config = mlTop()
             constraints = ()
-        elif CTerm._is_bottom(config):
+        elif is_bottom(config, weak=True):
             config = mlBottom()
             constraints = ()
         else:
@@ -61,9 +62,9 @@ class CTerm:
     @staticmethod
     def from_kast(kast: KInner) -> CTerm:
         """Interpret a given `KInner` as a `CTerm` by splitting the `config` and `constraints` (see `CTerm.kast`)."""
-        if CTerm._is_top(kast):
+        if is_top(kast, weak=True):
             return CTerm.top()
-        elif CTerm._is_bottom(kast):
+        elif is_bottom(kast, weak=True):
             return CTerm.bottom()
         else:
             config, constraint = split_config_and_constraints(kast)
@@ -93,40 +94,14 @@ class CTerm:
             raise ValueError(f'Expected cell label, found: {config}')
 
     @staticmethod
-    def _normalize_constraints(constraints: Iterable[KInner], maintain_order: bool = False) -> tuple[KInner, ...]:
-        constraints = (constraint for _constraint in constraints for constraint in flatten_label('#And', _constraint))
-        constraints = unique(constraints)
-        constraints = (constraint for constraint in constraints if not CTerm._is_spurious_constraint(constraint))
-        if not maintain_order:
-            constraints = sorted(constraints, key=CTerm._constraint_sort_key)
+    def _normalize_constraints(constraints: Iterable[KInner]) -> tuple[KInner, ...]:
+        constraints = sorted(normalize_constraints(constraints), key=CTerm._constraint_sort_key)
         return tuple(constraints)
-
-    @staticmethod
-    def _is_spurious_constraint(term: KInner) -> bool:
-        if type(term) is KApply and term.label.name == '#Equals' and term.args[0] == term.args[1]:
-            return True
-        if is_top(term):
-            return True
-        return False
-
-    @staticmethod
-    def _is_top(kast: KInner) -> bool:
-        flat = flatten_label('#And', kast)
-        if len(flat) == 1:
-            return is_top(single(flat))
-        return all(CTerm._is_top(term) for term in flat)
-
-    @staticmethod
-    def _is_bottom(kast: KInner) -> bool:
-        flat = flatten_label('#And', kast)
-        if len(flat) == 1:
-            return is_bottom(single(flat))
-        return any(CTerm._is_bottom(term) for term in flat)
 
     @property
     def is_bottom(self) -> bool:
         """Check if a given `CTerm` is trivially empty."""
-        return CTerm._is_bottom(self.config) or any(CTerm._is_bottom(cterm) for cterm in self.constraints)
+        return is_bottom(self.config, weak=True) or any(is_bottom(cterm, weak=True) for cterm in self.constraints)
 
     @staticmethod
     def _constraint_sort_key(term: KInner) -> tuple[int, str]:
@@ -318,7 +293,7 @@ class CSubst:
     def __init__(self, subst: Subst | None = None, constraints: Iterable[KInner] = ()) -> None:
         """Construct a new `CSubst` given a `Subst` and set of constraints as `KInner`, performing basic sanity checks."""
         object.__setattr__(self, 'subst', subst if subst is not None else Subst({}))
-        object.__setattr__(self, 'constraints', CTerm._normalize_constraints(constraints, maintain_order=True))
+        object.__setattr__(self, 'constraints', normalize_constraints(constraints))
 
     def __iter__(self) -> Iterator[Subst | KInner]:
         """Return an iterator with the head being the `subst` and the tail being the `constraints`."""

--- a/pyk/src/pyk/cterm/symbolic.py
+++ b/pyk/src/pyk/cterm/symbolic.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, NamedTuple, final
 
 from ..cterm import CSubst, CTerm
 from ..kast.inner import KApply, KLabel, KRewrite, KVariable, Subst
-from ..kast.manip import flatten_label, sort_ac_collections
+from ..kast.manip import flatten_label, is_spurious_constraint, sort_ac_collections
 from ..kast.pretty import PrettyPrinter
 from ..konvert import kast_to_kore, kore_to_kast
 from ..kore.rpc import (
@@ -243,7 +243,7 @@ class CTermSymbolic:
                 else:
                     consequent_constraints = list(
                         filter(
-                            lambda x: not CTerm._is_spurious_constraint(x),
+                            lambda x: not is_spurious_constraint(x),
                             map(config_match.subst, consequent.constraints),
                         )
                     )

--- a/pyk/src/pyk/cterm/symbolic.py
+++ b/pyk/src/pyk/cterm/symbolic.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, NamedTuple, final
 
 from ..cterm import CSubst, CTerm
 from ..kast.inner import KApply, KLabel, KRewrite, KVariable, Subst
-from ..kast.manip import flatten_label, is_spurious_constraint, sort_ac_collections
+from ..kast.manip import flatten_label, sort_ac_collections
 from ..kast.pretty import PrettyPrinter
 from ..konvert import kast_to_kore, kore_to_kast
 from ..kore.rpc import (
@@ -243,7 +243,7 @@ class CTermSymbolic:
                 else:
                     consequent_constraints = list(
                         filter(
-                            lambda x: not is_spurious_constraint(x),
+                            lambda x: not CTerm._is_spurious_constraint(x),
                             map(config_match.subst, consequent.constraints),
                         )
                     )

--- a/pyk/src/pyk/kast/inner.py
+++ b/pyk/src/pyk/kast/inner.py
@@ -928,3 +928,15 @@ def build_cons(unit: KInner, label: str | KLabel, terms: Iterable[KInner]) -> KI
         return KApply(label, (fst, build_cons(unit, label, it)))
     except StopIteration:
         return unit
+
+
+def flatten_label(label: str, kast: KInner) -> list[KInner]:
+    """Given a cons list, return a flat Python list of the elements.
+
+    -   Input: Cons operation to flatten.
+    -   Output: Items of cons list.
+    """
+    if type(kast) is KApply and kast.label.name == label:
+        items = (flatten_label(label, arg) for arg in kast.args)
+        return [c for cs in items for c in cs]
+    return [kast]

--- a/pyk/src/pyk/kast/inner.py
+++ b/pyk/src/pyk/kast/inner.py
@@ -928,15 +928,3 @@ def build_cons(unit: KInner, label: str | KLabel, terms: Iterable[KInner]) -> KI
         return KApply(label, (fst, build_cons(unit, label, it)))
     except StopIteration:
         return unit
-
-
-def flatten_label(label: str, kast: KInner) -> list[KInner]:
-    """Given a cons list, return a flat Python list of the elements.
-
-    -   Input: Cons operation to flatten.
-    -   Output: Items of cons list.
-    """
-    if type(kast) is KApply and kast.label.name == label:
-        items = (flatten_label(label, arg) for arg in kast.args)
-        return [c for cs in items for c in cs]
-    return [kast]

--- a/pyk/src/pyk/kast/manip.py
+++ b/pyk/src/pyk/kast/manip.py
@@ -6,8 +6,8 @@ from typing import TYPE_CHECKING
 
 from ..prelude.k import DOTS, GENERATED_TOP_CELL
 from ..prelude.kbool import FALSE, TRUE, andBool, impliesBool, notBool, orBool
-from ..prelude.ml import mlAnd, mlEqualsTrue, mlImplies, mlOr
-from ..utils import find_common_items, hash_str
+from ..prelude.ml import is_top, mlAnd, mlEqualsTrue, mlImplies, mlOr
+from ..utils import find_common_items, hash_str, unique
 from .att import EMPTY_ATT, Atts, KAtt, WithKAtt
 from .inner import (
     KApply,
@@ -19,6 +19,7 @@ from .inner import (
     Subst,
     bottom_up,
     collect,
+    flatten_label,
     top_down,
     var_occurrences,
 )
@@ -35,18 +36,6 @@ if TYPE_CHECKING:
     RL = TypeVar('RL', bound=KRuleLike)
 
 _LOGGER: Final = logging.getLogger(__name__)
-
-
-def flatten_label(label: str, kast: KInner) -> list[KInner]:
-    """Given a cons list, return a flat Python list of the elements.
-
-    -   Input: Cons operation to flatten.
-    -   Output: Items of cons list.
-    """
-    if type(kast) is KApply and kast.label.name == label:
-        items = (flatten_label(label, arg) for arg in kast.args)
-        return [c for cs in items for c in cs]
-    return [kast]
 
 
 def is_term_like(kast: KInner) -> bool:
@@ -672,6 +661,21 @@ def rename_generated_vars(term: KInner) -> KInner:
         return k.map_inner(_rename_vars)
 
     return _rename_vars(term)
+
+
+def is_spurious_constraint(term: KInner) -> bool:
+    if type(term) is KApply and term.label.name == '#Equals' and term.args[0] == term.args[1]:
+        return True
+    if is_top(term, weak=True):
+        return True
+    return False
+
+
+def normalize_constraints(constraints: Iterable[KInner]) -> tuple[KInner, ...]:
+    constraints = (constraint for _constraint in constraints for constraint in flatten_label('#And', _constraint))
+    constraints = unique(constraints)
+    constraints = (constraint for constraint in constraints if not is_spurious_constraint(constraint))
+    return tuple(constraints)
 
 
 def remove_useless_constraints(constraints: Iterable[KInner], initial_vars: Iterable[str]) -> list[KInner]:

--- a/pyk/src/pyk/kast/manip.py
+++ b/pyk/src/pyk/kast/manip.py
@@ -4,12 +4,10 @@ import logging
 from collections import Counter
 from typing import TYPE_CHECKING
 
-from pyk.kast.inner import flatten_label
-
 from ..prelude.k import DOTS, GENERATED_TOP_CELL
 from ..prelude.kbool import FALSE, TRUE, andBool, impliesBool, notBool, orBool
-from ..prelude.ml import is_top, mlAnd, mlEqualsTrue, mlImplies, mlOr
-from ..utils import find_common_items, hash_str, unique
+from ..prelude.ml import mlAnd, mlEqualsTrue, mlImplies, mlOr
+from ..utils import find_common_items, hash_str
 from .att import EMPTY_ATT, Atts, KAtt, WithKAtt
 from .inner import (
     KApply,
@@ -37,6 +35,18 @@ if TYPE_CHECKING:
     RL = TypeVar('RL', bound=KRuleLike)
 
 _LOGGER: Final = logging.getLogger(__name__)
+
+
+def flatten_label(label: str, kast: KInner) -> list[KInner]:
+    """Given a cons list, return a flat Python list of the elements.
+
+    -   Input: Cons operation to flatten.
+    -   Output: Items of cons list.
+    """
+    if type(kast) is KApply and kast.label.name == label:
+        items = (flatten_label(label, arg) for arg in kast.args)
+        return [c for cs in items for c in cs]
+    return [kast]
 
 
 def is_term_like(kast: KInner) -> bool:
@@ -662,21 +672,6 @@ def rename_generated_vars(term: KInner) -> KInner:
         return k.map_inner(_rename_vars)
 
     return _rename_vars(term)
-
-
-def is_spurious_constraint(term: KInner) -> bool:
-    if type(term) is KApply and term.label.name == '#Equals' and term.args[0] == term.args[1]:
-        return True
-    if is_top(term):
-        return True
-    return False
-
-
-def normalize_constraints(constraints: Iterable[KInner]) -> tuple[KInner, ...]:
-    constraints = (constraint for _constraint in constraints for constraint in flatten_label('#And', _constraint))
-    constraints = unique(constraints)
-    constraints = (constraint for constraint in constraints if not is_spurious_constraint(constraint))
-    return tuple(constraints)
 
 
 def remove_useless_constraints(constraints: Iterable[KInner], initial_vars: Iterable[str]) -> list[KInner]:

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1053,7 +1053,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         # Generate substitutions for additional targets `C_I`, which all exist by construction;
         # the constraints are cumulative, resulting in `cond_B #And cond_I`
         additional_csubsts = [
-            CSubst(not_none(a.cterm.match_with_constraint(self.node(ci).cterm)).subst)
+            not_none(a.cterm.match_with_constraint(self.node(ci).cterm))
             .add_constraint(csubst_b.constraint)
             .add_constraint(csubst.constraint)
             for ci, csubst in splits_from_b.items()

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1053,7 +1053,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         # Generate substitutions for additional targets `C_I`, which all exist by construction;
         # the constraints are cumulative, resulting in `cond_B #And cond_I`
         additional_csubsts = [
-            not_none(a.cterm.match_with_constraint(self.node(ci).cterm))
+            CSubst(not_none(a.cterm.match_with_constraint(self.node(ci).cterm)).subst)
             .add_constraint(csubst_b.constraint)
             .add_constraint(csubst.constraint)
             for ci, csubst in splits_from_b.items()

--- a/pyk/src/pyk/prelude/ml.py
+++ b/pyk/src/pyk/prelude/ml.py
@@ -2,9 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.utils import single
-
-from ..kast.inner import KApply, KLabel, build_assoc, flatten_label
+from ..kast.inner import KApply, KLabel, build_assoc
 from .k import GENERATED_TOP_CELL
 from .kbool import BOOL, FALSE, TRUE
 
@@ -22,26 +20,12 @@ ML_QUANTIFIERS: Final = {
 }
 
 
-def _is_top(term: KInner) -> bool:
+def is_top(term: KInner) -> bool:
     return isinstance(term, KApply) and term.label.name == '#Top'
 
 
-def is_top(term: KInner) -> bool:
-    flat = flatten_label('#And', term)
-    if len(flat) == 1:
-        return _is_top(single(flat))
-    return all(is_top(term) for term in flat)
-
-
-def _is_bottom(term: KInner) -> bool:
+def is_bottom(term: KInner) -> bool:
     return isinstance(term, KApply) and term.label.name == '#Bottom'
-
-
-def is_bottom(kast: KInner) -> bool:
-    flat = flatten_label('#And', kast)
-    if len(flat) == 1:
-        return _is_bottom(single(flat))
-    return any(is_bottom(term) for term in flat)
 
 
 def mlEquals(  # noqa: N802

--- a/pyk/src/pyk/prelude/ml.py
+++ b/pyk/src/pyk/prelude/ml.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..kast.inner import KApply, KLabel, build_assoc
+from pyk.utils import single
+
+from ..kast.inner import KApply, KLabel, build_assoc, flatten_label
 from .k import GENERATED_TOP_CELL
 from .kbool import BOOL, FALSE, TRUE
 
@@ -20,12 +22,24 @@ ML_QUANTIFIERS: Final = {
 }
 
 
-def is_top(term: KInner) -> bool:
-    return isinstance(term, KApply) and term.label.name == '#Top'
+def is_top(term: KInner, weak: bool = False) -> bool:
+    if weak:
+        flat = flatten_label('#And', term)
+        if len(flat) == 1:
+            return is_top(single(flat))
+        return all(is_top(term, weak=True) for term in flat)
+    else:
+        return isinstance(term, KApply) and term.label.name == '#Top'
 
 
-def is_bottom(term: KInner) -> bool:
-    return isinstance(term, KApply) and term.label.name == '#Bottom'
+def is_bottom(term: KInner, weak: bool = False) -> bool:
+    if weak:
+        flat = flatten_label('#And', term)
+        if len(flat) == 1:
+            return is_bottom(single(flat))
+        return any(is_bottom(term, weak=True) for term in flat)
+    else:
+        return isinstance(term, KApply) and term.label.name == '#Bottom'
 
 
 def mlEquals(  # noqa: N802

--- a/pyk/src/pyk/prelude/ml.py
+++ b/pyk/src/pyk/prelude/ml.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from ..kast.inner import KApply, KLabel, build_assoc
+from pyk.utils import single
+
+from ..kast.inner import KApply, KLabel, build_assoc, flatten_label
 from .k import GENERATED_TOP_CELL
 from .kbool import BOOL, FALSE, TRUE
 
@@ -20,12 +22,26 @@ ML_QUANTIFIERS: Final = {
 }
 
 
-def is_top(term: KInner) -> bool:
+def _is_top(term: KInner) -> bool:
     return isinstance(term, KApply) and term.label.name == '#Top'
 
 
-def is_bottom(term: KInner) -> bool:
+def is_top(term: KInner) -> bool:
+    flat = flatten_label('#And', term)
+    if len(flat) == 1:
+        return _is_top(single(flat))
+    return all(is_top(term) for term in flat)
+
+
+def _is_bottom(term: KInner) -> bool:
     return isinstance(term, KApply) and term.label.name == '#Bottom'
+
+
+def is_bottom(kast: KInner) -> bool:
+    flat = flatten_label('#And', kast)
+    if len(flat) == 1:
+        return _is_bottom(single(flat))
+    return any(is_bottom(term) for term in flat)
 
 
 def mlEquals(  # noqa: N802

--- a/pyk/src/pyk/prelude/ml.py
+++ b/pyk/src/pyk/prelude/ml.py
@@ -22,24 +22,34 @@ ML_QUANTIFIERS: Final = {
 }
 
 
-def is_top(term: KInner, weak: bool = False) -> bool:
-    if weak:
-        flat = flatten_label('#And', term)
-        if len(flat) == 1:
-            return is_top(single(flat))
-        return all(is_top(term, weak=True) for term in flat)
-    else:
-        return isinstance(term, KApply) and term.label.name == '#Top'
+def _is_top(term: KInner) -> bool:
+    return isinstance(term, KApply) and term.label.name == '#Top'
 
 
-def is_bottom(term: KInner, weak: bool = False) -> bool:
-    if weak:
-        flat = flatten_label('#And', term)
-        if len(flat) == 1:
-            return is_bottom(single(flat))
-        return any(is_bottom(term, weak=True) for term in flat)
-    else:
-        return isinstance(term, KApply) and term.label.name == '#Bottom'
+def is_top(term: KInner, *, weak: bool = False) -> bool:
+    if _is_top(term):
+        return True
+    if not weak:
+        return False
+    flat = flatten_label('#And', term)
+    if len(flat) == 1:
+        return is_top(single(flat))
+    return all(is_top(term, weak=True) for term in flat)
+
+
+def _is_bottom(term: KInner) -> bool:
+    return isinstance(term, KApply) and term.label.name == '#Bottom'
+
+
+def is_bottom(term: KInner, *, weak: bool = False) -> bool:
+    if _is_bottom(term):
+        return True
+    if not weak:
+        return False
+    flat = flatten_label('#And', term)
+    if len(flat) == 1:
+        return is_bottom(single(flat))
+    return any(is_bottom(term, weak=True) for term in flat)
 
 
 def mlEquals(  # noqa: N802

--- a/pyk/src/tests/integration/kprove/test_emit_json_spec.py
+++ b/pyk/src/tests/integration/kprove/test_emit_json_spec.py
@@ -5,12 +5,11 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pyk.cterm import CTerm
 from pyk.kast import EMPTY_ATT
 from pyk.kast.manip import remove_generated_cells
 from pyk.kast.outer import KDefinition, KRequire
 from pyk.kast.pretty import paren
-from pyk.prelude.ml import mlOr
+from pyk.prelude.ml import is_top, mlOr
 from pyk.testing import KProveTest
 
 from ..utils import K_FILES
@@ -43,7 +42,7 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove_claim(spec_module.claims[0], 'looping-1')
 
         # Then
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert is_top(mlOr([res.kast for res in result]), weak=True)
 
     def test_prove(self, kprove: KProve, spec_module: KFlatModule) -> None:
         # Given
@@ -64,4 +63,4 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove(spec_file, spec_module_name=spec_module_name, args=['-I', str(include_dir)])
 
         # Then
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert is_top(mlOr([res.kast for res in result]), weak=True)

--- a/pyk/src/tests/integration/kprove/test_emit_json_spec.py
+++ b/pyk/src/tests/integration/kprove/test_emit_json_spec.py
@@ -5,9 +5,8 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pyk.cterm import CTerm
 from pyk.kast import EMPTY_ATT
-from pyk.kast.manip import remove_generated_cells
+from pyk.kast.manip import is_top, remove_generated_cells
 from pyk.kast.outer import KDefinition, KRequire
 from pyk.kast.pretty import paren
 from pyk.prelude.ml import mlOr
@@ -43,7 +42,7 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove_claim(spec_module.claims[0], 'looping-1')
 
         # Then
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert is_top(mlOr([res.kast for res in result]))
 
     def test_prove(self, kprove: KProve, spec_module: KFlatModule) -> None:
         # Given
@@ -64,4 +63,4 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove(spec_file, spec_module_name=spec_module_name, args=['-I', str(include_dir)])
 
         # Then
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert is_top(mlOr([res.kast for res in result]))

--- a/pyk/src/tests/integration/kprove/test_emit_json_spec.py
+++ b/pyk/src/tests/integration/kprove/test_emit_json_spec.py
@@ -5,8 +5,9 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from pyk.cterm import CTerm
 from pyk.kast import EMPTY_ATT
-from pyk.kast.manip import is_top, remove_generated_cells
+from pyk.kast.manip import remove_generated_cells
 from pyk.kast.outer import KDefinition, KRequire
 from pyk.kast.pretty import paren
 from pyk.prelude.ml import mlOr
@@ -42,7 +43,7 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove_claim(spec_module.claims[0], 'looping-1')
 
         # Then
-        assert is_top(mlOr([res.kast for res in result]))
+        assert CTerm._is_top(mlOr([res.kast for res in result]))
 
     def test_prove(self, kprove: KProve, spec_module: KFlatModule) -> None:
         # Given
@@ -63,4 +64,4 @@ class TestEmitJsonSpec(KProveTest):
         result = kprove.prove(spec_file, spec_module_name=spec_module_name, args=['-I', str(include_dir)])
 
         # Then
-        assert is_top(mlOr([res.kast for res in result]))
+        assert CTerm._is_top(mlOr([res.kast for res in result]))

--- a/pyk/src/tests/integration/kprove/test_print_prove_rewrite.py
+++ b/pyk/src/tests/integration/kprove/test_print_prove_rewrite.py
@@ -2,11 +2,10 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KRewrite, KVariable
 from pyk.kast.manip import push_down_rewrites
 from pyk.kast.outer import KClaim
-from pyk.prelude.ml import mlOr
+from pyk.prelude.ml import is_top, mlOr
 from pyk.testing import KProveTest
 
 from ..utils import K_FILES
@@ -47,4 +46,4 @@ class TestPrintProveRewrite(KProveTest):
 
         # Then
         assert actual == expected
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert is_top(mlOr([res.kast for res in result]), weak=True)

--- a/pyk/src/tests/integration/kprove/test_print_prove_rewrite.py
+++ b/pyk/src/tests/integration/kprove/test_print_prove_rewrite.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KRewrite, KVariable
-from pyk.kast.manip import is_top, push_down_rewrites
+from pyk.kast.manip import push_down_rewrites
 from pyk.kast.outer import KClaim
 from pyk.prelude.ml import mlOr
 from pyk.testing import KProveTest
@@ -46,4 +47,4 @@ class TestPrintProveRewrite(KProveTest):
 
         # Then
         assert actual == expected
-        assert is_top(mlOr([res.kast for res in result]))
+        assert CTerm._is_top(mlOr([res.kast for res in result]))

--- a/pyk/src/tests/integration/kprove/test_print_prove_rewrite.py
+++ b/pyk/src/tests/integration/kprove/test_print_prove_rewrite.py
@@ -2,9 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KRewrite, KVariable
-from pyk.kast.manip import push_down_rewrites
+from pyk.kast.manip import is_top, push_down_rewrites
 from pyk.kast.outer import KClaim
 from pyk.prelude.ml import mlOr
 from pyk.testing import KProveTest
@@ -47,4 +46,4 @@ class TestPrintProveRewrite(KProveTest):
 
         # Then
         assert actual == expected
-        assert CTerm._is_top(mlOr([res.kast for res in result]))
+        assert is_top(mlOr([res.kast for res in result]))

--- a/pyk/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
+++ b/pyk/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
@@ -2,12 +2,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.cterm import CTerm
 from pyk.kast import Atts, KAtt
 from pyk.kast.inner import KToken
 from pyk.kast.outer import KClaim, KRule
 from pyk.prelude.kbool import BOOL
-from pyk.prelude.ml import mlOr
+from pyk.prelude.ml import is_top, mlOr
 from pyk.testing import KProveTest
 
 from ..utils import K_FILES
@@ -37,5 +36,5 @@ class TestSimpleProof(KProveTest):
         result2 = kprove.prove_claim(claim, 'claim-with-lemma', lemmas=[lemma])
 
         # Then
-        assert not CTerm._is_top(mlOr([res.kast for res in result1]))
-        assert CTerm._is_top(mlOr([res.kast for res in result2]))
+        assert not is_top(mlOr([res.kast for res in result1]), weak=True)
+        assert is_top(mlOr([res.kast for res in result2]), weak=True)

--- a/pyk/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
+++ b/pyk/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.cterm import CTerm
 from pyk.kast import Atts, KAtt
 from pyk.kast.inner import KToken
+from pyk.kast.manip import is_top
 from pyk.kast.outer import KClaim, KRule
 from pyk.prelude.kbool import BOOL
 from pyk.prelude.ml import mlOr
@@ -37,5 +37,5 @@ class TestSimpleProof(KProveTest):
         result2 = kprove.prove_claim(claim, 'claim-with-lemma', lemmas=[lemma])
 
         # Then
-        assert not CTerm._is_top(mlOr([res.kast for res in result1]))
-        assert CTerm._is_top(mlOr([res.kast for res in result2]))
+        assert not is_top(mlOr([res.kast for res in result1]))
+        assert is_top(mlOr([res.kast for res in result2]))

--- a/pyk/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
+++ b/pyk/src/tests/integration/kprove/test_prove_claim_with_lemmas.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from pyk.cterm import CTerm
 from pyk.kast import Atts, KAtt
 from pyk.kast.inner import KToken
-from pyk.kast.manip import is_top
 from pyk.kast.outer import KClaim, KRule
 from pyk.prelude.kbool import BOOL
 from pyk.prelude.ml import mlOr
@@ -37,5 +37,5 @@ class TestSimpleProof(KProveTest):
         result2 = kprove.prove_claim(claim, 'claim-with-lemma', lemmas=[lemma])
 
         # Then
-        assert not is_top(mlOr([res.kast for res in result1]))
-        assert is_top(mlOr([res.kast for res in result2]))
+        assert not CTerm._is_top(mlOr([res.kast for res in result1]))
+        assert CTerm._is_top(mlOr([res.kast for res in result2]))

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -1253,6 +1253,9 @@ class TestImpProof(KCFGExploreTest, KProveTest):
             state=f'N |-> {abstracted_var.name}:Int',
             constraint=mlAnd(
                 [
+                    mlEqualsTrue(KApply('_>Int_', [KVariable('N', 'Int'), KToken('1', 'Int')])),
+                    mlEqualsTrue(KApply('_>Int_', [KVariable('X', 'Int'), KToken('1', 'Int')])),
+                    mlEqualsTrue(KApply('_>Int_', [KVariable('Y', 'Int'), KToken('1', 'Int')])),
                     mlEqualsTrue(
                         orBool(
                             [
@@ -1271,9 +1274,6 @@ class TestImpProof(KCFGExploreTest, KProveTest):
                             ]
                         )
                     ),
-                    mlEqualsTrue(KApply('_>Int_', [KVariable('N', 'Int'), KToken('1', 'Int')])),
-                    mlEqualsTrue(KApply('_>Int_', [KVariable('X', 'Int'), KToken('1', 'Int')])),
-                    mlEqualsTrue(KApply('_>Int_', [KVariable('Y', 'Int'), KToken('1', 'Int')])),
                 ]
             ),
         )


### PR DESCRIPTION
Partial revert of #4249.

Due to problems in cross-machine orderings in the constraints of `CTerm`s observed by @goodlyrottenapple, this PR reverts the non-sortedness of `CTerm` constraints. The chronological order of `Split` constraints is still maintained.

