### PR TITLE
Run `TestImpProve` tests on both backends

### DIFF
--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -30,7 +30,7 @@ from .kore.rpc import ExecuteResult, StopReason
 from .kore.syntax import Pattern, kore_term
 from .ktool.kompile import Kompile, KompileBackend
 from .ktool.kprint import KPrint
-from .ktool.kprove import KProve
+from .ktool.kprove import KProve, ProveRpc
 from .ktool.krun import KRun
 from .prelude.k import GENERATED_TOP_CELL
 from .prelude.ml import is_top, mlAnd, mlOr
@@ -245,8 +245,9 @@ def exec_prove(options: ProveOptions) -> None:
     else:
         kompiled_directory = options.definition_dir
     kprove = KProve(kompiled_directory, use_directory=options.temp_directory)
+    prove_rpc = ProveRpc(kprove)
     try:
-        proofs = kprove.prove_rpc(options=options)
+        proofs = prove_rpc.prove_rpc(options=options)
     except RuntimeError as err:
         _, _, _, cpe = err.args
         exit_with_process_error(cpe)

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -4,6 +4,7 @@ import json
 import logging
 import sys
 from collections.abc import Iterable
+from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -13,6 +14,7 @@ from .cli.pyk import PrintInput, create_argument_parser, generate_options, parse
 from .cli.utils import LOG_FORMAT, loglevel
 from .coverage import get_rule_by_id, strip_coverage_logger
 from .cterm import CTerm
+from .cterm.symbolic import cterm_symbolic
 from .kast.inner import KInner
 from .kast.manip import (
     flatten_label,
@@ -25,6 +27,7 @@ from .kast.manip import (
 from .kast.outer import read_kast_definition
 from .kast.pretty import PrettyPrinter
 from .kast.utils import parse_outer
+from .kcfg import KCFGExplore
 from .kore.parser import KoreParser
 from .kore.rpc import ExecuteResult, StopReason
 from .kore.syntax import Pattern, kore_term
@@ -39,6 +42,7 @@ from .proof.show import APRProofNodePrinter, APRProofShow
 from .utils import check_dir_path, check_file_path, ensure_dir_path, exit_with_process_error
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from typing import Any, Final
 
     from .cli.pyk import (
@@ -244,8 +248,20 @@ def exec_prove(options: ProveOptions) -> None:
         _LOGGER.info(f'Using kompiled directory: {kompiled_directory}.')
     else:
         kompiled_directory = options.definition_dir
+
     kprove = KProve(kompiled_directory, use_directory=options.temp_directory)
-    prove_rpc = ProveRpc(kprove)
+
+    @contextmanager
+    def explore_context() -> Iterator[KCFGExplore]:
+        with cterm_symbolic(
+            definition=kprove.definition,
+            kompiled_kore=kprove.kompiled_kore,
+            definition_dir=kprove.definition_dir,
+        ) as cts:
+            yield KCFGExplore(cts)
+
+    prove_rpc = ProveRpc(kprove, explore_context)
+
     try:
         proofs = prove_rpc.prove_rpc(options=options)
     except RuntimeError as err:

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     from ..kast.outer import KClaim, KRule, KRuleLike
     from ..kast.pretty import SymbolTable
     from ..kcfg.semantics import KCFGSemantics
-    from ..kore.rpc import FallbackReason
     from ..proof import Proof, Prover
     from ..utils import BugReport
 
@@ -423,48 +422,11 @@ class ProveRpc:
     def __init__(self, kprove: KProve):
         self._kprove = kprove
 
-    def prove_rpc(
-        self,
-        options: ProveOptions,
-        kcfg_semantics: KCFGSemantics | None = None,
-        id: str | None = None,
-        port: int | None = None,
-        llvm_definition_dir: Path | None = None,
-        smt_timeout: int | None = None,
-        smt_retry_limit: int | None = None,
-        smt_tactic: str | None = None,
-        bug_report: BugReport | None = None,
-        haskell_log_format: KoreExecLogFormat = KoreExecLogFormat.ONELINE,
-        haskell_log_entries: Iterable[str] = (),
-        log_axioms_file: Path | None = None,
-        trace_rewrites: bool = False,
-        start_server: bool = True,
-        maude_port: int | None = None,
-        fallback_on: Iterable[FallbackReason] | None = None,
-        interim_simplification: int | None = None,
-        no_post_exec_simplify: bool = False,
-    ) -> list[Proof]:
+    def prove_rpc(self, options: ProveOptions, kcfg_semantics: KCFGSemantics | None = None) -> list[Proof]:
         def _prove_claim_rpc(claim: KClaim) -> Proof:
             return self._prove_claim_rpc(
                 claim,
                 kcfg_semantics=kcfg_semantics,
-                id=id,
-                port=port,
-                kore_rpc_command=options.kore_rpc_command,
-                llvm_definition_dir=llvm_definition_dir,
-                smt_timeout=smt_timeout,
-                smt_retry_limit=smt_retry_limit,
-                smt_tactic=smt_tactic,
-                bug_report=bug_report,
-                haskell_log_format=haskell_log_format,
-                haskell_log_entries=haskell_log_entries,
-                log_axioms_file=log_axioms_file,
-                trace_rewrites=trace_rewrites,
-                start_server=start_server,
-                maude_port=maude_port,
-                fallback_on=fallback_on,
-                interim_simplification=interim_simplification,
-                no_post_exec_simplify=no_post_exec_simplify,
                 max_depth=options.max_depth,
                 save_directory=options.save_directory,
                 max_iterations=options.max_iterations,
@@ -485,23 +447,6 @@ class ProveRpc:
         self,
         claim: KClaim,
         kcfg_semantics: KCFGSemantics | None = None,
-        id: str | None = None,
-        port: int | None = None,
-        kore_rpc_command: str | Iterable[str] | None = None,
-        llvm_definition_dir: Path | None = None,
-        smt_timeout: int | None = None,
-        smt_retry_limit: int | None = None,
-        smt_tactic: str | None = None,
-        bug_report: BugReport | None = None,
-        haskell_log_format: KoreExecLogFormat = KoreExecLogFormat.ONELINE,
-        haskell_log_entries: Iterable[str] = (),
-        log_axioms_file: Path | None = None,
-        trace_rewrites: bool = False,
-        start_server: bool = True,
-        maude_port: int | None = None,
-        fallback_on: Iterable[FallbackReason] | None = None,
-        interim_simplification: int | None = None,
-        no_post_exec_simplify: bool = False,
         max_depth: int | None = None,
         save_directory: Path | None = None,
         max_iterations: int | None = None,
@@ -528,28 +473,7 @@ class ProveRpc:
                 proof = APRProof.read_proof_data(save_directory, proof.id)
 
         if not proof.passed and (max_iterations is None or max_iterations > 0):
-            with cterm_symbolic(
-                definition,
-                kompiled_kore,
-                definition_dir,
-                id=id,
-                port=port,
-                kore_rpc_command=kore_rpc_command,
-                llvm_definition_dir=llvm_definition_dir,
-                smt_timeout=smt_timeout,
-                smt_retry_limit=smt_retry_limit,
-                smt_tactic=smt_tactic,
-                bug_report=bug_report,
-                haskell_log_format=haskell_log_format,
-                haskell_log_entries=haskell_log_entries,
-                log_axioms_file=log_axioms_file,
-                trace_rewrites=trace_rewrites,
-                start_server=start_server,
-                maude_port=maude_port,
-                fallback_on=fallback_on,
-                interim_simplification=interim_simplification,
-                no_post_exec_simplify=no_post_exec_simplify,
-            ) as cts:
+            with cterm_symbolic(definition, kompiled_kore, definition_dir) as cts:
                 kcfg_explore = KCFGExplore(cts, kcfg_semantics=kcfg_semantics)
                 if is_functional_claim:
                     assert type(proof) is EqualityProof

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -557,3 +557,10 @@ def _get_rule_log(debug_log_file: Path) -> list[list[tuple[str, bool, int]]]:
         axioms.pop(-1)
 
     return axioms
+
+
+class ProveRpc:
+    _kprove: KProve
+
+    def __init__(self, kprove: KProve):
+        self._kprove = kprove

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -428,14 +428,6 @@ class ProveRpc:
         self._explore_context = explore_context
 
     def prove_rpc(self, options: ProveOptions) -> list[Proof]:
-        def _prove_claim_rpc(claim: KClaim) -> Proof:
-            return self._prove_claim_rpc(
-                claim,
-                max_depth=options.max_depth,
-                save_directory=options.save_directory,
-                max_iterations=options.max_iterations,
-            )
-
         all_claims = self._kprove.get_claims(
             options.spec_file,
             spec_module_name=options.spec_module,
@@ -443,9 +435,19 @@ class ProveRpc:
             exclude_claim_labels=options.exclude_claim_labels,
             type_inference_mode=options.type_inference_mode,
         )
+
         if all_claims is None:
             raise ValueError(f'No claims found in file: {options.spec_file}')
-        return [_prove_claim_rpc(claim) for claim in all_claims]
+
+        return [
+            self._prove_claim_rpc(
+                claim,
+                max_depth=options.max_depth,
+                save_directory=options.save_directory,
+                max_iterations=options.max_iterations,
+            )
+            for claim in all_claims
+        ]
 
     def _prove_claim_rpc(
         self,

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -445,7 +445,7 @@ class ProveRpc:
         no_post_exec_simplify: bool = False,
     ) -> list[Proof]:
         def _prove_claim_rpc(claim: KClaim) -> Proof:
-            return self.prove_claim_rpc(
+            return self._prove_claim_rpc(
                 claim,
                 kcfg_semantics=kcfg_semantics,
                 id=id,
@@ -481,7 +481,7 @@ class ProveRpc:
             raise ValueError(f'No claims found in file: {options.spec_file}')
         return [_prove_claim_rpc(claim) for claim in all_claims]
 
-    def prove_claim_rpc(
+    def _prove_claim_rpc(
         self,
         claim: KClaim,
         kcfg_semantics: KCFGSemantics | None = None,

--- a/pyk/src/pyk/ktool/kprove.py
+++ b/pyk/src/pyk/ktool/kprove.py
@@ -348,64 +348,6 @@ class KProve(KPrint):
             _LOGGER.info(f'Proof pending: {proof.id}')
         return proof
 
-    def prove_rpc(
-        self,
-        options: ProveOptions,
-        kcfg_semantics: KCFGSemantics | None = None,
-        id: str | None = None,
-        port: int | None = None,
-        llvm_definition_dir: Path | None = None,
-        smt_timeout: int | None = None,
-        smt_retry_limit: int | None = None,
-        smt_tactic: str | None = None,
-        bug_report: BugReport | None = None,
-        haskell_log_format: KoreExecLogFormat = KoreExecLogFormat.ONELINE,
-        haskell_log_entries: Iterable[str] = (),
-        log_axioms_file: Path | None = None,
-        trace_rewrites: bool = False,
-        start_server: bool = True,
-        maude_port: int | None = None,
-        fallback_on: Iterable[FallbackReason] | None = None,
-        interim_simplification: int | None = None,
-        no_post_exec_simplify: bool = False,
-    ) -> list[Proof]:
-        def _prove_claim_rpc(claim: KClaim) -> Proof:
-            return self.prove_claim_rpc(
-                claim,
-                kcfg_semantics=kcfg_semantics,
-                id=id,
-                port=port,
-                kore_rpc_command=options.kore_rpc_command,
-                llvm_definition_dir=llvm_definition_dir,
-                smt_timeout=smt_timeout,
-                smt_retry_limit=smt_retry_limit,
-                smt_tactic=smt_tactic,
-                bug_report=bug_report,
-                haskell_log_format=haskell_log_format,
-                haskell_log_entries=haskell_log_entries,
-                log_axioms_file=log_axioms_file,
-                trace_rewrites=trace_rewrites,
-                start_server=start_server,
-                maude_port=maude_port,
-                fallback_on=fallback_on,
-                interim_simplification=interim_simplification,
-                no_post_exec_simplify=no_post_exec_simplify,
-                max_depth=options.max_depth,
-                save_directory=options.save_directory,
-                max_iterations=options.max_iterations,
-            )
-
-        all_claims = self.get_claims(
-            options.spec_file,
-            spec_module_name=options.spec_module,
-            claim_labels=options.claim_labels,
-            exclude_claim_labels=options.exclude_claim_labels,
-            type_inference_mode=options.type_inference_mode,
-        )
-        if all_claims is None:
-            raise ValueError(f'No claims found in file: {options.spec_file}')
-        return [_prove_claim_rpc(claim) for claim in all_claims]
-
     def get_claim_modules(
         self,
         spec_file: Path,
@@ -564,3 +506,61 @@ class ProveRpc:
 
     def __init__(self, kprove: KProve):
         self._kprove = kprove
+
+    def prove_rpc(
+        self,
+        options: ProveOptions,
+        kcfg_semantics: KCFGSemantics | None = None,
+        id: str | None = None,
+        port: int | None = None,
+        llvm_definition_dir: Path | None = None,
+        smt_timeout: int | None = None,
+        smt_retry_limit: int | None = None,
+        smt_tactic: str | None = None,
+        bug_report: BugReport | None = None,
+        haskell_log_format: KoreExecLogFormat = KoreExecLogFormat.ONELINE,
+        haskell_log_entries: Iterable[str] = (),
+        log_axioms_file: Path | None = None,
+        trace_rewrites: bool = False,
+        start_server: bool = True,
+        maude_port: int | None = None,
+        fallback_on: Iterable[FallbackReason] | None = None,
+        interim_simplification: int | None = None,
+        no_post_exec_simplify: bool = False,
+    ) -> list[Proof]:
+        def _prove_claim_rpc(claim: KClaim) -> Proof:
+            return self._kprove.prove_claim_rpc(
+                claim,
+                kcfg_semantics=kcfg_semantics,
+                id=id,
+                port=port,
+                kore_rpc_command=options.kore_rpc_command,
+                llvm_definition_dir=llvm_definition_dir,
+                smt_timeout=smt_timeout,
+                smt_retry_limit=smt_retry_limit,
+                smt_tactic=smt_tactic,
+                bug_report=bug_report,
+                haskell_log_format=haskell_log_format,
+                haskell_log_entries=haskell_log_entries,
+                log_axioms_file=log_axioms_file,
+                trace_rewrites=trace_rewrites,
+                start_server=start_server,
+                maude_port=maude_port,
+                fallback_on=fallback_on,
+                interim_simplification=interim_simplification,
+                no_post_exec_simplify=no_post_exec_simplify,
+                max_depth=options.max_depth,
+                save_directory=options.save_directory,
+                max_iterations=options.max_iterations,
+            )
+
+        all_claims = self._kprove.get_claims(
+            options.spec_file,
+            spec_module_name=options.spec_module,
+            claim_labels=options.claim_labels,
+            exclude_claim_labels=options.exclude_claim_labels,
+            type_inference_mode=options.type_inference_mode,
+        )
+        if all_claims is None:
+            raise ValueError(f'No claims found in file: {options.spec_file}')
+        return [_prove_claim_rpc(claim) for claim in all_claims]

--- a/pyk/src/tests/integration/ktool/test_imp.py
+++ b/pyk/src/tests/integration/ktool/test_imp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from contextlib import nullcontext
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -11,7 +12,7 @@ from pyk.kast.inner import KApply, KSequence, KVariable
 from pyk.kcfg.semantics import KCFGSemantics
 from pyk.ktool.kprove import ProveRpc
 from pyk.proof import ProofStatus
-from pyk.testing import KProveTest
+from pyk.testing import KCFGExploreTest, KProveTest
 from pyk.utils import single
 
 from ..utils import K_FILES
@@ -22,6 +23,7 @@ if TYPE_CHECKING:
 
     from pyk.cterm import CTerm
     from pyk.kast.outer import KDefinition
+    from pyk.kcfg import KCFGExplore
     from pyk.ktool.kprove import KProve
 
 _LOGGER: Final = logging.getLogger(__name__)
@@ -151,7 +153,7 @@ PROVE_TEST_DATA: Iterable[tuple[str, Path, str, str, ProofStatus]] = (
 )
 
 
-class TestImpProve(KProveTest):
+class TestImpProve(KCFGExploreTest, KProveTest):
     KOMPILE_MAIN_FILE = K_FILES / 'imp-verification.k'
 
     def semantics(self, definition: KDefinition) -> KCFGSemantics:
@@ -164,6 +166,7 @@ class TestImpProve(KProveTest):
     )
     def test_prove_rpc(
         self,
+        kcfg_explore: KCFGExplore,
         kprove: KProve,
         test_id: str,
         spec_file: str,
@@ -172,7 +175,7 @@ class TestImpProve(KProveTest):
         proof_status: ProofStatus,
     ) -> None:
         # Given
-        prove_rpc = ProveRpc(kprove)
+        prove_rpc = ProveRpc(kprove, lambda: nullcontext(kcfg_explore))
 
         # When
         proof = single(
@@ -184,7 +187,6 @@ class TestImpProve(KProveTest):
                         'claim_labels': [claim_id],
                     }
                 ),
-                kcfg_semantics=ImpSemantics(kprove.definition),
             )
         )
 

--- a/pyk/src/tests/integration/ktool/test_imp.py
+++ b/pyk/src/tests/integration/ktool/test_imp.py
@@ -9,6 +9,7 @@ import pytest
 from pyk.cli.pyk import ProveOptions
 from pyk.kast.inner import KApply, KSequence, KVariable
 from pyk.kcfg.semantics import KCFGSemantics
+from pyk.ktool.kprove import ProveRpc
 from pyk.proof import ProofStatus
 from pyk.testing import KProveTest
 from pyk.utils import single
@@ -170,8 +171,12 @@ class TestImpProve(KProveTest):
         claim_id: str,
         proof_status: ProofStatus,
     ) -> None:
+        # Given
+        prove_rpc = ProveRpc(kprove)
+
+        # When
         proof = single(
-            kprove.prove_rpc(
+            prove_rpc.prove_rpc(
                 ProveOptions(
                     {
                         'spec_file': Path(spec_file),
@@ -182,4 +187,6 @@ class TestImpProve(KProveTest):
                 kcfg_semantics=ImpSemantics(kprove.definition),
             )
         )
+
+        # Then
         assert proof.status == proof_status


### PR DESCRIPTION
* Extract class `ProveRpc`, and move methods `prove_rpc` and `prove_claim_rpc` there from `KProve`
* Factor out instantiation of `KCFGExplore` into a `Callable` parameter
* Make `TestImpProve` inherit from `KCFGExploreTest`