### PR TITLE
Move long-running pyk tests into Docker container

### DIFF
--- a/.github/actions/setup-pyk-env/action.yml
+++ b/.github/actions/setup-pyk-env/action.yml
@@ -6,16 +6,6 @@ inputs:
     required: true
     type: string
     default: '3.10'
-  install-k:
-    description: 'Install K'
-    required: true
-    type: boolean
-    default: false
-  k-deb-path:
-    description: 'Path to K .deb file'
-    required: true
-    type: string
-    default: kframework.deb
 runs:
   using: "composite"
   steps:
@@ -25,16 +15,6 @@ runs:
         python-version: ${{ inputs.python-version }}
     - name: 'Install Poetry'
       uses: Gr1N/setup-poetry@v9
-    - name: 'Install K'
-      if: fromJSON(inputs.install-k)
-      shell: bash
-      env:
-        DEB_PACKAGE_NAME: ${{ inputs.k-deb-path }}
-      run: |
-        sudo apt-get update
-        sudo apt-get -y install graphviz ./${DEB_PACKAGE_NAME}
-        sudo update-alternatives --set java /usr/lib/jvm/java-17-openjdk-amd64/bin/java
-        kompile --version
     - name: 'Install package'
       shell: bash
       run: poetry -C pyk install

--- a/.github/actions/with-k-docker/Dockerfile
+++ b/.github/actions/with-k-docker/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:jammy
+
+ARG K_DEB_PATH
+
+COPY ${K_DEB_PATH} /kframework.deb
+
+RUN    apt-get -y update  \
+    && apt-get -y install \
+         curl             \
+         graphviz         \
+         make             \
+         python3.10-dev   \
+         /kframework.deb  \
+    && apt-get -y clean
+
+RUN rm /kframework.deb
+
+ARG USER_ID=9876
+ARG GROUP_ID=9876
+RUN    groupadd -g ${GROUP_ID} user                     \
+    && useradd -m -u ${USER_ID} -s /bin/sh -g user user
+
+USER user
+WORKDIR /home/user
+
+ENV PATH=/home/user/.local/bin:${PATH}
+RUN    curl -sSL https://install.python-poetry.org | python3 - \
+    && poetry --version

--- a/.github/actions/with-k-docker/action.yml
+++ b/.github/actions/with-k-docker/action.yml
@@ -1,0 +1,41 @@
+name: 'With K Docker'
+description: 'Start a Docker container with the K .deb package installed'
+inputs:
+  container-name:
+    description: 'Docker container name to use'
+    required: true
+    type: string
+  k-deb-path:
+    description: 'Path to K .deb file'
+    required: true
+    type: string
+    default: kframework.deb
+runs:
+  using: 'composite'
+  steps:
+  - name: 'Set up Docker'
+    shell: bash {0}
+    run: |
+      set -euxo pipefail
+
+      CONTAINER_NAME=${{ inputs.container-name }}
+      TAG=runtimeverificationinc/${CONTAINER_NAME}
+      DOCKERFILE=${{ github.action_path }}/Dockerfile
+      K_DEB_PATH=${{ inputs.k-deb-path }}
+
+      docker build . \
+        --file ${DOCKERFILE}             \
+        --tag ${TAG}                     \
+        --build-arg K_DEB_PATH=${K_DEB_PATH}
+
+      docker run                 \
+        --name ${CONTAINER_NAME} \
+        --rm                     \
+        --interactive            \
+        --tty                    \
+        --detach                 \
+        --user root              \
+        ${TAG}
+
+      docker cp ./pyk/. ${CONTAINER_NAME}:/home/user
+      docker exec ${CONTAINER_NAME} chown -R user:user /home/user

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -227,11 +227,8 @@ jobs:
   pyk-profile:
     needs: test-package-ubuntu-jammy
     name: 'Pyk: Profiling'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux, normal]
     timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: ./pyk
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
@@ -239,25 +236,26 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: kframework.deb
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-k-docker
         with:
-          install-k: true
+          container-name: k-pyk-profile-${{ github.sha }}
           k-deb-path: kframework.deb
       - name: 'Run profiling'
         run: |
-          make profile PROF_ARGS=-n2
-          find /tmp/pytest-of-${USER}/pytest-current/ -type f -name '*.prof' | sort | xargs tail -n +1
+          docker exec -u user k-pyk-profile-${{ github.sha }} make profile PROF_ARGS=-n4
+          docker exec -u user k-pyk-profile-${{ github.sha }} /bin/bash -c 'find /tmp/pytest-of-user/pytest-current/ -type f -name "*.prof" | sort | xargs tail -n +1'
+      - name: 'Tear down Docker'
+        if: always()
+        run: |
+          docker stop --time=0 k-pyk-profile-${{ github.sha }}
 
 
   pyk-integration-tests:
     needs: test-package-ubuntu-jammy
     name: 'Pyk: Integration Tests'
-    runs-on: ubuntu-latest
-    timeout-minutes: 40
-    defaults:
-      run:
-        working-directory: ./pyk
+    runs-on: [self-hosted, linux, normal]
+    timeout-minutes: 30
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
@@ -265,13 +263,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: kframework.deb
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-k-docker
         with:
-          install-k: true
+          container-name: k-pyk-integration-${{ github.sha }}
           k-deb-path: kframework.deb
       - name: 'Run integration tests'
-        run: make test-integration TEST_ARGS='-n2 --timeout 300'
+        run: |
+          docker exec -u user k-pyk-integration-${{ github.sha }} make test-integration TEST_ARGS='-n4 --timeout 300'
+      - name: 'Tear down Docker'
+        if: always()
+        run: |
+          docker stop --time=0 k-pyk-integration-${{ github.sha }}
 
 
   pyk-regression-tests:
@@ -279,9 +282,6 @@ jobs:
     name: 'Pyk: Regression Tests'
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    defaults:
-      run:
-        working-directory: ./pyk
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
@@ -289,13 +289,18 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: kframework.deb
-      - name: 'Set up environment'
-        uses: ./.github/actions/setup-pyk-env
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-k-docker
         with:
-          install-k: true
+          container-name: k-pyk-regression-${{ github.sha }}
           k-deb-path: kframework.deb
       - name: 'Run K regression tests'
-        run: make test-regression-new -j2
+        run: |
+          docker exec -u user k-pyk-regression-${{ github.sha }} make test-regression-new -j4
+      - name: 'Tear down Docker'
+        if: always()
+        run: |
+          docker stop --time=0 k-pyk-regression-${{ github.sha }}
 
 
   performance-tests:

--- a/pyk/src/pyk/rpc/rpc.py
+++ b/pyk/src/pyk/rpc/rpc.py
@@ -33,14 +33,16 @@ class ServeRpcOptions(Options):
 
 
 class JsonRpcServer:
-    JSONRPC_VERSION: str = '2.0'
+    JSONRPC_VERSION: Final[str] = '2.0'
+
     methods: dict[str, Callable[..., Any]]
     options: ServeRpcOptions
-    http_server: HTTPServer
+    http_server: HTTPServer | None
 
     def __init__(self, options: ServeRpcOptions) -> None:
         self.methods = {}
         self.options = options
+        self.http_server = None
 
     def register_method(self, name: str, function: Callable[..., Any]) -> None:
         _LOGGER.info(f'Registered method {name} using {function}')
@@ -54,7 +56,15 @@ class JsonRpcServer:
         _LOGGER.info(f'JSON-RPC server at {self.options.addr}:{self.options.port} shut down.')
 
     def shutdown(self) -> None:
-        self.http_server.shutdown()
+        self._http_server().shutdown()
+
+    def port(self) -> int:
+        return self._http_server().server_port
+
+    def _http_server(self) -> HTTPServer:
+        if not self.http_server:
+            raise ValueError('Server has not been started')
+        return self.http_server
 
 
 class JsonRpcMethod(Protocol):


### PR DESCRIPTION
Fixes #4277

* Create action `with-k-docker` that starts a Docker container with K installed from a `.deb` package
* Move long-running tests into Docker container and on self-hosted runners