### PR TITLE
Sort `Ambiguity` items before reporting error

### DIFF
--- a/k-distribution/tests/regression-new/checks/paramAmb.k.out
+++ b/k-distribution/tests/regression-new/checks/paramAmb.k.out
@@ -1,10 +1,10 @@
 [Error] Inner Parser: Parsing ambiguity.
 1: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
-    #KRewrite(#SemanticCastToX(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToX(#token("X","#KVariable")),`wrap__PARAMAMB_T_X`(#SemanticCastToX(#token("X","#KVariable")))))
-2: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
     #KRewrite(#SemanticCastToA(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToA(#token("X","#KVariable")),`wrap__PARAMAMB_T_M`(#SemanticCastToA(#token("X","#KVariable")))))
-3: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
+2: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
     #KRewrite(#SemanticCastToB(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToB(#token("X","#KVariable")),`wrap__PARAMAMB_T_M`(#SemanticCastToB(#token("X","#KVariable")))))
+3: syntax {Sort} Sort ::= Sort "=>" Sort [klabel(#KRewrite), symbol]
+    #KRewrite(#SemanticCastToX(#token("X","#KVariable")),`label(_,_)_PARAMAMB_KItem_N_T`(#SemanticCastToX(#token("X","#KVariable")),`wrap__PARAMAMB_T_X`(#SemanticCastToX(#token("X","#KVariable")))))
 	Source(paramAmb.k)
 	Location(12,8,12,29)
 	12 |	  rule X => label(X, wrap X)

--- a/k-distribution/tests/regression-new/checks/priorityError.k.out
+++ b/k-distribution/tests/regression-new/checks/priorityError.k.out
@@ -9,10 +9,10 @@
 	22 |	    rule . => 1 r + 2 // unable to disambiguate - error
 	   .	              ^~~
 [Error] Inner Parser: Parsing ambiguity.
-1: syntax Exp ::= Exp "r" [klabel(rguard), symbol]
-    rguard(lguard(#token("1","Int")))
-2: syntax Exp ::= "l" Exp [klabel(lguard), symbol]
+1: syntax Exp ::= "l" Exp [klabel(lguard), symbol]
     lguard(rguard(#token("1","Int")))
+2: syntax Exp ::= Exp "r" [klabel(rguard), symbol]
+    rguard(lguard(#token("1","Int")))
 	Source(priorityError.k)
 	Location(23,15,23,20)
 	23 |	    rule . => l 1 r   // ambiguous - error

--- a/k-frontend/src/main/java/org/kframework/parser/inner/disambiguation/AmbFilterError.java
+++ b/k-frontend/src/main/java/org/kframework/parser/inner/disambiguation/AmbFilterError.java
@@ -2,6 +2,7 @@
 package org.kframework.parser.inner.disambiguation;
 
 import com.google.common.collect.Sets;
+import java.util.List;
 import java.util.Set;
 import org.kframework.kore.K;
 import org.kframework.parser.Ambiguity;
@@ -45,21 +46,22 @@ public class AmbFilterError extends SetsTransformerWithErrors<KEMException> {
       return candidate;
     }
 
-    String msg = "Parsing ambiguity.";
+    StringBuilder msg = new StringBuilder("Parsing ambiguity.");
 
-    for (int i = 0; i < amb.items().size(); i++) {
-      msg += "\n" + (i + 1) + ": ";
-      Term elem = (Term) amb.items().toArray()[i];
+    List<Term> sortedItems = amb.items().stream().sorted(Term.ord()).toList();
+    for (int i = 0; i < sortedItems.size(); i++) {
+      msg.append("\n").append(i + 1).append(": ");
+      Term elem = sortedItems.get(i);
       if (elem instanceof ProductionReference tc) {
-        msg += tc.production().toString();
+        msg.append(tc.production().toString());
       }
       // TODO: use the unparser
       // Unparser unparser = new Unparser(context);
       // msg += "\n   " + unparser.print(elem).replace("\n", "\n   ");
-      msg += "\n    " + new RemoveBracketVisitor().apply(elem);
+      msg.append("\n    ").append(new RemoveBracketVisitor().apply(elem));
     }
 
-    KEMException e = KEMException.innerParserError(msg, amb.items().iterator().next());
+    KEMException e = KEMException.innerParserError(msg.toString(), amb.items().iterator().next());
 
     return Left.apply(Sets.newHashSet(e));
   }


### PR DESCRIPTION
- Implement an `Ordering` for `Term`s
- Sort the items of an `Ambiguity` when reporting an error to stabilize the error message