### PR TITLE
Enable `--no-haskell-binary` by default on macOS

### DIFF
--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackend.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellBackend.java
@@ -14,6 +14,7 @@ import org.kframework.compile.Backend;
 import org.kframework.kompile.KompileOptions;
 import org.kframework.main.GlobalOptions;
 import org.kframework.main.Tool;
+import org.kframework.utils.OS;
 import org.kframework.utils.Stopwatch;
 import org.kframework.utils.errorsystem.KEMException;
 import org.kframework.utils.errorsystem.KExceptionManager;
@@ -50,7 +51,7 @@ public class HaskellBackend extends KoreBackend {
     sw.printIntermediate("  Print definition.kore");
     ProcessBuilder pb = files.getProcessBuilder();
     List<String> args = new ArrayList<>();
-    if (haskellKompileOptions.noHaskellBinary) {
+    if (haskellKompileOptions.noHaskellBinary || OS.current().equals(OS.OSX)) {
       args.add("kore-parser");
       args.add("--no-print-definition");
       args.add("definition.kore");

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
@@ -22,7 +22,7 @@ public class HaskellKompileOptions {
       names = "--no-haskell-binary",
       description =
           "Use the textual KORE format in the haskell backend instead of the binary KORE format."
-              + " This flag is enabled by default and cannot be disabled when running on macOS because of a bug in the underlying Haskell libraries.",
+              + " This flag is disabled by default, except when running on macOS, where it is enabled and cannot be disabled because of a bug in the underlying Haskell libraries.",
       hidden = true)
   public boolean noHaskellBinary = false;
 }

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
@@ -3,6 +3,7 @@ package org.kframework.backend.haskell;
 
 import com.beust.jcommander.Parameter;
 import com.google.inject.Inject;
+import org.kframework.utils.OS;
 import org.kframework.utils.inject.RequestScoped;
 
 @RequestScoped
@@ -22,7 +23,7 @@ public class HaskellKompileOptions {
       names = "--no-haskell-binary",
       description =
           "Use the textual KORE format in the haskell backend instead of the binary KORE format."
-              + " This is a development option, but may be necessary on MacOS due to known issues"
-              + " with the binary format.")
-  public boolean noHaskellBinary = false;
+              + " This flag is enabled by default and cannot be disabled when running on macOS because of a bug in the underlying Haskell libraries.",
+      hidden = true)
+  public boolean noHaskellBinary = OS.current().equals(OS.OSX);
 }

--- a/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
+++ b/haskell-backend/src/main/java/org/kframework/backend/haskell/HaskellKompileOptions.java
@@ -3,7 +3,6 @@ package org.kframework.backend.haskell;
 
 import com.beust.jcommander.Parameter;
 import com.google.inject.Inject;
-import org.kframework.utils.OS;
 import org.kframework.utils.inject.RequestScoped;
 
 @RequestScoped
@@ -25,5 +24,5 @@ public class HaskellKompileOptions {
           "Use the textual KORE format in the haskell backend instead of the binary KORE format."
               + " This flag is enabled by default and cannot be disabled when running on macOS because of a bug in the underlying Haskell libraries.",
       hidden = true)
-  public boolean noHaskellBinary = OS.current().equals(OS.OSX);
+  public boolean noHaskellBinary = false;
 }


### PR DESCRIPTION
A long standing nit I've had with K (and never got around to fixing) is that you need to remember to pass `--no-haskell-binary` to `kompile` on macOS, or K will crash when trying to execute any programs. This is annoying and bad UX, so this PR amends the frontend behaviour to enable this setting by default on macOS.