### PR TITLE
Add class `Formatter`

### DIFF
--- a/pyk/src/pyk/kast/formatter.py
+++ b/pyk/src/pyk/kast/formatter.py
@@ -29,8 +29,11 @@ class Formatter:
 
     def _format(self, term: KInner) -> list[str]:
         match term:
-            case KVariable(s, _) | KToken(s, _):
-                return [s]
+            case KToken(token, _):
+                return [token]
+            case KVariable(name, sort):
+                sort_str = f':{sort.name}' if sort else ''
+                return [f'{name}{sort_str}']
             case KSequence():
                 return self._format_ksequence(term)
             case KApply():

--- a/pyk/src/pyk/kast/formatter.py
+++ b/pyk/src/pyk/kast/formatter.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from ..utils import intersperse
+from .att import Atts
+from .inner import KApply, KToken, KVariable
+from .outer import KNonTerminal, KRegexTerminal, KSequence, KTerminal
+
+if TYPE_CHECKING:
+    from . import KInner
+    from .outer import KDefinition, KProduction
+
+
+class Formatter:
+    definition: KDefinition
+
+    _indent: int
+
+    def __init__(self, definition: KDefinition, *, indent: int = 0):
+        self.definition = definition
+        self._indent = indent
+
+    def __call__(self, term: KInner) -> str:
+        return self.format(term)
+
+    def format(self, term: KInner) -> str:
+        return ''.join(self._format(term))
+
+    def _format(self, term: KInner) -> list[str]:
+        match term:
+            case KVariable(s, _) | KToken(s, _):
+                return [s]
+            case KSequence():
+                return self._format_ksequence(term)
+            case KApply():
+                return self._format_kapply(term)
+            case _:
+                raise ValueError(f'Unsupported term: {term}')
+
+    def _format_ksequence(self, ksequence: KSequence) -> list[str]:
+        items = [self._format(item) for item in ksequence.items]  # recur
+        items.append(['.K'])
+        return [chunk for chunks in intersperse(items, [' ~> ']) for chunk in chunks]
+
+    def _format_kapply(self, kapply: KApply) -> list[str]:
+        production = self.definition.symbols[kapply.label.name]
+        formatt = production.att.get(Atts.FORMAT, production.default_format)
+        return [
+            chunk
+            for token in formatt.tokens
+            for chunks in self._interpret_token(token, production, kapply)
+            for chunk in chunks
+        ]
+
+    def _interpret_token(self, token: str, production: KProduction, kapply: KApply) -> list[str]:
+        if not token[0] == '%':
+            return [token]
+
+        escape = token[1:]
+
+        if escape[0].isdigit():
+            try:
+                index = int(escape)
+            except ValueError as err:
+                raise AssertionError(f'Incorrect format escape sequence: {token}') from err
+            return self._interpret_index(index, production, kapply)
+
+        assert len(escape) == 1
+
+        match escape:
+            case 'n':
+                return ['\n', self._indent * '  ']
+            case 'i':
+                self._indent += 1
+                return []
+            case 'd':
+                self._indent -= 1
+                return []
+            case 'c' | 'r':
+                return []  # TODO add color support
+            case _:
+                return [escape]
+
+    def _interpret_index(self, index: int, production: KProduction, kapply: KApply) -> list[str]:
+        assert index > 0
+        if index > len(production.items):
+            raise ValueError(f'Format escape index out of bounds: {index}: {production}')
+
+        item = production.items[index - 1]
+        match item:
+            case KTerminal(value):
+                return [value]
+            case KNonTerminal():
+                arg_index = sum(isinstance(item, KNonTerminal) for item in production.items[: index - 1])
+                if arg_index >= len(kapply.args):
+                    raise ValueError('NonTerminal index out of bounds: {arg_index}: {kapply}')
+                arg = kapply.args[arg_index]
+                return self._format(arg)  # recur
+            case KRegexTerminal():
+                raise ValueError(f'Invalid format index escape to regex terminal: {index}: {production}')
+            case _:
+                raise AssertionError()

--- a/pyk/src/tests/integration/kast/test_formatter.py
+++ b/pyk/src/tests/integration/kast/test_formatter.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import textwrap
+from itertools import count
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pyk.kast.formatter import Formatter
+from pyk.kast.inner import KApply, KSequence, KSort, KToken, KVariable
+from pyk.prelude.utils import token
+from pyk.testing import KompiledTest
+
+from ..utils import K_FILES
+
+if TYPE_CHECKING:
+    from pyk.kast import KInner
+    from pyk.kast.outer import KDefinition
+
+
+x, y = (KToken(name, KSort('Id')) for name in ['x', 'y'])
+
+
+TEST_DATA = (
+    (
+        KApply('<k>', KSequence()),
+        """
+        <k>
+          .K
+        </k>
+        """,
+    ),
+    (
+        KApply('<k>', KSequence(KVariable('X'))),
+        """
+        <k>
+          X ~> .K
+        </k>
+        """,
+    ),
+    (
+        KApply(
+            '<generatedTop>',
+            KApply(
+                '<T>',
+                KApply(
+                    '<k>',
+                    KSequence(
+                        KApply(
+                            'while(_)_',
+                            token(True),
+                            KApply(
+                                '{_}',
+                                KApply(
+                                    '__',
+                                    KApply('_=_;', x, KApply('_+_', x, token(1))),
+                                    KApply('_=_;', y, KApply('_-_', y, token(1))),
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                KApply(
+                    '<state>',
+                    KApply(
+                        '_Map_',
+                        KApply('_|->_', x, token(0)),
+                        KApply('_|->_', y, token(0)),
+                    ),
+                ),
+            ),
+            KApply('<generatedCounter>', token(0)),
+        ),
+        """
+        <T>
+          <k>
+            while (true) {
+              x = x + 1;
+              y = y - 1;
+            } ~> .K
+          </k>
+          <state>
+            x |-> 0
+            y |-> 0
+          </state>
+        </T>
+        """,
+    ),
+)
+
+
+class TestFormatter(KompiledTest):
+    KOMPILE_MAIN_FILE = K_FILES / 'imp.k'
+
+    @pytest.fixture
+    def formatter(self, definition: KDefinition) -> Formatter:
+        return Formatter(definition)
+
+    @pytest.mark.parametrize('term,output', TEST_DATA, ids=count())
+    def test(self, formatter: Formatter, term: KInner, output: str) -> None:
+        # Given
+        expected = textwrap.dedent(output).strip()
+
+        # When
+        actual = formatter(term)
+
+        # Then
+        assert actual == expected

--- a/pyk/src/tests/unit/kast/test_formatter.py
+++ b/pyk/src/tests/unit/kast/test_formatter.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import textwrap
+from itertools import count
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pyk.kast import KAtt
+from pyk.kast.att import Atts, Format
+from pyk.kast.formatter import Formatter
+from pyk.kast.inner import KLabel, KSort, KVariable
+from pyk.kast.outer import KDefinition, KFlatModule, KNonTerminal, KProduction, KTerminal
+from pyk.prelude.kint import INT
+from pyk.prelude.utils import token
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+    from typing import Final
+
+    from pyk.kast import KInner
+
+
+add: Final = KLabel('_+_')
+sub: Final = KLabel('_-_')
+cell: Final = KLabel('<cell>')
+
+
+def production(klabel: KLabel, sort: KSort, items: Iterable[KSort | str], formatt: str) -> KProduction:
+    _items = tuple(KNonTerminal(item) if isinstance(item, KSort) else KTerminal(item) for item in items)
+    return KProduction(sort=sort, items=_items, klabel=klabel, att=KAtt((Atts.FORMAT(Format.parse(formatt)),)))
+
+
+S: Final = KSort('S')
+DEFINITION: Final = KDefinition(
+    main_module_name='TEST',
+    all_modules=(
+        KFlatModule(
+            name='TEST',
+            sentences=(
+                production(cell, INT, ('<cell>', INT, '</cell>'), '%1%i%n%2%d%n%3'),
+                production(add, INT, (INT, '+', INT), '%1 %2 %3'),
+                production(sub, INT, (INT, '-', INT), '%1% %-% %3'),
+            ),
+        ),
+    ),
+)
+TEST_DATA: Final = (
+    (token(1), '1'),
+    (KVariable('X'), 'X'),
+    (KVariable('X', INT), 'X:Int'),
+    (add(token(1), token(2)), '1 + 2'),
+    (sub(token(1), token(2)), '1 - 2'),
+    (add(add(token(1), token(2)), token(3)), '1 + 2 + 3'),
+    (
+        cell(token(1)),
+        """
+        <cell>
+          1
+        </cell>
+        """,
+    ),
+    (
+        cell(cell(token(1))),
+        """
+        <cell>
+          <cell>
+            1
+          </cell>
+        </cell>
+        """,
+    ),
+)
+
+
+@pytest.mark.parametrize('term,output', TEST_DATA, ids=count())
+def test_formatter(term: KInner, output: str) -> None:
+    # Given
+    expected = textwrap.dedent(output).strip()
+    formatter = Formatter(DEFINITION)
+
+    # When
+    actual = formatter(term)
+
+    # Then
+    assert actual == expected


### PR DESCRIPTION
Implements pretty-printing KAST terms based on the `format` attribute.