### PR TITLE
Fix flaky un-alias test

### DIFF
--- a/pyk/src/tests/integration/test_kprint.py
+++ b/pyk/src/tests/integration/test_kprint.py
@@ -289,11 +289,6 @@ PRETTY_PRINT_ALIAS_TEST_DATA: Iterable[tuple[str, KInner, str]] = (
     ),
     (
         'multiple-rules-3',
-        andBool([leInt(intToken(0), KVariable('CONTRACT_ID')), ltInt(KVariable('CONTRACT_ID'), intToken(9))]),
-        '#range ( 0 <= CONTRACT_ID < 9 )',
-    ),
-    (
-        'multiple-rules-4',
         andBool([leInt(intToken(0), KVariable('CONTRACT_ID')), leInt(KVariable('CONTRACT_ID'), intToken(9))]),
         '#range ( 0 <= CONTRACT_ID <= 9 )',
     ),
@@ -364,7 +359,6 @@ class TestUnparsingDefn(KPrintTest):
 
             rule #range ( LB <  X <  UB ) => LB  <Int X andBool X  <Int UB
             rule #range ( LB <  X <= UB ) => LB  <Int X andBool X <=Int UB
-            rule #range ( LB <= X <  UB ) => LB <=Int X andBool X  <Int UB
             rule #range ( LB <= X <= UB ) => LB <=Int X andBool X <=Int UB
         endmodule
     """


### PR DESCRIPTION
In https://github.com/runtimeverification/k/pull/4300, I added new tests that reproduced an issue from Kontrol. Unfortunately, one of those test cases overlapped with the existing test case for this code. As a result, the test became flaky (maybe 1 in 10 runs on my machine) would fail because the `#range` and `rangeHundred` aliases overlapped for the `0 <= X < 100` case.

The fix is just to remove the overlapping rule ported in from Kontrol; I only added the 4 different rules because it was a direct copy-paste. We are still testing the regressive behaviour fixed in #4300 equally well because there are still multiple `#range` alias symbols that should be considered by `indexed_rewrite`.

I have verified as far as possible that the test no longer flakes on my machine.