### PR TITLE
Enable SimpleSub type inference by default

### DIFF
--- a/k-frontend/src/main/java/org/kframework/parser/inner/ParseInModule.java
+++ b/k-frontend/src/main/java/org/kframework/parser/inner/ParseInModule.java
@@ -142,7 +142,7 @@ public class ParseInModule implements Serializable, AutoCloseable {
     this.typeInferenceDebug = typeInferenceDebug;
     this.typeInferenceMode =
         typeInferenceMode == InnerParsingOptions.TypeInferenceMode.DEFAULT
-            ? InnerParsingOptions.TypeInferenceMode.Z3
+            ? InnerParsingOptions.TypeInferenceMode.SIMPLESUB
             : typeInferenceMode;
     this.partialParseDebug = partialParseDebug;
   }


### PR DESCRIPTION
Closes #4315

The SimpleSub type inference mode is already enabled with no issues in
- [evm-semantics](https://github.com/runtimeverification/evm-semantics/blob/baab34ead0233809ea6ae61289fd1df53a89f95a/kevm-pyk/src/kevm_pyk/kompile.py#L116)
- [mir-semantics](https://github.com/runtimeverification/mir-semantics/blob/fec3d1af683076416e714207da985404897e15e8/kmir/kbuild.toml)
- [c-semantics](https://github.com/runtimeverification/c-semantics/blob/ce570a522583f8a268076ff341544752749fd4b6/Makefile#L66)

so this PR makes it the default.