### PR TITLE
Run homebrew release on macOS 14 / arm64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
 
   macos-build:
     name: 'Build MacOS Package'
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 120
     environment: production
     needs: [set-release-id, source-tarball]
@@ -208,7 +208,7 @@ jobs:
           git commit Formula/$PACKAGE.rb -m "Update ${PACKAGE} to ${VERSION}: part 1"
           ../kframework/package/macos/brew-build-and-update-to-local-bottle ${PACKAGE} ${VERSION} ${ROOT_URL}
           git reset HEAD^
-          LOCAL_BOTTLE_NAME=$(basename $(find . -name "kframework--${VERSION}.ventura.bottle*.tar.gz"))
+          LOCAL_BOTTLE_NAME=$(basename $(find . -name "kframework--${VERSION}.arm64_sonoma.bottle*.tar.gz"))
           BOTTLE_NAME=$(echo ${LOCAL_BOTTLE_NAME#./} | sed 's!kframework--!kframework-!')
           ../kframework/package/macos/brew-update-to-final ${PACKAGE} ${VERSION} ${ROOT_URL}
           echo "path=${LOCAL_BOTTLE_NAME}" >> ${GITHUB_OUTPUT}
@@ -237,7 +237,7 @@ jobs:
 
   macos-test:
     name: 'Test MacOS Package'
-    runs-on: macos-13
+    runs-on: macos-14
     timeout-minutes: 60
     environment: production
     needs: [macos-build, set-release-id]


### PR DESCRIPTION
We are working on dropping support for intel macOS across K-related projects; one of the last load-bearing things we relied on that platform for was running Homebrew builds and tests. As of this year, Github offer hosted macOS 14 / arm64 runners that solve the problem we ran into previously where our own hosted runners were not ephemeral enough to properly run these builds.

This PR moves the relevant parts of our release workflows over to the new hosted runners; this code isn't directly tested in the PR flow so I opened a dummy PR that runs the relevant parts of the workflow. You can see the tests passing here: https://github.com/runtimeverification/k/pull/4372