### PR TITLE
Revert "Use LLVM 17 by default in flake"

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
     let
       allOverlays = [
         (_: _: {
-          llvm-version = 17;
+          llvm-version = 15;
           llvm-backend-build-type = "Release";
         })
         llvm-backend.overlays.default


### PR DESCRIPTION
Temporary fix while Cachix is broken.

Reverts runtimeverification/k#4370