### PR TITLE
 Set `--maxfail=0` for CI integration tests 

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -270,7 +270,7 @@ jobs:
           k-deb-path: kframework.deb
       - name: 'Run integration tests'
         run: |
-          docker exec -u user k-pyk-integration-${{ github.sha }} make test-integration TEST_ARGS='-n4 --timeout 300'
+          docker exec -u user k-pyk-integration-${{ github.sha }} make test-integration TEST_ARGS='-n4 --maxfail=0 --timeout=300'
       - name: 'Tear down Docker'
         if: always()
         run: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -243,7 +243,7 @@ jobs:
           k-deb-path: kframework.deb
       - name: 'Run profiling'
         run: |
-          docker exec -u user k-pyk-profile-${{ github.sha }} make profile PROF_ARGS='--maxfail=1 -n4'
+          docker exec -u user k-pyk-profile-${{ github.sha }} make profile PROF_ARGS=-n4
           docker exec -u user k-pyk-profile-${{ github.sha }} /bin/bash -c 'find /tmp/pytest-of-user/pytest-current/ -type f -name "*.prof" | sort | xargs tail -n +1'
       - name: 'Tear down Docker'
         if: always()

--- a/pyk/Makefile
+++ b/pyk/Makefile
@@ -22,18 +22,18 @@ poetry-install:
 
 # Tests
 
-TEST_ARGS ?= --maxfail=1
+TEST_ARGS :=
 
 test: test-all
 
 test-all: poetry-install
-	$(POETRY_RUN) pytest src/tests --verbose --durations=0 --numprocesses=4 --dist=worksteal $(TEST_ARGS)
+	$(POETRY_RUN) pytest src/tests --maxfail=1 --verbose --durations=0 --numprocesses=4 --dist=worksteal $(TEST_ARGS)
 
 test-unit: poetry-install
-	$(POETRY_RUN) pytest src/tests/unit --verbose $(TEST_ARGS)
+	$(POETRY_RUN) pytest src/tests/unit --maxfail=1 --verbose $(TEST_ARGS)
 
 test-integration: poetry-install
-	$(POETRY_RUN) pytest src/tests/integration --verbose --durations=0 --numprocesses=4 --dist=worksteal $(TEST_ARGS)
+	$(POETRY_RUN) pytest src/tests/integration --maxfail=1 --verbose --durations=0 --numprocesses=4 --dist=worksteal $(TEST_ARGS)
 
 test-regression-new: poetry-install
 	$(MAKE) -C regression-new
@@ -58,10 +58,10 @@ cov-integration: test-integration
 
 # Profiling
 
-PROF_ARGS ?= --maxfail=1
+PROF_ARGS :=
 
 profile: poetry-install
-	$(POETRY_RUN) pytest src/tests/profiling --verbose --durations=0 --numprocesses=4 --dist=worksteal $(PROF_ARGS)
+	$(POETRY_RUN) pytest src/tests/profiling --maxfail=1 --verbose --durations=0 --numprocesses=4 --dist=worksteal $(PROF_ARGS)
 
 
 # Checks and formatting


### PR DESCRIPTION
Does the same as #4371, but without modifying code generated from the Python project template.