### PR TITLE
Build and start to deploy pyk documentation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,6 +435,8 @@ jobs:
           path: gh-pages
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
           fetch-depth: 0
+      - name: 'Install Poetry'
+        uses: Gr1N/setup-poetry@v9
       - name: 'Checkout PL Tutorial code'
         uses: actions/checkout@v4
         with:
@@ -457,6 +459,11 @@ jobs:
           npm run build-sitemap
           cd -
           mv web/public_content ./
+          cd pyk
+          make docs
+          cd -
+          mkdir public_content/pyk
+          cp -r pyk/docs/build/html/* public_content/pyk
           rm -rf $(find . -maxdepth 1 -not -name public_content -a -not -name .git -a -not -path . -a -not -path .. -a -not -name CNAME)
           mv public_content/* ./
           rm -rf public_content


### PR DESCRIPTION
This PR adapts the old Pyk [Github Pages workflow](https://github.com/runtimeverification/pyk/blob/68bffc5ed0994d2c462d91fa3415f170cb0ec91f/.github/workflows/master.yml) to build the Pyk API documentation and stash it at '/pyk' under the current web root.

I've tested this locally in a Docker container as far as is possible, but I want to make sure that a release goes through correctly before I follow this up by actually editing the site to point to the documentation with a link.