### PR TITLE
Install Python 3.10 in `gh-pages` job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -435,6 +435,10 @@ jobs:
           path: gh-pages
           token: ${{ secrets.JENKINS_GITHUB_PAT }}
           fetch-depth: 0
+      - name: 'Install Python'
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
       - name: 'Install Poetry'
         uses: Gr1N/setup-poetry@v9
       - name: 'Checkout PL Tutorial code'


### PR DESCRIPTION
Related:
* #4387
* #4390

The job installs `pyk` to build the Sphinx docs, which requires Python >=3.10.