### PR TITLE
Exclude the `pyk` directory from Jekyll conversion

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,1 +1,3 @@
 theme: jekyll-theme-slate
+exclude:
+  - pyk/


### PR DESCRIPTION
Related:
* #4379 

CSS and JS fles are currently not deployed for https://kframework.org/pyk/, this is an attempt to fix that.