### PR TITLE
Bypass Jekyll on GitHub Pages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,0 @@
-theme: jekyll-theme-slate
-exclude:
-  - pyk/


### PR DESCRIPTION
Related:
* #4393 

Jekyll is not used for https://kframework.org/, this PR disables the default build step on deployment to GitHub Pages.