### PR TITLE
Including `compute_ordinals` and `get_axiom_by_ordinal` in Pyk `kore.Definition`

### DIFF
--- a/pyk/src/pyk/kore/syntax.py
+++ b/pyk/src/pyk/kore/syntax.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from io import StringIO
 from typing import ClassVar  # noqa: TC003
-from typing import TYPE_CHECKING, List, final
+from typing import TYPE_CHECKING, final
 
 from ..dequote import enquoted
 from ..utils import check_type
@@ -2202,7 +2202,7 @@ class Definition(Kore, WithAttrs, Iterable[Module]):
         new_modules = []
         rule_ordinal = 0
         for module in self.modules:
-            new_sentences: List[Sentence] = []
+            new_sentences: list[Sentence] = []
             for sentence in module.sentences:
                 if type(sentence) is Axiom:
                     ordinal_attr = App('ordinal', (), [String(str(rule_ordinal))])

--- a/pyk/src/pyk/kore/syntax.py
+++ b/pyk/src/pyk/kore/syntax.py
@@ -2170,7 +2170,6 @@ class Module(Kore, WithAttrs, Iterable[Sentence]):
 class Definition(Kore, WithAttrs, Iterable[Module]):
     modules: tuple[Module, ...]
     attrs: tuple[App, ...]
-    ordinals: dict[int, Axiom]
 
     def __init__(self, modules: Iterable[Module] = (), attrs: Iterable[App] = ()):
         object.__setattr__(self, 'modules', tuple(modules))
@@ -2195,8 +2194,12 @@ class Definition(Kore, WithAttrs, Iterable[Module]):
             output.write('\n\n')
             module.write(output)
 
+    @cached_property
+    def axioms(self) -> tuple[Axiom, ...]:
+        return tuple(sent for module in self.modules for sent in module if isinstance(sent, Axiom))
+
     def get_axiom_by_ordinal(self, ordinal: int) -> Axiom:
-        return self.ordinals[ordinal]
+        return self.axioms[ordinal]
 
     def compute_ordinals(self) -> Definition:
         new_modules = []
@@ -2208,7 +2211,6 @@ class Definition(Kore, WithAttrs, Iterable[Module]):
                     ordinal_attr = App('ordinal', (), [String(str(rule_ordinal))])
                     new_sentence = sentence.let_attrs(sentence.attrs + (ordinal_attr,))
                     new_sentences.append(new_sentence)
-                    self.ordinals[rule_ordinal] = new_sentence
                     rule_ordinal += 1
                 else:
                     new_sentences.append(sentence)


### PR DESCRIPTION
In this PR, we're translating the logic of these functions from the LLVM Backend `ast.Definition` to Pyk `kore.Definition`. This will allow us to perform the same kind of `rule_ordinal` number-agnostic testing for both kinds of `Definition` classes on the Math Proof Team's test suite!