### PR TITLE
Publish `pyk` on PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,8 +365,6 @@ jobs:
 
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v9
-        with:
-          python-version: '3.10'
 
       - name: Setup Caching
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,37 +347,6 @@ jobs:
             const { owner, repo } = context.repo
             await github.rest.repos.deleteRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }} })
 
-  pyk-publish:
-    name: 'Publish pyk'
-    runs-on: ubuntu-latest
-    environment: production
-    permissions:
-      id-token: write
-    needs: [set-release-id, source-tarball]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10'
-
-      - name: Install Poetry
-        uses: Gr1N/setup-poetry@v9
-
-      - name: Build pyk
-        working-directory: pyk
-        run: |
-          make build
-
-      - name: Publish pyk to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
-        with:
-          packages-dir: pyk/dist
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
-
   release:
     name: 'Publish Release'
     runs-on: [self-hosted, linux, normal]
@@ -434,6 +403,37 @@ jobs:
           script: |
             const { owner, repo } = context.repo
             await github.rest.repos.updateRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }}, prerelease: false })
+
+  pyk-publish:
+    name: 'Publish pyk'
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      id-token: write
+    needs: [set-release-id, source-tarball]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install Poetry
+        uses: Gr1N/setup-poetry@v9
+
+      - name: Build pyk
+        working-directory: pyk
+        run: |
+          make build
+
+      - name: Publish pyk to PyPI
+        uses: pypa/gh-action-pypi-publish@v1
+        with:
+          packages-dir: pyk/dist
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
 
   notify-dependents:
     name: 'Notify Dependents'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -410,7 +410,7 @@ jobs:
     environment: production
     permissions:
       id-token: write
-    needs: [set-release-id, source-tarball]
+    needs: release
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -438,7 +438,7 @@ jobs:
   notify-dependents:
     name: 'Notify Dependents'
     runs-on: ubuntu-latest
-    needs: release
+    needs: pyk-publish
     steps:
       - name: Check out code
         uses: actions/checkout@v4
@@ -494,7 +494,7 @@ jobs:
     name: 'GitHub Pages deployment'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [pyk-build-docs, release]
+    needs: [pyk-build-docs, pyk-publish]
     steps:
       - name: 'Install pandoc/texlive/calibre'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,7 +358,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Python
+      - name: Install Python
         uses: actions/setup-python@v5.1.0
         with:
           python-version: '3.10'
@@ -367,7 +367,7 @@ jobs:
         uses: Gr1N/setup-poetry@v9
         with:
           python-version: '3.10'
-    
+
       - name: Setup Caching
         uses: actions/cache@v4
         with:
@@ -375,13 +375,13 @@ jobs:
           key: ${{ runner.os }}-poetry-${{ hashFiles('pyk/pyproject.toml') }}
           restore-keys: |
             ${{ runner.os }}-poetry-
-      
+
       - name: Build pyk
         working-directory: pyk
         run: |
           make build
 
-      - name: Publish pyk to PypI
+      - name: Publish pyk to PyPI
         uses: pypa/gh-action-pypi-publish@v1.8.14
         with:
           packages-dir: pyk/dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -349,7 +349,7 @@ jobs:
 
   pyk-publish:
     name: 'Publish pyk'
-    runs-on: [self-hosted, linux, flyweight]
+    runs-on: ubuntu-latest
     environment: production
     permissions:
       id-token: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,47 @@ jobs:
             const { owner, repo } = context.repo
             await github.rest.repos.deleteRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }} })
 
+  pyk-publish:
+    name: 'Publish pyk'
+    runs-on: [self-hosted, linux, flyweight]
+    environment: production
+    permissions:
+      id-token: write
+    needs: [set-release-id, source-tarball]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5.1.0
+        with:
+          python-version: '3.10'
+
+      - name: Install Poetry
+        uses: Gr1N/setup-poetry@v9
+        with:
+          python-version: '3.10'
+    
+      - name: Setup Caching
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/poetry/virtualenvs
+          key: ${{ runner.os }}-poetry-${{ hashFiles('pyk/pyproject.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-poetry-
+      
+      - name: Build pyk
+        working-directory: pyk
+        run: |
+          make build
+
+      - name: Publish pyk to PypI
+        uses: pypa/gh-action-pypi-publish@v1.8.14
+        with:
+          packages-dir: pyk/dist
+          user: __token__
+          password: ${{ secrets.PYPI_TOKEN }}
+
   release:
     name: 'Publish Release'
     runs-on: [self-hosted, linux, normal]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,7 +359,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Install Python
-        uses: actions/setup-python@v5.1.0
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
 
@@ -382,7 +382,7 @@ jobs:
           make build
 
       - name: Publish pyk to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@v1
         with:
           packages-dir: pyk/dist
           user: __token__

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -366,14 +366,6 @@ jobs:
       - name: Install Poetry
         uses: Gr1N/setup-poetry@v9
 
-      - name: Setup Caching
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/poetry/virtualenvs
-          key: ${{ runner.os }}-poetry-${{ hashFiles('pyk/pyproject.toml') }}
-          restore-keys: |
-            ${{ runner.os }}-poetry-
-
       - name: Build pyk
         working-directory: pyk
         run: |


### PR DESCRIPTION
Fixes #4239

~Blocked on~:
* #4438
* #4461

Add job `pyk-publish` to publish `pyk` on PyPI (under package name `kframework`).

Release workflow changes from

```
       release --- notify-dependents
                \
pyk-build-docs --- gh-pages
```

to

```
release --- pyk-publish --- notify-dependents
                         \
         pyk-build-docs --- gh-pages

```