### PR TITLE
Add sort injections on the KAST level

### DIFF
--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -261,7 +261,6 @@ def exec_prove(options: ProveOptions) -> None:
     def explore_context() -> Iterator[KCFGExplore]:
         with cterm_symbolic(
             definition=kprove.definition,
-            kompiled_kore=kprove.kompiled_kore,
             definition_dir=kprove.definition_dir,
         ) as cts:
             yield KCFGExplore(cts)

--- a/pyk/src/pyk/cterm/symbolic.py
+++ b/pyk/src/pyk/cterm/symbolic.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
 
     from ..kast import KInner
     from ..kast.outer import KDefinition
-    from ..kore.kompiled import KompiledKore
     from ..kore.rpc import FallbackReason, LogEntry
     from ..kore.syntax import Pattern
     from ..utils import BugReport
@@ -74,20 +73,17 @@ class CTermSMTError(Exception):
 class CTermSymbolic:
     _kore_client: KoreClient
     _definition: KDefinition
-    _kompiled_kore: KompiledKore
     _trace_rewrites: bool
 
     def __init__(
         self,
         kore_client: KoreClient,
         definition: KDefinition,
-        kompiled_kore: KompiledKore,
         *,
         trace_rewrites: bool = False,
     ):
         self._kore_client = kore_client
         self._definition = definition
-        self._kompiled_kore = kompiled_kore
         self._trace_rewrites = trace_rewrites
 
     def kast_to_kore(self, kinner: KInner) -> Pattern:
@@ -319,7 +315,6 @@ class CTermSymbolic:
 @contextmanager
 def cterm_symbolic(
     definition: KDefinition,
-    kompiled_kore: KompiledKore,
     definition_dir: Path,
     *,
     id: str | None = None,
@@ -360,7 +355,7 @@ def cterm_symbolic(
             no_post_exec_simplify=no_post_exec_simplify,
         ) as server:
             with KoreClient('localhost', server.port, bug_report=bug_report, bug_report_id=id) as client:
-                yield CTermSymbolic(client, definition, kompiled_kore, trace_rewrites=trace_rewrites)
+                yield CTermSymbolic(client, definition, trace_rewrites=trace_rewrites)
     else:
         if port is None:
             raise ValueError('Missing port with start_server=False')
@@ -376,4 +371,4 @@ def cterm_symbolic(
                 ],
             }
         with KoreClient('localhost', port, bug_report=bug_report, bug_report_id=id, dispatch=dispatch) as client:
-            yield CTermSymbolic(client, definition, kompiled_kore, trace_rewrites=trace_rewrites)
+            yield CTermSymbolic(client, definition, trace_rewrites=trace_rewrites)

--- a/pyk/src/pyk/cterm/symbolic.py
+++ b/pyk/src/pyk/cterm/symbolic.py
@@ -91,7 +91,7 @@ class CTermSymbolic:
         self._trace_rewrites = trace_rewrites
 
     def kast_to_kore(self, kinner: KInner) -> Pattern:
-        return kast_to_kore(self._definition, self._kompiled_kore, kinner, sort=GENERATED_TOP_CELL)
+        return kast_to_kore(self._definition, kinner, sort=GENERATED_TOP_CELL)
 
     def kore_to_kast(self, pattern: Pattern) -> KInner:
         return kore_to_kast(self._definition, pattern)

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1182,14 +1182,6 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         """Returns the module associated with a given name."""
         return self.all_modules_dict[name]
 
-    def return_sort(self, label: KLabel) -> KSort:
-        """Returns the return sort of a given `KLabel` by looking up the production."""
-        return self.symbols[label.name].sort
-
-    def argument_sorts(self, label: KLabel) -> list[KSort]:
-        """Returns the argument sorts of a given `KLabel` by looking up the production."""
-        return self.symbols[label.name].argument_sorts
-
     @cached_property
     def subsort_table(self) -> FrozenDict[KSort, frozenset[KSort]]:
         """Return a mapping from sorts to all their proper subsorts."""

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1320,28 +1320,27 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
             case KSequence(_):
                 return KSort('K')
             case KApply(label, _):
-                prod = self.symbols[label.name]
-                if prod.sort not in prod.params:
-                    return prod.sort
-                elif len(prod.params) == len(label.params):
-                    param_dict: dict[KSort, KSort] = {}
-                    for pparam, lparam in zip(prod.params, label.params, strict=True):
-                        if pparam not in param_dict:
-                            param_dict[pparam] = lparam
-                        elif param_dict[pparam] != lparam:
-                            return None
-                    if prod.sort in param_dict and param_dict[prod.sort] not in prod.params:
-                        return param_dict[prod.sort]
-                return None
+                sort, _ = self.resolve_sorts(label)
+                return sort
             case _:
                 return None
 
     def sort_strict(self, kast: KInner) -> KSort:
-        """Computes the sort of a given term using best-effort simple sorting algorithm, dies on algorithm failure."""
+        """Compute the sort of a given term using best-effort simple sorting algorithm, dies on algorithm failure."""
         sort = self.sort(kast)
         if sort is None:
             raise ValueError(f'Could not determine sort of term: {kast}')
         return sort
+
+    def resolve_sorts(self, label: KLabel) -> tuple[KSort, tuple[KSort, ...]]:
+        """Compute the result and argument sorts for a given production based on a `KLabel`."""
+        prod = self.symbols[label.name]
+        sorts = dict(zip(prod.params, label.params, strict=True))
+
+        def resolve(sort: KSort) -> KSort:
+            return sorts.get(sort, sort)
+
+        return resolve(prod.sort), tuple(resolve(sort) for sort in prod.argument_sorts)
 
     def least_common_supersort(self, sort1: KSort, sort2: KSort) -> KSort | None:
         """Computes the lowest-upper-bound of two sorts in the sort lattice using very simple approach, returning `None` on failure (not necessarily meaning there isn't a lub)."""

--- a/pyk/src/pyk/konvert/_kast_to_kore.py
+++ b/pyk/src/pyk/konvert/_kast_to_kore.py
@@ -57,20 +57,14 @@ ML_PATTERN_LABELS: Final = dict(
 )
 
 
-def kast_to_kore(
-    kast_defn: KDefinition,
-    kompiled_kore: KompiledKore,
-    kast: KInner,
-    sort: KSort | None = None,
-) -> Pattern:
-    if sort is None:
-        sort = K
-    kast = kast_defn.add_ksequence_under_k_productions(kast)
-    kast = kast_defn.sort_vars(kast, sort)
-    kast = kast_defn.add_cell_map_items(kast)
-    kast = kast_defn.add_sort_params(kast)
+def kast_to_kore(definition: KDefinition, kast: KInner, sort: KSort | None = None) -> Pattern:
+    sort = sort or K
+    kast = definition.add_ksequence_under_k_productions(kast)
+    kast = definition.sort_vars(kast, sort)
+    kast = definition.add_cell_map_items(kast)
+    kast = definition.add_sort_params(kast)
     kast = _replace_ksequence_by_kapply(kast)
-    kast = _add_sort_injections(kast_defn, kast, sort)
+    kast = _add_sort_injections(definition, kast, sort)
     kore = _kast_to_kore(kast)
     return kore
 
@@ -217,17 +211,17 @@ def krule_to_kore(kast_defn: KDefinition, kompiled_kore: KompiledKore, krule: KR
     top_level_k_sort = KSort('GeneratedTopCell')
     # The backend does not like rewrite rules without a precondition
     if len(krule_lhs_constraints) > 0:
-        kore_lhs0: Pattern = kast_to_kore(kast_defn, kompiled_kore, krule_lhs, sort=top_level_k_sort)
+        kore_lhs0: Pattern = kast_to_kore(kast_defn, krule_lhs, sort=top_level_k_sort)
     else:
         kore_lhs0 = And(
             top_level_kore_sort,
             (
-                kast_to_kore(kast_defn, kompiled_kore, krule_lhs, sort=top_level_k_sort),
+                kast_to_kore(kast_defn, krule_lhs, sort=top_level_k_sort),
                 Top(top_level_kore_sort),
             ),
         )
 
-    kore_rhs0: Pattern = kast_to_kore(kast_defn, kompiled_kore, krule_rhs, sort=top_level_k_sort)
+    kore_rhs0: Pattern = kast_to_kore(kast_defn, krule_rhs, sort=top_level_k_sort)
 
     kore_lhs = kompiled_kore.add_injections(kore_lhs0, sort=top_level_kore_sort)
     kore_rhs = kompiled_kore.add_injections(kore_rhs0, sort=top_level_kore_sort)

--- a/pyk/src/pyk/konvert/_kast_to_kore.py
+++ b/pyk/src/pyk/konvert/_kast_to_kore.py
@@ -211,9 +211,9 @@ def krule_to_kore(kast_defn: KDefinition, kompiled_kore: KompiledKore, krule: KR
     top_level_k_sort = KSort('GeneratedTopCell')
     # The backend does not like rewrite rules without a precondition
     if len(krule_lhs_constraints) > 0:
-        kore_lhs0: Pattern = kast_to_kore(kast_defn, krule_lhs, sort=top_level_k_sort)
+        kore_lhs: Pattern = kast_to_kore(kast_defn, krule_lhs, sort=top_level_k_sort)
     else:
-        kore_lhs0 = And(
+        kore_lhs = And(
             top_level_kore_sort,
             (
                 kast_to_kore(kast_defn, krule_lhs, sort=top_level_k_sort),
@@ -221,10 +221,8 @@ def krule_to_kore(kast_defn: KDefinition, kompiled_kore: KompiledKore, krule: KR
             ),
         )
 
-    kore_rhs0: Pattern = kast_to_kore(kast_defn, krule_rhs, sort=top_level_k_sort)
+    kore_rhs: Pattern = kast_to_kore(kast_defn, krule_rhs, sort=top_level_k_sort)
 
-    kore_lhs = kompiled_kore.add_injections(kore_lhs0, sort=top_level_kore_sort)
-    kore_rhs = kompiled_kore.add_injections(kore_rhs0, sort=top_level_kore_sort)
     prio = krule.priority
     attrs = [App(symbol='priority', sorts=(), args=(String(str(prio)),))]
     if Atts.LABEL in krule.att:

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -268,7 +268,7 @@ class KPrint:
         if not force_kast:
             try:
                 _LOGGER.info('Invoking kast_to_kore')
-                return kast_to_kore(self.definition, self.kompiled_kore, kast, sort)
+                return kast_to_kore(self.definition, kast, sort)
             except ValueError as ve:
                 _LOGGER.warning(ve)
 

--- a/pyk/src/pyk/ktool/kprint.py
+++ b/pyk/src/pyk/ktool/kprint.py
@@ -16,7 +16,6 @@ from ..kast.inner import KInner
 from ..kast.outer import read_kast_definition
 from ..kast.pretty import PrettyPrinter
 from ..konvert import kast_to_kore, kore_to_kast
-from ..kore.kompiled import KompiledKore
 from ..kore.parser import KoreParser
 from ..kore.syntax import App, SortApp
 from ..kore.tools import PrintOutput, kore_print
@@ -225,10 +224,6 @@ class KPrint:
     @cached_property
     def definition(self) -> KDefinition:
         return read_kast_definition(self.definition_dir / 'compiled.json')
-
-    @cached_property
-    def kompiled_kore(self) -> KompiledKore:
-        return KompiledKore.load(self.definition_dir)
 
     @property
     def definition_hash(self) -> str:

--- a/pyk/src/pyk/prelude/k.py
+++ b/pyk/src/pyk/prelude/k.py
@@ -1,9 +1,21 @@
-from typing import Final
+from __future__ import annotations
 
-from ..kast.inner import KSort, KToken
+from typing import TYPE_CHECKING
+
+from ..kast.inner import KApply, KLabel, KSort, KToken
+
+if TYPE_CHECKING:
+    from typing import Final
+
+    from ..kast import KInner
+
 
 K: Final = KSort('K')
 K_ITEM: Final = KSort('KItem')
 GENERATED_TOP_CELL: Final = KSort('GeneratedTopCell')
 
 DOTS: Final = KToken('...', K)
+
+
+def inj(from_sort: KSort, to_sort: KSort, term: KInner) -> KInner:
+    return KApply(KLabel('inj', (from_sort, to_sort)), (term,))

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -708,9 +708,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
     def init_proof(self, proof: APRProof) -> None:
         def _inject_module(module_name: str, import_name: str, sentences: list[KRuleLike]) -> None:
             _module = KFlatModule(module_name, sentences, [KImport(import_name)])
-            _kore_module = kflatmodule_to_kore(
-                self.kcfg_explore.cterm_symbolic._definition, self.kcfg_explore.cterm_symbolic._kompiled_kore, _module
-            )
+            _kore_module = kflatmodule_to_kore(self.kcfg_explore.cterm_symbolic._definition, _module)
             self.kcfg_explore.cterm_symbolic._kore_client.add_module(_kore_module, name_as_id=True)
 
         subproofs: list[Proof] = (

--- a/pyk/src/pyk/testing/_kompiler.py
+++ b/pyk/src/pyk/testing/_kompiler.py
@@ -286,10 +286,9 @@ class CTermSymbolicTest(KoreClientTest):
         self,
         kore_client: KoreClient,
         definition: KDefinition,
-        kompiled_kore: KompiledKore,
         bug_report: BugReport | None,
     ) -> CTermSymbolic:
-        return CTermSymbolic(kore_client, definition, kompiled_kore)
+        return CTermSymbolic(kore_client, definition)
 
 
 class KCFGExploreTest(CTermSymbolicTest):
@@ -321,11 +320,10 @@ class ParallelTest(KoreServerTest, ABC):
         _kore_server: KoreServer,
         definition: KDefinition,
         bug_report: BugReport | None,
-        kompiled_kore: KompiledKore,
     ) -> Callable[[int, Iterable[str]], APRProver]:
         def _create_prover(max_depth: int, cut_point_rules: Iterable[str]) -> APRProver:
             kore_client = self.create_kore_client(_kore_server, bug_report)
-            ct_symb = CTermSymbolic(kore_client, definition, kompiled_kore)
+            ct_symb = CTermSymbolic(kore_client, definition)
             _kcfg_explore = KCFGExplore(ct_symb, kcfg_semantics=self.semantics(definition))
             return APRProver(kcfg_explore=_kcfg_explore, execute_depth=max_depth, cut_point_rules=cut_point_rules)
 

--- a/pyk/src/tests/integration/konvert/test_cell_map.py
+++ b/pyk/src/tests/integration/konvert/test_cell_map.py
@@ -6,7 +6,6 @@ import pytest
 
 from pyk.kast.inner import KApply, KSort, KVariable
 from pyk.konvert import kast_to_kore, kore_to_kast
-from pyk.kore.kompiled import KompiledKore
 from pyk.kore.parser import KoreParser
 from pyk.prelude.kint import INT, intToken
 from pyk.testing import KompiledTest
@@ -14,7 +13,6 @@ from pyk.testing import KompiledTest
 from ..utils import K_FILES
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from typing import Final
 
     from pyk.kast import KInner
@@ -96,10 +94,6 @@ KORE_TO_KAST_TEST_DATA: Final = BIDIRECTIONAL_TEST_DATA + (
 class TestKonvertCellMap(KompiledTest):
     KOMPILE_MAIN_FILE = K_FILES / 'cell-map.k'
 
-    @pytest.fixture(scope='class')
-    def kompiled_kore(self, definition_dir: Path) -> KompiledKore:
-        return KompiledKore.load(definition_dir)
-
     @pytest.mark.parametrize(
         'test_id,sort,kore_text,kast',
         KAST_TO_KORE_TEST_DATA,
@@ -108,7 +102,6 @@ class TestKonvertCellMap(KompiledTest):
     def test_kast_to_kore(
         self,
         definition: KDefinition,
-        kompiled_kore: KompiledKore,
         test_id: str,
         sort: KSort,
         kore_text: str,
@@ -118,7 +111,7 @@ class TestKonvertCellMap(KompiledTest):
         kore = KoreParser(kore_text).pattern()
 
         # When
-        actual_kore = kast_to_kore(definition, kompiled_kore, kast, sort=sort)
+        actual_kore = kast_to_kore(definition, kast, sort=sort)
 
         # Then
         assert actual_kore == kore

--- a/pyk/src/tests/integration/konvert/test_simple_proofs.py
+++ b/pyk/src/tests/integration/konvert/test_simple_proofs.py
@@ -8,7 +8,6 @@ from pyk.kast import Atts
 from pyk.kast.inner import KApply, KLabel, KRewrite, KSequence, KSort, KToken, KVariable
 from pyk.kast.outer import KRule
 from pyk.konvert import kast_to_kore, kore_to_kast, krule_to_kore
-from pyk.kore.kompiled import KompiledKore
 from pyk.kore.parser import KoreParser
 from pyk.prelude.bytes import bytesToken
 from pyk.prelude.kbool import BOOL, TRUE
@@ -21,7 +20,6 @@ from pyk.utils import single
 from ..utils import K_FILES, TEST_DATA_DIR
 
 if TYPE_CHECKING:
-    from pathlib import Path
     from typing import Final
 
     from pyk.kast import KInner
@@ -651,10 +649,6 @@ class TestKonvertSimpleProofs(KPrintTest):
     KOMPILE_MAIN_FILE = K_FILES / 'simple-proofs.k'
     KOMPILE_ARGS = {'syntax_module': 'SIMPLE-PROOFS'}
 
-    @pytest.fixture(scope='class')
-    def kompiled_kore(self, definition_dir: Path) -> KompiledKore:
-        return KompiledKore.load(definition_dir)
-
     @pytest.mark.parametrize(
         'test_id,sort,kore_text,kast',
         KAST_TO_KORE_TEST_DATA,
@@ -733,7 +727,6 @@ class TestKonvertSimpleProofs(KPrintTest):
     def test_krule_to_kore(
         self,
         definition: KDefinition,
-        kompiled_kore: KompiledKore,
         rule_id: str,
         kore_text: str,
     ) -> None:
@@ -741,7 +734,7 @@ class TestKonvertSimpleProofs(KPrintTest):
         rule = single(r for r in main_module.rules if Atts.LABEL in r.att and r.att[Atts.LABEL] == rule_id)
 
         # When
-        actual_kore_text = krule_to_kore(definition, kompiled_kore, rule).text
+        actual_kore_text = krule_to_kore(definition, rule).text
 
         # Then
         assert actual_kore_text == kore_text
@@ -754,13 +747,12 @@ class TestKonvertSimpleProofs(KPrintTest):
     def test_explicit_krule_to_kore(
         self,
         definition: KDefinition,
-        kompiled_kore: KompiledKore,
         test_id: str,
         rule: KRule,
         kore_text: str,
     ) -> None:
         # When
-        actual_kore_text = krule_to_kore(definition, kompiled_kore, rule).text
+        actual_kore_text = krule_to_kore(definition, rule).text
 
         # Then
         assert actual_kore_text == kore_text

--- a/pyk/src/tests/integration/konvert/test_simple_proofs.py
+++ b/pyk/src/tests/integration/konvert/test_simple_proofs.py
@@ -663,7 +663,6 @@ class TestKonvertSimpleProofs(KPrintTest):
     def test_kast_to_kore(
         self,
         definition: KDefinition,
-        kompiled_kore: KompiledKore,
         test_id: str,
         sort: KSort,
         kore_text: str,
@@ -673,7 +672,7 @@ class TestKonvertSimpleProofs(KPrintTest):
         kore = KoreParser(kore_text).pattern()
 
         # When
-        actual_kore = kast_to_kore(definition, kompiled_kore, kast, sort=sort)
+        actual_kore = kast_to_kore(definition, kast, sort=sort)
 
         # Then
         assert actual_kore == kore
@@ -686,7 +685,6 @@ class TestKonvertSimpleProofs(KPrintTest):
     def test_kast_to_kore_frontend_comp(
         self,
         definition: KDefinition,
-        kompiled_kore: KompiledKore,
         test_id: str,
         sort: KSort,
         kore_text: str,
@@ -700,7 +698,7 @@ class TestKonvertSimpleProofs(KPrintTest):
         frontend_kore = kprint.kast_to_kore(kast=kast, sort=sort, force_kast=True)
 
         # When
-        actual_kore = kast_to_kore(definition, kompiled_kore, kast, sort=sort)
+        actual_kore = kast_to_kore(definition, kast, sort=sort)
 
         # Then
         assert actual_kore == frontend_kore

--- a/pyk/src/tests/profiling/profile_kast_to_kore.py
+++ b/pyk/src/tests/profiling/profile_kast_to_kore.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import shutil
 import sys
 from typing import TYPE_CHECKING
 
@@ -8,7 +7,6 @@ from pyk.kast import KInner
 from pyk.kast.inner import KSort
 from pyk.kast.outer import read_kast_definition
 from pyk.konvert import kast_to_kore, kore_to_kast
-from pyk.kore.kompiled import KompiledKore
 
 from .utils import TEST_DATA_DIR
 
@@ -20,28 +18,19 @@ if TYPE_CHECKING:
 
 def test_kast_to_kore(profile: Profiler, tmp_path: Path) -> None:
     kast_to_kore_dir = TEST_DATA_DIR / 'kast-to-kore'
-    kast_defn_file = kast_to_kore_dir / 'compiled.json'
-    kore_defn_file = kast_to_kore_dir / 'definition.kore'
+    definition_file = kast_to_kore_dir / 'compiled.json'
     kinner_file = kast_to_kore_dir / 'kinner.json'
 
     sys.setrecursionlimit(10**8)
 
-    with profile('init-kast-defn.prof', sort_keys=('cumtime',), limit=50):
-        kast_defn = read_kast_definition(kast_defn_file)
-
-    shutil.copy(kore_defn_file, tmp_path)
-    with profile('init-kore-defn.prof', sort_keys=('cumtime',), limit=50):
-        kore_defn = KompiledKore.load(tmp_path)  # first time from KORE
-
-    kore_defn.write(tmp_path)
-    with profile('reinit-kore-defn.prof', sort_keys=('cumtime',), limit=25):
-        kore_defn = KompiledKore.load(tmp_path)  # second time from JSON
+    with profile('init-defn.prof', sort_keys=('cumtime',), limit=50):
+        definition = read_kast_definition(definition_file)
 
     kast = KInner.from_json(kinner_file.read_text())
 
     for file_name in ['kast-to-kore-1.prof', 'kast-to-kore-2.prof']:
         with profile(file_name, sort_keys=('cumtime',), limit=25):
-            kore = kast_to_kore(kast_defn, kore_defn, kast, sort=KSort('GeneratedTopCell'))
+            kore = kast_to_kore(definition, kast, sort=KSort('GeneratedTopCell'))
 
     with profile('kore-to-kast.prof', sort_keys=('cumtime',), limit=25):
-        kore_to_kast(kast_defn, kore)
+        kore_to_kast(definition, kore)


### PR DESCRIPTION
Eliminates `kompiled_kore` from
* `kast_to_kore`
* `krule_to_kore`
* `kflatmodule_to_kore`
* `KPrint`
* `CTermSymbolic`

by
* Adding sort injections on the KAST level as a pass in `kast_to_kore`
* Removing an unnecessary `add_injections` step from `krule_to_kore`