### PR TITLE
Move simple jobs to latest Ubuntu version

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -11,7 +11,7 @@ jobs:
 
   version-bump:
     name: 'Version Bump'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -11,7 +11,7 @@ jobs:
 
   change-base:
     name: 'Change base to develop branch'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ jobs:
 
   set-release-id:
     name: 'Set Release ID'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Get release_id'
         run: echo "release_id=$(jq --raw-output '.release.id' $GITHUB_EVENT_PATH)" >> ${GITHUB_OUTPUT}
@@ -48,8 +48,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - runner: ubuntu-20.04
-            os: ubuntu-20.04
+          - runner: ubuntu-24.04
+            os: ubuntu-24.04
           - runner: macos-13
             os: macos-13
           - runner: MacM1
@@ -456,7 +456,7 @@ jobs:
 
   gh-pages:
     name: 'GitHub Pages deployment'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 30
     needs: [pyk-build-docs, release]
     steps:

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -14,7 +14,7 @@ jobs:
 
   nix-flake-submodule-sync:
     name: 'Nix flake submodule sync'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: 'Check out code, set up Git'
         uses: actions/checkout@v4


### PR DESCRIPTION
These jobs were previously running on an old version of Ubuntu, the image for which will be deprecated at some point. This PR just bumps them to use a newer version; the jobs aren't interacting with the OS in any meaningful way so this won't be a breaking change.