### PR TITLE
Escape literal spaces in Flex regex

### DIFF
--- a/k-frontend/src/main/java/org/kframework/definition/regex/RegexSyntax.java
+++ b/k-frontend/src/main/java/org/kframework/definition/regex/RegexSyntax.java
@@ -130,9 +130,11 @@ public class RegexSyntax {
     private Flex() {}
 
     public static final Set<Integer> reservedTokens =
-        Stream.concat(K.reservedTokens.stream(), codePoints('/', '<', '>').stream())
+        Stream.concat(K.reservedTokens.stream(), codePoints('/', '<', '>', ' ').stream())
             .collect(Collectors.toSet());
-    public static final Set<Integer> reservedCharClassTokens = K.reservedCharClassTokens;
+    public static final Set<Integer> reservedCharClassTokens =
+        Stream.concat(K.reservedCharClassTokens.stream(), codePoints(' ').stream())
+            .collect(Collectors.toSet());
     private static final RegexSyntax printer =
         new RegexSyntax(reservedTokens, reservedCharClassTokens) {
           // Parenthesize non-ASCII codepoints because Flex treats them as a sequence of bytes


### PR DESCRIPTION
The C semantics fails to build with the latest K (https://github.com/runtimeverification/c-semantics/pull/1146) due to the spaces [here](https://github.com/runtimeverification/c-semantics/blob/23f6fe2e274f35cb171363588f3c194462c403a2/core/semantics/language/directive.k#L3) not being escaped when printed to Flex.

This PR addresses that by adding `' '` as a reserved token for Flex regex.