### PR TITLE
Refactor `parse_outer`

### DIFF
--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -413,7 +413,12 @@ def exec_parse_outer(options: ParseOuterOptions) -> None:
     search_paths = [definition_file.parent, *options.includes]
     main_module_name = options.main_module or definition_file.stem.upper()
 
-    final_definition = parse_outer(definition_file, main_module_name, search_paths, options.md_selector)
+    final_definition = parse_outer(
+        definition_file,
+        main_module_name,
+        search_paths=search_paths,
+        md_selector=options.md_selector,
+    )
 
     result_text = json.dumps(final_definition.to_dict())
     try:
@@ -427,7 +432,12 @@ def exec_kompilex(options: KompileXCommandOptions) -> None:
     search_paths = [definition_file.parent, *options.includes]
     main_module_name = options.main_module or definition_file.stem.upper()
 
-    final_definition = parse_outer(definition_file, main_module_name, search_paths, options.md_selector)
+    final_definition = parse_outer(
+        definition_file,
+        main_module_name,
+        search_paths=search_paths,
+        md_selector=options.md_selector,
+    )
 
     if options.pre_parsed_prelude:
         prelude_json = json.loads(options.pre_parsed_prelude.read())

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -415,7 +415,7 @@ def exec_parse_outer(options: ParseOuterOptions) -> None:
     final_definition = parse_outer(
         definition_file,
         main_module_name,
-        search_paths=options.includes,
+        include_dirs=options.includes,
         md_selector=options.md_selector,
     )
 
@@ -433,7 +433,7 @@ def exec_kompilex(options: KompileXCommandOptions) -> None:
     final_definition = parse_outer(
         definition_file,
         main_module_name,
-        search_paths=options.includes,
+        include_dirs=options.includes,
         md_selector=options.md_selector,
     )
 

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -410,13 +410,12 @@ def exec_json_to_kore(options: JsonToKoreOptions) -> None:
 
 def exec_parse_outer(options: ParseOuterOptions) -> None:
     definition_file = options.main_file.resolve()
-    search_paths = [definition_file.parent, *options.includes]
     main_module_name = options.main_module or definition_file.stem.upper()
 
     final_definition = parse_outer(
         definition_file,
         main_module_name,
-        search_paths=search_paths,
+        search_paths=options.includes,
         md_selector=options.md_selector,
     )
 
@@ -429,13 +428,12 @@ def exec_parse_outer(options: ParseOuterOptions) -> None:
 
 def exec_kompilex(options: KompileXCommandOptions) -> None:
     definition_file = Path(options.main_file).resolve()
-    search_paths = [definition_file.parent, *options.includes]
     main_module_name = options.main_module or definition_file.stem.upper()
 
     final_definition = parse_outer(
         definition_file,
         main_module_name,
-        search_paths=search_paths,
+        search_paths=options.includes,
         md_selector=options.md_selector,
     )
 

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -48,12 +48,7 @@ def _slurp(
     include_source: bool = True,
 ) -> tuple[Module, ...]:
     processed_files = processed_files if processed_files is not None else []
-    _LOGGER.info(f'Reading {definition_file}')
-    text = definition_file.read_text()
-    if definition_file.suffix == '.md':
-        text = select_code_blocks(text, md_selector)
-    parser = OuterParser(text, source=definition_file if include_source else None)
-    definition = parser.definition()
+    definition = _parse_file(definition_file, md_selector, include_source)
     result = definition.modules
     for require in definition.requires:
         required_file = _resolve_require(require, search_paths)
@@ -67,6 +62,17 @@ def _slurp(
                 include_source=include_source,
             )
     return result
+
+
+def _parse_file(definition_file: Path, md_selector: str, include_source: bool) -> Definition:
+    _LOGGER.info(f'Reading {definition_file}')
+
+    text = definition_file.read_text()
+    if definition_file.suffix == '.md':
+        text = select_code_blocks(text, md_selector)
+
+    parser = OuterParser(text, source=definition_file if include_source else None)
+    return parser.definition()
 
 
 def _resolve_require(require: Require, search_paths: Iterable[Path]) -> Path:

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -22,6 +22,7 @@ _LOGGER: Final = logging.getLogger(__name__)
 def parse_outer(
     definition_file: Path,
     main_module: str,
+    *,
     search_paths: Iterable[Path] = (),
     md_selector: str = 'k',
     include_source: bool = True,

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -27,6 +27,7 @@ def parse_outer(
     md_selector: str = 'k',
     include_source: bool = True,
 ) -> KDefinition:
+    search_paths = list(search_paths)
     modules = _slurp(
         definition_file,
         search_paths=search_paths,
@@ -41,9 +42,9 @@ def parse_outer(
 def _slurp(
     definition_file: Path,
     *,
-    search_paths: Iterable[Path] = (),
-    md_selector: str = 'k',
-    include_source: bool = True,
+    search_paths: list[Path],
+    md_selector: str,
+    include_source: bool,
 ) -> tuple[Module, ...]:
     pending = [definition_file]
     done: set[Path] = set()
@@ -74,7 +75,7 @@ def _parse_file(definition_file: Path, md_selector: str, include_source: bool) -
     return parser.definition()
 
 
-def _resolve_require(require: Require, search_paths: Iterable[Path]) -> Path:
+def _resolve_require(require: Require, search_paths: list[Path]) -> Path:
     try_files = [include_dir / require.path for include_dir in search_paths]
     for file in try_files:
         if file.is_file():

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ._ast_to_kast import _ast_to_kast
@@ -11,7 +12,6 @@ from .outer_syntax import Definition
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from pathlib import Path
     from typing import Final
 
     from .outer_syntax import Require
@@ -23,7 +23,7 @@ def parse_outer(
     definition_file: Path,
     main_module: str,
     *,
-    include_dirs: Iterable[Path] = (),
+    include_dirs: Iterable[str | Path] = (),
     md_selector: str = 'k',
     include_source: bool = True,
 ) -> KDefinition:
@@ -42,11 +42,11 @@ def parse_outer(
 def slurp_definitions(
     main_file: Path,
     *,
-    include_dirs: Iterable[Path] = (),
+    include_dirs: Iterable[str | Path] = (),
     md_selector: str = 'k',
     include_source: bool = True,
 ) -> dict[Path, Definition]:
-    include_dirs = list(include_dirs)
+    _include_dirs = [Path(include_dir) for include_dir in include_dirs]
 
     result: dict[Path, Definition] = {}
 
@@ -58,7 +58,7 @@ def slurp_definitions(
             continue
 
         definition = _parse_file(current_file, md_selector, include_source)
-        pending += reversed([_resolve_require(require, current_file, include_dirs) for require in definition.requires])
+        pending += reversed([_resolve_require(require, current_file, _include_dirs) for require in definition.requires])
 
         result[current_file] = definition
 

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -72,6 +72,6 @@ def _slurp(
 def _resolve_require(require: Require, search_paths: Iterable[Path]) -> Path:
     try_files = [include_dir / require.path for include_dir in search_paths]
     for file in try_files:
-        if file.exists():
-            return file
-    raise FileNotFoundError(f'{require.path} not found\nLookup directories: {[str(path) for path in search_paths]}')
+        if file.is_file():
+            return file.resolve()
+    raise FileNotFoundError(f'{require.path} not found. Search paths: {[str(path) for path in search_paths]}')

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -27,7 +27,13 @@ def parse_outer(
     md_selector: str = 'k',
     include_source: bool = True,
 ) -> KDefinition:
-    modules = _slurp(definition_file, search_paths, [definition_file], md_selector, include_source)
+    modules = _slurp(
+        definition_file,
+        search_paths=search_paths,
+        processed_files=[definition_file],
+        md_selector=md_selector,
+        include_source=include_source,
+    )
     final_definition = _ast_to_kast(Definition(modules), main_module=main_module)
     assert isinstance(final_definition, KDefinition)
     return final_definition
@@ -35,6 +41,7 @@ def parse_outer(
 
 def _slurp(
     definition_file: Path,
+    *,
     search_paths: Iterable[Path] = (),
     processed_files: list[Path] | None = None,
     md_selector: str = 'k',
@@ -62,5 +69,11 @@ def _slurp(
         required_file = try_files[index]
         if required_file not in processed_files:
             processed_files.append(required_file)
-            result += _slurp(required_file, search_paths, processed_files, md_selector, include_source)
+            result += _slurp(
+                required_file,
+                search_paths=search_paths,
+                processed_files=processed_files,
+                md_selector=md_selector,
+                include_source=include_source,
+            )
     return result

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -20,7 +20,7 @@ _LOGGER: Final = logging.getLogger(__name__)
 
 
 def parse_outer(
-    definition_file: Path,
+    definition_file: str | Path,
     main_module: str,
     *,
     include_dirs: Iterable[str | Path] = (),
@@ -40,12 +40,13 @@ def parse_outer(
 
 
 def slurp_definitions(
-    main_file: Path,
+    main_file: str | Path,
     *,
     include_dirs: Iterable[str | Path] = (),
     md_selector: str = 'k',
     include_source: bool = True,
 ) -> dict[Path, Definition]:
+    main_file = Path(main_file).resolve()
     _include_dirs = [Path(include_dir) for include_dir in include_dirs]
 
     result: dict[Path, Definition] = {}

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -71,12 +71,7 @@ def _slurp(
 
 def _resolve_require(require: Require, search_paths: Iterable[Path]) -> Path:
     try_files = [include_dir / require.path for include_dir in search_paths]
-    try:
-        # Get the first source file we can find by iterating through search_paths
-        index = [file.exists() for file in try_files].index(True)
-    except ValueError as v:
-        # TODO Include the source location of the requires clause
-        raise FileNotFoundError(
-            f'{require.path} not found\nLookup directories: {[str(path) for path in search_paths]}'
-        ) from v
-    return try_files[index]
+    for file in try_files:
+        if file.exists():
+            return file
+    raise FileNotFoundError(f'{require.path} not found\nLookup directories: {[str(path) for path in search_paths]}')

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -27,8 +27,7 @@ def parse_outer(
     md_selector: str = 'k',
     include_source: bool = True,
 ) -> KDefinition:
-    search_paths = list(search_paths)
-    parsed_files = _slurp(
+    parsed_files = slurp_definitions(
         definition_file,
         search_paths=search_paths,
         md_selector=md_selector,
@@ -40,27 +39,28 @@ def parse_outer(
     return final_definition
 
 
-def _slurp(
-    definition_file: Path,
+def slurp_definitions(
+    main_file: Path,
     *,
-    search_paths: list[Path],
-    md_selector: str,
-    include_source: bool,
+    search_paths: Iterable[Path] = (),
+    md_selector: str = 'k',
+    include_source: bool = True,
 ) -> dict[Path, Definition]:
+    search_paths = list(search_paths)
+
     result: dict[Path, Definition] = {}
 
-    pending = [definition_file]
-
+    pending = [main_file]
     while pending:  # DFS
-        definition_file = pending.pop()
+        current_file = pending.pop()
 
-        if definition_file in result:
+        if current_file in result:
             continue
 
-        definition = _parse_file(definition_file, md_selector, include_source)
+        definition = _parse_file(current_file, md_selector, include_source)
         pending += reversed([_resolve_require(require, search_paths) for require in definition.requires])
 
-        result[definition_file] = definition
+        result[current_file] = definition
 
     return result
 

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -30,7 +30,6 @@ def parse_outer(
     modules = _slurp(
         definition_file,
         search_paths=search_paths,
-        processed_files=[definition_file],
         md_selector=md_selector,
         include_source=include_source,
     )
@@ -43,7 +42,6 @@ def _slurp(
     definition_file: Path,
     *,
     search_paths: Iterable[Path] = (),
-    processed_files: list[Path] | None = None,
     md_selector: str = 'k',
     include_source: bool = True,
 ) -> tuple[Module, ...]:

--- a/pyk/src/pyk/kast/utils.py
+++ b/pyk/src/pyk/kast/utils.py
@@ -58,7 +58,7 @@ def slurp_definitions(
             continue
 
         definition = _parse_file(current_file, md_selector, include_source)
-        pending += reversed([_resolve_require(require, search_paths) for require in definition.requires])
+        pending += reversed([_resolve_require(require, current_file, search_paths) for require in definition.requires])
 
         result[current_file] = definition
 
@@ -76,9 +76,10 @@ def _parse_file(definition_file: Path, md_selector: str, include_source: bool) -
     return parser.definition()
 
 
-def _resolve_require(require: Require, search_paths: list[Path]) -> Path:
-    try_files = [include_dir / require.path for include_dir in search_paths]
+def _resolve_require(require: Require, definition_file: Path, search_paths: list[Path]) -> Path:
+    try_dirs = [definition_file.parent] + search_paths
+    try_files = [include_dir / require.path for include_dir in try_dirs]
     for file in try_files:
         if file.is_file():
             return file.resolve()
-    raise FileNotFoundError(f'{require.path} not found. Search paths: {[str(path) for path in search_paths]}')
+    raise FileNotFoundError(f'{require.path} not found. Searched paths: {[str(path) for path in try_dirs]}')

--- a/pyk/src/tests/unit/kast/test_utils.py
+++ b/pyk/src/tests/unit/kast/test_utils.py
@@ -30,7 +30,7 @@ def test_parse_outer(test_file: Path) -> None:
     actual = parse_outer(
         test_file,
         main_module,
-        search_paths=(test_file.parent, test_file.parent / 'include'),
+        search_paths=[test_file.parent / 'include'],
         include_source=False,
     )
 

--- a/pyk/src/tests/unit/kast/test_utils.py
+++ b/pyk/src/tests/unit/kast/test_utils.py
@@ -30,7 +30,7 @@ def test_parse_outer(test_file: Path) -> None:
     actual = parse_outer(
         test_file,
         main_module,
-        search_paths=[test_file.parent / 'include'],
+        include_dirs=[test_file.parent / 'include'],
         include_source=False,
     )
 

--- a/pyk/src/tests/unit/kast/test_utils.py
+++ b/pyk/src/tests/unit/kast/test_utils.py
@@ -27,7 +27,12 @@ def test_parse_outer(test_file: Path) -> None:
     main_module = test_file.stem.upper()
 
     # When
-    actual = parse_outer(test_file, main_module, (test_file.parent, test_file.parent / 'include'), include_source=False)
+    actual = parse_outer(
+        test_file,
+        main_module,
+        search_paths=(test_file.parent, test_file.parent / 'include'),
+        include_source=False,
+    )
 
     # Then
     assert actual == expected


### PR DESCRIPTION
Preparatory refactoring for:
* #4406

Changes:
* Expose function `slurp_definitions`
* When slurping, a given file's parent is always considered for requires (and takes priority)
* Extract a few helper functions
* Rename, remove or change type for a few parameters