### PR TITLE
Rename the `pyk` distribution package to `kframework`

### DIFF
--- a/pyk/.cruft.json
+++ b/pyk/.cruft.json
@@ -5,7 +5,7 @@
   "context": {
     "cookiecutter": {
       "project_name": "pyk",
-      "project_slug": "pyk",
+      "project_slug": "kframework",
       "package_name": "pyk",
       "version": "0.1.0",
       "description": "",

--- a/pyk/README.md
+++ b/pyk/README.md
@@ -5,21 +5,23 @@
 
 ## Installation
 
-Prerequsites: `python >= 3.10`, `pip >= 20.0.2`, `poetry >= 1.3.2`.
-
 ```bash
-make build
-pip install dist/*.whl
+pip install kframework
 ```
 
 
 ## For Developers
 
-Use `make` to run common tasks (see the [Makefile](Makefile) for a complete list of available targets).
+Prerequsites: `python >= 3.10`, `poetry >= 1.3.2`.
+
+Use `make` to run common tasks
+(see the [Makefile](https://github.com/runtimeverification/k/blob/master/pyk/Makefile)
+for a complete list of available targets).
 
 * `make build`: Build wheel
 * `make check`: Check code style
 * `make format`: Format code
 * `make test-unit`: Run unit tests
+* `make test-integration`: Run integration tests
 
 For interactive use, spawn a shell with `poetry shell` (after `poetry install`), then run an interpreter.

--- a/pyk/pyproject.toml
+++ b/pyk/pyproject.toml
@@ -3,12 +3,17 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
-name = "pyk"
+name = "kframework"
 version = "7.0.41"
 description = ""
 authors = [
     "Runtime Verification, Inc. <contact@runtimeverification.com>",
 ]
+readme = "README.md"
+
+[[tool.poetry.packages]]
+include = "pyk"
+from = "src"
 
 [tool.poetry.dependencies]
 python = "^3.10"


### PR DESCRIPTION
Related:
* #4239

Changes:
* Change `tool.poetry.name` to `kframework`
* Add `pyk` to `tool.poetry.packages`
* Update `README.md` in preparation for PyPI upload