### PR TITLE
Allow a longer time for Pyk documentation builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -424,7 +424,7 @@ jobs:
     name: 'Build Pyk Documentation'
     needs: ubuntu-jammy
     runs-on: [self-hosted, linux, normal]
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
Now that we're building a Docker environment for this job, it can hit its time limit of 10 minutes easily: https://github.com/runtimeverification/k/actions/runs/9481407834/job/26125129742