### PR TITLE
Cut on circularity rule application, better error message

### DIFF
--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -175,7 +175,6 @@ class KCFGExplore:
         new_nodes = []
         curr_node_id = edge.source.id
         while new_depth < orig_depth:
-            _LOGGER.info(f'Taking {section_depth} steps from node {self.id}: {shorten_hashes(curr_node_id)}')
             curr_node_id = self.step(cfg, curr_node_id, logs, depth=section_depth)
             new_nodes.append(curr_node_id)
             new_depth += section_depth

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -67,8 +67,7 @@ class KCFGExplore:
                     sent = self.cterm_symbolic._definition.sentence_by_unique_id[node_log.result.rule_id]
                     _rule_lines.append(f'{sent.label}:{sent.source}')
                 else:
-                    _LOGGER.warning(f'Unknown unique id attached to rule log entry: {node_log}')
-                    _rule_lines.append('UNKNOWN')
+                    _rule_lines.append(f'{node_log.result.rule_id}:UNKNOWN')
         return _rule_lines
 
     def implication_failure_reason(self, antecedent: CTerm, consequent: CTerm) -> tuple[bool, str]:

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -154,8 +154,9 @@ class KCFGExplore:
         _LOGGER.info(f'Found new node at depth {depth} {self.id}: {shorten_hashes((node.id, new_node.id))}')
         logs[new_node.id] = exec_res.logs
         out_edges = cfg.edges(source_id=node.id)
+        rule_logs = self._extract_rule_labels(exec_res.logs)
         if len(out_edges) == 0:
-            cfg.create_edge(node.id, new_node.id, depth=depth, rules=self._extract_rule_labels(exec_res.logs))
+            cfg.create_edge(node.id, new_node.id, depth=depth, rules=rule_logs)
         else:
             edge = out_edges[0]
             if depth > edge.depth:
@@ -163,8 +164,8 @@ class KCFGExplore:
                     f'Step depth {depth} greater than original edge depth {edge.depth} {self.id}: {shorten_hashes((edge.source.id, edge.target.id))}'
                 )
             cfg.remove_edge(edge.source.id, edge.target.id)
-            cfg.create_edge(edge.source.id, new_node.id, depth=depth)
-            cfg.create_edge(new_node.id, edge.target.id, depth=(edge.depth - depth))
+            cfg.create_edge(edge.source.id, new_node.id, depth=depth, rules=rule_logs)
+            cfg.create_edge(new_node.id, edge.target.id, depth=(edge.depth - depth), rules=edge.rules[depth:])
         return new_node.id
 
     def section_edge(

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -67,6 +67,8 @@ class KCFGExplore:
                     sent = self.cterm_symbolic._definition.sentence_by_unique_id[node_log.result.rule_id]
                     _rule_lines.append(f'{sent.label}:{sent.source}')
                 else:
+                    if node_log.result.rule_id == 'UNKNOWN':
+                        _LOGGER.warning(f'Unknown unique id attached to rule log entry: {node_log}')
                     _rule_lines.append(f'{node_log.result.rule_id}:UNKNOWN')
         return _rule_lines
 

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -155,7 +155,7 @@ class KCFGExplore:
         logs[new_node.id] = exec_res.logs
         out_edges = cfg.edges(source_id=node.id)
         if len(out_edges) == 0:
-            cfg.create_edge(node.id, new_node.id, depth=depth)
+            cfg.create_edge(node.id, new_node.id, depth=depth, rules=self._extract_rule_labels(exec_res.logs))
         else:
             edge = out_edges[0]
             if depth > edge.depth:

--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -519,7 +519,7 @@ class State:
         for conjunct in manip.conjuncts(pattern):
             key, value = extract_entry(conjunct)
             if key in res:
-                raise ValueError(f'Duplicate substitution entry key: {key.text}')
+                raise ValueError(f'Duplicate substitution entry key: {key.text} -> {[res[key].text, value.text]}')
             res[key] = value
         return res
 

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -800,7 +800,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
 
         # Ensure that we cut at applications of circularity, so that subsumption into target state will be checked
         cut_rules = list(self.cut_point_rules)
-        if step.circularity and self.circularity_rule_id is not None:
+        if step.circularity and step.nonzero_depth and self.circularity_rule_id is not None:
             cut_rules.append(self.circularity_rule_id)
 
         # Ensure that we record progress ASAP for circularities, so the circularity rule will be included for execution as soon as possible

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -800,7 +800,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
 
         # Ensure that we cut at applications of circularity, so that subsumption into target state will be checked
         cut_rules = list(self.cut_point_rules)
-        if step.circularity and step.nonzero_depth and self.circularity_rule_id is not None:
+        if step.circularity and self.circularity_rule_id is not None:
             cut_rules.append(self.circularity_rule_id)
 
         # Ensure that we record progress ASAP for circularities, so the circularity rule will be included for execution as soon as possible

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -164,10 +164,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
                     else:
                         shortest_path.append(succ.source)
 
-            def nonzero_depth(proof: APRProof, node: KCFG.Node) -> bool:
-                return not proof.kcfg.zero_depth_between(proof.init, node.id)
-
-            module_name = self.circularities_module_name if nonzero_depth(self, node) else self.dependencies_module_name
+            module_name = self.circularities_module_name if self.nonzero_depth(node) else self.dependencies_module_name
 
             steps.append(
                 APRProofStep(
@@ -179,7 +176,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
                     shortest_path_to_node=tuple(shortest_path),
                     prior_loops_cache=FrozenDict(self.prior_loops_cache),
                     circularity=self.circularity,
-                    nonzero_depth=nonzero_depth(self, node),
+                    nonzero_depth=self.nonzero_depth(node),
                 )
             )
         return steps
@@ -196,6 +193,9 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
             self.add_bounded(result.node_id)
         else:
             raise ValueError(f'Incorrect result type, expected APRProofResult: {result}')
+
+    def nonzero_depth(self, node: KCFG.Node) -> bool:
+        return not self.kcfg.zero_depth_between(self.init, node.id)
 
     @property
     def module_name(self) -> str:

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -805,7 +805,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
 
         # Ensure that we record progress ASAP for circularities, so the circularity rule will be included for execution as soon as possible
         execute_depth = self.execute_depth
-        if step.circularity and not step.nonzero_depth:
+        if step.circularity and not step.nonzero_depth and (execute_depth is None or execute_depth > 1):
             execute_depth = 1
 
         extend_result = self.kcfg_explore.extend_cterm(

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -198,6 +198,10 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         return not self.kcfg.zero_depth_between(self.init, node.id)
 
     @property
+    def rule_id(self) -> str:
+        return f'APRPROOF-{self.id.upper()}'
+
+    @property
     def module_name(self) -> str:
         return self._make_module_name(self.id)
 
@@ -396,14 +400,14 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
             return [self.as_rule(priority=priority)]
         _rules = []
         for _edge in self.kcfg.edges():
-            _rule = _edge.to_rule(f'APRPROOF-{self.id.upper()}-BASIC-BLOCK', priority=priority)
+            _rule = _edge.to_rule(self.rule_id, priority=priority)
             assert type(_rule) is KRule
             _rules.append(_rule)
         return _rules
 
     def as_rule(self, priority: int = 20) -> KRule:
         _edge = KCFG.Edge(self.kcfg.node(self.init), self.kcfg.node(self.target), depth=0, rules=())
-        _rule = _edge.to_rule(f'APRPROOF-{self.id.upper()}-BASIC-BLOCK', priority=priority)
+        _rule = _edge.to_rule(self.rule_id, priority=priority)
         assert type(_rule) is KRule
         return _rule
 

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -388,7 +388,11 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         )
 
     def as_rules(self, priority: int = 20, direct_rule: bool = False) -> list[KRule]:
-        if (self.passed and direct_rule) or (self.admitted and not self.kcfg.predecessors(self.target)):
+        if (
+            self.circularity
+            or (self.passed and direct_rule)
+            or (self.admitted and not self.kcfg.predecessors(self.target))
+        ):
             return [self.as_rule(priority=priority)]
         _rules = []
         for _edge in self.kcfg.edges():

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -508,7 +508,7 @@ APR_PROVE_TEST_DATA: Iterable[
         'sum-loop',
         None,
         None,
-        [],  # If we do not include `IMP.while` in this list, we get 4 branches instead of 2
+        [],
         True,
         ProofStatus.PASSED,
         2,

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -508,7 +508,7 @@ APR_PROVE_TEST_DATA: Iterable[
         'sum-loop',
         None,
         None,
-        ['IMP.while'],  # If we do not include `IMP.while` in this list, we get 4 branches instead of 2
+        [],  # If we do not include `IMP.while` in this list, we get 4 branches instead of 2
         True,
         ProofStatus.PASSED,
         2,


### PR DESCRIPTION
Related: https://github.com/runtimeverification/k/issues/4359
Related: https://github.com/runtimeverification/haskell-backend/issues/3912

This PR is to support passing the final tests on the RPC prover in KEVM. In particular:

- A bug we've been hitting in Haskell backend gets a better error message, to hopefully be more informative off the bat.
- A duplicate log message in `KCFGExplore.section_edge` is removed.
- When doing `KCFGExlore.section_edge`, we were previously just dropping the rule labels of the applied rules on the new edges. Now we save them and store them appropriately on the KCFG.
- When computing the rule labels to store in the KCFG, if the unique-id is not present in teh definition, we still use the supplied unique id because the HB now returns the rule label instead if it's present (https://github.com/runtimeverification/haskell-backend/pull/3916). We just report the location of the rule as `UNKNOWN`.
- The logic for how we apply circularity rules is refined a bit:
  - When discharging a circularity proof obligation, we always consider the circularity rule itself to be a cut-point rule. That's because we need the state immediately following the application of the circularity rule to compare it to subsumption into the initial target state.
  - When discharging a circularity proof obligation, if we have not made any progress yet on the proof, we first take an execution step of depth 1 before resuming normal execute depth. This is because we cannot inject the circularity rule for consideration until we've made some progress, but want to enable it for consideration as early as possible.
  - A test of IMP that before had to manually massage the cut-point-rules list does not have to do that anymore, and is passing directly.