### PR TITLE
Escape @ in _make_module_name

### DIFF
--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -291,7 +291,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
     @staticmethod
     def _make_module_name(proof_id: str) -> str:
         return 'M-' + re.sub(
-            r'[\[\]]|[_%().:,]+', lambda match: 'bkt' if match.group(0) in ['[', ']'] else '-', proof_id.upper()
+            r'[\[\]]|[_%().:,@]+', lambda match: 'bkt' if match.group(0) in ['[', ']'] else '-', proof_id.upper()
         )
 
     @staticmethod


### PR DESCRIPTION
Fixes https://github.com/runtimeverification/kontrol/issues/613.
I have verified this change fixes the issue in kontrol with module names generated from contracts with an `@` symbol on their path.