### PR TITLE
Extract release job `notify-dependents`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -461,7 +461,7 @@ jobs:
     name: 'GitHub Pages deployment'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [pyk-build-docs, notify-dependents]
+    needs: [pyk-build-docs, release]
     steps:
       - name: 'Install pandoc/texlive/calibre'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,6 +405,11 @@ jobs:
           script: |
             const { owner, repo } = context.repo
             await github.rest.repos.updateRelease({ owner, repo, release_id: ${{ needs.set-release-id.outputs.release_id }}, prerelease: false })
+
+  notify-dependents:
+    runs-on: ubuntu-latest
+    needs: release
+    steps:
       - name: 'Update dependents'
         env:
           GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
@@ -456,7 +461,7 @@ jobs:
     name: 'GitHub Pages deployment'
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [pyk-build-docs, release]
+    needs: [pyk-build-docs, notify-dependents]
     steps:
       - name: 'Install pandoc/texlive/calibre'
         run: |


### PR DESCRIPTION
Related:
* #4416 

Changes

```
release+notify -
                \
pyk-build-docs ---  gh-pages
```

to

```
       release --- notify
                \
pyk-build-docs --- gh-pages
```

This will let us notify dependents after both the K and pyk release jobs go through:

```
release --- pyk-publish --- notify
                         \
         pyk-build-docs --- gh-pages
```