### PR TITLE
Fix docs build release job

### DIFF
--- a/.github/actions/with-k-docker/Dockerfile
+++ b/.github/actions/with-k-docker/Dockerfile
@@ -19,7 +19,7 @@ RUN    apt-get -y update    \
          /kframework.deb
 
 RUN if [[ "${INSTALL_BACKEND_DEBS}" == "true" ]]; then \
-      apt-get -y install /llvm-backend.deb \
+      apt-get -y install /llvm-backend.deb; \
     fi
 
 RUN apt-get -y clean

--- a/.github/actions/with-k-docker/Dockerfile
+++ b/.github/actions/with-k-docker/Dockerfile
@@ -3,6 +3,7 @@ ARG BASE_DISTRO
 FROM ubuntu:${BASE_DISTRO}
 
 ARG K_DEB_PATH
+ARG INSTALL_BACKEND_DEBS
 ARG LLVM_BACKEND_DEB_PATH
 
 COPY ${K_DEB_PATH} /kframework.deb
@@ -15,9 +16,13 @@ RUN    apt-get -y update    \
          make               \
          python3.10-dev     \
          python3.10-venv    \
-         /llvm-backend.deb  \
-         /kframework.deb    \
-    && apt-get -y clean
+         /kframework.deb
+
+RUN if [[ "${INSTALL_BACKEND_DEBS}" == "true" ]]; then \
+      apt-get -y install /llvm-backend.deb \
+    fi
+
+RUN apt-get -y clean
 
 RUN rm /llvm-backend.deb
 RUN rm /kframework.deb

--- a/.github/actions/with-k-docker/Dockerfile
+++ b/.github/actions/with-k-docker/Dockerfile
@@ -18,7 +18,7 @@ RUN    apt-get -y update    \
          python3.10-venv    \
          /kframework.deb
 
-RUN if [[ "${INSTALL_BACKEND_DEBS}" == "true" ]]; then \
+RUN if [ "${INSTALL_BACKEND_DEBS}" = "true" ]; then \
       apt-get -y install /llvm-backend.deb; \
     fi
 

--- a/.github/actions/with-k-docker/action.yml
+++ b/.github/actions/with-k-docker/action.yml
@@ -40,7 +40,7 @@ runs:
       gh release download                           \
         --repo runtimeverification/llvm-backend     \
         --pattern "*ubuntu_${BASE_DISTRO}.deb"      \
-        --output "${LLVM_BACKEND_DEB_PATH}          \
+        --output "${LLVM_BACKEND_DEB_PATH}"         \
         v$(cat deps/llvm-backend_release)
 
       CONTAINER_NAME=${{ inputs.container-name }}

--- a/.github/actions/with-k-docker/action.yml
+++ b/.github/actions/with-k-docker/action.yml
@@ -37,16 +37,17 @@ runs:
     run: |
       set -euxo pipefail
 
+      CONTAINER_NAME=${{ inputs.container-name }}
+      TAG=runtimeverificationinc/${CONTAINER_NAME}
+      DOCKERFILE=${{ github.action_path }}/Dockerfile
+      K_DEB_PATH=${{ inputs.k-deb-path }}
+      LLVM_BACKEND_DEB_PATH=llvm-backend.deb
+
       gh release download                           \
         --repo runtimeverification/llvm-backend     \
         --pattern "*ubuntu_${BASE_DISTRO}.deb"      \
         --output "${LLVM_BACKEND_DEB_PATH}"         \
         v$(cat deps/llvm-backend_release)
-
-      CONTAINER_NAME=${{ inputs.container-name }}
-      TAG=runtimeverificationinc/${CONTAINER_NAME}
-      DOCKERFILE=${{ github.action_path }}/Dockerfile
-      K_DEB_PATH=${{ inputs.k-deb-path }}
 
       docker build . \
         --file ${DOCKERFILE}                                        \

--- a/.github/actions/with-k-docker/action.yml
+++ b/.github/actions/with-k-docker/action.yml
@@ -10,6 +10,11 @@ inputs:
     required: true
     type: string
     default: kframework.deb
+  install-backend-debs:
+    description: 'Whether to install a separate package for the LLVM backend'
+    required: true
+    type: boolean
+    default: true
   distro:
     description: 'Distribution to setup Docker for.'
     required: true
@@ -28,26 +33,27 @@ runs:
     env:
       BASE_DISTRO: ${{ inputs.distro }}
       GH_TOKEN: ${{ github.token }}
+      INSTALL_BACKEND_DEBS: ${{ inputs.install-backend-debs }}
     run: |
       set -euxo pipefail
 
       gh release download                           \
         --repo runtimeverification/llvm-backend     \
-        --pattern "*ubuntu_${BASE_DISTRO}.deb"  \
-        --output llvm-backend.deb                   \
+        --pattern "*ubuntu_${BASE_DISTRO}.deb"      \
+        --output "${LLVM_BACKEND_DEB_PATH}          \
         v$(cat deps/llvm-backend_release)
 
       CONTAINER_NAME=${{ inputs.container-name }}
       TAG=runtimeverificationinc/${CONTAINER_NAME}
       DOCKERFILE=${{ github.action_path }}/Dockerfile
       K_DEB_PATH=${{ inputs.k-deb-path }}
-      LLVM_BACKEND_DEB_PATH=llvm-backend.deb
 
       docker build . \
         --file ${DOCKERFILE}                                        \
         --tag ${TAG}                                                \
         --build-arg BASE_DISTRO=${BASE_DISTRO}                      \
         --build-arg K_DEB_PATH=${K_DEB_PATH}                        \
+        --build-arg INSTALL_BACKEND_DEBS=${INSTALL_BACKEND_DEBS}    \
         --build-arg LLVM_BACKEND_DEB_PATH=${LLVM_BACKEND_DEB_PATH}
 
   - name: 'Run Docker container'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,6 +443,7 @@ jobs:
         with:
           container-name: k-pyk-docs-${{ github.sha }}
           k-deb-path: kframework_amd64_ubuntu_jammy.deb
+          install-backend-debs: false
       - name: 'Build documentation in Docker container'
         run: docker exec -u user k-pyk-docs-${{ github.sha }} make docs
       - name: 'Copy documentation from Docker container'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -258,30 +258,6 @@ jobs:
         run: docker stop --time=0 k-pyk-docs-${{ github.sha }}
 
 
-  pyk-build-docs-test:
-    name: 'Pyk: Documentation (TEST)'
-    needs: test-package-ubuntu-jammy
-    runs-on: [self-hosted, linux, normal]
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-      - name: 'Download K package from the Summary Page'
-        uses: actions/download-artifact@v4
-        with:
-          name: kframework.deb
-      - name: 'Set up Docker'
-        uses: ./.github/actions/with-k-docker
-        with:
-          container-name: k-pyk-docs-${{ github.sha }}
-          k-deb-path: kframework.deb
-          install-backend-debs: false
-      - name: 'Build documentation'
-        run: docker exec -u user k-pyk-docs-${{ github.sha }} make docs
-      - name: 'Tear down Docker'
-        if: always()
-        run: docker stop --time=0 k-pyk-docs-${{ github.sha }}
-
-
   pyk-profile:
     needs: test-frontend-package-ubuntu-jammy
     name: 'Pyk: Profiling'

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -258,6 +258,30 @@ jobs:
         run: docker stop --time=0 k-pyk-docs-${{ github.sha }}
 
 
+  pyk-build-docs-test:
+    name: 'Pyk: Documentation (TEST)'
+    needs: test-package-ubuntu-jammy
+    runs-on: [self-hosted, linux, normal]
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+      - name: 'Download K package from the Summary Page'
+        uses: actions/download-artifact@v4
+        with:
+          name: kframework.deb
+      - name: 'Set up Docker'
+        uses: ./.github/actions/with-k-docker
+        with:
+          container-name: k-pyk-docs-${{ github.sha }}
+          k-deb-path: kframework.deb
+          install-backend-debs: false
+      - name: 'Build documentation'
+        run: docker exec -u user k-pyk-docs-${{ github.sha }} make docs
+      - name: 'Tear down Docker'
+        if: always()
+        run: docker stop --time=0 k-pyk-docs-${{ github.sha }}
+
+
   pyk-profile:
     needs: test-frontend-package-ubuntu-jammy
     name: 'Pyk: Profiling'


### PR DESCRIPTION
This PR fixes a bug that's been breaking the Pyk documentation release jobs; the issue was that we were trying to install the standalone LLVM backend `.deb` package on top of an existing K installation that _already_ contains the LLVM backend.

The fix is to add a flag to the K Docker reusable action that allows the backend installation step to be skipped. You can see a successful run of the fixed workflow here: https://github.com/runtimeverification/k/actions/runs/9604052282/job/26489371015?pr=4464