### PR TITLE
Iterate over an Assoc's elements with top_down/bottom_up

### DIFF
--- a/pyk/src/pyk/kore/syntax.py
+++ b/pyk/src/pyk/kore/syntax.py
@@ -1625,8 +1625,8 @@ class Assoc(MLSyntaxSugar):
         return ()
 
     @property
-    def patterns(self) -> tuple[()]:
-        return ()
+    def patterns(self) -> tuple[Pattern, ...]:
+        return self.app.args
 
     @property
     def ctor_patterns(self) -> tuple[App]:
@@ -1651,8 +1651,7 @@ class LeftAssoc(Assoc):
         return LeftAssoc(app=app)
 
     def let_patterns(self, patterns: Iterable[Pattern]) -> LeftAssoc:
-        () = patterns
-        return self
+        return self.let(app=self.app.let(args=patterns))
 
     @property
     def pattern(self) -> Pattern:
@@ -1707,8 +1706,7 @@ class RightAssoc(Assoc):
         return RightAssoc(app=app)
 
     def let_patterns(self, patterns: Iterable[Pattern]) -> RightAssoc:
-        () = patterns
-        return self
+        return self.let(app=self.app.let(args=patterns))
 
     @property
     def pattern(self) -> Pattern:


### PR DESCRIPTION
The `top_down` and `bottom_up` operations on a `Kore` structure don't iterate over the arguments in a `LeftAssoc` or `RightAssoc`. This fixes that.