### PR TITLE
Add link to pyk docs to ToC page

### DIFF
--- a/web/toc.md
+++ b/web/toc.md
@@ -17,6 +17,7 @@ output:
 
 - [Homepage](/web/pages/index.md)
 - [Install K](https://github.com/runtimeverification/k/releases/latest)
+- [Pyk Documentation](/pyk)
 - [K Tutorial](/k-distribution/k-tutorial/README.md)
   - [Section 1: Basic K Concepts](/k-distribution/k-tutorial/1_basic/README.md)
     - [Lesson 1.1: Setting up a K Environment](/k-distribution/k-tutorial/1_basic/01_installing/README.md)


### PR DESCRIPTION
The link will appear on the left sidebar on https://kframework.org/.