### PR TITLE
Inline `app` in `Assoc`

### DIFF
--- a/pyk/src/pyk/kllvm/convert.py
+++ b/pyk/src/pyk/kllvm/convert.py
@@ -112,7 +112,7 @@ def pattern_to_llvm(pattern: Pattern) -> kllvm.Pattern:
         case App(symbol, sorts, args):
             return _composite_pattern(symbol, sorts, args)
         case Assoc():
-            return _composite_pattern(pattern.symbol(), pattern.sorts, [pattern.app])
+            return _composite_pattern(pattern.symbol(), [], [pattern.app])
         case MLPattern():
             return _composite_pattern(pattern.symbol(), pattern.sorts, pattern.ctor_patterns)
         case _:

--- a/pyk/src/pyk/kllvm/convert.py
+++ b/pyk/src/pyk/kllvm/convert.py
@@ -112,7 +112,7 @@ def pattern_to_llvm(pattern: Pattern) -> kllvm.Pattern:
         case App(symbol, sorts, args):
             return _composite_pattern(symbol, sorts, args)
         case Assoc():
-            return _composite_pattern(pattern.symbol(), pattern.sorts, pattern.ctor_patterns)
+            return _composite_pattern(pattern.symbol(), pattern.sorts, [pattern.app])
         case MLPattern():
             return _composite_pattern(pattern.symbol(), pattern.sorts, pattern.ctor_patterns)
         case _:

--- a/pyk/src/pyk/kllvm/convert.py
+++ b/pyk/src/pyk/kllvm/convert.py
@@ -6,6 +6,7 @@ from ..kore.syntax import (
     ML_SYMBOLS,
     AliasDecl,
     App,
+    Assoc,
     Axiom,
     Claim,
     Definition,
@@ -110,6 +111,8 @@ def pattern_to_llvm(pattern: Pattern) -> kllvm.Pattern:
             return kllvm.VariablePattern(name, sort_to_llvm(sort))
         case App(symbol, sorts, args):
             return _composite_pattern(symbol, sorts, args)
+        case Assoc():
+            return _composite_pattern(pattern.symbol(), pattern.sorts, pattern.ctor_patterns)
         case MLPattern():
             return _composite_pattern(pattern.symbol(), pattern.sorts, pattern.ctor_patterns)
         case _:
@@ -206,6 +209,8 @@ def llvm_to_pattern(pattern: kllvm.Pattern) -> Pattern:
             symbol, sorts, patterns = _unpack_composite_pattern(pattern)
             if symbol in ML_SYMBOLS:
                 return MLPattern.of(symbol, sorts, patterns)
+            elif symbol in [r'\left-assoc', r'\right-assoc']:
+                return Assoc.of(symbol, sorts, patterns)
             else:
                 return App(symbol, sorts, patterns)
         case _:

--- a/pyk/src/pyk/kore/manip.py
+++ b/pyk/src/pyk/kore/manip.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from .syntax import And, Assoc, EVar, MLQuant, Top
+from .syntax import And, EVar, MLQuant, Top
 
 if TYPE_CHECKING:
     from collections.abc import Collection
@@ -27,9 +27,6 @@ def free_occs(pattern: Pattern, *, bound_vars: Collection[str] = ()) -> dict[str
                 occurrences[pattern.name].append(pattern)
             else:
                 occurrences[pattern.name] = [pattern]
-
-        elif isinstance(pattern, Assoc):
-            collect(pattern.app, bound_vars)
 
         elif isinstance(pattern, MLQuant):
             new_bound_vars = {pattern.var.name}.union(bound_vars)

--- a/pyk/src/pyk/kore/match.py
+++ b/pyk/src/pyk/kore/match.py
@@ -25,15 +25,15 @@ def match_dv(pattern: Pattern, sort: Sort | None = None) -> DV:
     return dv
 
 
-def match_symbol(app: App, symbol: str) -> None:
-    if app.symbol != symbol:
-        raise ValueError(f'Expected symbol {symbol}, found: {app.symbol}')
+def match_symbol(actual: str, expected: str) -> None:
+    if actual != expected:
+        raise ValueError(f'Expected symbol {expected}, found: {actual}')
 
 
 def match_app(pattern: Pattern, symbol: str | None = None) -> App:
     app = check_type(pattern, App)
     if symbol is not None:
-        match_symbol(app, symbol)
+        match_symbol(app.symbol, symbol)
     return app
 
 
@@ -41,8 +41,11 @@ def match_inj(pattern: Pattern) -> App:
     return match_app(pattern, 'inj')
 
 
-def match_left_assoc(pattern: Pattern) -> LeftAssoc:
-    return check_type(pattern, LeftAssoc)
+def match_left_assoc(pattern: Pattern, symbol: str | None = None) -> LeftAssoc:
+    assoc = check_type(pattern, LeftAssoc)
+    if symbol is not None:
+        match_symbol(assoc.symbol, symbol)
+    return assoc
 
 
 def match_list(pattern: Pattern) -> tuple[Pattern, ...]:
@@ -50,9 +53,8 @@ def match_list(pattern: Pattern) -> tuple[Pattern, ...]:
         match_app(pattern, "Lbl'Stop'List")
         return ()
 
-    assoc = match_left_assoc(pattern)
-    cons = match_app(assoc.app, "Lbl'Unds'List'Unds'")
-    items = (match_app(arg, 'LblListItem') for arg in cons.args)
+    assoc = match_left_assoc(pattern, "Lbl'Unds'List'Unds'")
+    items = (match_app(arg, 'LblListItem') for arg in assoc.args)
     elems = (item.args[0] for item in items)
     return tuple(elems)
 
@@ -62,9 +64,8 @@ def match_set(pattern: Pattern) -> tuple[Pattern, ...]:
         match_app(pattern, "Lbl'Stop'Set")
         return ()
 
-    assoc = match_left_assoc(pattern)
-    cons = match_app(assoc.app, "Lbl'Unds'Set'Unds'")
-    items = (match_app(arg, 'LblSetItem') for arg in cons.args)
+    assoc = match_left_assoc(pattern, "Lbl'Unds'Set'Unds'")
+    items = (match_app(arg, 'LblSetItem') for arg in assoc.args)
     elems = (item.args[0] for item in items)
     return tuple(elems)
 
@@ -79,9 +80,8 @@ def match_map(pattern: Pattern, *, cell: str | None = None) -> tuple[tuple[Patte
         match_app(pattern, stop_symbol)
         return ()
 
-    assoc = match_left_assoc(pattern)
-    cons = match_app(assoc.app, cons_symbol)
-    items = (match_app(arg, item_symbol) for arg in cons.args)
+    assoc = match_left_assoc(pattern, cons_symbol)
+    items = (match_app(arg, item_symbol) for arg in assoc.args)
     entries = ((item.args[0], item.args[1]) for item in items)
     return tuple(entries)
 

--- a/pyk/src/pyk/kore/parser.py
+++ b/pyk/src/pyk/kore/parser.py
@@ -405,7 +405,7 @@ class KoreParser:
         self._match(TokenType.LPAREN)
         app = self.app()
         self._match(TokenType.RPAREN)
-        return cls(app)  # type: ignore
+        return cls(app.symbol, app.sorts, app.args)  # type: ignore
 
     def left_assoc(self) -> LeftAssoc:
         return self._assoc(TokenType.ML_LEFT_ASSOC, LeftAssoc)

--- a/pyk/src/pyk/kore/prelude.py
+++ b/pyk/src/pyk/kore/prelude.py
@@ -186,12 +186,10 @@ def kseq(kitems: Iterable[Pattern], *, dotvar: EVar | None = None) -> Pattern:
     if len(args) == 1:
         return tail
 
-    app = App(KSEQ, (), args)
-
     if len(args) == 2:
-        return app
+        return App(KSEQ, (), args)
 
-    return RightAssoc(app)
+    return RightAssoc(KSEQ, (), args)
 
 
 def k_config_var(var: str) -> DV:
@@ -224,7 +222,7 @@ LBL_LIST_ITEM: Final = SymbolId('LblListItem')
 def list_pattern(*args: Pattern) -> Pattern:
     if not args:
         return STOP_LIST
-    return LeftAssoc(App(LBL_LIST, args=(App(LBL_LIST_ITEM, args=(arg,)) for arg in args)))
+    return LeftAssoc(LBL_LIST, args=(App(LBL_LIST_ITEM, args=(arg,)) for arg in args))
 
 
 STOP_SET: Final = App("Lbl'Stop'Set")
@@ -235,7 +233,7 @@ LBL_SET_ITEM: Final = SymbolId('LblSetItem')
 def set_pattern(*args: Pattern) -> Pattern:
     if not args:
         return STOP_SET
-    return LeftAssoc(App(LBL_SET, args=(App(LBL_SET_ITEM, args=(arg,)) for arg in args)))
+    return LeftAssoc(LBL_SET, args=(App(LBL_SET_ITEM, args=(arg,)) for arg in args))
 
 
 STOP_MAP: Final = App("Lbl'Stop'Map")
@@ -249,7 +247,7 @@ def map_pattern(*args: tuple[Pattern, Pattern], cell: str | None = None) -> Patt
 
     cons_symbol = SymbolId(f"Lbl'Unds'{cell}Map'Unds'") if cell else LBL_MAP
     item_symbol = SymbolId(f'Lbl{cell}MapItem') if cell else LBL_MAP_ITEM
-    return LeftAssoc(App(cons_symbol, args=(App(item_symbol, args=arg) for arg in args)))
+    return LeftAssoc(cons_symbol, args=(App(item_symbol, args=arg) for arg in args))
 
 
 STOP_RANGEMAP: Final = App("Lbl'Stop'RangeMap")
@@ -263,10 +261,8 @@ def rangemap_pattern(*args: tuple[tuple[Pattern, Pattern], Pattern]) -> Pattern:
         return STOP_RANGEMAP
 
     return LeftAssoc(
-        App(
-            LBL_RANGEMAP,
-            args=(App(LBL_RANGEMAP_ITEM, args=(App(LBL_RANGEMAP_RANGE, args=arg[0]), arg[1])) for arg in args),
-        )
+        LBL_RANGEMAP,
+        args=(App(LBL_RANGEMAP_ITEM, args=(App(LBL_RANGEMAP_RANGE, args=arg[0]), arg[1])) for arg in args),
     )
 
 
@@ -306,7 +302,7 @@ def json_object(pattern: Pattern) -> App:
 
 
 def jsons(patterns: Iterable[Pattern]) -> RightAssoc:
-    return RightAssoc(App(LBL_JSONS, (), chain(patterns, (STOP_JSONS,))))
+    return RightAssoc(LBL_JSONS, (), chain(patterns, (STOP_JSONS,)))
 
 
 def json_key(key: str) -> App:
@@ -370,10 +366,10 @@ def kore_to_json(pattern: Pattern) -> Any:
 def _iter_json_list(app: App) -> Iterator[Pattern]:
     from . import match as km
 
-    km.match_symbol(app, LBL_JSON_LIST.value)
+    km.match_app(app, LBL_JSON_LIST.value)
     curr = km.match_app(app.args[0])
     while curr.symbol != STOP_JSONS.symbol:
-        km.match_symbol(curr, LBL_JSONS.value)
+        km.match_app(curr, LBL_JSONS.value)
         yield curr.args[0]
         curr = km.match_app(curr.args[1])
 
@@ -381,10 +377,10 @@ def _iter_json_list(app: App) -> Iterator[Pattern]:
 def _iter_json_object(app: App) -> Iterator[tuple[str, Pattern]]:
     from . import match as km
 
-    km.match_symbol(app, LBL_JSON_OBJECT.value)
+    km.match_app(app, LBL_JSON_OBJECT.value)
     curr = km.match_app(app.args[0])
     while curr.symbol != STOP_JSONS.symbol:
-        km.match_symbol(curr, LBL_JSONS.value)
+        km.match_app(curr, LBL_JSONS.value)
         entry = km.match_app(curr.args[0], LBL_JSON_ENTRY.value)
         key = km.kore_str(km.inj(entry.args[0]))
         value = entry.args[1]

--- a/pyk/src/pyk/kore/syntax.py
+++ b/pyk/src/pyk/kore/syntax.py
@@ -563,10 +563,6 @@ class Assoc(Pattern):
     def pattern(self) -> Pattern: ...
 
     @property
-    def sorts(self) -> tuple[()]:
-        return ()
-
-    @property
     def patterns(self) -> tuple[()]:
         return ()
 
@@ -581,7 +577,6 @@ class Assoc(Pattern):
     def write(self, output: IO[str]) -> None:
         output.write(self.symbol())
         output.write('{')
-        _write_sep_by_comma(self.sorts, output)
         output.write('}(')
         self.app.write(output)
         output.write(')')

--- a/pyk/src/pyk/kore/syntax.py
+++ b/pyk/src/pyk/kore/syntax.py
@@ -1609,11 +1609,7 @@ class DV(MLPattern, WithSort):
         return {'tag': 'DV', 'sort': self.sort.dict, 'value': self.value.value}
 
 
-class MLSyntaxSugar(MLPattern): ...
-
-
-# TODO AppAssoc, OrAssoc
-class Assoc(MLSyntaxSugar):
+class Assoc(MLPattern):
     app: App
 
     @property

--- a/pyk/src/pyk/kore/syntax.py
+++ b/pyk/src/pyk/kore/syntax.py
@@ -570,10 +570,6 @@ class Assoc(Pattern):
     def patterns(self) -> tuple[()]:
         return ()
 
-    @property
-    def ctor_patterns(self) -> tuple[App]:
-        return (self.app,)
-
     def _dict(self, dicts: list) -> dict[str, Any]:
         return {
             'tag': self._tag(),
@@ -587,7 +583,7 @@ class Assoc(Pattern):
         output.write('{')
         _write_sep_by_comma(self.sorts, output)
         output.write('}(')
-        _write_sep_by_comma(self.ctor_patterns, output)
+        self.app.write(output)
         output.write(')')
 
 

--- a/pyk/src/pyk/ktool/kfuzz.py
+++ b/pyk/src/pyk/ktool/kfuzz.py
@@ -8,7 +8,7 @@ from hypothesis.strategies import builds, fixed_dictionaries, integers
 from ..kast.inner import KSort
 from ..konvert import _kast_to_kore
 from ..kore.parser import KoreParser
-from ..kore.syntax import Assoc, EVar
+from ..kore.syntax import EVar
 from ..prelude.k import inj
 from ..prelude.kint import intToken
 from .krun import llvm_interpret_raw
@@ -80,10 +80,6 @@ def fuzz(
 
     def test(subst_case: Mapping[EVar, Pattern]) -> None:
         def sub(p: Pattern) -> Pattern:
-            if isinstance(p, Assoc):
-                symbol = p.symbol()
-                args = (arg.top_down(sub) for arg in p.app.args)
-                return p.of(symbol, patterns=(p.app.let(args=args),))
             if p in subst_case:
                 assert isinstance(p, EVar)
                 return subst_case[p]

--- a/pyk/src/tests/integration/ktool/test_fuzz.py
+++ b/pyk/src/tests/integration/ktool/test_fuzz.py
@@ -8,7 +8,7 @@ import pytest
 from pyk.kast.inner import KSort
 from pyk.kore.parser import KoreParser
 from pyk.kore.prelude import inj, top_cell_initializer
-from pyk.kore.syntax import DV, App, Assoc, EVar, SortApp, String
+from pyk.kore.syntax import DV, App, EVar, SortApp, String
 from pyk.ktool.kfuzz import fuzz, kintegers
 from pyk.ktool.kprint import _kast
 from pyk.testing import KompiledTest
@@ -38,10 +38,6 @@ class TestImpFuzz(KompiledTest):
     def check(p: Pattern) -> None:
         def check_inner(p: Pattern) -> Pattern:
             match p:
-                case Assoc():
-                    symbol = p.symbol()
-                    args = (arg.top_down(check_inner) for arg in p.app.args)
-                    return p.of(symbol, patterns=(p.app.let(args=args),))
                 case App("Lbl'UndsPipe'-'-GT-Unds'", args=(key, val)):
                     match key, val:
                         case (

--- a/pyk/src/tests/unit/kore/test_ml_pattern.py
+++ b/pyk/src/tests/unit/kore/test_ml_pattern.py
@@ -18,7 +18,6 @@ from pyk.kore.syntax import (
     Iff,
     Implies,
     In,
-    LeftAssoc,
     MLPattern,
     Mu,
     Next,
@@ -26,7 +25,6 @@ from pyk.kore.syntax import (
     Nu,
     Or,
     Rewrites,
-    RightAssoc,
     SortApp,
     String,
     SVar,
@@ -71,8 +69,6 @@ ML_PATTERN_OF_TEST_DATA: Final = (
     ('next', r'\next', (s,), (x,), Next(s, x)),
     ('rewrites', r'\rewrites', (s,), (x, y), Rewrites(s, x, y)),
     ('dv', r'\dv', (s,), (val,), DV(s, val)),
-    ('left-assoc', r'\left-assoc', (), (app,), LeftAssoc(app)),
-    ('right-assoc', r'\right-assoc', (), (app,), RightAssoc(app)),
 )
 
 


### PR DESCRIPTION
Related:
* #4466

This allows type-safe traversal of `Assoc` using `top_down` and `bottom_up`.