### PR TITLE
Use portable sed invocation

### DIFF
--- a/k-distribution/include/kframework/ktest-common.mak
+++ b/k-distribution/include/kframework/ktest-common.mak
@@ -28,5 +28,4 @@ LLVM_KRUN=${K_BIN}/llvm-krun
 # and kdep
 KDEP=${K_BIN}/kdep
 # command to strip paths from test outputs
-# REMOVE_PATHS=| sed 's!\('`pwd`'\|'${BUILTIN_DIR}'\|/nix/store/.\+/include/kframework/builtin\)/\(\./\)\{0,2\}!!g'
 REMOVE_PATHS=| sed 's!\('`pwd`'\)/\(\./\)\{0,2\}!!g' | sed 's!\('${BUILTIN_DIR}'\)/\(\./\)\{0,2\}!!g' | sed 's!\('/nix/store/.\+/include/kframework/builtin'\)/\(\./\)\{0,2\}!!g'

--- a/k-distribution/include/kframework/ktest-common.mak
+++ b/k-distribution/include/kframework/ktest-common.mak
@@ -28,4 +28,5 @@ LLVM_KRUN=${K_BIN}/llvm-krun
 # and kdep
 KDEP=${K_BIN}/kdep
 # command to strip paths from test outputs
-REMOVE_PATHS=| sed 's!\('`pwd`'\|'${BUILTIN_DIR}'\|/nix/store/.\+/include/kframework/builtin\)/\(\./\)\{0,2\}!!g'
+# REMOVE_PATHS=| sed 's!\('`pwd`'\|'${BUILTIN_DIR}'\|/nix/store/.\+/include/kframework/builtin\)/\(\./\)\{0,2\}!!g'
+REMOVE_PATHS=| sed 's!\('`pwd`'\)/\(\./\)\{0,2\}!!g' | sed 's!\('${BUILTIN_DIR}'\)/\(\./\)\{0,2\}!!g' | sed 's!\('/nix/store/.\+/include/kframework/builtin'\)/\(\./\)\{0,2\}!!g'

--- a/k-distribution/include/kframework/ktest-common.mak
+++ b/k-distribution/include/kframework/ktest-common.mak
@@ -28,9 +28,4 @@ LLVM_KRUN=${K_BIN}/llvm-krun
 # and kdep
 KDEP=${K_BIN}/kdep
 # command to strip paths from test outputs
-<<<<<<< Updated upstream
-REMOVE_PATHS=| sed 's!\('`pwd`'\)/\(\./\)\{0,2\}!!g' | sed 's!\('${BUILTIN_DIR}'\)/\(\./\)\{0,2\}!!g' | sed 's!\('/nix/store/.\+/include/kframework/builtin'\)/\(\./\)\{0,2\}!!g'
-=======
-# REMOVE_PATHS=| sed 's!\('`pwd`'\|'${BUILTIN_DIR}'\|/nix/store/.\+/include/kframework/builtin\)/\(\./\)\{0,2\}!!g'
 REMOVE_PATHS=| sed 's!\('`pwd`'\)/\(\./\)\{0,2\}!!g' | sed 's!\('${BUILTIN_DIR}'\)/\(\./\)\{0,2\}!!g' | sed 's!\('/nix/store/..*/include/kframework/builtin'\)/\(\./\)\{0,2\}!!g'
->>>>>>> Stashed changes

--- a/k-distribution/include/kframework/ktest-common.mak
+++ b/k-distribution/include/kframework/ktest-common.mak
@@ -28,4 +28,9 @@ LLVM_KRUN=${K_BIN}/llvm-krun
 # and kdep
 KDEP=${K_BIN}/kdep
 # command to strip paths from test outputs
+<<<<<<< Updated upstream
 REMOVE_PATHS=| sed 's!\('`pwd`'\)/\(\./\)\{0,2\}!!g' | sed 's!\('${BUILTIN_DIR}'\)/\(\./\)\{0,2\}!!g' | sed 's!\('/nix/store/.\+/include/kframework/builtin'\)/\(\./\)\{0,2\}!!g'
+=======
+# REMOVE_PATHS=| sed 's!\('`pwd`'\|'${BUILTIN_DIR}'\|/nix/store/.\+/include/kframework/builtin\)/\(\./\)\{0,2\}!!g'
+REMOVE_PATHS=| sed 's!\('`pwd`'\)/\(\./\)\{0,2\}!!g' | sed 's!\('${BUILTIN_DIR}'\)/\(\./\)\{0,2\}!!g' | sed 's!\('/nix/store/..*/include/kframework/builtin'\)/\(\./\)\{0,2\}!!g'
+>>>>>>> Stashed changes


### PR DESCRIPTION
The `\|` operator is not portable to BSD / macOS sed, which makes some tests appear flaky when run on those platforms. This PR switches the offending command over to a wordier, but correct invocation.