### PR TITLE
README: Add libunwind-dev to list of dependencies for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ sudo apt-get install    \
     libjemalloc-dev     \
     libmpfr-dev         \
     libsecp256k1-dev    \
+    libunwind-dev       \
     libyaml-dev         \
     libz3-dev           \
     lld-15              \


### PR DESCRIPTION
Without this installed the build on Debian still works, but the following error is produced when you try to run `kompile`:

    ld.lld: error: unable to find library -lunwind
    clang: error: linker command failed with exit code 1...

There is no need to rebuild the K framework after installing `libunwind-dev`; it's just the shared library in its dependency `libunwind8` that we need to fix this. (But we use `libunwind-dev` in the README anyway for consistency.)

This is apparently not seen on MacOS, probably because -lunwind because it's a part of LLVM there.