### PR TITLE
install-build-deps script

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ for details about supported configurations and system setup.
 ## Contents
 
 1.  [Prerequisite Install Guide](#prerequisite-install-guide)
-2.  [Build and Install Guide](#build-and-install-guide)
+2.  [Build and Install Guide]
 3.  [IDE Setup](#ide-setup)
 4.  [Running the Test Suite](#running-the-test-suite)
 5.  [Changing the KORE Data Structures](#changing-the-kore-data-structures)
@@ -72,69 +72,13 @@ must first be installed.
 
 ## The Short Version
 
-On Ubuntu Linux 22.04 (Jammy):
+Regardless of system, unless you cloned with `--recusrive` you will first
+have to run `git submodule update --init --recursive`.
 
-```shell
-git submodule update --init --recursive
-sudo apt-get install    \
-    bison               \
-    build-essential     \
-    clang-15            \
-    cmake               \
-    curl                \
-    flex                \
-    g++                 \
-    gcc                 \
-    libboost-test-dev   \
-    libfmt-dev          \
-    libgmp-dev          \
-    libjemalloc-dev     \
-    libmpfr-dev         \
-    libsecp256k1-dev    \
-    libunwind-dev       \
-    libyaml-dev         \
-    libz3-dev           \
-    lld-15              \
-    llvm-15-tools       \
-    m4                  \
-    maven               \
-    openjdk-17-jdk      \
-    pkg-config          \
-    python3             \
-    python3-dev         \
-    z3                  \
-    zlib1g-dev
-curl -sSL https://get.haskellstack.org/ | sh
-```
-
-If you install this list of dependencies, continue directly to the [Build and Install Guide](#build-and-install-guide).
-
-On macOS using [Homebrew](https://brew.sh/):
-
-```shell
-git submodule update --init --recursive
-brew install    \
-    bison       \
-    boost       \
-    cmake       \
-    flex        \
-    fmt         \
-    gcc         \
-    gmp         \
-    openjdk     \
-    jemalloc    \
-    libyaml     \
-    llvm        \
-    make        \
-    maven       \
-    mpfr        \
-    pkg-config  \
-    python      \
-    secp256k1   \
-    stack       \
-    zlib        \
-    z3
-```
+You then need the build and runtime dependencies. If you are on a
+Debian-based system (including Ubuntu) or MacOS with [Homebrew] installed,
+you can run `./install-build-deps` and continue directly to the
+[Build and Install Guide].
 
 ## The Long Version
 
@@ -451,3 +395,10 @@ of artifacts, you can run `mvn dependency:purge-local-repository`.
 If tests fail but you want to run the build anyway to see what happens, you can use `mvn package -DskipTests`.
 
 If you still cannot build, please contact a K developer.
+
+
+
+<!-------------------------------------------------------------------->
+[Build and Install Guide]: #build-and-install-guide
+
+[Homebrew]: https://brew.sh/

--- a/install-build-deps
+++ b/install-build-deps
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+#
+#   Install OS packages containing dependencies required to build K.
+#
+set -Eeuo pipefail
+
+die() { local ec="$1"; shift; echo "ERROR: $@"; exit $ec; }
+
+inst_Debian() {
+    echo '===== Debian packages:'
+    sudo apt-get install -q     \
+        bison                   \
+        build-essential         \
+        clang-15                \
+        cmake                   \
+        curl                    \
+        flex                    \
+        g++                     \
+        gcc                     \
+        libboost-test-dev       \
+        libfmt-dev              \
+        libgmp-dev              \
+        libjemalloc-dev         \
+        libmpfr-dev             \
+        libsecp256k1-dev        \
+        libunwind-dev           \
+        libyaml-dev             \
+        libz3-dev               \
+        lld-15                  \
+        llvm-15-tools           \
+        m4                      \
+        maven                   \
+        openjdk-17-jdk          \
+        pkg-config              \
+        python3                 \
+        python3-dev             \
+        z3                      \
+        zlib1g-dev
+
+    if stack --version >/dev/null 2>&1; then
+        echo 'Using existing Haskell Stack installation.'
+    else
+        echo '===== Haskell Stack:'
+        curl -sSL https://get.haskellstack.org/ | sh
+    fi
+}
+
+inst_MacOS() {
+    echo '===== Brew packages'
+    brew install    \
+        bison       \
+        boost       \
+        cmake       \
+        flex        \
+        fmt         \
+        gcc         \
+        gmp         \
+        openjdk     \
+        jemalloc    \
+        libyaml     \
+        llvm        \
+        make        \
+        maven       \
+        mpfr        \
+        pkg-config  \
+        python      \
+        secp256k1   \
+        stack       \
+        zlib        \
+        z3
+}
+
+try() {
+    local command="$1"; shift
+    local platform="$1"; shift
+
+    echo "===== Checking for $command for platform $platform"
+    $command --version >/dev/null 2>&1 || return 1
+    echo "----- Found platform $platform"
+    inst_$platform
+}
+
+try apt-get Debian     && exit 0
+try brew MacOS          && exit 0
+die 1 'Cannot find known platform. Your system appears to be unsupported.'


### PR DESCRIPTION
Add an `install-build-deps` script to replace the manual commands in the README. See commit message(s) for details.

__WARNING:__ This commit is based on the commit in #4054; if you merge this it will merge that one too. (The script includes the `libunwind-dev` package added in that commit.)

You'll probably want to do a quick check that this works on MacOS and update the commit message appropriately.