### PR TITLE
Bug report sequence storage changes

### DIFF
--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -71,7 +71,9 @@ class Transport(ContextManager['Transport'], ABC):
         if self._bug_report:
             bug_report_request = f'{req_name}_request.json'
             self._bug_report.add_file_contents(req, Path(bug_report_request))
-            self._bug_report.add_request_command(req_name, self._command(req_name, bug_report_request))
+            self._bug_report.add_request_command(
+                f'{req_name}_request.json', self._command(req_name, bug_report_request)
+            )
 
         server_addr = self._description()
         _LOGGER.info(f'Sending request to {server_addr}: {request_id} - {method_name}')
@@ -84,7 +86,7 @@ class Transport(ContextManager['Transport'], ABC):
             bug_report_response = f'{req_name}_response.json'
             self._bug_report.add_file_contents(resp, Path(bug_report_response))
             self._bug_report.add_request_command(
-                req_name,
+                f'{req_name}_response.json',
                 [
                     'diff',
                     '-b',

--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -71,9 +71,7 @@ class Transport(ContextManager['Transport'], ABC):
         if self._bug_report:
             bug_report_request = f'{req_name}_request.json'
             self._bug_report.add_file_contents(req, Path(bug_report_request))
-            self._bug_report.add_request_command(
-                f'{req_name}_request.json', self._command(req_name, bug_report_request)
-            )
+            self._bug_report.add_request(f'{req_name}_request.json')
 
         server_addr = self._description()
         _LOGGER.info(f'Sending request to {server_addr}: {request_id} - {method_name}')
@@ -85,16 +83,7 @@ class Transport(ContextManager['Transport'], ABC):
         if self._bug_report:
             bug_report_response = f'{req_name}_response.json'
             self._bug_report.add_file_contents(resp, Path(bug_report_response))
-            self._bug_report.add_request_command(
-                f'{req_name}_response.json',
-                [
-                    'diff',
-                    '-b',
-                    '-s',
-                    f'{req_name}_actual.json',
-                    f'{req_name}_response.json',
-                ],
-            )
+            self._bug_report.add_request(f'{req_name}_response.json')
         return resp
 
     @abstractmethod

--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -71,7 +71,7 @@ class Transport(ContextManager['Transport'], ABC):
         if self._bug_report:
             bug_report_request = f'{req_name}_request.json'
             self._bug_report.add_file_contents(req, Path(bug_report_request))
-            self._bug_report.add_command(self._command(req_name, bug_report_request))
+            self._bug_report.add_request_command(req_name, self._command(req_name, bug_report_request))
 
         server_addr = self._description()
         _LOGGER.info(f'Sending request to {server_addr}: {request_id} - {method_name}')
@@ -83,14 +83,15 @@ class Transport(ContextManager['Transport'], ABC):
         if self._bug_report:
             bug_report_response = f'{req_name}_response.json'
             self._bug_report.add_file_contents(resp, Path(bug_report_response))
-            self._bug_report.add_command(
+            self._bug_report.add_request_command(
+                req_name,
                 [
                     'diff',
                     '-b',
                     '-s',
                     f'{req_name}_actual.json',
                     f'{req_name}_response.json',
-                ]
+                ],
             )
         return resp
 

--- a/pyk/src/pyk/utils.py
+++ b/pyk/src/pyk/utils.py
@@ -688,7 +688,7 @@ class BugReport:
             ntf.flush()
             self.add_file(Path(ntf.name), arcname)
 
-    def add_request_command(self, req_name: str, args: Iterable[str]) -> None:
+    def add_request(self, req_name: str) -> None:
         self.add_file_contents(req_name, Path(f'sequence/{self._command_id}'))
         self._command_id += 1
 

--- a/pyk/src/pyk/utils.py
+++ b/pyk/src/pyk/utils.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import logging
 import os
 import shlex
@@ -666,14 +665,12 @@ class BugReport:
     _command_id: int
     _defn_id: int
     _file_remap: dict[str, str]
-    _requests_sequence: dict[int, str]
 
     def __init__(self, bug_report: Path) -> None:
         self._bug_report = bug_report.with_suffix('.tar')
         self._command_id = 0
         self._defn_id = 0
         self._file_remap = {}
-        self._requests_sequence = {}
         if self._bug_report.exists():
             _LOGGER.warning(f'Bug report exists, removing: {self._bug_report}')
             self._bug_report.unlink()
@@ -692,9 +689,8 @@ class BugReport:
             self.add_file(Path(ntf.name), arcname)
 
     def add_request_command(self, req_name: str, args: Iterable[str]) -> None:
-        self._requests_sequence[self._command_id] = req_name
-        self.add_file_contents(json.dumps(self._requests_sequence), Path('requests_sequence.json'))
-        self.add_command(args)
+        self.add_file_contents(req_name, Path(f'sequence/{self._command_id}'))
+        self._command_id += 1
 
     def add_command(self, args: Iterable[str]) -> None:
         def _remap_arg(_a: str) -> str:

--- a/pyk/src/pyk/utils.py
+++ b/pyk/src/pyk/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import os
 import shlex
@@ -665,12 +666,14 @@ class BugReport:
     _command_id: int
     _defn_id: int
     _file_remap: dict[str, str]
+    _requests_sequence: dict[int, str]
 
     def __init__(self, bug_report: Path) -> None:
         self._bug_report = bug_report.with_suffix('.tar')
         self._command_id = 0
         self._defn_id = 0
         self._file_remap = {}
+        self._requests_sequence = {}
         if self._bug_report.exists():
             _LOGGER.warning(f'Bug report exists, removing: {self._bug_report}')
             self._bug_report.unlink()
@@ -687,6 +690,11 @@ class BugReport:
             ntf.write(input)
             ntf.flush()
             self.add_file(Path(ntf.name), arcname)
+
+    def add_request_command(self, req_name: str, args: Iterable[str]) -> None:
+        self._requests_sequence[self._command_id] = req_name
+        self.add_file_contents(json.dumps(self._requests_sequence), Path('requests_sequence.json'))
+        self.add_command(args)
 
     def add_command(self, args: Iterable[str]) -> None:
         def _remap_arg(_a: str) -> str:

--- a/pyk/src/pyk/utils.py
+++ b/pyk/src/pyk/utils.py
@@ -689,7 +689,7 @@ class BugReport:
             self.add_file(Path(ntf.name), arcname)
 
     def add_request(self, req_name: str) -> None:
-        self.add_file_contents(req_name, Path(f'sequence/{self._command_id}'))
+        self.add_file_contents(req_name, Path(f'sequence/{self._command_id:03}'))
         self._command_id += 1
 
     def add_command(self, args: Iterable[str]) -> None:


### PR DESCRIPTION
Changes bug reports in the case of KoreServer proofs to indicate the sequence of requests not through the `commands` directory, as this wasn't being used, but through a simpler `sequence` directory, which contains files `0`, `1`, `2`, etc. which just contain the name of the request/response file in that position.