### PR TITLE
fix bug in inference of parametric sorts

### DIFF
--- a/k-distribution/tests/regression-new/mint-llvm-2/Makefile
+++ b/k-distribution/tests/regression-new/mint-llvm-2/Makefile
@@ -1,0 +1,7 @@
+DEF=test
+EXT=test
+TESTDIR=.
+KOMPILE_BACKEND=llvm
+KOMPILE_FLAGS=--syntax-module TEST
+
+include ../../../include/kframework/ktest.mak

--- a/k-distribution/tests/regression-new/mint-llvm-2/test.k
+++ b/k-distribution/tests/regression-new/mint-llvm-2/test.k
@@ -1,0 +1,12 @@
+module TEST
+  imports BOOL
+  imports MINT
+
+  syntax MInt{64}
+  syntax MInt{32}
+
+  syntax MInt{32} ::= m32() [function]
+  syntax MInt{64} ::= m64() [function]
+  rule m64() => 0p64
+  rule m32() => 0p32
+endmodule

--- a/k-frontend/src/main/java/org/kframework/compile/AddSortInjections.java
+++ b/k-frontend/src/main/java/org/kframework/compile/AddSortInjections.java
@@ -488,7 +488,12 @@ public class AddSortInjections {
     }
 
     Set<Sort> nonParametric =
-        filteredEntries.stream().filter(s -> s.params().isEmpty()).collect(Collectors.toSet());
+        filteredEntries.stream()
+            .filter(
+                s ->
+                    s.params().isEmpty()
+                        || stream(s.params()).allMatch(p -> mod.allSorts().contains(p)))
+            .collect(Collectors.toSet());
     Set<Sort> bounds = mod.subsorts().upperBounds(nonParametric);
     // Anything less than KBott or greater than K is a syntactic sort from kast.md which should not
     // be considered


### PR DESCRIPTION
There existed a bug where in some cases, AddSortInjections would not correctly compute the least upper bound of two identical concrete parametric sorts, leading to failures at parsing time. This ought to fix that bug.