### PR TITLE
Allow log origin "proxy"

### DIFF
--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -622,6 +622,7 @@ class LogRewrite(LogEntry):
 class LogOrigin(str, Enum):
     KORE_RPC = 'kore-rpc'
     BOOSTER = 'booster'
+    PROXY = 'proxy'
     LLVM = 'llvm'
 
 


### PR DESCRIPTION
With https://github.com/runtimeverification/haskell-backend/pull/3974, `kore-rpc-booster` increments execution depth and emits a rewrite trace in the scenario of pruning all but one branches in a branching execute response. The trace has origin `"proxy"`, because that's where the step is effectively taken. This PR makes sure `pyk` is ready to handle this.