### PR TITLE
Adapt `kore-integration-tests` dev shell to new name

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -210,7 +210,7 @@
             };
         };
         defaultPackage = packages.k;
-        devShells.kore-integration-tests = pkgs.kore-tests (pkgs.k-framework {
+        devShells.kore-integration-tests = pkgs.kore-tests (pkgs.mk-k-framework {
           inherit (pkgs) haskell-backend-bins;
           llvm-kompile-libs = { };
         });


### PR DESCRIPTION
The name change from `k-framework` to `mk-k-framework` was incomplete, the `kore-integration-test` dev shell did not work any more. This shell is used for the Haskell Backend integration tests.
I have tested that [the change here makes the integration test shell work again](https://github.com/runtimeverification/haskell-backend/pull/3965/commits/de1cc7dde7f5f6092ee28ec8c30f78d89075ea92). Merging this will unblock the [dependency upgrade PR in Haskell Backend](https://github.com/runtimeverification/haskell-backend/pull/3965).