### PR TITLE
Fix attribute parsing

### DIFF
--- a/pyk/src/pyk/kast/outer_parser.py
+++ b/pyk/src/pyk/kast/outer_parser.py
@@ -379,10 +379,13 @@ class OuterParser:
             value: str
             if self._la.type == TokenType.LPAREN:
                 self._consume()
-                if self._la.type is TokenType.ATTR_CONTENT:
-                    value = self._consume()
-                else:
-                    value = _dequote_string(self._match(TokenType.STRING))
+                match self._la.type:
+                    case TokenType.ATTR_CONTENT:
+                        value = self._consume()
+                    case TokenType.STRING:
+                        value = _dequote_string(self._consume())
+                    case _:
+                        value = ''
                 self._match(TokenType.RPAREN)
             else:
                 value = ''

--- a/pyk/src/tests/unit/kast/test_outer_parser.py
+++ b/pyk/src/tests/unit/kast/test_outer_parser.py
@@ -114,6 +114,26 @@ SENTENCE_TEST_DATA: Final = (
         SyntaxDefn(SortDecl('Foo'), (PriorityBlock((Production((Terminal('foo'),)),)),)),
     ),
     (
+        'syntax Foo ::= "foo" [symbol]',
+        SyntaxDefn(SortDecl('Foo'), (PriorityBlock((Production((Terminal('foo'),), att=Att((('symbol', ''),))),)),)),
+    ),
+    (
+        'syntax Foo ::= "foo" [symbol()]',
+        SyntaxDefn(SortDecl('Foo'), (PriorityBlock((Production((Terminal('foo'),), att=Att((('symbol', ''),))),)),)),
+    ),
+    (
+        'syntax Foo ::= "foo" [symbol("")]',
+        SyntaxDefn(SortDecl('Foo'), (PriorityBlock((Production((Terminal('foo'),), att=Att((('symbol', ''),))),)),)),
+    ),
+    (
+        'syntax Foo ::= "foo" [symbol(foo)]',
+        SyntaxDefn(SortDecl('Foo'), (PriorityBlock((Production((Terminal('foo'),), att=Att((('symbol', 'foo'),))),)),)),
+    ),
+    (
+        'syntax Foo ::= "foo" [symbol("foo")]',
+        SyntaxDefn(SortDecl('Foo'), (PriorityBlock((Production((Terminal('foo'),), att=Att((('symbol', 'foo'),))),)),)),
+    ),
+    (
         'syntax Foo ::= Bar',
         SyntaxDefn(SortDecl('Foo'), (PriorityBlock((Production((NonTerminal(Sort('Bar')),)),)),)),
     ),


### PR DESCRIPTION
Fixes `OuterParser` for attributes of the form `foo()`.