### PR TITLE
Removing example of relative position as Napoleon can't render it properly

### DIFF
--- a/pyk/src/pyk/kllvm/hints/prooftrace.py
+++ b/pyk/src/pyk/kllvm/hints/prooftrace.py
@@ -201,7 +201,7 @@ class LLVMFunctionEvent(LLVMStepEvent):
 
     @property
     def relative_position(self) -> str:
-        """Return the relative position of the LLVM function event in the proof trace. Ex.: (0:0:0:0)."""
+        """Return the relative position of the LLVM function event in the proof trace."""
         return self._function_event.relative_position
 
     @property
@@ -243,7 +243,7 @@ class LLVMHookEvent(LLVMStepEvent):
 
     @property
     def relative_position(self) -> str:
-        """Return the relative position of the hook event in the proof trace. Ex.: (0:0:0:0)."""
+        """Return the relative position of the hook event in the proof trace."""
         return self._hook_event.relative_position
 
     @property


### PR DESCRIPTION
Fix: https://github.com/Pi-Squared-Inc/pi2/issues/1644

Unfortunately, Napoleon extensions can't escape `:` and treat everything before it as a type thus, the rendering of this example was outputting a wrong and malformed description of the function as shown below:
![Captura de Tela 2024-07-19 às 10 01 18](https://github.com/user-attachments/assets/2091230d-dd0f-4575-9308-515ffbf12041)

As this isn't a key feature description, we chose to remove it to get cleaner documentation:
![Captura de Tela 2024-07-19 às 10 04 41](https://github.com/user-attachments/assets/d203151b-38d9-45db-8e57-3993e8b7d1ee)


This is a known issue discussed here: https://github.com/sphinx-doc/sphinx/issues/9273

