### PR TITLE
Hotfix adjust sed expression for flake update hs backend

### DIFF
--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -50,7 +50,7 @@ jobs:
           cd haskell-backend/src/main/native/haskell-backend
           git checkout "${hs_backend_version}"
           cd -
-          sed -i 's!    haskell-backend.url = "github:runtimeverification/haskell-backend/.*";!    haskell-backend.url = "github:runtimeverification/haskell-backend/'"${hs_backend_version}"'";!' flake.nix
+          sed -i 's!      url = "github:runtimeverification/haskell-backend/.*";!      url = "github:runtimeverification/haskell-backend/'"${hs_backend_version}"'";!' flake.nix
           if git add flake.nix haskell-backend/src/main/native/haskell-backend && git commit -m "flake.nix, haskell-backend/src/main/native/haskell-backend: update to version ${hs_backend_version}"; then
             changed=true
           fi

--- a/flake.lock
+++ b/flake.lock
@@ -65,16 +65,16 @@
         "z3": "z3"
       },
       "locked": {
-        "lastModified": 1720572621,
-        "narHash": "sha256-/j0swzk75vBmtYE62t044W7tCRULxwYfygb+C01Ar9A=",
+        "lastModified": 1721316629,
+        "narHash": "sha256-Iq161QQX78LtJnDyOm2zv0c+leGBb/bo0laKsk86pUo=",
         "owner": "runtimeverification",
         "repo": "haskell-backend",
-        "rev": "3ecef6a3bf991a95ac3dba2900a721bbcd5f5ce7",
+        "rev": "8d61e69a3cc73ae15306775bb2e97ec31247690a",
         "type": "github"
       },
       "original": {
         "owner": "runtimeverification",
-        "ref": "v0.1.32",
+        "ref": "v0.1.46",
         "repo": "haskell-backend",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
   inputs = {
     llvm-backend.url = "github:runtimeverification/llvm-backend/v0.1.59";
     haskell-backend = {
-      url = "github:runtimeverification/haskell-backend/v0.1.32";
+      url = "github:runtimeverification/haskell-backend/v0.1.46";
       inputs.rv-utils.follows = "llvm-backend/rv-utils";
       inputs.nixpkgs.follows = "llvm-backend/nixpkgs";
     };


### PR DESCRIPTION
The upgrade mechanism for HS backend in `k` was broken by some changes to the nix flake which modified the syntax for the `haskell-backend` dependency in `flake.nix`.
This PR fixes the update script and updates HS backend to the latest version.

* [update-deps.yml] adjusts the `sed` expression
* (by manually running the shell script from the above:)
  - update HS backend to version 0.1.46
  - update `flake.lock` to reflect this update

