### PR TITLE
Use `gnu` tar format for the bug reports

### DIFF
--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -264,7 +264,7 @@ class JsonRpcClientFacade(ContextManager['JsonRpcClientFacade']):
                 if (host, port) in client_cache:
                     self._update_clients(method, client_cache[(host, port)])
                 else:
-                    new_id = None if bug_report_id is None else bug_report_id + '_' + str(transport)[:8]
+                    new_id = None if bug_report_id is None else bug_report_id + '_' + str(transport)
                     new_client = JsonRpcClient(
                         host, port, timeout=timeout, bug_report=bug_report, bug_report_id=new_id, transport=transport
                     )

--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -264,7 +264,7 @@ class JsonRpcClientFacade(ContextManager['JsonRpcClientFacade']):
                 if (host, port) in client_cache:
                     self._update_clients(method, client_cache[(host, port)])
                 else:
-                    new_id = None if bug_report_id is None else bug_report_id + '_' + str(transport)
+                    new_id = None if bug_report_id is None else bug_report_id + '_' + str(transport)[:8]
                     new_client = JsonRpcClient(
                         host, port, timeout=timeout, bug_report=bug_report, bug_report_id=new_id, transport=transport
                     )

--- a/pyk/src/pyk/utils.py
+++ b/pyk/src/pyk/utils.py
@@ -681,7 +681,7 @@ class BugReport:
     def add_file(self, finput: Path, arcname: Path) -> None:
         if str(finput) not in self._file_remap:
             self._file_remap[str(finput)] = str(arcname)
-            with tarfile.open(self._bug_report, 'a') as tar:
+            with tarfile.open(self._bug_report, 'a', format=tarfile.GNU_FORMAT) as tar:
                 tar.add(finput, arcname=arcname)
                 _LOGGER.info(f'Added file to bug report {self._bug_report}:{arcname}: {finput}')
 


### PR DESCRIPTION
This change enforces the GNU format of tar files instead of the default POSIX.1-2001 pax format. This is necessary because:
- the filenames in the bug reports are often longer than the format-portable restriction of 256 characters
- the Haskell [library](https://hackage.haskell.org/package/tar-0.6.3.0/changelog) we use to work with tar does not support the pax format. However, it does support the GNU format which also allows long names.