### PR TITLE
Add extra check for lldb path in krun --debugger

### DIFF
--- a/k-distribution/src/main/scripts/bin/krun
+++ b/k-distribution/src/main/scripts/bin/krun
@@ -37,7 +37,7 @@ filterSubst=
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   LLDB_FILE="$(dirname "$0")/../lib/kllvm/lldb/k_lldb_path"
-  if [ -f "$LLDB_FILE" ]; then
+  if [[ -f "$LLDB_FILE" && -f "$(cat "$LLDB_FILE")" ]]; then
     DBG_EXE="$(cat "$LLDB_FILE")"
   else
     DBG_EXE="lldb"


### PR DESCRIPTION
When invoking `krun --debugger` on MacOS, we check a file that's supposed to specify where the lldb we use is installed on the system.

Sometimes the contents of this file are `LLDB-NOTFOUND` and we're supposed to fall back to whatever lldb is on the user's PATH. There's a bug where we don't handle this case properly, and this change fixes that.