### PR TITLE
Reusing backend information to construct KCFGs more efficiently

### DIFF
--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -250,7 +250,7 @@ class KCFGExplore:
                 extend_results.append(Stuck())
         # Cut rule
         elif len(next_states) == 1:
-            if not self.kcfg_semantics.can_make_custom_step(next_states[0].state):
+            if not self.kcfg_semantics.can_make_custom_step(cterm):
                 (next_node_logs, rules) = (
                     ((), []) if extend_results else (next_node_logs, self._extract_rule_labels(next_node_logs))
                 )

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -240,7 +240,7 @@ class KCFGExplore:
 
         # Basic block
         if depth > 0:
-            extend_results.append((Step(cterm, depth, next_node_logs, self._extract_rule_labels(next_node_logs))))
+            extend_results.append(Step(cterm, depth, next_node_logs, self._extract_rule_labels(next_node_logs)))
 
         # Stuck or vacuous
         if not next_states:

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -250,7 +250,7 @@ class KCFGExplore:
                 extend_results.append(Stuck())
         # Cut rule
         elif len(next_states) == 1:
-            if not self.kcfg_semantics.can_make_custom_step(cterm):
+            if not self.kcfg_semantics.can_make_custom_step(next_states[0]):
                 (next_node_logs, rules) = (
                     ((), []) if extend_results else (next_node_logs, self._extract_rule_labels(next_node_logs))
                 )

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -250,7 +250,7 @@ class KCFGExplore:
                 extend_results.append(Stuck())
         # Cut rule
         elif len(next_states) == 1:
-            if not self.kcfg_semantics.can_make_custom_step(next_states[0]):
+            if not self.kcfg_semantics.can_make_custom_step(next_states[0].state):
                 (next_node_logs, rules) = (
                     ((), []) if extend_results else (next_node_logs, self._extract_rule_labels(next_node_logs))
                 )

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -220,17 +220,12 @@ class KCFGExplore:
         module_name: str | None = None,
     ) -> list[KCFGExtendResult]:
 
-        def log(message: str, *, warning: bool = False) -> None:
-            _LOGGER.log(logging.WARNING if warning else logging.INFO, f'Extend result for {self.id}: {message}')
-
         custom_step_result = self.kcfg_semantics.custom_step(_cterm)
         if custom_step_result is not None:
-            log(f'custom step node: {node_id}')
             return [custom_step_result]
 
         abstract_cterm = self.kcfg_semantics.abstract_node(_cterm)
         if _cterm != abstract_cterm:
-            log(f'abstraction node: {node_id}')
             return [Abstract(abstract_cterm)]
 
         cterm, next_states, depth, vacuous, next_node_logs = self.cterm_symbolic.execute(
@@ -245,29 +240,21 @@ class KCFGExplore:
 
         # Basic block
         if depth > 0:
-            log(f'basic block at depth {depth}: {node_id}')
-            extend_results.append(Step(cterm, depth, next_node_logs, self._extract_rule_labels(next_node_logs)))
+            extend_results.append((Step(cterm, depth, next_node_logs, self._extract_rule_labels(next_node_logs))))
 
         # Stuck or vacuous
         if not next_states:
             if vacuous:
-                log(f'vacuous node: {node_id}', warning=True)
                 extend_results.append(Vacuous())
-            else:
-                log(f'stuck node: {node_id}')
+            elif depth == 0:
                 extend_results.append(Stuck())
         # Cut rule
         elif len(next_states) == 1:
-            log(f'cut-rule basic block at depth {depth}: {node_id}')
-            extend_results.append(
-                Step(
-                    next_states[0].state,
-                    1,
-                    next_node_logs,
-                    self._extract_rule_labels(next_node_logs),
-                    cut=True,
+            if not self.kcfg_semantics.can_make_custom_step(cterm):
+                (next_node_logs, rules) = (
+                    ((), []) if extend_results else (next_node_logs, self._extract_rule_labels(next_node_logs))
                 )
-            )
+                extend_results.append(Step(next_states[0].state, 1, next_node_logs, rules, cut=True, info='cut-rule'))
         # Branch
         elif all(branch_constraint for _, branch_constraint in next_states):
             branch_preds = [flatten_label('#And', not_none(rule_predicate)) for _, rule_predicate in next_states]
@@ -280,17 +267,14 @@ class KCFGExplore:
                 )
             )
             branches = [mlAnd(pred for pred in branch_pred if pred not in common_preds) for branch_pred in branch_preds]
-            if common_preds:
-                log(
-                    f'Common predicates found in branches: {[self.pretty_print(ml_pred_to_bool(cp)) for cp in common_preds]}'
-                )
-            constraint_strs = [self.pretty_print(ml_pred_to_bool(bc)) for bc in branches]
-            log(f'{len(branches)} branches: {node_id} -> {constraint_strs}')
-            extend_results.append(Branch(branches))
+            info = f'{[self.pretty_print(ml_pred_to_bool(bc)) for bc in branches]}'
+            extend_results.append(Branch(branches, info=info))
         else:
             # NDBranch
-            log(f'{len(next_states)} non-deterministic branches: {node_id}')
             next_cterms = [cterm for cterm, _ in next_states]
-            extend_results.append(NDBranch(next_cterms, next_node_logs, self._extract_rule_labels(next_node_logs)))
+            (next_node_logs, rules) = (
+                ((), []) if extend_results else (next_node_logs, self._extract_rule_labels(next_node_logs))
+            )
+            extend_results.append(NDBranch(next_cterms, next_node_logs, rules))
 
         return extend_results

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1321,8 +1321,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         return KCFG.Node.from_dict(store.read_node_data(node_id))
 
 
-class KCFGExtendResult(ABC):
-    info: str = field(default='')
+class KCFGExtendResult(ABC): ...
 
 
 @final

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -509,30 +509,45 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         node: KCFG.Node,
         logs: dict[int, tuple[LogEntry, ...]],
     ) -> None:
+
+        def log(message: str, *, warning: bool = False) -> None:
+            result_info = extend_result.info if type(extend_result) is Step or type(extend_result) is Branch else ''
+            result_info_message = f': {result_info}' if result_info else ''
+            _LOGGER.log(
+                logging.WARNING if warning else logging.INFO,
+                f'Extend result for {node.id}: {message}{result_info_message}',
+            )
+
         match extend_result:
             case Vacuous():
                 self.add_vacuous(node.id)
+                log(f'vacuous node: {node.id}', warning=True)
 
             case Stuck():
                 self.add_stuck(node.id)
+                log(f'stuck node: {node.id}')
 
             case Abstract(cterm):
                 new_node = self.create_node(cterm)
                 self.create_cover(node.id, new_node.id)
+                log(f'abstraction node: {node.id}')
 
             case Step(cterm, depth, next_node_logs, rule_labels, _):
                 next_node = self.create_node(cterm)
                 logs[next_node.id] = next_node_logs
                 self.create_edge(node.id, next_node.id, depth, rules=rule_labels)
+                log(f'basic block at depth {depth}: {node.id} --> {next_node.id}')
 
-            case Branch(constraints, _):
-                self.split_on_constraints(node.id, constraints)
+            case Branch(branches, _):
+                branch_node_ids = self.split_on_constraints(node.id, branches)
+                log(f'{len(branches)} branches: {node.id} --> {branch_node_ids}')
 
             case NDBranch(cterms, next_node_logs, rule_labels):
                 next_ids = [self.create_node(cterm).id for cterm in cterms]
                 for i in next_ids:
                     logs[i] = next_node_logs
                 self.create_ndbranch(node.id, next_ids, rules=rule_labels)
+                log(f'{len(cterms)} non-deterministic branches: {node.id} --> {next_ids}')
 
             case _:
                 raise AssertionError()
@@ -1306,7 +1321,8 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         return KCFG.Node.from_dict(store.read_node_data(node_id))
 
 
-class KCFGExtendResult(ABC): ...
+class KCFGExtendResult(ABC):
+    info: str = field(default='')
 
 
 @final
@@ -1333,6 +1349,7 @@ class Step(KCFGExtendResult):
     logs: tuple[LogEntry, ...]
     rule_labels: list[str]
     cut: bool = field(default=False)
+    info: str = field(default='')
 
 
 @final
@@ -1340,10 +1357,12 @@ class Step(KCFGExtendResult):
 class Branch(KCFGExtendResult):
     constraints: tuple[KInner, ...]
     heuristic: bool
+    info: str = field(default='')
 
-    def __init__(self, constraints: Iterable[KInner], *, heuristic: bool = False):
+    def __init__(self, constraints: Iterable[KInner], *, heuristic: bool = False, info: str = ''):
         object.__setattr__(self, 'constraints', tuple(constraints))
         object.__setattr__(self, 'heuristic', heuristic)
+        object.__setattr__(self, 'info', info)
 
 
 @final

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -515,7 +515,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             result_info_message = f': {result_info}' if result_info else ''
             _LOGGER.log(
                 logging.WARNING if warning else logging.INFO,
-                f'Extend result for {node.id}: {message}{result_info_message}',
+                f'Extend KCFG: {message}{result_info_message}',
             )
 
         match extend_result:

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -515,7 +515,7 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             result_info_message = f': {result_info}' if result_info else ''
             _LOGGER.log(
                 logging.WARNING if warning else logging.INFO,
-                f'Extend KCFG: {message}{result_info_message}',
+                f'Extending current KCFG with the following: {message}{result_info_message}',
             )
 
         match extend_result:

--- a/pyk/src/pyk/kcfg/semantics.py
+++ b/pyk/src/pyk/kcfg/semantics.py
@@ -19,6 +19,9 @@ class KCFGSemantics(ABC):
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool: ...
 
     @abstractmethod
+    def can_make_custom_step(self, c: CTerm) -> bool: ...
+
+    @abstractmethod
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None: ...
 
 
@@ -30,6 +33,9 @@ class DefaultSemantics(KCFGSemantics):
         return c
 
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
+        return False
+
+    def can_make_custom_step(self, c: CTerm) -> bool:
         return False
 
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None:

--- a/pyk/src/pyk/kcfg/semantics.py
+++ b/pyk/src/pyk/kcfg/semantics.py
@@ -12,17 +12,27 @@ class KCFGSemantics(ABC):
     @abstractmethod
     def is_terminal(self, c: CTerm) -> bool: ...
 
+    """Checks whether or not a given CTerm is terminal."""
+
     @abstractmethod
     def abstract_node(self, c: CTerm) -> CTerm: ...
+
+    """Implements an abstraction mechanism."""
 
     @abstractmethod
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool: ...
 
+    """Checks whether or not the two given CTerms represent the same loop head."""
+
     @abstractmethod
     def can_make_custom_step(self, c: CTerm) -> bool: ...
 
+    """Checks whether or not the semantics can make a custom step from a given CTerm."""
+
     @abstractmethod
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None: ...
+
+    """Implements a custom semantic step."""
 
 
 class DefaultSemantics(KCFGSemantics):

--- a/pyk/src/pyk/kcfg/semantics.py
+++ b/pyk/src/pyk/kcfg/semantics.py
@@ -12,27 +12,27 @@ class KCFGSemantics(ABC):
     @abstractmethod
     def is_terminal(self, c: CTerm) -> bool: ...
 
-    """Checks whether or not a given CTerm is terminal."""
+    """Check whether or not a given ``CTerm`` is terminal."""
 
     @abstractmethod
     def abstract_node(self, c: CTerm) -> CTerm: ...
 
-    """Implements an abstraction mechanism."""
+    """Implement an abstraction mechanism."""
 
     @abstractmethod
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool: ...
 
-    """Checks whether or not the two given CTerms represent the same loop head."""
+    """Check whether or not the two given ``CTerm``s represent the same loop head."""
 
     @abstractmethod
     def can_make_custom_step(self, c: CTerm) -> bool: ...
 
-    """Checks whether or not the semantics can make a custom step from a given CTerm."""
+    """Check whether or not the semantics can make a custom step from a given ``CTerm``."""
 
     @abstractmethod
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None: ...
 
-    """Implements a custom semantic step."""
+    """Implement a custom semantic step."""
 
 
 class DefaultSemantics(KCFGSemantics):

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -793,7 +793,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         to_cache: bool = False
         use_cache: NodeIdLike | None = None
 
-        print(f'{step.node.id}'-{step.circularity}-{step.nonzero_depth})
+        print(f'{step.node.id}' - {step.circularity} - {step.nonzero_depth})
 
         prior_loops: tuple[int, ...] = ()
         if step.bmc_depth is not None:

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -800,7 +800,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
                 _LOGGER.warning(f'Bounded node {step.proof_id}: {step.node.id} at bmc depth {step.bmc_depth}')
                 return [APRProofBoundedResult(node_id=step.node.id, prior_loops_cache_update=prior_loops)]
 
-        # Check if the current node and target ar terminal
+        # Check if the current node and target are terminal
         is_terminal = self.kcfg_explore.kcfg_semantics.is_terminal(step.node.cterm)
         target_is_terminal = self.kcfg_explore.kcfg_semantics.is_terminal(step.target.cterm)
 

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -173,7 +173,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
 
             predecessor_edges = self.kcfg.edges(target_id=node.id)
             predecessor_node_id: NodeIdLike | None = (
-                single(predecessor_edges).source.id if predecessor_edges is not None else None
+                single(predecessor_edges).source.id if predecessor_edges != [] else None
             )
 
             steps.append(

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -793,6 +793,8 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         to_cache: bool = False
         use_cache: NodeIdLike | None = None
 
+        print(f'{step}')
+
         prior_loops: tuple[int, ...] = ()
         if step.bmc_depth is not None:
             for node in step.shortest_path_to_node:
@@ -854,8 +856,8 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
 
         assert len(extend_results) <= 2
         if len(extend_results) == 2:
-            # Do not cache if we are proving a circularity and have not made a step yet
-            if not (step.circularity and not step.nonzero_depth):
+            # Do not cache if we have not made a step yet, to avoid circularity issues
+            if not step.nonzero_depth:
                 _LOGGER.info(f'Caching next step for edge starting from {step.node.id}')
                 to_cache = True
             else:

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -793,8 +793,6 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         to_cache: bool = False
         use_cache: NodeIdLike | None = None
 
-        print(f'{step.node.id}' - {step.circularity} - {step.nonzero_depth})
-
         prior_loops: tuple[int, ...] = ()
         if step.bmc_depth is not None:
             for node in step.shortest_path_to_node:

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -807,6 +807,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
             execute_depth = 1
 
         if step.predecessor_node_id in self.next_steps:
+            _LOGGER.info(f'Using cached step for edge {step.predecessor_node_id} --> {step.node.id}')
             extend_results = [self.next_steps.pop(step.predecessor_node_id)]
         else:
             extend_results = self.kcfg_explore.extend_cterm(

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -833,6 +833,8 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         if step.circularity and not step.nonzero_depth:
             execute_depth = 1
 
+        use_cache: NodeIdLike | None = None
+
         # If the step has already been cached, do not invoke the backend and only send a signal back to the proof to use the cache
         if step.cached:
             _LOGGER.info(f'Using cached step for edge {step.predecessor_node_id} --> {step.node.id}')
@@ -848,6 +850,8 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
                 module_name=step.module_name,
                 node_id=step.node.id,
             )
+
+        to_cache: bool = False
 
         # We can obtain two results at most
         assert len(extend_results) <= 2

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -46,7 +46,7 @@ class APRProofResult:
 class APRProofExtendResult(APRProofResult):
     """Holds the description of how an APRProof should be extended.
 
-    Fields:
+    Attributes:
         extend_results: Holds the KCFG extension to be applied.
         to_cache: Holds an indicator of whether or not the provided extension
                   should be cached instead of being applied.

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -793,6 +793,8 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         to_cache: bool = False
         use_cache: NodeIdLike | None = None
 
+        print(f'{step.node.id}'-{step.circularity}-{step.nonzero_depth})
+
         prior_loops: tuple[int, ...] = ()
         if step.bmc_depth is not None:
             for node in step.shortest_path_to_node:
@@ -855,7 +857,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         assert len(extend_results) <= 2
         if len(extend_results) == 2:
             # Do not cache if we have not made a step yet, to avoid circularity issues
-            if not step.nonzero_depth:
+            if step.nonzero_depth:
                 _LOGGER.info(f'Caching next step for edge starting from {step.node.id}')
                 to_cache = True
             else:

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -196,7 +196,11 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
     def commit(self, result: APRProofResult) -> None:
         self.prior_loops_cache[result.node_id] = result.prior_loops_cache_update
         if isinstance(result, APRProofExtendResult):
-            self.kcfg.extend(result.extend_result, self.kcfg.node(result.node_id), logs=self.logs)
+            self.kcfg.extend(
+                result.extend_result,
+                node=self.kcfg.node(result.node_id),
+                logs=self.logs,
+            )
         elif isinstance(result, APRProofSubsumeResult):
             self.kcfg.create_cover(result.node_id, self.target, csubst=result.csubst)
         elif isinstance(result, APRProofTerminalResult):
@@ -815,14 +819,15 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
             )
 
         assert len(extend_results) == 1 or len(extend_results) == 2
-        extend_result = extend_results[0]
         if len(extend_results) == 2:
             assert step.node.id not in self.next_steps
             self.next_steps[step.node.id] = extend_results[1]
 
         return [
             APRProofExtendResult(
-                node_id=step.node.id, extend_result=extend_result, prior_loops_cache_update=prior_loops
+                node_id=step.node.id,
+                extend_result=extend_results[0],
+                prior_loops_cache_update=prior_loops,
             )
         ]
 

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -856,10 +856,11 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
 
         assert len(extend_results) <= 2
         if len(extend_results) == 2:
-            # Do not cache if we have not made a step yet, to avoid circularity issues
+            # Cache only if the step is non-zero depth
             if step.nonzero_depth:
                 _LOGGER.info(f'Caching next step for edge starting from {step.node.id}')
                 to_cache = True
+            # Otherwise, discard the second result
             else:
                 extend_results = [extend_results[0]]
 

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -793,8 +793,6 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         to_cache: bool = False
         use_cache: NodeIdLike | None = None
 
-        print(f'{step}')
-
         prior_loops: tuple[int, ...] = ()
         if step.bmc_depth is not None:
             for node in step.shortest_path_to_node:

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -44,6 +44,16 @@ class APRProofResult:
 
 @dataclass
 class APRProofExtendResult(APRProofResult):
+    """Holds the description of how an APRProof should be extended.
+
+    Fields:
+        extend_results: Holds the KCFG extension to be applied.
+        to_cache: Holds an indicator of whether or not the provided extension
+                  should be cached instead of being applied.
+        use_cache: If not None, holds the identifier of the node whose cached extension
+                   should be applied instead of the provided extension.
+    """
+
     extend_results: list[KCFGExtendResult]
     to_cache: bool = field(default=False)
     use_cache: NodeIdLike | None = field(default=None)
@@ -828,7 +838,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         if step.circularity and not step.nonzero_depth and (execute_depth is None or execute_depth > 1):
             execute_depth = 1
 
-        if step.cached:
+        if step.cached and not (step.circularity and not step.nonzero_depth):
             _LOGGER.info(f'Using cached step for edge {step.predecessor_node_id} --> {step.node.id}')
             extend_results = []
             use_cache = step.predecessor_node_id

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -838,7 +838,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         if step.circularity and not step.nonzero_depth and (execute_depth is None or execute_depth > 1):
             execute_depth = 1
 
-        if step.cached and not (step.circularity and not step.nonzero_depth):
+        if step.cached:
             _LOGGER.info(f'Using cached step for edge {step.predecessor_node_id} --> {step.node.id}')
             extend_results = []
             use_cache = step.predecessor_node_id
@@ -854,8 +854,12 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
 
         assert len(extend_results) <= 2
         if len(extend_results) == 2:
-            _LOGGER.info(f'Caching next step for edge starting from {step.node.id}')
-            to_cache = True
+            # Do not cache if we are proving a circularity and have not made a step yet
+            if not (step.circularity and not step.nonzero_depth):
+                _LOGGER.info(f'Caching next step for edge starting from {step.node.id}')
+                to_cache = True
+            else:
+                extend_results = [extend_results[0]]
 
         return [
             APRProofExtendResult(

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -822,6 +822,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
         assert len(extend_results) == 1 or len(extend_results) == 2
         if len(extend_results) == 2:
             assert step.node.id not in self.next_steps
+            _LOGGER.info(f'Caching next step for edge starting from {step.node.id}')
             self.next_steps[step.node.id] = extend_results[1]
 
         return [

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -188,14 +188,14 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
 
     def commit(self, result: APRProofResult) -> None:
         self.prior_loops_cache[result.node_id] = result.prior_loops_cache_update
-        if isinstance(result, APRProofBoundedResult):
-            self.add_bounded(result.node_id)
-        elif isinstance(result, APRProofTerminalResult):
-            self.add_terminal(result.node_id)
+        if isinstance(result, APRProofExtendResult):
+            self.kcfg.extend(result.extend_result, self.kcfg.node(result.node_id), logs=self.logs)
         elif isinstance(result, APRProofSubsumeResult):
             self.kcfg.create_cover(result.node_id, self.target, csubst=result.csubst)
-        elif isinstance(result, APRProofExtendResult):
-            self.kcfg.extend(result.extend_result, self.kcfg.node(result.node_id), logs=self.logs)
+        elif isinstance(result, APRProofTerminalResult):
+            self.add_terminal(result.node_id)
+        elif isinstance(result, APRProofBoundedResult):
+            self.add_bounded(result.node_id)
         else:
             raise ValueError(f'Incorrect result type, expected APRProofResult: {result}')
 

--- a/pyk/src/tests/integration/ktool/test_imp.py
+++ b/pyk/src/tests/integration/ktool/test_imp.py
@@ -58,6 +58,9 @@ class ImpSemantics(KCFGSemantics):
             return k_cell_1[0].label.name == 'while(_)_'
         return False
 
+    def can_make_custom_step(self, c: CTerm) -> bool:
+        return False
+
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
         return None
 

--- a/pyk/src/tests/integration/proof/test_custom_step.py
+++ b/pyk/src/tests/integration/proof/test_custom_step.py
@@ -63,18 +63,24 @@ class CustomStepSemanticsWithoutStep(KCFGSemantics):
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
         return False
 
+    def can_make_custom_step(self, c: CTerm) -> bool:
+        return False
+
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
         return None
 
 
 class CustomStepSemanticsWithStep(CustomStepSemanticsWithoutStep):
-    def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
+    def can_make_custom_step(self, c: CTerm) -> bool:
         k_cell = c.cell('K_CELL')
-        if (
+        return (
             type(k_cell) is KSequence
             and type(k_cell[0]) is KApply
             and k_cell[0].label.name == 'c_CUSTOM-STEP-SYNTAX_Step'
-        ):
+        )
+
+    def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
+        if self.can_make_custom_step(c):
             new_cterm = CTerm.from_kast(set_cell(c.kast, 'K_CELL', KSequence(KApply('d_CUSTOM-STEP-SYNTAX_Step'))))
             return Step(new_cterm, 1, (), ['CUSTOM-STEP.c.d'], cut=True)
         return None

--- a/pyk/src/tests/integration/proof/test_goto.py
+++ b/pyk/src/tests/integration/proof/test_goto.py
@@ -44,6 +44,9 @@ class GotoSemantics(KCFGSemantics):
             return k_cell[0].label.name == 'jumpi'
         return False
 
+    def can_make_custom_step(self, c: CTerm) -> bool:
+        return False
+
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
         return None
 

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -74,6 +74,9 @@ class ImpSemantics(KCFGSemantics):
             return k_cell_1[0].label.name == 'while(_)_'
         return False
 
+    def can_make_custom_step(self, c: CTerm) -> bool:
+        return False
+
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
         return None
 

--- a/pyk/src/tests/integration/proof/test_refute_node.py
+++ b/pyk/src/tests/integration/proof/test_refute_node.py
@@ -63,6 +63,9 @@ class RefuteSemantics(KCFGSemantics):
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
         return False
 
+    def can_make_custom_step(self, c: CTerm) -> bool:
+        return False
+
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
         return None
 

--- a/pyk/src/tests/integration/proof/test_simple.py
+++ b/pyk/src/tests/integration/proof/test_simple.py
@@ -36,6 +36,9 @@ class SimpleSemantics(KCFGSemantics):
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
         return False
 
+    def can_make_custom_step(self, c: CTerm) -> bool:
+        return False
+
     def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
         return None
 

--- a/pyk/src/tests/unit/test-data/pyk_toml_test.toml
+++ b/pyk/src/tests/unit/test-data/pyk_toml_test.toml
@@ -1,6 +1,6 @@
 [coverage]
 output = "default-file"
-definition = "/var/folders/ks/1p8zyp5j7xz_v1krhl4l17tm0000gn/T"
+definition = "/tmp"
 
 [print]
 input = "kast-json"

--- a/pyk/src/tests/unit/test-data/pyk_toml_test.toml
+++ b/pyk/src/tests/unit/test-data/pyk_toml_test.toml
@@ -1,6 +1,6 @@
 [coverage]
 output = "default-file"
-definition = "/tmp"
+definition = "/var/folders/ks/1p8zyp5j7xz_v1krhl4l17tm0000gn/T"
 
 [print]
 input = "kast-json"


### PR DESCRIPTION
This PR leverages information provided by the backend as part of an `execute` request to construct more than one KCFG element: specifically, vacuous nodes, stuck nodes, edges resulting from cut-nodes, branches, and non-deterministic branches.

In addition, it moves the associated printing to the KCFG class, allowing for more informative prints: for example, we can now print the target nodes of edges and branches, the absence of which (personally) was making debugging of large proofs slightly more difficult.

The PR also removes the `always_check_subsumption` flag, which was not used and was made obsolete by the subsumption logic in `step_proof`.