### PR TITLE
Update .gitignore for MacOS and Pycharm

### DIFF
--- a/pyk/.gitignore
+++ b/pyk/.gitignore
@@ -10,3 +10,6 @@ __pycache__/
 
 .kprove*
 *.debug-log
+
+.idea/
+.DS_Store


### PR DESCRIPTION
Since I usually use PyCharm for Python development and work on macOS, I need to update the `.gitignore` file.