### PR TITLE
Set pyk version with `importlib.metadata.version`

### DIFF
--- a/package/version.sh
+++ b/package/version.sh
@@ -27,7 +27,6 @@ version_sub() {
     sed --in-place 's/^version = ".*"$/version = "'${version}'"/'                                                     pyk/pyproject.toml
     sed --in-place "s/^version = '.*'$/version = '${version}'/"                                                       pyk/docs/conf.py
     sed --in-place "s/^release = '.*'$/release = '${version}'/"                                                       pyk/docs/conf.py
-    sed --in-place "s/^__version__: Final = '.*'/__version__: Final = '${version}'/"                                  pyk/src/pyk/__init__.py
 }
 
 version_command="$1" ; shift

--- a/pyk/src/pyk/__init__.py
+++ b/pyk/src/pyk/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from importlib.metadata import version
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Final
 
 
-__version__: Final = '7.1.0'
+__version__: Final = version('kframework')


### PR DESCRIPTION
Closes #4614

Uses `importlib.metadata.version` to read the version from `pyproject.toml` rather than manually `sed`ding.