### PR TITLE
Create Split without CSubst

### DIFF
--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -263,13 +263,12 @@ def cterm_match(cterm1: CTerm, cterm2: CTerm) -> CSubst | None:
     Returns:
         A `CSubst` which can instantiate `cterm1` to `cterm2`, or `None` if no such `CSubst` exists.
     """
+    # todo: delete this function and use cterm1.match_with_constraint(cterm2) directly after closing #4496
     subst = cterm1.config.match(cterm2.config)
     if subst is None:
         return None
     source_constraints = [subst(c) for c in cterm1.constraints]
-    constraints = [c for c in cterm2.constraints if c not in source_constraints] + [
-        c for c in source_constraints if c not in cterm2.constraints
-    ]
+    constraints = [c for c in cterm2.constraints if c not in source_constraints]
     return CSubst(subst, constraints)
 
 

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -337,7 +337,7 @@ class CSubst:
         constraints = [self.subst(constraint) for constraint in cterm.constraints] + list(self.constraints)
         return CTerm(config, constraints)
 
-    def __call__(self, cterm: CTerm):
+    def __call__(self, cterm: CTerm) -> CTerm:
         """Overload for `CSubst.apply`."""
         return self.apply(cterm)
 

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -253,6 +253,26 @@ class CTerm:
         return CTerm(self.config, new_constraints)
 
 
+def cterm_match(cterm1: CTerm, cterm2: CTerm) -> CSubst | None:
+    """Find a substitution which can instantiate `cterm1` to `cterm2`.
+
+    Args:
+        cterm1: `CTerm` to instantiate to `cterm2`.
+        cterm2: `CTerm` to instantiate `cterm1` to.
+
+    Returns:
+        A `CSubst` which can instantiate `cterm1` to `cterm2`, or `None` if no such `CSubst` exists.
+    """
+    subst = cterm1.config.match(cterm2.config)
+    if subst is None:
+        return None
+    source_constraints = [subst(c) for c in cterm1.constraints]
+    constraints = [c for c in cterm2.constraints if c not in source_constraints] + [
+        c for c in source_constraints if c not in cterm2.constraints
+    ]
+    return CSubst(subst, constraints)
+
+
 def anti_unify(state1: KInner, state2: KInner, kdef: KDefinition | None = None) -> tuple[KInner, Subst, Subst]:
     """Return a generalized state over the two input states.
 

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -333,8 +333,8 @@ class CSubst:
 
     def apply(self, cterm: CTerm) -> CTerm:
         """Apply this `CSubst` to the given `CTerm` (instantiating the free variables, and adding the constraints)."""
-        _kast = self.subst(cterm.kast)
-        return CTerm(_kast, [self.constraint])
+        config = self.subst(cterm.config)
+        return CTerm(config, [self.constraint])
 
 
 def cterm_build_claim(

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -38,7 +38,7 @@ class CTerm:
 
     Contains the data:
     - `config`: the _configuration_ (structural component of the state, potentially containing free variabls)
-    - `constraints`: conditiions which limit/constraint the free variables from the `config`
+    - `constraints`: conditions which limit/constraint the free variables from the `config`
     """
 
     config: KInner  # TODO Optional?
@@ -336,6 +336,10 @@ class CSubst:
         config = self.subst(cterm.config)
         constraints = [self.subst(constraint) for constraint in cterm.constraints] + list(self.constraints)
         return CTerm(config, constraints)
+
+    def __call__(self, cterm: CTerm):
+        """Overload for `CSubst.apply`."""
+        return self.apply(cterm)
 
 
 def cterm_build_claim(

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -334,7 +334,8 @@ class CSubst:
     def apply(self, cterm: CTerm) -> CTerm:
         """Apply this `CSubst` to the given `CTerm` (instantiating the free variables, and adding the constraints)."""
         config = self.subst(cterm.config)
-        return CTerm(config, [self.constraint])
+        constraints = [self.subst(constraint) for constraint in cterm.constraints] + list(self.constraints)
+        return CTerm(config, constraints)
 
 
 def cterm_build_claim(

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1045,9 +1045,15 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         source = self.node(source_id)
         targets = [self.node(nid) for nid in target_ids]
         substs = [source.cterm.config.match(target.cterm.config) for target in targets]
+        csubsts: list[CSubst] = []
         if None in substs:
             return None
-        csubsts = [CSubst(subst, target.cterm.constraints) for subst, target in zip(substs, targets, strict=True)]
+        for subst, target in zip(substs, targets, strict=True):
+            constraints: list[KInner] = []
+            for c in target.cterm.constraints:
+                if c not in source.cterm.constraints:
+                    constraints.append(c)
+            csubsts.append(CSubst(subst, constraints))
         return self.create_split(source.id, zip(target_ids, csubsts, strict=True))
 
     def ndbranches(self, *, source_id: NodeIdLike | None = None, target_id: NodeIdLike | None = None) -> list[NDBranch]:

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1050,7 +1050,10 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
             subst = source.cterm.config.match(target.cterm.config)
             if subst is None:
                 return None
-            constraints = [c for c in target.cterm.constraints if c not in source.cterm.constraints]
+            source_constraints = [subst(c) for c in source.cterm.constraints]
+            constraints = [c for c in target.cterm.constraints if c not in source_constraints] + [
+                c for c in source_constraints if c not in target.cterm.constraints
+            ]
             csubsts.append(CSubst(subst, constraints))
 
         return self.create_split(source.id, zip(target_ids, csubsts, strict=True))

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1041,8 +1041,9 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         return split
 
     def create_split_by_nodes(self, source_id: NodeIdLike, target_ids: Iterable[NodeIdLike]) -> KCFG.Split | None:
+        """Create a split without crafting a CSubst."""
         source = self.node(source_id)
-        targets = [self.node(nid) for nid in list(target_ids)]
+        targets = [self.node(nid) for nid in target_ids]
         substs = [source.cterm.config.match(target.cterm.config) for target in targets]
         if None in substs:
             return None

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1040,6 +1040,15 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         self.add_successor(split)
         return split
 
+    def create_split_by_nodes(self, source_id: NodeIdLike, target_ids: Iterable[NodeIdLike]) -> KCFG.Split | None:
+        source = self.node(source_id)
+        targets = [self.node(nid) for nid in list(target_ids)]
+        substs = [source.cterm.config.match(target.cterm.config) for target in targets]
+        if None in substs:
+            return None
+        csubsts = [CSubst(subst, target.cterm.constraints) for subst, target in zip(substs, targets, strict=True)]
+        return self.create_split(source.id, zip(target_ids, csubsts, strict=True))
+
     def ndbranches(self, *, source_id: NodeIdLike | None = None, target_id: NodeIdLike | None = None) -> list[NDBranch]:
         source_id = self._resolve(source_id) if source_id is not None else None
         target_id = self._resolve(target_id) if target_id is not None else None

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1046,10 +1046,10 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         """Create a split without crafting a CSubst."""
         source = self.node(source_id)
         targets = [self.node(nid) for nid in target_ids]
-        csubsts = [cterm_match(source.cterm, target.cterm) for target in targets]
-        if any(csubst is None for csubst in csubsts):
+        try:
+            csubsts = [not_none(cterm_match(source.cterm, target.cterm)) for target in targets]
+        except ValueError:
             return None
-
         return self.create_split(source.id, zip(target_ids, csubsts, strict=True))
 
     def ndbranches(self, *, source_id: NodeIdLike | None = None, target_id: NodeIdLike | None = None) -> list[NDBranch]:

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -1044,16 +1044,15 @@ class KCFG(Container[Union['KCFG.Node', 'KCFG.Successor']]):
         """Create a split without crafting a CSubst."""
         source = self.node(source_id)
         targets = [self.node(nid) for nid in target_ids]
-        substs = [source.cterm.config.match(target.cterm.config) for target in targets]
         csubsts: list[CSubst] = []
-        if None in substs:
-            return None
-        for subst, target in zip(substs, targets, strict=True):
-            constraints: list[KInner] = []
-            for c in target.cterm.constraints:
-                if c not in source.cterm.constraints:
-                    constraints.append(c)
+
+        for target in targets:
+            subst = source.cterm.config.match(target.cterm.config)
+            if subst is None:
+                return None
+            constraints = [c for c in target.cterm.constraints if c not in source.cterm.constraints]
             csubsts.append(CSubst(subst, constraints))
+
         return self.create_split(source.id, zip(target_ids, csubsts, strict=True))
 
     def ndbranches(self, *, source_id: NodeIdLike | None = None, target_id: NodeIdLike | None = None) -> list[NDBranch]:

--- a/pyk/src/tests/unit/test_cterm.py
+++ b/pyk/src/tests/unit/test_cterm.py
@@ -13,7 +13,7 @@ from pyk.prelude.k import GENERATED_TOP_CELL
 from pyk.prelude.kint import INT, intToken
 from pyk.prelude.ml import mlAnd, mlEqualsTrue
 
-from .utils import a, b, c, config, config_int, f, g, ge, h, k, lt, x, y, z
+from .utils import a, b, c, f, g, ge_ml, h, k, lt_ml, x, y, z
 
 if TYPE_CHECKING:
     from typing import Final
@@ -192,24 +192,24 @@ APPLY_TEST_DATA: Final = (
     (CTerm.top(), CSubst(), CTerm.top()),
     (CTerm.bottom(), CSubst(), CTerm.bottom()),
     (
-        CTerm(config('X')),
+        CTerm(k(KVariable('X'))),
         CSubst(),
-        CTerm(config('X')),
+        CTerm(k(KVariable('X'))),
     ),
     (
-        CTerm(config('X')),
+        CTerm(k(KVariable('X'))),
         CSubst(Subst({'X': intToken(5)})),
-        CTerm(config_int(5)),
+        CTerm(k(intToken(5))),
     ),
     (
-        CTerm(config('X')),
+        CTerm(k(KVariable('X'))),
         CSubst(Subst({'X': KVariable('Y')})),
-        CTerm(config('Y')),
+        CTerm(k(KVariable('Y'))),
     ),
     (
-        CTerm(config('X'), [lt('X', 5)]),
-        CSubst(Subst({'X': KVariable('Y')}), [ge('Y', 0)]),
-        CTerm(config('Y'), [ge('Y', 0), lt('Y', 5)]),
+        CTerm(k(KVariable('X')), [lt_ml('X', 5)]),
+        CSubst(Subst({'X': KVariable('Y')}), [ge_ml('Y', 0)]),
+        CTerm(k(KVariable('Y')), [ge_ml('Y', 0), lt_ml('Y', 5)]),
     ),
 )
 

--- a/pyk/src/tests/unit/test_cterm.py
+++ b/pyk/src/tests/unit/test_cterm.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from .utils import config, config_int, lt, ge
 from itertools import count
 from typing import TYPE_CHECKING
 
 import pytest
 
-from pyk.cterm import CTerm, cterm_build_claim, cterm_build_rule, CSubst
+from pyk.cterm import CSubst, CTerm, cterm_build_claim, cterm_build_rule
 from pyk.kast import Atts, KAtt
 from pyk.kast.inner import KApply, KLabel, KRewrite, KSequence, KSort, KVariable, Subst
 from pyk.kast.outer import KClaim
@@ -14,7 +13,7 @@ from pyk.prelude.k import GENERATED_TOP_CELL
 from pyk.prelude.kint import INT, intToken
 from pyk.prelude.ml import mlAnd, mlEqualsTrue
 
-from .utils import a, b, c, f, g, h, k, x, y, z
+from .utils import a, b, c, config, config_int, f, g, ge, h, k, lt, x, y, z
 
 if TYPE_CHECKING:
     from typing import Final
@@ -211,11 +210,14 @@ APPLY_TEST_DATA: Final = (
         CTerm(config('X'), [lt('X', 5)]),
         CSubst(Subst({'X': KVariable('Y')}), [ge('Y', 0)]),
         CTerm(config('Y'), [ge('Y', 0), lt('Y', 5)]),
-    )
+    ),
 )
 
 
-@pytest.mark.parametrize('term,subst,expected', APPLY_TEST_DATA,)
+@pytest.mark.parametrize(
+    'term,subst,expected',
+    APPLY_TEST_DATA,
+)
 def test_csubst_apply(term: CTerm, subst: CSubst, expected: CTerm) -> None:
     # When
     actual = subst(term)

--- a/pyk/src/tests/unit/test_kcfg.py
+++ b/pyk/src/tests/unit/test_kcfg.py
@@ -891,6 +891,7 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
         [CTerm(k(KVariable('X'))), CTerm(k(KVariable('Y')))],
         None,  # todo: support split from top, because top means anything can be matched
     ),
+    # not mutually exclusive
     (
         CTerm.top(),
         [CTerm.top(), CTerm.top()],
@@ -898,6 +899,7 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
             KCFG.Node(1, CTerm.top()), [(KCFG.Node(2, CTerm.top()), CSubst()), (KCFG.Node(3, CTerm.top()), CSubst())]
         ),
     ),
+    # not mutually exclusive
     (
         CTerm(k(KVariable('X'))),
         [CTerm(k(KVariable('X'))), CTerm(k(KVariable('Y'))), CTerm(k(KVariable('Z')))],
@@ -911,6 +913,10 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
         ),
     ),
     (CTerm(k(KVariable('X'))), [CTerm(k(KVariable('Y'))), CTerm(KApply('<bot>', [KVariable('Z')]))], None),
+    # not mutually exclusive
+    # this target doesn't meet the implication relationship with source.
+    # So the CTerm of target and CSubst.apply(target) are not logically equal.
+    # But source -> CSubst.apply(target) can always be true.
     (
         CTerm(k(KVariable('X')), [ge_ml('X', 0), lt_ml('X', 10)]),
         [CTerm(k(KVariable('Y')), [ge_ml('Y', 0)]), CTerm(k(KVariable('Z')), [ge_ml('Z', 5)])],
@@ -928,6 +934,29 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
                         [
                             ge_ml('Z', 5),
                             lt_ml('Z', 10),
+                            ge_ml('Z', 0),
+                        ],
+                    ),
+                ),
+            ],
+        ),
+    ),
+    (
+        CTerm(k(KVariable('X')), [ge_ml('X', 0), lt_ml('X', 10)]),
+        [CTerm(k(KVariable('Y')), [ge_ml('Y', 0), lt_ml('Y', 5)]), CTerm(k(KVariable('Z')), [ge_ml('Z', 5), lt_ml('Z', 10)])],
+        KCFG.Split(
+            KCFG.Node(1, CTerm(k(KVariable('X')), [ge_ml('X', 0), lt_ml('X', 10)])),
+            [
+                (
+                    KCFG.Node(2, CTerm(k(KVariable('Y')), [ge_ml('Y', 0), lt_ml('Y', 5)])),
+                    CSubst(Subst({'X': KVariable('Y')}), [lt_ml('Y', 5), lt_ml('Y', 10)]),
+                ),
+                (
+                    KCFG.Node(3, CTerm(k(KVariable('Z')), [ge_ml('Z', 5), lt_ml('Z', 10)])),
+                    CSubst(
+                        Subst({'X': KVariable('Z')}),
+                        [
+                            ge_ml('Z', 5),
                             ge_ml('Z', 0),
                         ],
                     ),

--- a/pyk/src/tests/unit/test_kcfg.py
+++ b/pyk/src/tests/unit/test_kcfg.py
@@ -925,7 +925,7 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
             [
                 (
                     KCFG.Node(2, CTerm(k(KVariable('Y')), [ge_ml('Y', 0)])),
-                    CSubst(Subst({'X': KVariable('Y')}), [lt_ml('Y', 10)]),
+                    CSubst(Subst({'X': KVariable('Y')}), []),
                 ),
                 (
                     KCFG.Node(3, CTerm(k(KVariable('Z')), [ge_ml('Z', 5)])),
@@ -933,8 +933,6 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
                         Subst({'X': KVariable('Z')}),
                         [
                             ge_ml('Z', 5),
-                            lt_ml('Z', 10),
-                            ge_ml('Z', 0),
                         ],
                     ),
                 ),
@@ -952,17 +950,11 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
             [
                 (
                     KCFG.Node(2, CTerm(k(KVariable('Y')), [ge_ml('Y', 0), lt_ml('Y', 5)])),
-                    CSubst(Subst({'X': KVariable('Y')}), [lt_ml('Y', 5), lt_ml('Y', 10)]),
+                    CSubst(Subst({'X': KVariable('Y')}), [lt_ml('Y', 5)]),
                 ),
                 (
                     KCFG.Node(3, CTerm(k(KVariable('Z')), [ge_ml('Z', 5), lt_ml('Z', 10)])),
-                    CSubst(
-                        Subst({'X': KVariable('Z')}),
-                        [
-                            ge_ml('Z', 5),
-                            ge_ml('Z', 0),
-                        ],
-                    ),
+                    CSubst(Subst({'X': KVariable('Z')}), [ge_ml('Z', 5)]),
                 ),
             ],
         ),

--- a/pyk/src/tests/unit/test_kcfg.py
+++ b/pyk/src/tests/unit/test_kcfg.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Final
 
 import pytest
-from unit.utils import config, ge, lt
+from unit.utils import ge_ml, k, lt_ml
 
 from pyk.cterm import CSubst, CTerm
 from pyk.kast.inner import KApply, KRewrite, KToken, KVariable, Subst
@@ -888,7 +888,7 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
     (CTerm.top(), [CTerm.top(), CTerm.bottom()], None),
     (
         CTerm.top(),
-        [CTerm(config('X')), CTerm(config('Y'))],
+        [CTerm(k(KVariable('X'))), CTerm(k(KVariable('Y')))],
         None,  # todo: support split from top, because top means anything can be matched
     ),
     (
@@ -899,33 +899,36 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
         ),
     ),
     (
-        CTerm(config('X')),
-        [CTerm(config('X')), CTerm(config('Y')), CTerm(config('Z'))],
+        CTerm(k(KVariable('X'))),
+        [CTerm(k(KVariable('X'))), CTerm(k(KVariable('Y'))), CTerm(k(KVariable('Z')))],
         KCFG.Split(
-            KCFG.Node(1, CTerm(config('X'))),
+            KCFG.Node(1, CTerm(k(KVariable('X')))),
             [
-                (KCFG.Node(2, CTerm(config('X'))), CSubst(Subst({'X': KVariable('X')}))),
-                (KCFG.Node(3, CTerm(config('Y'))), CSubst(Subst({'X': KVariable('Y')}))),
-                (KCFG.Node(4, CTerm(config('Z'))), CSubst(Subst({'X': KVariable('Z')}))),
+                (KCFG.Node(2, CTerm(k(KVariable('X')))), CSubst(Subst({'X': KVariable('X')}))),
+                (KCFG.Node(3, CTerm(k(KVariable('Y')))), CSubst(Subst({'X': KVariable('Y')}))),
+                (KCFG.Node(4, CTerm(k(KVariable('Z')))), CSubst(Subst({'X': KVariable('Z')}))),
             ],
         ),
     ),
-    (CTerm(config('X')), [CTerm(config('Y')), CTerm(KApply('<bot>', [KVariable('Z')]))], None),
+    (CTerm(k(KVariable('X'))), [CTerm(k(KVariable('Y'))), CTerm(KApply('<bot>', [KVariable('Z')]))], None),
     (
-        CTerm(config('X'), [ge('X', 0), lt('X', 10)]),
-        [CTerm(config('Y'), [ge('Y', 0)]), CTerm(config('Z'), [ge('Z', 5)])],
+        CTerm(k(KVariable('X')), [ge_ml('X', 0), lt_ml('X', 10)]),
+        [CTerm(k(KVariable('Y')), [ge_ml('Y', 0)]), CTerm(k(KVariable('Z')), [ge_ml('Z', 5)])],
         KCFG.Split(
-            KCFG.Node(1, CTerm(config('X'), [ge('X', 0), lt('X', 10)])),
+            KCFG.Node(1, CTerm(k(KVariable('X')), [ge_ml('X', 0), lt_ml('X', 10)])),
             [
-                (KCFG.Node(2, CTerm(config('Y'), [ge('Y', 0)])), CSubst(Subst({'X': KVariable('Y')}), [lt('Y', 10)])),
                 (
-                    KCFG.Node(3, CTerm(config('Z'), [ge('Z', 5)])),
+                    KCFG.Node(2, CTerm(k(KVariable('Y')), [ge_ml('Y', 0)])),
+                    CSubst(Subst({'X': KVariable('Y')}), [lt_ml('Y', 10)]),
+                ),
+                (
+                    KCFG.Node(3, CTerm(k(KVariable('Z')), [ge_ml('Z', 5)])),
                     CSubst(
                         Subst({'X': KVariable('Z')}),
                         [
-                            ge('Z', 5),
-                            lt('Z', 10),
-                            ge('Z', 0),
+                            ge_ml('Z', 5),
+                            lt_ml('Z', 10),
+                            ge_ml('Z', 0),
                         ],
                     ),
                 ),

--- a/pyk/src/tests/unit/test_kcfg.py
+++ b/pyk/src/tests/unit/test_kcfg.py
@@ -943,7 +943,10 @@ CREATE_SPLIT_BY_NODES_TEST_DATA: Final = (
     ),
     (
         CTerm(k(KVariable('X')), [ge_ml('X', 0), lt_ml('X', 10)]),
-        [CTerm(k(KVariable('Y')), [ge_ml('Y', 0), lt_ml('Y', 5)]), CTerm(k(KVariable('Z')), [ge_ml('Z', 5), lt_ml('Z', 10)])],
+        [
+            CTerm(k(KVariable('Y')), [ge_ml('Y', 0), lt_ml('Y', 5)]),
+            CTerm(k(KVariable('Z')), [ge_ml('Z', 5), lt_ml('Z', 10)]),
+        ],
         KCFG.Split(
             KCFG.Node(1, CTerm(k(KVariable('X')), [ge_ml('X', 0), lt_ml('X', 10)])),
             [

--- a/pyk/src/tests/unit/utils.py
+++ b/pyk/src/tests/unit/utils.py
@@ -4,6 +4,8 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from pyk.kast.inner import KApply, KLabel, KVariable
+from pyk.prelude.kint import geInt, intToken, ltInt
+from pyk.prelude.ml import mlEqualsTrue
 
 if TYPE_CHECKING:
     from typing import Final
@@ -16,3 +18,19 @@ x, y, z = map(KVariable, ('x', 'y', 'z'))
 f, g, h = map(KLabel, ('f', 'g', 'h'))
 
 k = KLabel('<k>')
+
+
+def lt(var: str, n: int) -> KApply:
+    return mlEqualsTrue(ltInt(KVariable(var), intToken(n)))
+
+
+def ge(var: str, n: int) -> KApply:
+    return mlEqualsTrue(geInt(KVariable(var), intToken(n)))
+
+
+def config(var: str) -> KApply:
+    return KApply('<top>', KVariable(var))
+
+
+def config_int(n: int) -> KApply:
+    return KApply('<top>', intToken(n))

--- a/pyk/src/tests/unit/utils.py
+++ b/pyk/src/tests/unit/utils.py
@@ -20,17 +20,9 @@ f, g, h = map(KLabel, ('f', 'g', 'h'))
 k = KLabel('<k>')
 
 
-def lt(var: str, n: int) -> KApply:
+def lt_ml(var: str, n: int) -> KApply:
     return mlEqualsTrue(ltInt(KVariable(var), intToken(n)))
 
 
-def ge(var: str, n: int) -> KApply:
+def ge_ml(var: str, n: int) -> KApply:
     return mlEqualsTrue(geInt(KVariable(var), intToken(n)))
-
-
-def config(var: str) -> KApply:
-    return KApply('<top>', KVariable(var))
-
-
-def config_int(n: int) -> KApply:
-    return KApply('<top>', intToken(n))


### PR DESCRIPTION
1. generate `CSubst` from the targets for `Split`
2. fix a bug in `CSubst.apply`.
