### PR TITLE
Fix MacOS brew release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,6 +301,8 @@ jobs:
           # test suite, so the PL-tutorial is disabled for now.
           #   - https://github.com/runtimeverification/k/issues/3705
           cd homebrew-k-old
+          # brew tap expects a git repository, so we initialise the current folder as a dummy repo
+          git init
           brew tap runtimeverification/k "file:///$(pwd)"
           brew install ${{ needs.macos-build.outputs.bottle_path }} -v
           # cp -R /usr/local/share/kframework/pl-tutorial ~


### PR DESCRIPTION
It looks like the semantics of `brew tap` have changed from `brew` version `4.3.16`  to `4.3.18`  (a recent change to the public github macos runners). `brew tap` now no longer takes an arbitrary `file://...`  path... the path must be a git repo. The fix seems to be to `git init` the folder before calling `brew tap`