### PR TITLE
release.yml: On failure run publish with verbose option enabled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,19 @@ jobs:
             export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
             kup publish k-framework-binary .#k --keep-days 180
             kup publish k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
+      
+      - name: 'DEBUG: Populate Cache Failure Log Dump'
+        if: failure()
+        uses: workflow/nix-shell-action@v3.3.2
+        env:
+          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_KFB_TOKEN }}'
+          GC_DONT_GC: '1'
+        with:
+          packages: jq
+          script: |
+            export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
+            kup publish --verbose k-framework-binary .#k --keep-days 180
+            kup publish --verbose k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
 
   ubuntu-noble:
     name: 'K Ubuntu Noble Package'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,22 +84,9 @@ jobs:
           packages: jq
           script: |
             export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
-            kup publish k-framework-binary .#k --keep-days 180
-            kup publish k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
-      
-      - name: 'DEBUG: Populate Cache Failure Log Dump'
-        if: failure()
-        uses: workflow/nix-shell-action@v3.3.2
-        env:
-          CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_KFB_TOKEN }}'
-          GC_DONT_GC: '1'
-        with:
-          packages: jq
-          script: |
-            export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
             kup publish --verbose k-framework-binary .#k --keep-days 180
             kup publish --verbose k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
-
+      
   ubuntu-noble:
     name: 'K Ubuntu Noble Package'
     runs-on: [self-hosted, linux, normal]


### PR DESCRIPTION
On failure we need more informaiton why the upload to cachix failed. More information is always needed. 