### PR TITLE
More readable and informative status bar

### DIFF
--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -561,7 +561,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         refuted = len(self.node_refutations)
         return (
             super().one_line_summary
-            + f' --- {nodes} nodes|{branches} branches|{terminal} terminal --- {pending} pending|{passed} passed|{failing} failing|{vacuous} vacuous|{refuted} refuted|{stuck} stuck'
+            + f': {nodes} nodes: {pending} pending|{passed} passed|{failing} failing|{vacuous} vacuous|{refuted} refuted|{stuck} stuck'
         )
 
     def get_refutation_id(self, node_id: int) -> str:

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -551,11 +551,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         nodes = len(self.kcfg.nodes)
         pending = len(self.pending)
         failing = len(self.failing)
-        branches = 0
-        for branch in self.kcfg.ndbranches() + self.kcfg.splits():
-            branches += len(branch.targets)
         vacuous = len(self.kcfg.vacuous)
-        terminal = len(self.terminal)
         stuck = len(self.kcfg.stuck)
         passed = len([cover for cover in self.kcfg.covers() if cover.target.id == self.target])
         refuted = len(self.node_refutations)


### PR DESCRIPTION
This PR adjusts the proof info shown in the status bar. In particular, it:
- removes the `branches` info, since this number refers to all of the internal branchings of the proof, it differs from the number of leaves, and it is not clear how it is useful to the end-user;
- removes the `terminal` info, since this can be computed from the other information; it could also be confusing to end-users as to why there are always two terminal nodes to begin with (final node of `setUp` and `target`);
- reduces horizontal space so that there is a greater chance that full status does not overflow and more info can be seen when test name is large.
