### PR TITLE
Correct how pyk loads seqstrict attribute

### DIFF
--- a/pyk/regression-new/seqstrict-predicate/1.test.out
+++ b/pyk/regression-new/seqstrict-predicate/1.test.out
@@ -1,3 +1,8 @@
-<k>
-  10 ~> .K
-</k>
+<generatedTop>
+  <k>
+    10 ~> .K
+  </k>
+  <generatedCounter>
+    0
+  </generatedCounter>
+</generatedTop>

--- a/pyk/regression-new/skipped
+++ b/pyk/regression-new/skipped
@@ -103,7 +103,6 @@ rand
 rangemap-tests-llvm
 rat
 search-bound
-seqstrict-predicate
 set-symbolic-tests
 set_unification
 spec-rule-application

--- a/pyk/src/pyk/kast/att.py
+++ b/pyk/src/pyk/kast/att.py
@@ -336,7 +336,7 @@ class Atts:
     PROJECTION: Final = AttKey('projection', type=_NONE)
     RIGHT: Final = AttKey('right', type=_ANY)  # RIGHT and RIGHT_INTERNAL on the Frontend
     SIMPLIFICATION: Final = AttKey('simplification', type=_ANY)
-    SEQSTRICT: Final = AttKey('seqstrict', type=_NONE)
+    SEQSTRICT: Final = AttKey('seqstrict', type=_ANY)
     SORT: Final = AttKey('org.kframework.kore.Sort', type=_ANY)
     SOURCE: Final = AttKey('org.kframework.attributes.Source', type=_PATH)
     STRICT: Final = AttKey('strict', type=_ANY)


### PR DESCRIPTION
@ACassimiro discovered a bug where we aren't allowing arguments on the `seqstrict` attribute in pyk.

This PR addresses this, and enables a previously failing test in `regression-new` that was due to this bug.