### PR TITLE
No trimming of split constraints when printed

### DIFF
--- a/pyk/src/pyk/kcfg/show.py
+++ b/pyk/src/pyk/kcfg/show.py
@@ -149,7 +149,7 @@ class KCFGShow:
             _constraint_strs = [
                 self.kprint.pretty_print(ml_pred_to_bool(constraint, unsafe=True)) for constraint in csubst.constraints
             ]
-            constraint_strs = _multi_line_print('constraint', _constraint_strs, 'true', max_width=max_width)
+            constraint_strs = _multi_line_print('constraint', _constraint_strs, 'true')
             if len(csubst.subst.minimize()) > 0 and minimize:
                 subst_strs = ['subst: ...']
             else:

--- a/pyk/src/tests/unit/test-data/pyk_toml_test.toml
+++ b/pyk/src/tests/unit/test-data/pyk_toml_test.toml
@@ -1,6 +1,6 @@
 [coverage]
 output = "default-file"
-definition = "/var/folders/ks/1p8zyp5j7xz_v1krhl4l17tm0000gn/T"
+definition = "/tmp"
 
 [print]
 input = "kast-json"

--- a/pyk/src/tests/unit/test-data/pyk_toml_test.toml
+++ b/pyk/src/tests/unit/test-data/pyk_toml_test.toml
@@ -1,6 +1,6 @@
 [coverage]
 output = "default-file"
-definition = "/tmp"
+definition = "/var/folders/ks/1p8zyp5j7xz_v1krhl4l17tm0000gn/T"
 
 [print]
 input = "kast-json"


### PR DESCRIPTION
This PR disables the trimming of split constraints when showing a KCFG. 

The reason for this is as follows:
- the constraints guide the debugging of Kontrol proofs in many cases, and it is likely that they will serve a similar purpose for other semantics;
- if `--no-minimize` is turned on, which disables the trimming, the KCFG will also contain all of the substitutions printed explicitly, which are very large and hinder navigation through the KCFG considerably.