### PR TITLE
Adding is-loop functionality

### DIFF
--- a/pyk/src/pyk/kcfg/semantics.py
+++ b/pyk/src/pyk/kcfg/semantics.py
@@ -20,6 +20,11 @@ class KCFGSemantics(ABC):
     """Implement an abstraction mechanism."""
 
     @abstractmethod
+    def is_loop(self, c: CTerm) -> bool: ...
+
+    """Check whether or not the given ``CTerm`` represents a loop head."""
+
+    @abstractmethod
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool: ...
 
     """Check whether or not the two given ``CTerm``s represent the same loop head."""
@@ -46,6 +51,9 @@ class DefaultSemantics(KCFGSemantics):
 
     def abstract_node(self, c: CTerm) -> CTerm:
         return c
+
+    def is_loop(self, c: CTerm) -> bool:
+        return False
 
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
         return False

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -786,7 +786,7 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
     def step_proof(self, step: APRProofStep) -> list[APRProofResult]:
         # Check if the current node should be bounded
         prior_loops: tuple[int, ...] = ()
-        if step.bmc_depth is not None:
+        if step.bmc_depth is not None and self.kcfg_explore.kcfg_semantics.is_loop(step.node.cterm):
             for node in step.shortest_path_to_node:
                 if self.kcfg_explore.kcfg_semantics.same_loop(node.cterm, step.node.cterm):
                     if node.id in step.prior_loops_cache:

--- a/pyk/src/tests/integration/ktool/test_imp.py
+++ b/pyk/src/tests/integration/ktool/test_imp.py
@@ -52,10 +52,19 @@ class ImpSemantics(DefaultSemantics):
     def abstract_node(self, c: CTerm) -> CTerm:
         return c
 
+    def is_loop(self, c: CTerm) -> bool:
+        k_cell = c.cell('K_CELL')
+        return (
+            type(k_cell) is KSequence
+            and type(k_cell[0]) is KApply
+            and len(k_cell) > 0
+            and k_cell[0].label.name == 'while(_)_'
+        )
+
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
         k_cell_1 = c1.cell('K_CELL')
         k_cell_2 = c2.cell('K_CELL')
-        if k_cell_1 == k_cell_2 and type(k_cell_1) is KSequence and type(k_cell_1[0]) is KApply:
+        if k_cell_1 == k_cell_2 and type(k_cell_1) is KSequence and len(k_cell_1) > 0 and type(k_cell_1[0]) is KApply:
             return k_cell_1[0].label.name == 'while(_)_'
         return False
 

--- a/pyk/src/tests/integration/proof/test_custom_step.py
+++ b/pyk/src/tests/integration/proof/test_custom_step.py
@@ -58,18 +58,6 @@ class CustomStepSemanticsWithoutStep(DefaultSemantics):
             return True
         return False
 
-    def abstract_node(self, c: CTerm) -> CTerm:
-        return c
-
-    def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
-        return False
-
-    def can_make_custom_step(self, c: CTerm) -> bool:
-        return False
-
-    def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
-        return None
-
 
 class CustomStepSemanticsWithStep(CustomStepSemanticsWithoutStep):
     def can_make_custom_step(self, c: CTerm) -> bool:

--- a/pyk/src/tests/integration/proof/test_goto.py
+++ b/pyk/src/tests/integration/proof/test_goto.py
@@ -23,7 +23,6 @@ if TYPE_CHECKING:
     from pyk.cterm import CTerm
     from pyk.kast.outer import KDefinition
     from pyk.kcfg import KCFGExplore
-    from pyk.kcfg.kcfg import KCFGExtendResult
     from pyk.kcfg.semantics import KCFGSemantics
     from pyk.ktool.kprove import KProve
 
@@ -31,11 +30,14 @@ _LOGGER: Final = logging.getLogger(__name__)
 
 
 class GotoSemantics(DefaultSemantics):
-    def is_terminal(self, c: CTerm) -> bool:
-        return False
-
-    def abstract_node(self, c: CTerm) -> CTerm:
-        return c
+    def is_loop(self, c: CTerm) -> bool:
+        k_cell = c.cell('K_CELL')
+        return (
+            type(k_cell) is KSequence
+            and len(k_cell) > 0
+            and type(k_cell[0]) is KApply
+            and k_cell[0].label.name == 'jumpi'
+        )
 
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
         k_cell = c1.cell('K_CELL')
@@ -44,12 +46,6 @@ class GotoSemantics(DefaultSemantics):
         if pc_cell_1 == pc_cell_2 and type(k_cell) is KSequence and len(k_cell) > 0 and type(k_cell[0]) is KApply:
             return k_cell[0].label.name == 'jumpi'
         return False
-
-    def can_make_custom_step(self, c: CTerm) -> bool:
-        return False
-
-    def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
-        return None
 
 
 APRBMC_PROVE_TEST_DATA: Iterable[

--- a/pyk/src/tests/integration/proof/test_imp.py
+++ b/pyk/src/tests/integration/proof/test_imp.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from pyk.kast.inner import KInner
     from pyk.kast.outer import KDefinition
     from pyk.kcfg import KCFGExplore
-    from pyk.kcfg.kcfg import KCFGExtendResult
     from pyk.kcfg.semantics import KCFGSemantics
     from pyk.ktool.kprint import KPrint, SymbolTable
     from pyk.ktool.kprove import KProve
@@ -65,21 +64,21 @@ class ImpSemantics(DefaultSemantics):
             return True
         return False
 
-    def abstract_node(self, c: CTerm) -> CTerm:
-        return c
+    def is_loop(self, c: CTerm) -> bool:
+        k_cell = c.cell('K_CELL')
+        return (
+            type(k_cell) is KSequence
+            and len(k_cell) > 0
+            and type(k_cell[0]) is KApply
+            and k_cell[0].label.name == 'while(_)_'
+        )
 
     def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
         k_cell_1 = c1.cell('K_CELL')
         k_cell_2 = c2.cell('K_CELL')
-        if k_cell_1 == k_cell_2 and type(k_cell_1) is KSequence and type(k_cell_1[0]) is KApply:
+        if k_cell_1 == k_cell_2 and type(k_cell_1) is KSequence and len(k_cell_1) > 0 and type(k_cell_1[0]) is KApply:
             return k_cell_1[0].label.name == 'while(_)_'
         return False
-
-    def can_make_custom_step(self, c: CTerm) -> bool:
-        return False
-
-    def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
-        return None
 
 
 EMPTY_STATES: Final[list[tuple[str, str]]] = []

--- a/pyk/src/tests/integration/proof/test_refute_node.py
+++ b/pyk/src/tests/integration/proof/test_refute_node.py
@@ -30,7 +30,6 @@ if TYPE_CHECKING:
     from pyk.kast.inner import KInner
     from pyk.kast.outer import KDefinition
     from pyk.kcfg import KCFGExplore
-    from pyk.kcfg.kcfg import KCFGExtendResult
     from pyk.kcfg.semantics import KCFGSemantics
     from pyk.ktool.kprove import KProve
 
@@ -58,18 +57,6 @@ class RefuteSemantics(DefaultSemantics):
         if type(k_cell) is KVariable:
             return True
         return False
-
-    def abstract_node(self, c: CTerm) -> CTerm:
-        return c
-
-    def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
-        return False
-
-    def can_make_custom_step(self, c: CTerm) -> bool:
-        return False
-
-    def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
-        return None
 
 
 REFUTE_NODE_TEST_DATA: Iterable[tuple[str, Iterable[KInner], ProofStatus]] = (

--- a/pyk/src/tests/integration/proof/test_simple.py
+++ b/pyk/src/tests/integration/proof/test_simple.py
@@ -17,7 +17,6 @@ if TYPE_CHECKING:
     from pyk.cterm import CTerm
     from pyk.kast.outer import KDefinition
     from pyk.kcfg import KCFGExplore
-    from pyk.kcfg.kcfg import KCFGExtendResult
     from pyk.kcfg.semantics import KCFGSemantics
     from pyk.ktool.kprove import KProve
 
@@ -30,18 +29,6 @@ class SimpleSemantics(DefaultSemantics):
         if type(k_cell) is KSequence and type(k_cell[0]) is KApply and k_cell[0].label.name == 'f_SIMPLE-PROOFS_Step':
             return True
         return False
-
-    def abstract_node(self, c: CTerm) -> CTerm:
-        return c
-
-    def same_loop(self, c1: CTerm, c2: CTerm) -> bool:
-        return False
-
-    def can_make_custom_step(self, c: CTerm) -> bool:
-        return False
-
-    def custom_step(self, c: CTerm) -> KCFGExtendResult | None:
-        return None
 
 
 class TestSimpleProof(KCFGExploreTest, KProveTest):

--- a/pyk/src/tests/unit/test-data/pyk_toml_test.toml
+++ b/pyk/src/tests/unit/test-data/pyk_toml_test.toml
@@ -1,6 +1,6 @@
 [coverage]
 output = "default-file"
-definition = "/var/folders/ks/1p8zyp5j7xz_v1krhl4l17tm0000gn/T"
+definition = "/tmp"
 
 [print]
 input = "kast-json"

--- a/pyk/src/tests/unit/test-data/pyk_toml_test.toml
+++ b/pyk/src/tests/unit/test-data/pyk_toml_test.toml
@@ -1,6 +1,6 @@
 [coverage]
 output = "default-file"
-definition = "/tmp"
+definition = "/var/folders/ks/1p8zyp5j7xz_v1krhl4l17tm0000gn/T"
 
 [print]
 input = "kast-json"


### PR DESCRIPTION
This PR adds a recogniser function for loops to the KCFG semantics. This allows us to avoid unnecessary KCFG traversal computation in the cases when the node examined is not a loop head. This computation turned out to be quite expensive in real-world proofs with a high branching factor.