### PR TITLE
Bug: Correctly typing and initialising `prior_loops_cache`

### DIFF
--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -584,7 +584,9 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
             kcfg._resolve(int(node_id)): proof_id for node_id, proof_id in proof_dict['node_refutations'].items()
         }
 
-        prior_loops_cache = {int(k): v for k, v in proof_dict.get('loops_cache', {}).items()}
+        prior_loops_cache: dict[int, tuple[int, ...]] = {
+            int(k): tuple(v) for k, v in proof_dict.get('loops_cache', {}).items()
+        }
 
         return APRProof(
             id=id,

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -135,7 +135,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         admitted: bool = False,
         _exec_time: float = 0,
         error_info: Exception | None = None,
-        prior_loops_cache: dict[int, tuple[int, ...]] | None = None,
+        prior_loops_cache: dict[int, Iterable[int]] | None = None,
     ):
         Proof.__init__(self, id, proof_dir=proof_dir, subproof_ids=subproof_ids, admitted=admitted)
         KCFGExploration.__init__(self, kcfg, terminal)
@@ -148,7 +148,9 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         self.logs = logs
         self.circularity = circularity
         self.node_refutations = {}
-        self.prior_loops_cache = prior_loops_cache if prior_loops_cache is not None else {}
+        self.prior_loops_cache = (
+            {int(k): tuple(v) for k, v in prior_loops_cache.items()} if prior_loops_cache is not None else {}
+        )
         self.kcfg._kcfg_store = KCFGStore(self.proof_subdir / 'kcfg') if self.proof_subdir else None
         self._exec_time = _exec_time
         self.error_info = error_info
@@ -584,9 +586,7 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
             kcfg._resolve(int(node_id)): proof_id for node_id, proof_id in proof_dict['node_refutations'].items()
         }
 
-        prior_loops_cache: dict[int, tuple[int, ...]] = {
-            int(k): tuple(v) for k, v in proof_dict.get('loops_cache', {}).items()
-        }
+        prior_loops_cache = {int(k): v for k, v in proof_dict.get('loops_cache', {}).items()}
 
         return APRProof(
             id=id,


### PR DESCRIPTION
If an APR proof on disk contains a `loops_cache`, it cannot be executed further because of a typing error in the style of:
```
...
File "/nix/store/6bi78qgqbnqryswaly3m4rggsqkrj72w-python3.10-kframework-7.1.145/lib/python3.10/site-packages/pyk/proof/reachability.py", line 793, in step_proof                                                                                    
    prior_loops = step.prior_loops_cache[node.id] + (node.id,)                                                                                                                                                                                        
TypeError: can only concatenate list (not "tuple") to list     
```
when initialising `prior_loops_cache` from disk. 

This PR corrects this bug by enforcing the correct types.