### PR TITLE
updating the `minimize_kcfg` method to accept an optional heuristics parameter for merging node.

### DIFF
--- a/pyk/src/pyk/kcfg/exploration.py
+++ b/pyk/src/pyk/kcfg/exploration.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING
 
 from pyk.kcfg.kcfg import KCFG, NodeAttr
 from pyk.kcfg.minimize import KCFGMinimizer
+from pyk.kcfg.semantics import KCFGSemantics
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -109,5 +110,5 @@ class KCFGExploration:
     #
 
     # Minimizing the KCFG
-    def minimize_kcfg(self, merge: bool = False) -> None:
-        KCFGMinimizer(self.kcfg).minimize(merge=merge)
+    def minimize_kcfg(self, heuristics: KCFGSemantics | None = None, merge: bool = False) -> None:
+        KCFGMinimizer(kcfg=self.kcfg, heuristics=heuristics).minimize(merge=merge)

--- a/pyk/src/pyk/kcfg/exploration.py
+++ b/pyk/src/pyk/kcfg/exploration.py
@@ -4,13 +4,13 @@ from typing import TYPE_CHECKING
 
 from pyk.kcfg.kcfg import KCFG, NodeAttr
 from pyk.kcfg.minimize import KCFGMinimizer
-from pyk.kcfg.semantics import KCFGSemantics
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from typing import Any
 
     from pyk.kcfg.kcfg import NodeIdLike
+    from pyk.kcfg.semantics import KCFGSemantics
 
 
 class KCFGExplorationNodeAttr(NodeAttr):


### PR DESCRIPTION
This pull request includes changes to the `pyk/src/pyk/kcfg/exploration.py` file to enhance the functionality of the `minimize_kcfg` method by incorporating heuristics. The most important changes include importing the `KCFGSemantics` module and updating the `minimize_kcfg` method to accept an optional heuristics parameter.