### PR TITLE
modified:   .github/workflows/master-pr.yml

### DIFF
--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -11,7 +11,10 @@ jobs:
   change-base:
     name: 'Change base to develop branch'
     runs-on: ubuntu-24.04
-    permissions: "write-all"
+    permissions:
+      pull-requests: write
+      actions: write
+      contents: read
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -11,10 +11,7 @@ jobs:
   change-base:
     name: 'Change base to develop branch'
     runs-on: ubuntu-24.04
-    permissions:
-      pull-requests: write
-      actions: write
-      contents: read
+    permissions: "write-all"
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           set -x
           pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
-          comment_body='The default branch has been changed from master to develop. Thank you for your support!'
+          comment_body='The target branch has been updated from master > develop. Thank you for your support!'
           curl -X POST                                                               \
             -H "Accept: application/vnd.github+json"                                 \
             -H "Authorization: Bearer ${GITHUB_TOKEN}"                               \

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -12,16 +12,16 @@ jobs:
   change-base:
     name: 'Change base to develop branch'
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: write
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.JENKINS_GITHUB_PAT }}
-          # fetch-depth 0 means deep clone the repo
           fetch-depth: 0
       - name: 'Change base'
         env:
-          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
           set -x
           pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -8,7 +8,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-
   change-base:
     name: 'Change base to develop branch'
     runs-on: ubuntu-24.04
@@ -30,3 +29,15 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}"                                \
             "https://api.github.com/repos/runtimeverification/k/pulls/${pull_number}" \
             -d '{"base":"develop"}'
+      - name: 'Post comment about base change'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -x
+          pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
+          comment_body='The default branch has been changed from master to develop. Thank you for your support!'
+          curl -X POST                                                               \
+            -H "Accept: application/vnd.github+json"                                 \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}"                               \
+            "https://api.github.com/repos/runtimeverification/k/issues/${pull_number}/comments" \
+            -d "{\"body\":\"${comment_body}\"}"

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: write
+      actions: write
+      contents: read
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -28,15 +28,3 @@ jobs:
             -H "Authorization: Bearer ${GITHUB_TOKEN}"                                \
             "https://api.github.com/repos/runtimeverification/k/pulls/${pull_number}" \
             -d '{"base":"develop"}'
-      - name: 'Post comment about base change'
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        run: |
-          set -x
-          pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
-          comment_body='Target Branch Changed! Thank you for your support!'
-          curl -X POST                                                               \
-            -H "Accept: application/vnd.github+json"                                 \
-            -H "Authorization: Bearer ${GITHUB_TOKEN}"                               \
-            "https://api.github.com/repos/runtimeverification/k/issues/${pull_number}/comments" \
-            -d "{\"body\":\"${comment_body}\"}"

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -x
           pull_number=$(jq --raw-output .pull_request.number "${GITHUB_EVENT_PATH}")
-          comment_body='The target branch has been updated from master > develop. Thank you for your support!'
+          comment_body='Target Branch Changed! Thank you for your support!'
           curl -X POST                                                               \
             -H "Accept: application/vnd.github+json"                                 \
             -H "Authorization: Bearer ${GITHUB_TOKEN}"                               \

--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -1,4 +1,4 @@
-name: 'Test PR'
+name: 'Configure PR'
 on:
   pull_request:
     branches:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -4,16 +4,15 @@ on:
     types: [opened, reopened, synchronize]
     branches:
       - 'develop'
-  workflow_run:
-    workflows: ['Configure PR']
-    types:
-      - completed
+  issue_comment:
+    types: [created]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   format-check:
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.comment.body == 'Target Branch Changed! Thank you for your support!') }}
     name: 'Java: Linting'
     runs-on: ubuntu-latest
     steps:
@@ -33,6 +32,7 @@ jobs:
 
 
   pyk-code-quality-checks:
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.comment.body == 'Target Branch Changed! Thank you for your support!') }}
     name: 'Pyk: Code Quality & Unit Tests'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -59,6 +59,7 @@ jobs:
 
 
   code-quality:
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.comment.body == 'Target Branch Changed! Thank you for your support!') }}
     name: 'Code Quality Checks'
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -1,9 +1,13 @@
 name: 'Test PR'
 on:
   pull_request:
-    types: [opened, edited, reopened, synchronize]
+    types: [opened, reopened, synchronize]
     branches:
       - 'develop'
+  workflow_run:
+    workflows: ['Test PR']
+    types:
+      - completed
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'develop'
   workflow_run:
-    workflows: ['Test PR']
+    workflows: ['Configure PR']
     types:
       - completed
 concurrency:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -4,15 +4,12 @@ on:
     types: [opened, reopened, synchronize]
     branches:
       - 'develop'
-  issue_comment:
-    types: [created]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
   format-check:
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.comment.body == 'Target Branch Changed! Thank you for your support!') }}
     name: 'Java: Linting'
     runs-on: ubuntu-latest
     steps:
@@ -32,7 +29,6 @@ jobs:
 
 
   pyk-code-quality-checks:
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.comment.body == 'Target Branch Changed! Thank you for your support!') }}
     name: 'Pyk: Code Quality & Unit Tests'
     runs-on: ubuntu-latest
     timeout-minutes: 5
@@ -59,7 +55,6 @@ jobs:
 
 
   code-quality:
-    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'issue_comment' && github.event.comment.body == 'Target Branch Changed! Thank you for your support!') }}
     name: 'Code Quality Checks'
     runs-on: ubuntu-latest
     needs:


### PR DESCRIPTION
Problem: Prs opened by forks do not have access to secrets. The WF to change from default banch > develop uses a secret inaccessible by forks.
- Modifying the workflow permissions to enable explicit write allowance to the API endpoint used for modifying the pull request base branch.
- Removed references to internal secrets.

Reference Material: 
[Overview of modifying permissions 
](https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#modifying-the-permissions-for-the-github_token)

[Permission breakdown](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token) of what allows what when modifying job permissions (solution used) 

Checking the API endpoints affected by setting 'pull-requests' > 'write' [lists the api endpoint we are using in the WF](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-pull-requests) to change the base branch 

