### PR TITLE
Refactor rule parsing

### DIFF
--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -211,7 +211,7 @@ class FunctionRule(Rule):
             case And(ops=(In(right=x), y)):
                 return (x,) + FunctionRule._get_patterns(y)
             case _:
-                raise AssertionError()
+                raise ValueError(f'Cannot extract argument list from pattern: {pattern.text}')
 
     @staticmethod
     def _extract_rhs(axiom: Axiom) -> tuple[App, Pattern, Pattern | None]:
@@ -271,7 +271,7 @@ def _extract_condition(pattern: Pattern) -> Pattern | None:
         case Equals(left=cond):
             return cond
         case _:
-            raise AssertionError()
+            raise ValueError(f'Cannot extract condition from pattern: {pattern.text}')
 
 
 def _extract_uid(axiom: Axiom) -> str:

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -177,12 +177,16 @@ class FunctionRule(Rule):
         # Cases 7-10 of get_left_hand_side
         # Cases 0-3 of get_requires
         match axiom.pattern:
-            case Implies(left=And(ops=(Not(), And(ops=(_req, pat))))):
-                return FunctionRule._get_patterns(pat), _extract_condition(_req)
-            case Implies(left=And(ops=(_req, pat))):
-                return FunctionRule._get_patterns(pat), _extract_condition(_req)
+            case Implies(left=And(ops=(Not(), And(ops=(_req, _args))))):
+                pass
+            case Implies(left=And(ops=(_req, _args))):
+                pass
             case _:
                 raise ValueError(f'Cannot extract LHS from axiom: {axiom.text}')
+
+        args = FunctionRule._get_patterns(_args)
+        req = _extract_condition(_req)
+        return args, req
 
     @staticmethod
     def _get_patterns(pattern: Pattern) -> tuple[Pattern, ...]:

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -56,7 +56,7 @@ class Rule(ABC):
             return RewriteRule.from_axiom(axiom)
 
         if 'simplification' in axiom.attrs_by_key:
-            return SimpliRule.from_axiom(axiom)
+            return AppRule.from_axiom(axiom)
 
         return FunctionRule.from_axiom(axiom)
 
@@ -192,9 +192,17 @@ class FunctionRule(Rule):
                 raise ValueError(f'Cannot extract argument list from pattern: {pattern.text}')
 
 
+class SimpliRule(Rule, ABC):
+    lhs: Pattern
+    rhs: Pattern
+    req: Pattern | None
+    ens: Pattern | None
+    priority: int
+
+
 @final
 @dataclass
-class SimpliRule(Rule):
+class AppRule(SimpliRule):
     lhs: App
     rhs: Pattern
     req: Pattern | None
@@ -202,10 +210,10 @@ class SimpliRule(Rule):
     priority: int
 
     @staticmethod
-    def from_axiom(axiom: Axiom) -> SimpliRule:
-        lhs, rhs, req, ens = SimpliRule._extract(axiom)
+    def from_axiom(axiom: Axiom) -> AppRule:
+        lhs, rhs, req, ens = AppRule._extract(axiom)
         priority = _extract_priority(axiom)
-        return SimpliRule(
+        return AppRule(
             lhs=lhs,
             rhs=rhs,
             req=req,

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -182,7 +182,7 @@ class FunctionRule(Rule):
                 ),
                 right=Equals(left=App() as app, right=_rhs),
             ):
-                args = FunctionRule._get_patterns(_args)
+                args = FunctionRule._extract_args(_args)
                 lhs = app.let(args=args)
                 req = _extract_condition(_req)
                 rhs, ens = _extract_rhs(_rhs)
@@ -191,14 +191,12 @@ class FunctionRule(Rule):
                 raise ValueError(f'Cannot extract function rule from axiom: {axiom.text}')
 
     @staticmethod
-    def _get_patterns(pattern: Pattern) -> tuple[Pattern, ...]:
-        # get_patterns(\top()) = []
-        # get_patterns(\and(\in(_, X), Y)) = X : get_patterns(Y)
+    def _extract_args(pattern: Pattern) -> tuple[Pattern, ...]:
         match pattern:
             case Top():
                 return ()
             case And(ops=(In(left=EVar(), right=arg), rest)):
-                return (arg,) + FunctionRule._get_patterns(rest)
+                return (arg,) + FunctionRule._extract_args(rest)
             case _:
                 raise ValueError(f'Cannot extract argument list from pattern: {pattern.text}')
 

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -103,7 +103,7 @@ class Rule(ABC):
 
 
 @final
-@dataclass
+@dataclass(frozen=True)
 class RewriteRule(Rule):
     lhs: App
     rhs: App
@@ -160,7 +160,7 @@ class RewriteRule(Rule):
 
 
 @final
-@dataclass
+@dataclass(frozen=True)
 class FunctionRule(Rule):
     lhs: App
     rhs: Pattern
@@ -225,7 +225,7 @@ class SimpliRule(Rule, Generic[P], ABC):
 
 
 @final
-@dataclass
+@dataclass(frozen=True)
 class AppRule(SimpliRule[App]):
     lhs: App
     rhs: Pattern
@@ -247,7 +247,7 @@ class AppRule(SimpliRule[App]):
 
 
 @final
-@dataclass
+@dataclass(frozen=True)
 class CeilRule(SimpliRule):
     lhs: Ceil
     rhs: Pattern
@@ -269,7 +269,7 @@ class CeilRule(SimpliRule):
 
 
 @final
-@dataclass
+@dataclass(frozen=True)
 class EqualsRule(SimpliRule):
     lhs: Equals
     rhs: Pattern

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -122,8 +122,6 @@ class RewriteRule(Rule):
         # Cases 0-5 of get_left_hand_side
         # Cases 5-10 of get_requires
         match axiom.pattern:
-            case Rewrites(left=And(ops=(Not(), And(ops=(_req, lhs))))):
-                pass
             case Rewrites(left=And(ops=(lhs, _req))):
                 pass
             case _:

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -246,12 +246,12 @@ class SimpliRule(Rule):
         # Cases 11-12 of get_left_hand_side
         # Case 0 of get_right_hand_side
         match axiom.pattern:
+            case Implies(right=Equals(left=Ceil())):
+                raise ValueError(f'Axiom is a ceil rule: {axiom.text}')
             case Implies(left=Top(), right=Equals(left=lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):
                 pass
             case Implies(left=Equals(left=req), right=Equals(left=lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):
                 pass
-            case Implies(right=Equals(left=Ceil())):
-                raise ValueError(f'Axiom is a ceil rule: {axiom.text}')
             case _:
                 raise ValueError(f'Cannot extract simplification rule from axiom: {axiom.text}')
         ens = _extract_ensures(_ens)

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -74,8 +74,7 @@ class Rule(ABC):
             return False
 
         match axiom.pattern:
-            case Implies(right=Equals(left=Ceil())):
-                # Ceil rule
+            case Implies(right=Equals(left=Ceil() | Equals())):
                 return False
 
         return True
@@ -246,8 +245,8 @@ class SimpliRule(Rule):
         # Cases 11-12 of get_left_hand_side
         # Case 0 of get_right_hand_side
         match axiom.pattern:
-            case Implies(right=Equals(left=Ceil())):
-                raise ValueError(f'Axiom is a ceil rule: {axiom.text}')
+            case Implies(right=Equals(left=Ceil() | Equals())):
+                raise ValueError(fr'Axiom is a \ceil or \equals rule: {axiom.text}')
             case Implies(left=Top(), right=Equals(left=lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):
                 pass
             case Implies(left=Equals(left=req), right=Equals(left=lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -241,8 +241,6 @@ class SimpliRule(Rule):
         match axiom.pattern:
             case Implies(left=_req, right=Equals(left=App() as lhs, right=And(ops=(rhs, _ens)))):
                 pass
-            case Implies(right=Equals(left=Ceil() | Equals())):
-                raise ValueError(fr'Axiom is a \ceil or \equals rule: {axiom.text}')
             case _:
                 raise ValueError(f'Cannot extract simplification rule from axiom: {axiom.text}')
         req = _extract_condition(_req)

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, final
 
 from .prelude import inj
-from .syntax import And, App, Axiom, Ceil, Equals, EVar, Implies, In, Not, Rewrites, SortVar, String, Top
+from .syntax import DV, And, App, Axiom, Ceil, Equals, EVar, Implies, In, Not, Rewrites, SortApp, SortVar, String, Top
 
 if TYPE_CHECKING:
     from typing import Final
@@ -232,7 +232,7 @@ def _extract_condition(pattern: Pattern) -> Pattern | None:
     match pattern:
         case Top():
             return None
-        case Equals(left=cond):
+        case Equals(left=cond, right=DV(SortApp('SortBool'), String('true'))):
             return cond
         case _:
             raise ValueError(f'Cannot extract condition from pattern: {pattern.text}')

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -208,8 +208,8 @@ class FunctionRule(Rule):
         match pattern:
             case Top():
                 return ()
-            case And(ops=(In(right=x), y)):
-                return (x,) + FunctionRule._get_patterns(y)
+            case And(ops=(In(left=EVar(), right=arg), rest)):
+                return (arg,) + FunctionRule._get_patterns(rest)
             case _:
                 raise ValueError(f'Cannot extract argument list from pattern: {pattern.text}')
 

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -73,9 +73,16 @@ class Rule(ABC):
         if any(attr in axiom.attrs_by_key for attr in _SKIPPED_ATTRS):
             return False
 
-        match axiom.pattern:
-            case Implies(right=Equals(left=Ceil() | Equals())):
-                return False
+        if 'simplification' in axiom.attrs_by_key:
+            match axiom.pattern:
+                case Implies(
+                    left=Top() | Equals(),
+                    right=Equals(
+                        left=Ceil() | Equals(),
+                        right=And(ops=(_, Top() | Equals())),
+                    ),
+                ):
+                    return False
 
         return True
 

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -1,8 +1,3 @@
-"""Parse KORE axioms into rewrite rules.
-
-Based on the [LLVM Backend's implementation](https://github.com/runtimeverification/llvm-backend/blob/d5eab4b0f0e610bc60843ebb482f79c043b92702/lib/ast/pattern_matching.cpp).
-"""
-
 from __future__ import annotations
 
 from abc import ABC
@@ -118,11 +113,6 @@ class RewriteRule(Rule):
 
     @staticmethod
     def _extract(axiom: Axiom) -> tuple[App, App, Pattern | None, Pattern | None, EVar | None]:
-        # Cases 0-5 of get_left_hand_side
-        # Cases 5-10 of get_requires
-        # Case 2 of get_right_hand_side:
-        # 2: rhs(\rewrites(_, \and(X, Y))) = get_builtin(\and(X, Y))
-        # Below is a special case without get_builtin
         match axiom.pattern:
             case Rewrites(left=And(ops=(_lhs, _req)), right=_rhs):
                 pass
@@ -172,9 +162,6 @@ class FunctionRule(Rule):
 
     @staticmethod
     def _extract(axiom: Axiom) -> tuple[App, Pattern, Pattern | None, Pattern | None]:
-        # Cases 7-10 of get_left_hand_side
-        # Cases 0-3 of get_requires
-        # Case 0 of get_right_hand_side
         match axiom.pattern:
             case Implies(
                 left=And(
@@ -224,8 +211,6 @@ class SimpliRule(Rule):
 
     @staticmethod
     def _extract(axiom: Axiom) -> tuple[App, Pattern, Pattern | None, Pattern | None]:
-        # Cases 11-12 of get_left_hand_side
-        # Case 0 of get_right_hand_side
         match axiom.pattern:
             case Implies(left=_req, right=Equals(left=App() as lhs, right=_rhs)):
                 req = _extract_condition(_req)

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from abc import ABC
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, final
@@ -13,6 +14,9 @@ if TYPE_CHECKING:
     from .syntax import Definition, Pattern
 
     Attrs = dict[str, tuple[Pattern, ...]]
+
+
+_LOGGER: Final = logging.getLogger(__name__)
 
 
 # There's a simplification rule with irregular form in the prelude module INJ.
@@ -77,6 +81,7 @@ class Rule(ABC):
                         right=And(ops=(_, Top() | Equals())),
                     ),
                 ):
+                    _LOGGER.info(fr'Skipping \ceil or \equals simplification rule: {axiom.text}')
                     return False
 
         return True

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -177,16 +177,16 @@ class FunctionRule(Rule):
         # Cases 7-10 of get_left_hand_side
         # Cases 0-3 of get_requires
         match axiom.pattern:
-            case Implies(left=And(ops=(Not(), And(ops=(_req, _args))))):
-                pass
-            case Implies(left=And(ops=(_req, _args))):
-                pass
+            case Implies(
+                left=And(
+                    ops=(Not(), And(ops=(_req, _args))) | (_req, _args),
+                ),
+            ):
+                args = FunctionRule._get_patterns(_args)
+                req = _extract_condition(_req)
+                return args, req
             case _:
                 raise ValueError(f'Cannot extract LHS from axiom: {axiom.text}')
-
-        args = FunctionRule._get_patterns(_args)
-        req = _extract_condition(_req)
-        return args, req
 
     @staticmethod
     def _get_patterns(pattern: Pattern) -> tuple[Pattern, ...]:
@@ -205,11 +205,10 @@ class FunctionRule(Rule):
         # Case 0 of get_right_hand_side
         match axiom.pattern:
             case Implies(right=Equals(left=App() as app, right=_rhs)):
-                pass
+                rhs, ens = _extract_rhs(_rhs)
+                return app, rhs, ens
             case _:
                 raise ValueError(f'Cannot extract RHS from axiom: {axiom.text}')
-        rhs, ens = _extract_rhs(_rhs)
-        return app, rhs, ens
 
 
 @final
@@ -239,12 +238,11 @@ class SimpliRule(Rule):
         # Case 0 of get_right_hand_side
         match axiom.pattern:
             case Implies(left=_req, right=Equals(left=App() as lhs, right=_rhs)):
-                pass
+                req = _extract_condition(_req)
+                rhs, ens = _extract_rhs(_rhs)
+                return lhs, rhs, req, ens
             case _:
                 raise ValueError(f'Cannot extract simplification rule from axiom: {axiom.text}')
-        req = _extract_condition(_req)
-        rhs, ens = _extract_rhs(_rhs)
-        return lhs, rhs, req, ens
 
 
 def _extract_rhs(pattern: Pattern) -> tuple[Pattern, Pattern | None]:

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -157,7 +157,7 @@ class RewriteRule(Rule):
                 pass
             case _:
                 raise ValueError(f'Cannot extract RHS from axiom: {axiom.text}')
-        ens = _extract_ensures(_ens)
+        ens = _extract_condition(_ens)
         return rhs, ens
 
 
@@ -221,7 +221,7 @@ class FunctionRule(Rule):
                 pass
             case _:
                 raise ValueError(f'Cannot extract RHS from axiom: {axiom.text}')
-        ens = _extract_ensures(_ens)
+        ens = _extract_condition(_ens)
         return app, rhs, ens
 
 
@@ -262,16 +262,16 @@ class SimpliRule(Rule):
                 raise ValueError(fr'Axiom is a \ceil or \equals rule: {axiom.text}')
             case _:
                 raise ValueError(f'Cannot extract simplification rule from axiom: {axiom.text}')
-        ens = _extract_ensures(_ens)
+        ens = _extract_condition(_ens)
         return lhs, rhs, req, ens
 
 
-def _extract_ensures(ens: Top | Equals | None) -> Pattern | None:
-    match ens:
+def _extract_condition(pattern: Top | Equals) -> Pattern | None:
+    match pattern:
         case Top():
             return None
-        case Equals(left=res):
-            return res
+        case Equals(left=cond):
+            return cond
         case _:
             raise AssertionError()
 

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -123,10 +123,6 @@ class RewriteRule(Rule):
         # Cases 0-5 of get_left_hand_side
         # Cases 5-10 of get_requires
         match axiom.pattern:
-            case Rewrites(left=And(ops=(Top(), lhs))):
-                pass
-            case Rewrites(left=And(ops=(Equals(left=req), lhs))):
-                pass
             case Rewrites(left=And(ops=(lhs, Top()))):
                 pass
             case Rewrites(left=And(ops=(lhs, Equals(left=req)))):

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -228,7 +228,7 @@ class FunctionRule(Rule):
 @final
 @dataclass
 class SimpliRule(Rule):
-    lhs: Pattern
+    lhs: App
     rhs: Pattern
     req: Pattern | None
     ens: Pattern | None
@@ -247,17 +247,19 @@ class SimpliRule(Rule):
         )
 
     @staticmethod
-    def _extract(axiom: Axiom) -> tuple[Pattern, Pattern, Pattern | None, Pattern | None]:
+    def _extract(axiom: Axiom) -> tuple[App, Pattern, Pattern | None, Pattern | None]:
         req: Pattern | None = None
         # Cases 11-12 of get_left_hand_side
         # Case 0 of get_right_hand_side
         match axiom.pattern:
+            case Implies(left=Top(), right=Equals(left=App() as lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):
+                pass
+            case Implies(
+                left=Equals(left=req), right=Equals(left=App() as lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))
+            ):
+                pass
             case Implies(right=Equals(left=Ceil() | Equals())):
                 raise ValueError(fr'Axiom is a \ceil or \equals rule: {axiom.text}')
-            case Implies(left=Top(), right=Equals(left=lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):
-                pass
-            case Implies(left=Equals(left=req), right=Equals(left=lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):
-                pass
             case _:
                 raise ValueError(f'Cannot extract simplification rule from axiom: {axiom.text}')
         ens = _extract_ensures(_ens)

--- a/pyk/src/pyk/kore/rule.py
+++ b/pyk/src/pyk/kore/rule.py
@@ -153,7 +153,7 @@ class RewriteRule(Rule):
         # 2: rhs(\rewrites(_, \and(X, Y))) = get_builtin(\and(X, Y))
         # Below is a special case without get_builtin
         match axiom.pattern:
-            case Rewrites(right=And(ops=(App("Lbl'-LT-'generatedTop'-GT-'") as rhs, Top() | Equals() as _ens))):
+            case Rewrites(right=And(ops=(App("Lbl'-LT-'generatedTop'-GT-'") as rhs, _ens))):
                 pass
             case _:
                 raise ValueError(f'Cannot extract RHS from axiom: {axiom.text}')
@@ -217,7 +217,7 @@ class FunctionRule(Rule):
     def _extract_rhs(axiom: Axiom) -> tuple[App, Pattern, Pattern | None]:
         # Case 0 of get_right_hand_side
         match axiom.pattern:
-            case Implies(right=Equals(left=App() as app, right=And(ops=(rhs, Top() | Equals() as _ens)))):
+            case Implies(right=Equals(left=App() as app, right=And(ops=(rhs, _ens)))):
                 pass
             case _:
                 raise ValueError(f'Cannot extract RHS from axiom: {axiom.text}')
@@ -252,11 +252,9 @@ class SimpliRule(Rule):
         # Cases 11-12 of get_left_hand_side
         # Case 0 of get_right_hand_side
         match axiom.pattern:
-            case Implies(left=Top(), right=Equals(left=App() as lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))):
+            case Implies(left=Top(), right=Equals(left=App() as lhs, right=And(ops=(rhs, _ens)))):
                 pass
-            case Implies(
-                left=Equals(left=req), right=Equals(left=App() as lhs, right=And(ops=(rhs, Top() | Equals() as _ens)))
-            ):
+            case Implies(left=Equals(left=req), right=Equals(left=App() as lhs, right=And(ops=(rhs, _ens)))):
                 pass
             case Implies(right=Equals(left=Ceil() | Equals())):
                 raise ValueError(fr'Axiom is a \ceil or \equals rule: {axiom.text}')
@@ -266,7 +264,7 @@ class SimpliRule(Rule):
         return lhs, rhs, req, ens
 
 
-def _extract_condition(pattern: Top | Equals) -> Pattern | None:
+def _extract_condition(pattern: Pattern) -> Pattern | None:
     match pattern:
         case Top():
             return None

--- a/pyk/src/tests/integration/kore/test_rule.py
+++ b/pyk/src/tests/integration/kore/test_rule.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 @pytest.fixture(scope='module')
 def definition(kompile: Kompiler) -> Definition:
     main_file = K_FILES / 'imp.k'
-    definition_dir = kompile(main_file=main_file)
+    definition_dir = kompile(main_file=main_file, backend='haskell')
     kore_file = definition_dir / 'definition.kore'
     kore_text = kore_file.read_text()
     definition = KoreParser(kore_text).definition()
@@ -33,4 +33,6 @@ def test_extract_all(definition: Definition) -> None:
     cnt = Counter(type(rule).__name__ for rule in rules)
     assert cnt['RewriteRule']
     assert cnt['FunctionRule']
-    assert cnt['SimpliRule']
+    assert cnt['AppRule']
+    assert cnt['CeilRule']
+    assert cnt['EqualsRule']


### PR DESCRIPTION
* Remove unnecessary cases
* Make pattern matching logic more concise
* Process three cases of simplification rules: `AppRule`, `CeilRule`, `EqualsRule`