### PR TITLE
add check for multiple config decls in one module

### DIFF
--- a/k-distribution/tests/regression-new/checks/checkMultipleConfig.k
+++ b/k-distribution/tests/regression-new/checks/checkMultipleConfig.k
@@ -1,0 +1,5 @@
+module CHECKMULTIPLECONFIG
+  imports INT
+  configuration <extraLocalConfig> 1 </extraLocalConfig>
+  configuration <mainConfig> <extraLocalConfig/> </mainConfig>
+endmodule

--- a/k-distribution/tests/regression-new/checks/checkMultipleConfig.k.out
+++ b/k-distribution/tests/regression-new/checks/checkMultipleConfig.k.out
@@ -1,0 +1,1 @@
+[Error] Compiler: Only one configuration declaration may be declared per module. Found 2 in module CHECKMULTIPLECONFIG.

--- a/k-frontend/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/k-frontend/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -360,13 +360,13 @@ public class DefinitionParsing {
                                   s instanceof Bubble
                                       && ((Bubble) s).sentenceType().equals(configuration))
                           .count();
-                  if (numConfigDecl == 0) {
+                  if (numConfigDecl == 1) {
                     return Module(
                         mod.name(),
                         mod.imports().$bar(Set(Import(mapModule, true))).toSet(),
                         mod.localSentences(),
                         mod.att());
-                  } else if (numConfigDecl != 1) {
+                  } else if (numConfigDecl != 0) {
                     throw KEMException.compilerError(
                         "Only one configuration declaration may be declared per module. Found "
                             + numConfigDecl

--- a/k-frontend/src/main/java/org/kframework/kompile/DefinitionParsing.java
+++ b/k-frontend/src/main/java/org/kframework/kompile/DefinitionParsing.java
@@ -353,18 +353,26 @@ public class DefinitionParsing {
     Definition definitionWithMapForConfig =
         DefinitionTransformer.from(
                 mod -> {
-                  boolean hasConfigDecl =
+                  long numConfigDecl =
                       stream(mod.localSentences())
-                          .anyMatch(
+                          .filter(
                               s ->
                                   s instanceof Bubble
-                                      && ((Bubble) s).sentenceType().equals(configuration));
-                  if (hasConfigDecl) {
+                                      && ((Bubble) s).sentenceType().equals(configuration))
+                          .count();
+                  if (numConfigDecl == 0) {
                     return Module(
                         mod.name(),
                         mod.imports().$bar(Set(Import(mapModule, true))).toSet(),
                         mod.localSentences(),
                         mod.att());
+                  } else if (numConfigDecl != 1) {
+                    throw KEMException.compilerError(
+                        "Only one configuration declaration may be declared per module. Found "
+                            + numConfigDecl
+                            + " in module "
+                            + mod.name()
+                            + ".");
                   }
                   return mod;
                 },


### PR DESCRIPTION
If multiple config declarations appear in one module, it can only even theoretically be well formed if one is supposed to be nested inside the other. However, in order to handle such a case, we would need to parse each one separately, check whether they contain nested declarations, check whether the nesting is acyclic, and then only after doing all that, process each declaration and produce syntax for them. This would be quite complex, however, no additional modularity is added by allowing this because there is no reason not to merge both config declarations into a single one if they are located in the same module.

This didn't work anyway, but the error message you got when this happened was quite unintuitive and it wasn't clear what was going on. So in this PR we add a much friendlier error message for this case to explain why the definition was rejected.