### PR TITLE
Generate injection instances

### DIFF
--- a/pyk/src/pyk/k2lean4/Prelude.lean
+++ b/pyk/src/pyk/k2lean4/Prelude.lean
@@ -4,3 +4,8 @@ abbrev SortId : Type := String
 abbrev SortInt : Type := Int
 abbrev SortString : Type := String
 abbrev SortStringBuffer : Type := String
+
+class Inj (From To : Type) : Type where
+  inj (x : From) : To
+
+def inj {From To : Type} [inst : Inj From To] := inst.inj

--- a/pyk/src/pyk/k2lean4/model.py
+++ b/pyk/src/pyk/k2lean4/model.py
@@ -136,6 +136,8 @@ class Instance(Declaration):
         ident: str | DeclId | None = None,
         modifiers: Modifiers | None = None,
     ):
+        if priority and priority < 0:
+            raise ValueError('Priority must be non-negative')
         if not signature.ty:
             # TODO refine type to avoid this check
             raise ValueError('Missing type from signature')

--- a/pyk/src/pyk/k2lean4/model.py
+++ b/pyk/src/pyk/k2lean4/model.py
@@ -150,7 +150,7 @@ class Instance(Declaration):
     def __str__(self) -> str:
         modifiers = f'{self.modifiers} ' if self.modifiers else ''
         attr_kind = f'{self.attr_kind.value} ' if self.attr_kind else ''
-        priority = f' priority := {self.priority}' if self.priority is not None else ''
+        priority = f' (priority := {self.priority})' if self.priority is not None else ''
         ident = f' {self.ident}' if self.ident else ''
         signature = f' {self.signature}' if self.signature else ''
 


### PR DESCRIPTION
Closes #4724

Generate an instance of `Inj Subsort Supersort` for each pairs `(Subsort, Supersort)`.

If `Subsort` has no subsorts, `inj` is just the corresponding constructor:

```lean
instance : Inj SortBalanceCell SortKItem where
  inj := SortKItem.inj_SortBalanceCell
```

otherwise, each injection into the subsort is handled with a case to ensure transitivity:

```lean
instance : Inj SortEndStatusCode SortKItem where
  inj
    | SortEndStatusCode.inj_SortExceptionalStatusCode x => SortKItem.inj_SortExceptionalStatusCode x
    | x => SortKItem.inj_SortEndStatusCode x
```

The default case is only generated if the subsort has actual constructors (i.e. ones not induced by subsorts).

```lean
instance : Inj SortTxData SortKItem where
  inj
    | SortTxData.inj_SortAccessListTx x => SortKItem.inj_SortAccessListTx x
    | SortTxData.inj_SortDynamicFeeTx x => SortKItem.inj_SortDynamicFeeTx x
    | SortTxData.inj_SortLegacyTx x => SortKItem.inj_SortLegacyTx x
``` 