### PR TITLE
 Fix build_rule

### DIFF
--- a/pyk/src/pyk/kast/inner.py
+++ b/pyk/src/pyk/kast/inner.py
@@ -877,6 +877,22 @@ def var_occurrences(term: KInner) -> dict[str, list[KVariable]]:
     return _var_occurrences
 
 
+def keep_vars_sorted(occurrences: dict[str, list[KVariable]]) -> dict[str, KVariable]:
+    """Keep the sort of variables from the occurrences dictionary."""
+    occurrences_sorted: dict[str, KVariable] = {}
+    for k, vs in occurrences.items():
+        sort = None
+        for v in vs:
+            if v.sort is not None:
+                if sort is None:
+                    sort = v.sort
+                elif sort != v.sort:
+                    sort = None
+                    break
+        occurrences_sorted[k] = KVariable(k, sort)
+    return occurrences_sorted
+
+
 def collect(callback: Callable[[KInner], None], kinner: KInner) -> None:
     """Collect information about a given term traversing it top-down using a function with side effects.
 

--- a/pyk/src/tests/integration/proof/test_refute_node.py
+++ b/pyk/src/tests/integration/proof/test_refute_node.py
@@ -295,7 +295,7 @@ class TestAPRProof(KCFGExploreTest, KProveTest):
         expected = KClaim(
             body=KRewrite(KApply('_<=Int_', KVariable('N', 'Int'), KToken('0', 'Int')), KToken('false', 'Bool')),
             requires=KApply(
-                '_<=Int_', KApply('_+Int_', KVariable('_L', None), KVariable('N', 'Int')), KToken('0', 'Int')
+                '_<=Int_', KApply('_+Int_', KVariable('_L', 'Int'), KVariable('N', 'Int')), KToken('0', 'Int')
             ),
             att=KAtt(entries=[Atts.LABEL('refute-node-claim')]),
         )

--- a/pyk/src/tests/unit/kast/test_inner.py
+++ b/pyk/src/tests/unit/kast/test_inner.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pyk.kast.inner import flatten_label
+from pyk.kast.inner import KVariable, flatten_label, keep_vars_sorted
 
 from ..utils import a, f, g, x, y, z
 
@@ -37,6 +37,31 @@ FLATTEN_LABEL_DATA: Final[tuple[tuple[str, KInner, list[KInner]], ...]] = (
 def test_flatten_label(label: str, kast: KInner, expected: list[KInner]) -> None:
     # When
     actual = flatten_label(label, kast)
+
+    # Then
+    assert actual == expected
+
+
+KEEP_VARS_SORTED_DATA: Final[tuple[tuple[dict[str, list[KVariable]], dict[str, KVariable]], ...]] = (
+    (
+        {'a': [KVariable('a'), KVariable('a')], 'b': [KVariable('b'), KVariable('b')]},
+        {'a': KVariable('a'), 'b': KVariable('b')},
+    ),
+    (
+        {'a': [KVariable('a', 'K'), KVariable('a', 'X')], 'b': [KVariable('b', 'K'), KVariable('b', 'X')]},
+        {'a': KVariable('a'), 'b': KVariable('b')},
+    ),
+    (
+        {'a': [KVariable('a', 'K'), KVariable('a')], 'b': [KVariable('b', 'K'), KVariable('b', 'K')]},
+        {'a': KVariable('a', 'K'), 'b': KVariable('b', 'K')},
+    ),
+)
+
+
+@pytest.mark.parametrize('occurrences,expected', KEEP_VARS_SORTED_DATA, ids=count())
+def test_keep_vars_sorted(occurrences: dict[str, list[KVariable]], expected: dict[str, KVariable]) -> None:
+    # When
+    actual = keep_vars_sorted(occurrences)
 
     # Then
     assert actual == expected

--- a/pyk/src/tests/unit/kast/test_inner.py
+++ b/pyk/src/tests/unit/kast/test_inner.py
@@ -55,6 +55,10 @@ KEEP_VARS_SORTED_DATA: Final[tuple[tuple[dict[str, list[KVariable]], dict[str, K
         {'a': [KVariable('a', 'K'), KVariable('a')], 'b': [KVariable('b', 'K'), KVariable('b', 'K')]},
         {'a': KVariable('a', 'K'), 'b': KVariable('b', 'K')},
     ),
+    (
+        {'a': [KVariable('a', 'A'), KVariable('a'), KVariable('a', 'B')]},
+        {'a': KVariable('a')},
+    ),
 )
 
 

--- a/pyk/src/tests/unit/test_cterm.py
+++ b/pyk/src/tests/unit/test_cterm.py
@@ -103,14 +103,14 @@ def test_cterm_match_with_constraint(t1: CTerm, t2: CTerm) -> None:
 
 BUILD_RULE_TEST_DATA: Final = (
     (
-        T(k(KVariable('K_CELL')), mem(KVariable('MEM_CELL'))),
+        T(k(KVariable('K_CELL', 'K')), mem(KVariable('MEM_CELL'))),
         T(
             k(KVariable('K_CELL')),
             mem(KApply('_[_<-_]', [KVariable('MEM_CELL'), KVariable('KEY'), KVariable('VALUE')])),
         ),
         ['K_CELL'],
         T(
-            k(KVariable('_K_CELL')),
+            k(KVariable('_K_CELL', 'K')),
             mem(
                 KRewrite(
                     KVariable('MEM_CELL'),


### PR DESCRIPTION
During the verification of automatic generated kclaim from summarization, current build_rule may lead to `Could not determine sort of term` error because the introduction of new variables in `build_rule`.

This PR tries the best to keep the sort of variables during their corresponding var introduction and keep its default behavior.