### PR TITLE
Generate rewrite relation

### DIFF
--- a/pyk/src/pyk/k2lean4/Prelude.lean
+++ b/pyk/src/pyk/k2lean4/Prelude.lean
@@ -20,7 +20,7 @@ These theorems should be provable directly from the function rules and the seman
  -/
 
 -- Basic K types
-abbrev SortBool         : Type := Int
+abbrev SortBool         : Type := Bool
 abbrev SortBytes        : Type := ByteArray
 abbrev SortId           : Type := String
 abbrev SortInt          : Type := Int

--- a/pyk/src/pyk/k2lean4/k2lean4.py
+++ b/pyk/src/pyk/k2lean4/k2lean4.py
@@ -7,6 +7,7 @@ from graphlib import TopologicalSorter
 from itertools import count
 from typing import TYPE_CHECKING, NamedTuple
 
+from ..dequote import bytes_encode
 from ..konvert import unmunge
 from ..kore.internal import CollectionKind
 from ..kore.kompiled import KoreSymbolTable
@@ -397,11 +398,15 @@ class K2Lean4:
             case 'SortBool' | 'SortInt':
                 return Term(value)
             case 'SortBytes':
-                raise ValueError('TODO')  # TODO
+                return self._transform_bytes_dv(value)
             case 'SortId' | 'SortString' | 'SortStringBuffer':
                 raise ValueError('TODO')  # TODO
             case _:
                 raise ValueError(f'Unsupported sort: {sort}')
+
+    def _transform_bytes_dv(self, value: str) -> Term:
+        bytes_str = ', '.join(f'0x{byte:02X}' for byte in bytes_encode(value))
+        return Term(f'⟨#[{bytes_str}⟩]')
 
     def _transform_app(self, symbol: str, args: Iterable[Pattern]) -> Term:
         if symbol in self.structure_symbols:

--- a/pyk/src/pyk/k2lean4/k2lean4.py
+++ b/pyk/src/pyk/k2lean4/k2lean4.py
@@ -375,7 +375,7 @@ class K2Lean4:
 
     def _def_binders(self, defs: Mapping[str, Pattern]) -> list[Binder]:
         return [
-            ExplBinder((f'def{ident}',), Term(f'{self._transform_pattern(pattern)} = some {ident}'))
+            ExplBinder((f'defn{ident}',), Term(f'{self._transform_pattern(pattern)} = some {ident}'))
             for ident, pattern in defs.items()
         ]
 

--- a/pyk/src/pyk/k2lean4/k2lean4.py
+++ b/pyk/src/pyk/k2lean4/k2lean4.py
@@ -454,8 +454,13 @@ class K2Lean4:
 
     def _transform_arg(self, pattern: Pattern) -> Term:
         term = self._transform_pattern(pattern)
+
         if not isinstance(pattern, App):
             return term
+
+        if pattern.symbol in self.structure_symbols:
+            return term
+
         return Term(f'({term})')
 
     def _transform_inj_app(self, sorts: tuple[Sort, ...], args: tuple[Pattern, ...]) -> Term:

--- a/pyk/src/pyk/k2lean4/k2lean4.py
+++ b/pyk/src/pyk/k2lean4/k2lean4.py
@@ -395,14 +395,20 @@ class K2Lean4:
 
     def _transform_dv(self, sort: str, value: str) -> Term:
         match sort:
-            case 'SortBool' | 'SortInt':
+            case 'SortBool':
                 return Term(value)
+            case 'SortInt':
+                return self._transform_int_dv(value)
             case 'SortBytes':
                 return self._transform_bytes_dv(value)
             case 'SortId' | 'SortString' | 'SortStringBuffer':
                 return self._transform_string_dv(value)
             case _:
                 raise ValueError(f'Unsupported sort: {sort}')
+
+    def _transform_int_dv(self, value: str) -> Term:
+        val = int(value)
+        return Term(str(val)) if val >= 0 else Term(f'({val})')
 
     def _transform_bytes_dv(self, value: str) -> Term:
         bytes_str = ', '.join(f'0x{byte:02X}' for byte in bytes_encode(value))

--- a/pyk/src/pyk/kore/internal.py
+++ b/pyk/src/pyk/kore/internal.py
@@ -86,6 +86,8 @@ class KoreDefn:
                     sorts[name] = sent
                 case SymbolDecl(Symbol(name)):
                     symbols[name] = sent
+                    if 'function' in sent.attrs_by_key:
+                        functions.setdefault(name, [])
                 case Axiom(attrs=(App('subsort', (SortApp(subsort), SortApp(supersort))),)):
                     subsorts.append((subsort, supersort))
                 case Axiom():


### PR DESCRIPTION
Closes #4728

Generates an inductive type `Rewrites : GeneratedTopCell -> GeneratedTopCell -> Prop` where each constructor (except for the first one which expresses transitivity) encodes a K rewrite rule.

Each constructor has the following signature:
* An implicit binder for each free variable.
* An explicit binder for each function application which expresses definedness of the function over the arguments.
* An explicit binder for the requires clause.
* The type `Rewrites <lhs> <rhs>`.