### PR TITLE
Generate function definitions

### DIFF
--- a/k-frontend/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
+++ b/k-frontend/src/main/java/org/kframework/backend/kore/ModuleToKORE.java
@@ -34,6 +34,7 @@ import org.kframework.builtin.Sorts;
 import org.kframework.compile.AddSortInjections;
 import org.kframework.compile.ComputeTransitiveFunctionDependencies;
 import org.kframework.compile.ExpandMacros;
+import org.kframework.compile.NumberSentences;
 import org.kframework.compile.RefreshRules;
 import org.kframework.compile.RewriteToTop;
 import org.kframework.definition.Claim;
@@ -723,6 +724,7 @@ public class ModuleToKORE {
             BooleanUtils.TRUE,
             BooleanUtils.TRUE,
             Att.empty().add(Att.SIMPLIFICATION()));
+    ceilMapRule = (Rule) NumberSentences.number(ceilMapRule);
     rules.add(ceilMapRule);
   }
 

--- a/pyk/src/pyk/klean/generate.py
+++ b/pyk/src/pyk/klean/generate.py
@@ -26,9 +26,9 @@ def generate(
     k2lean4 = K2Lean4(defn)
     genmodel = {
         'Sorts': (k2lean4.sort_module, ['Prelude']),
-        'Func': (k2lean4.func_module, ['Sorts']),
         'Inj': (k2lean4.inj_module, ['Sorts']),
-        'Rewrite': (k2lean4.rewrite_module, ['Func', 'Inj']),
+        'Func': (k2lean4.func_module, ['Inj']),
+        'Rewrite': (k2lean4.rewrite_module, ['Func']),
     }
 
     modules = _gen_modules(context['library_name'], genmodel)

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -350,8 +350,9 @@ class K2Lean4:
             rule_str = sorted_rules[0]
             term = Term(f'{rule_str}{arg_str}')
         else:
-            rules_str = f'[{", ".join(sorted_rules)}]'
-            term = Term(f'{rules_str}.findSome? (·{arg_str})')
+            assert arg_str  # a function with multiple rules is not nullary
+            rules_str = ' <|> '.join(f'({rule_str}{arg_str})' for rule_str in sorted_rules)
+            term = Term(rules_str)
 
         val = SimpleVal(term)
         func = decl.symbol.name

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -426,7 +426,7 @@ class K2Lean4:
 
     def _transform_bytes_dv(self, value: str) -> Term:
         bytes_str = ', '.join(f'0x{byte:02X}' for byte in bytes_encode(value))
-        return Term(f'⟨#[{bytes_str}⟩]')
+        return Term(f'⟨#[{bytes_str}]⟩')
 
     def _transform_string_dv(self, value: str) -> Term:
         escapes = {

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -517,7 +517,7 @@ def _param_sorts(decl: SymbolDecl) -> list[str]:
 
 def _ordered_sorts(defn: KoreDefn) -> list[list[str]]:
     deps = _sort_dependencies(defn)
-    sccs = _sort_sccs(deps)
+    sccs = _sccs(deps)
 
     sorts_by_scc: dict[int, set[str]] = {}
     for sort, scc in sccs.items():
@@ -565,17 +565,17 @@ def _sort_dependencies(defn: KoreDefn) -> dict[str, set[str]]:
 
 
 # TODO Implement a more efficient algorithm, e.g. Tarjan's algorithm
-def _sort_sccs(deps: dict[str, set[str]]) -> dict[str, int]:
+def _sccs(deps: dict[str, set[str]]) -> dict[str, int]:
     res: dict[str, int] = {}
 
     scc = count()
-    for sort, dep_sorts in deps.items():
-        if sort in res:
+    for elem, dep_elems in deps.items():
+        if elem in res:
             continue
         idx = next(scc)
-        res[sort] = idx
-        for dep in dep_sorts:
-            if sort in deps[dep]:
+        res[elem] = idx
+        for dep in dep_elems:
+            if elem in deps[dep]:
                 res[dep] = idx
 
     return res

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -378,6 +378,9 @@ class K2Lean4:
         if not isinstance(pattern, App):
             return term
 
+        if not pattern.args:
+            return term
+
         if pattern.symbol in self.structure_symbols:
             return term
 

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -251,10 +251,10 @@ class K2Lean4:
         return res
 
     def func_module(self) -> Module:
-        commands = [self._transform_func(func) for func in self.defn.functions]
+        commands = [self._func_axiom(func) for func in self.defn.functions]
         return Module(commands=commands)
 
-    def _transform_func(self, func: str) -> Axiom:
+    def _func_axiom(self, func: str) -> Axiom:
         ident = _symbol_ident(func)
         decl = self.defn.symbols[func]
         sort_params = [var.name for var in decl.symbol.vars]

--- a/pyk/src/pyk/klean/model.py
+++ b/pyk/src/pyk/klean/model.py
@@ -197,6 +197,52 @@ class Instance(Declaration):
                 raise AssertionError()
 
 
+class Definition(Declaration):
+    ident: DeclId
+    val: DeclVal
+    signature: Signature | None
+    deriving: tuple[str, ...]
+    modifiers: Modifiers | None
+
+    def __init__(
+        self,
+        ident: str | DeclId,
+        val: DeclVal,
+        signature: Signature | None = None,
+        deriving: Iterable[str] | None = None,
+        modifiers: Modifiers | None = None,
+    ):
+        ident = DeclId(ident) if isinstance(ident, str) else ident
+        deriving = tuple(deriving) if deriving is not None else ()
+        object.__setattr__(self, 'ident', ident)
+        object.__setattr__(self, 'val', val)
+        object.__setattr__(self, 'signature', signature)
+        object.__setattr__(self, 'deriving', deriving)
+        object.__setattr__(self, 'modifiers', modifiers)
+
+    def __str__(self) -> str:
+        modifiers = f'{self.modifiers} ' if self.modifiers else ''
+        signature = f' {self.signature}' if self.signature else ''
+
+        decl = f'{modifiers}def {self.ident}{signature}'
+
+        lines = []
+        match self.val:
+            case SimpleVal():
+                lines.append(f'{decl} := {self.val}')
+            case StructVal(fields):
+                lines.append(f'{decl} where')
+                lines.extend(indent(str(field), 2) for field in fields)
+            case _:
+                raise AssertionError()
+
+        if self.deriving:
+            deriving = ', '.join(self.deriving)
+            lines.append(f'  deriving {deriving}')
+
+        return '\n'.join(lines)
+
+
 class DeclVal(ABC): ...
 
 

--- a/pyk/src/pyk/klean/model.py
+++ b/pyk/src/pyk/klean/model.py
@@ -233,8 +233,9 @@ class Definition(Declaration):
             case StructVal(fields):
                 lines.append(f'{decl} where')
                 lines.extend(indent(str(field), 2) for field in fields)
-            case _:
-                raise AssertionError()
+            case AltsVal(alts):
+                lines.append(f'{decl}')
+                lines.extend(indent(str(alt), 2) for alt in alts)
 
         if self.deriving:
             deriving = ', '.join(self.deriving)
@@ -265,6 +266,18 @@ class StructVal(DeclVal):
 
     def __str__(self) -> str:
         return indent('\n'.join(str(field) for field in self.fields), 2)
+
+
+@final
+@dataclass(frozen=True)
+class AltsVal(DeclVal):
+    alts: tuple[Alt, ...]
+
+    def __init__(self, alts: Iterable[Alt]):
+        object.__setattr__(self, 'alts', tuple(alts))
+
+    def __str__(self) -> str:
+        return indent('\n'.join(str(alt) for alt in self.alts), 2)
 
 
 @final

--- a/pyk/src/pyk/klean/template/{{ cookiecutter.package_name }}/{{ cookiecutter.library_name }}/Prelude.lean
+++ b/pyk/src/pyk/klean/template/{{ cookiecutter.package_name }}/{{ cookiecutter.library_name }}/Prelude.lean
@@ -210,3 +210,8 @@ class Inj (From To : Type) : Type where
   inj (x : From) : To
 
 def inj {From To : Type} [inst : Inj From To] := inst.inj
+
+def «_+Int_» (x0 : SortInt) (x1 : SortInt) : Option SortInt := some (x0 + x1)
+def «_-Int_» (x0 : SortInt) (x1 : SortInt) : Option SortInt := some (x0 - x1)
+def «_*Int_» (x0 : SortInt) (x1 : SortInt) : Option SortInt := some (x0 * x1)
+def «_<=Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool := some (x0 <= x1)


### PR DESCRIPTION
Closes #4727

Generate a function definition for each (interpreted) function symbol and each function rule.

The definition for a function symbols applies its rule functions in an order respecting priorities:

```lean
def «#lookup(_,_)_IMP_KItem_Id_Map» (x0 : SortId) (x1 : SortMap) : Option SortKItem :=
  [_acfc941, _0e4f65f].findSome? (· x0 x1)
```

A function rule evaluates to `none` if
* the LHS pattern doesn't match;
* a function application is the requires clause or the RHS is undefined;
* the requires clause does not hold;
 
and to `some` otherwise:

```lean
def _acfc941 : SortId → SortMap → Option SortKItem
  | X, M => do
    let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortId SortKItem) X) M
    let _Val1 <- «Map:lookup» M ((@inj SortId SortKItem) X)
    guard _Val0
    return _Val1

def _0e4f65f : SortId → SortMap → Option SortKItem
  | X, M => some (SortKItem.«Error(_,_)_IMP_KItem_Id_Map» X M)
```

Function definitions depending on an uninterpreted function are marked `noncomputable`.