### PR TITLE
Process complex LHS patterns in function rules

### DIFF
--- a/pyk/poetry.lock
+++ b/pyk/poetry.lock
@@ -915,6 +915,25 @@ files = [
 ]
 
 [[package]]
+name = "networkx"
+version = "3.4.2"
+description = "Python package for creating and manipulating graphs and networks"
+optional = false
+python-versions = ">=3.10"
+files = [
+    {file = "networkx-3.4.2-py3-none-any.whl", hash = "sha256:df5d4365b724cf81b8c6a7312509d0c22386097011ad1abe274afd5e9d3bbc5f"},
+    {file = "networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1"},
+]
+
+[package.extras]
+default = ["matplotlib (>=3.7)", "numpy (>=1.24)", "pandas (>=2.0)", "scipy (>=1.10,!=1.11.0,!=1.11.1)"]
+developer = ["changelist (==0.5)", "mypy (>=1.1)", "pre-commit (>=3.2)", "rtoml"]
+doc = ["intersphinx-registry", "myst-nb (>=1.1)", "numpydoc (>=1.8.0)", "pillow (>=9.4)", "pydata-sphinx-theme (>=0.15)", "sphinx (>=7.3)", "sphinx-gallery (>=0.16)", "texext (>=0.6.7)"]
+example = ["cairocffi (>=1.7)", "contextily (>=1.6)", "igraph (>=0.11)", "momepy (>=0.7.2)", "osmnx (>=1.9)", "scikit-learn (>=1.5)", "seaborn (>=0.13)"]
+extra = ["lxml (>=4.6)", "pydot (>=3.0.1)", "pygraphviz (>=1.14)", "sympy (>=1.10)"]
+test = ["pytest (>=7.2)", "pytest-cov (>=4.0)"]
+
+[[package]]
 name = "packaging"
 version = "24.1"
 description = "Core utilities for Python packages"
@@ -1578,4 +1597,4 @@ test = ["big-O", "importlib-resources ; python_version < \"3.9\"", "jaraco.funct
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "d68e4d3e42c6afe82f422433eb2260b436cc4001a839646c108b84de9c444296"
+content-hash = "d9ef3b1975fe061f9dfbb4e1408b0dee5af5ea0bcb2dee2262dc11d548025877"

--- a/pyk/pyproject.toml
+++ b/pyk/pyproject.toml
@@ -23,6 +23,7 @@ cookiecutter = "^2.6.0"
 filelock = "^3.9.0"
 graphviz = "^0.20.1"
 hypothesis = "^6.103.1"
+networkx = "^3.4.2"
 psutil = "^5.9.5"
 pybind11 = "^2.10.3"
 pytest = "*"
@@ -96,4 +97,8 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = "cookiecutter.*"
+ignore_missing_imports = true
+
+[[tool.mypy.overrides]]
+module = "networkx"
 ignore_missing_imports = true

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -645,35 +645,35 @@ class K2Lean4:
                 pterm = self._transform_arg(pat, concrete=True)
                 return Term(f'(@retr {subsort} {supersort}) {var}'), Term(f'some {pterm}')
             case ListMatcher(_, prefix, middle, suffix):
-                arg = Term(f'ListHook.split {var} {len(prefix)} {len(suffix)}')
+                arg = Term(f'(ListHook SortKItem).split {var}.coll {len(prefix)} {len(suffix)}')
                 pterm = list_from(prefix)
                 mterm = self._transform_pattern(middle, concrete=True)
                 sterm = list_from(suffix)
                 pattern = Term(f'some ({pterm}, {mterm}, {sterm})')
                 return arg, pattern
             case EmptyListMatcher(_):
-                arg = Term(f'ListHook.size {var}')
+                arg = Term(f'(ListHook SortKItem).size {var}.coll')
                 pattern = Term('0')
                 return arg, pattern
             case SetMatcher(_, elems, rest):
                 eterm = list_from(elems)
                 rterm = self._transform_arg(rest, concrete=True)
-                arg = Term(f'SetHook.split {var} {eterm}')
+                arg = Term(f'(SetHook SortKItem).split {var}.coll {eterm}')
                 pattern = Term(f'some {rterm}')
                 return arg, pattern
             case EmptySetMatcher(_):
-                arg = Term(f'SetHook.size {var}')
+                arg = Term(f'(SetHook SortKItem).size {var}.coll')
                 pattern = Term('0')
                 return arg, pattern
             case MapMatcher(_, keys, values, rest):
                 kterm = list_from(keys)
-                arg = Term(f'MapHook.split {var} {kterm}')
+                arg = Term(f'(MapHook SortKItem).split {var}.coll {kterm}')
                 vterm = list_from(values)
                 rterm = self._transform_pattern(rest, concrete=True)
                 pattern = Term(f'some ({vterm}, {rterm})')
                 return arg, pattern
             case EmptyMapMatcher(_):
-                arg = Term(f'MapHook.size {var}')
+                arg = Term(f'(MapHook SortKItem).size {var}.coll')
                 pattern = Term('0')
                 return arg, pattern
             case _:

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -806,6 +806,10 @@ class K2Lean4:
                     var = EVar(next(free), SortApp('SortList'))
                     matchers.append(ListMatcher(var, (head,), tail, ()))
                     return var
+                case App("Lbl'Unds'List'Unds'", (), (init, App('LblListItem', (), (last,)))):
+                    var = EVar(next(free), SortApp('SortList'))
+                    matchers.append(ListMatcher(var, (), init, (last,)))
+                    return var
                 case App("Lbl'Stop'List"):
                     var = EVar(next(free), SortApp('SortList'))
                     matchers.append(EmptyListMatcher(var))

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -14,7 +14,7 @@ from ..dequote import bytes_encode
 from ..konvert import unmunge
 from ..kore.internal import CollectionKind
 from ..kore.kompiled import KoreSymbolTable
-from ..kore.manip import collect_symbols, elim_aliases, free_occs
+from ..kore.manip import collect_symbols, elim_aliases, free_occs, rename_unique
 from ..kore.syntax import DV, And, App, EVar, SortApp, String, Top
 from ..utils import FrozenDict, POSet
 from .model import (
@@ -783,7 +783,8 @@ class K2Lean4:
             generations = nx.topological_generations(dg)
             return [[matchers[i] for i in generation] for generation in generations]
 
-        pattern = lhs.bottom_up(abstract_matchers)
+        pattern, _eq_classes = rename_unique(lhs, (f"Var'Unds'Uniq{i}" for i in count()))
+        pattern = pattern.bottom_up(abstract_matchers)
         assert isinstance(pattern, App)
         ordered = order_matchers(matchers)
 

--- a/pyk/src/pyk/klean/template/{{ cookiecutter.package_name }}/{{ cookiecutter.library_name }}/Prelude.lean
+++ b/pyk/src/pyk/klean/template/{{ cookiecutter.package_name }}/{{ cookiecutter.library_name }}/Prelude.lean
@@ -54,6 +54,7 @@ structure MapHookSig (K V : Type) where
   includes   : map → map → Bool -- map inclusion
   choice     : map → K -- arbitrary key from a map
   nodup      : forall al : map, List.Nodup (keys al)
+  split      : map → List K → Option (List V × map)
 
 -- We use axioms to have uninterpreted functions
 namespace MapHookDef
@@ -76,6 +77,7 @@ namespace MapHookDef
   axiom includesAx   : mapCAx K V → mapCAx K V → Bool -- map inclusion
   axiom choiceAx     : mapCAx K V → K -- arbitrary key from a map
   axiom nodupAx      : forall m, List.Nodup (keysAx K V m)
+  axiom splitAx      : mapCAx K V → List K → Option (List V × (mapCAx K V))
 end MapHookDef
 
 -- Uninterpreted Map implementation
@@ -97,7 +99,8 @@ noncomputable def MapHook (K V : Type) : MapHookSig K V :=
     size       := MapHookDef.sizeAx K V,
     includes   := MapHookDef.includesAx K V,
     choice     := MapHookDef.choiceAx K V,
-    nodup      := MapHookDef.nodupAx K V}
+    nodup      := MapHookDef.nodupAx K V,
+    split      := MapHookDef.splitAx K V }
 
 instance {K V : Type} [BEq K] [BEq V]: BEq (MapHook K V).map where
   beq := List.beq
@@ -120,6 +123,7 @@ structure SetHookSig (T : Type) where
   inclusion    : set → set → Bool
   size         : set → Int
   choice       : set → T
+  split        : set → List T → Option set
 
 namespace SetHookDef
   variable (T : Type)
@@ -134,6 +138,7 @@ namespace SetHookDef
   axiom inclusionAx    : setCAx T → setCAx T → Bool
   axiom sizeAx         : setCAx T → Int
   axiom choiceAx       : setCAx T → T
+  axiom splitAx        : setCAx T → List T → Option (setCAx T)
 end SetHookDef
 
 noncomputable def SetHook (T : Type) : SetHookSig T :=
@@ -147,7 +152,8 @@ noncomputable def SetHook (T : Type) : SetHookSig T :=
     inSet        := SetHookDef.inSetAx T,
     inclusion    := SetHookDef.inclusionAx T,
     size         := SetHookDef.sizeAx T,
-    choice       := SetHookDef.choiceAx T }
+    choice       := SetHookDef.choiceAx T,
+    split        := SetHookDef.splitAx T }
 
 /-
 The `List` sort is an ordered collection that may contain duplicate elements.
@@ -176,6 +182,8 @@ structure listHookSig (T : Type) where
   -- the hook is `in`, but clashes with Lean syntax
   inList    : T → list → Bool
   size      : list → Int
+  -- split list into prefix, middle and postfix, given prefix and postfix length
+  split     : list → Nat → Nat → Option (List T × list × List T)
 
 namespace ListHookDef
   variable (T : Type)
@@ -192,6 +200,7 @@ namespace ListHookDef
   axiom rangeAx     : listCAx T → Int → Int → Option (listCAx T)
   axiom inListAx    : T → listCAx T → Bool
   axiom sizeAx      : listCAx T → Int
+  axiom splitAx     : listCAx T → Nat → Nat → Option (List T × (listCAx T) × List T)
 end ListHookDef
 
 noncomputable def ListHook (T : Type) : listHookSig T :=
@@ -207,7 +216,8 @@ noncomputable def ListHook (T : Type) : listHookSig T :=
     fill      := ListHookDef.fillAx T,
     range     := ListHookDef.rangeAx T,
     inList    := ListHookDef.inListAx T,
-    size      := ListHookDef.sizeAx T }
+    size      := ListHookDef.sizeAx T,
+    split     := ListHookDef.splitAx T }
 
 class Inj (From To : Type) : Type where
   inj (x : From) : To

--- a/pyk/src/pyk/klean/template/{{ cookiecutter.package_name }}/{{ cookiecutter.library_name }}/Prelude.lean
+++ b/pyk/src/pyk/klean/template/{{ cookiecutter.package_name }}/{{ cookiecutter.library_name }}/Prelude.lean
@@ -221,8 +221,10 @@ noncomputable def ListHook (T : Type) : listHookSig T :=
 
 class Inj (From To : Type) : Type where
   inj (x : From) : To
+  retr (x : To) : Option From
 
 def inj {From To : Type} [inst : Inj From To] := inst.inj
+def retr {From To : Type} [inst : Inj From To] := inst.retr
 
 def «_+Int_» (x0 : SortInt) (x1 : SortInt) : Option SortInt := some (x0 + x1)
 def «_-Int_» (x0 : SortInt) (x1 : SortInt) : Option SortInt := some (x0 - x1)

--- a/pyk/src/pyk/kore/manip.py
+++ b/pyk/src/pyk/kore/manip.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-from itertools import count
 from typing import TYPE_CHECKING
 
 from .syntax import And, App, EVar, MLQuant, Top
 
 if TYPE_CHECKING:
-    from collections.abc import Collection, Iterator
+    from collections.abc import Collection
 
     from .syntax import Pattern
 
@@ -56,31 +55,6 @@ def collect_symbols(pattern: Pattern) -> set[str]:
 
     pattern.collect(add_symbol)
     return res
-
-
-def rename_unique(pattern: Pattern, free: Iterator[str]) -> tuple[Pattern, dict[EVar, int]]:
-    var_names = set(free_occs(pattern))
-    class_idx = count()
-    classes = {}
-
-    def rename(pattern: Pattern) -> Pattern:
-        match pattern:
-            case EVar() as var:
-                if var not in classes:
-                    classes[var] = next(class_idx)
-                    return pattern
-
-                while (new_name := next(free)) in var_names:
-                    continue
-
-                var_names.add(new_name)
-                new_var = pattern.let(name=new_name)
-                classes[new_var] = classes[var]
-                return new_var
-            case _:
-                return pattern
-
-    return pattern.bottom_up(rename), classes
 
 
 def elim_aliases(pattern: Pattern) -> Pattern:

--- a/pyk/src/pyk/kore/manip.py
+++ b/pyk/src/pyk/kore/manip.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+from itertools import count
 from typing import TYPE_CHECKING
 
 from .syntax import And, App, EVar, MLQuant, Top
 
 if TYPE_CHECKING:
-    from collections.abc import Collection
+    from collections.abc import Collection, Iterator
 
     from .syntax import Pattern
 
@@ -55,6 +56,31 @@ def collect_symbols(pattern: Pattern) -> set[str]:
 
     pattern.collect(add_symbol)
     return res
+
+
+def rename_unique(pattern: Pattern, free: Iterator[str]) -> tuple[Pattern, dict[EVar, int]]:
+    var_names = set(free_occs(pattern))
+    class_idx = count()
+    classes = {}
+
+    def rename(pattern: Pattern) -> Pattern:
+        match pattern:
+            case EVar() as var:
+                if var not in classes:
+                    classes[var] = next(class_idx)
+                    return pattern
+
+                while (new_name := next(free)) in var_names:
+                    continue
+
+                var_names.add(new_name)
+                new_var = pattern.let(name=new_name)
+                classes[new_var] = classes[var]
+                return new_var
+            case _:
+                return pattern
+
+    return pattern.bottom_up(rename), classes
 
 
 def elim_aliases(pattern: Pattern) -> Pattern:


### PR DESCRIPTION
Eliminates patterns that are not supported by Lean from the LHS of function rules.

For example, since `_List_` is a function, instead of matching the last item of a list as

```lean
noncomputable def _2ede380 : SortList → Option SortInt
  | _List_ _Gen0 (ListItem (SortKItem.inj_SortInt I)) => ...
  | _ => none
```

the following definition is generated:

```lean
noncomputable def _2ede380 : SortList → Option SortInt
  | _Pat0 => match (ListHook SortKItem).split _Pat0.coll 0 1 with
    | some ([], _Gen0, [SortKItem.inj_SortInt I]) => ...
    | _ => none
```

where `split` is repsonsible for deconstructing the list into prefix, middle and suffix.