### PR TITLE
Add support for generating `deriving` clause

### DIFF
--- a/pyk/src/pyk/klean/README.md
+++ b/pyk/src/pyk/klean/README.md
@@ -10,19 +10,21 @@ After installation of the `kframework` package, the code generator is available
 on the command line under the `klean` command.
 
 ```
-usage: klean [-h] [-o DIR] [-l NAME] [-r LABEL] DEFN_DIR PKG_NAME
+usage: klean [-h] [-o DIR] [-l NAME] [-r LABEL] [--derive-beq] [--derive-decidableeq] DEFN_DIR PKG_NAME
 
 Generate a Lean 4 project from a K definition
 
 positional arguments:
-  DEFN_DIR            definition directory
-  PKG_NAME            name of the generated Lean 4 package (in kebab-case)
+  DEFN_DIR              definition directory
+  PKG_NAME              name of the generated Lean 4 package (in kebab-case)
 
 options:
-  -h, --help          show this help message and exit
-  -o, --output DIR    output directory (default: .)
-  -l, --library NAME  name of the generated Lean library (default: package name in PascalCase)
-  -r, --rule LABEL    labels of rules to include (default: all)
+  -h, --help            show this help message and exit
+  -o, --output DIR      output directory (default: .)
+  -l, --library NAME    name of the generated Lean library (default: package name in PascalCase)
+  -r, --rule LABEL      labels of rules to include (default: all)
+  --derive-beq          derive BEq for all types
+  --derive-decidableeq  derive DecidableEq for all types except SortKItem and its dependents
 ```
 
 The `-r` flag can be provided multiple times, each time with a rule label, to

--- a/pyk/src/pyk/klean/__main__.py
+++ b/pyk/src/pyk/klean/__main__.py
@@ -70,6 +70,10 @@ def klean(args: Iterable[str]) -> None:
             'package_name': ns.package_name,
             'library_name': ns.library_name,
         },
+        config={
+            'derive_beq': ns.derive_beq,
+            'derive_decidableeq': ns.derive_decidableeq,
+        },
     )
 
 
@@ -113,6 +117,16 @@ def _parser() -> ArgumentParser:
         metavar='LABEL',
         action='append',
         help='labels of rules to include (default: all)',
+    )
+    parser.add_argument(
+        '--derive-beq',
+        action='store_true',
+        help='derive BEq for all types',
+    )
+    parser.add_argument(
+        '--derive-decidableeq',
+        action='store_true',
+        help='derive DecidableEq for all types except SortKItem and its dependents',
     )
     return parser
 

--- a/pyk/src/pyk/klean/generate.py
+++ b/pyk/src/pyk/klean/generate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import TYPE_CHECKING, TypedDict
 
-from .k2lean4 import K2Lean4
+from . import k2lean4 as k2l
 from .model import Module
 
 if TYPE_CHECKING:
@@ -22,8 +22,9 @@ def generate(
     defn: KoreDefn,
     context: GenContext,
     output_dir: Path,
+    config: k2l.Config | None = None,
 ) -> Path:
-    k2lean4 = K2Lean4(defn)
+    k2lean4 = k2l.K2Lean4(defn, config=config)
     genmodel = {
         'Sorts': (k2lean4.sort_module, ['Prelude']),
         'Inj': (k2lean4.inj_module, ['Sorts']),

--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from functools import cached_property
 from graphlib import TopologicalSorter
 from itertools import count
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, TypedDict
 
 from ..dequote import bytes_encode
 from ..konvert import unmunge
@@ -66,9 +66,22 @@ class Field(NamedTuple):
     ty: Term
 
 
-@dataclass(frozen=True)
+class Config(TypedDict, total=False):
+    derive_beq: bool | None
+    derive_decidableeq: bool | None
+
+
+@dataclass
 class K2Lean4:
     defn: KoreDefn
+    derive_beq: bool
+    derive_decidableeq: bool
+
+    def __init__(self, defn: KoreDefn, *, config: Config | None = None):
+        config = config or {}
+        self.defn = defn
+        self.derive_beq = bool(config.get('derive_beq'))
+        self.derive_decidableeq = bool(config.get('derive_decidableeq'))
 
     @cached_property
     def symbol_table(self) -> KoreSymbolTable:

--- a/pyk/src/pyk/klean/model.py
+++ b/pyk/src/pyk/klean/model.py
@@ -391,11 +391,12 @@ class Structure(Declaration):
         where = ' where' if self.ctor else ''
         lines.append(f'{modifiers}structure {self.ident}{binders}{extends}{ty}{where}')
 
-        if self.deriving:
-            lines.append(f'  deriving {self.deriving}')
-
         if self.ctor:
             lines.extend(f'  {line}' for line in str(self.ctor).splitlines())
+
+        if self.deriving:
+            deriving = ', '.join(self.deriving)
+            lines.append(f'  deriving {deriving}')
 
         return '\n'.join(lines)
 

--- a/pyk/src/tests/integration/klean/test_generate.py
+++ b/pyk/src/tests/integration/klean/test_generate.py
@@ -48,6 +48,10 @@ def test_generate(
             'package_name': 'klean-imp',
             'library_name': 'KLeanImp',
         },
+        config={
+            'derive_beq': True,
+            'derive_decidableeq': True,
+        },
     )
 
     proc_res = run_process_2(['lake', 'build'], cwd=project_dir, check=False)


### PR DESCRIPTION
Adds command line flags `--derive-beq` and `--derive-decidableeq`, which enable generating `deriving` clauses for the respective instances.