### PR TITLE
Pretty-print constructor rules

### DIFF
--- a/pyk/src/pyk/klean/k2lean4.py
+++ b/pyk/src/pyk/klean/k2lean4.py
@@ -942,7 +942,7 @@ class K2Lean4:
 
         lhs_term = self._transform_pattern(lhs)
         rhs_term = self._transform_pattern(rhs)
-        return Ctor(_rule_name(rule), Signature(binders, Term(f'Rewrites {lhs_term} {rhs_term}')))
+        return Ctor(_rule_name(rule), Signature(binders, Term(f'{lhs_term}', f'{rhs_term}', 'Rewrites')))
 
     def _elim_fun_apps(self, pattern: Pattern, free: Iterator[str]) -> tuple[Pattern, dict[str, Pattern]]:
         """Replace ``foo(bar(x))`` with ``z`` and return mapping ``{y: bar(x), z: foo(y)}`` with ``y``, ``z`` fresh variables."""

--- a/pyk/src/pyk/klean/model.py
+++ b/pyk/src/pyk/klean/model.py
@@ -491,7 +491,15 @@ class Signature:
         object.__setattr__(self, 'ty', ty)
 
     def __str__(self) -> str:
-        binders = ' '.join(str(binder) for binder in self.binders)
+        max_inline_binders = 6
+        first_binder_sep = ''
+        binders_sep = ' '
+        binders_indent = 0
+        if max_inline_binders < len(self.binders):
+            binders_sep = '\n'
+            first_binder_sep = '\n'
+            binders_indent = 4
+        binders = indent(f'{binders_sep}'.join(str(binder) for binder in self.binders), binders_indent)
         sep = ' ' if self.binders else ''
         ty = f'{sep}: {self.ty}' if self.ty else ''
         return f'{binders}{ty}'

--- a/pyk/src/pyk/klean/model.py
+++ b/pyk/src/pyk/klean/model.py
@@ -17,6 +17,13 @@ def indent(text: str, n: int) -> str:
     return '\n'.join(res)
 
 
+# TODO: Improve
+def format_state(s: str) -> str:
+    s = s.replace(',', ',\n ')
+    s = s.replace('{ ', '{\n ')
+    return s
+
+
 @final
 @dataclass(frozen=True)
 class Module:

--- a/pyk/src/pyk/klean/model.py
+++ b/pyk/src/pyk/klean/model.py
@@ -502,7 +502,16 @@ class Signature:
         binders = indent(f'{binders_sep}'.join(str(binder) for binder in self.binders), binders_indent)
         sep = ' ' if self.binders else ''
         ty = f'{sep}: {self.ty}' if self.ty else ''
-        return f'{binders}{ty}'
+        if self.ty and self.ty.label == 'Rewrites':
+            assert self.ty.term
+            assert self.ty.auxterm
+            rw = self.ty.label
+            lhs = format_state(self.ty.term)
+            rhs = format_state(self.ty.auxterm)
+            ty1 = f'{sep}: {rw}\n'
+            ty2 = indent(f'{lhs}\n{rhs}', 4)
+            ty = f'{ty1}{ty2}'
+        return f'{first_binder_sep}{binders}{ty}'
 
 
 class Binder(ABC): ...

--- a/pyk/src/pyk/klean/model.py
+++ b/pyk/src/pyk/klean/model.py
@@ -550,6 +550,13 @@ class InstBinder(BracketBinder):
 @dataclass(frozen=True)
 class Term:
     term: str  # TODO: refine
+    auxterm: str | None
+    label: str | None
+
+    def __init__(self, term: str, auxterm: str | None = None, label: str | None = None):
+        object.__setattr__(self, 'term', term)
+        object.__setattr__(self, 'auxterm', auxterm)
+        object.__setattr__(self, 'label', label)
 
     def __str__(self) -> str:
         return self.term


### PR DESCRIPTION
This PR introduces some logic to have a prettier generation of the constructors. Especially the constructors of the Rewrite relations.
In particular:
- Adds two extra fields to the `Term` class to allow encoding the `lhs` and `rhs` of rewrite rules
- Adds the following logic to the `__str__` method of the `Signature` class:
  - If there are more than 6 binders, each binder will be in a new line
  - If the constructor of a rewrite relation is being printed, the LHS and RHS are not printed all in one line

The pretty-printing of rewrite states is not as optimal as it could be, but it compiles and allows for easier manipulation of the generated code.