### PR TITLE
modified:   .github/workflows/master-pr.yml

### DIFF
--- a/.github/workflows/master-pr.yml
+++ b/.github/workflows/master-pr.yml
@@ -6,6 +6,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  pull-requests: write
 
 jobs:
 
@@ -16,7 +19,6 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.JENKINS_GITHUB_PAT }}
           # fetch-depth 0 means deep clone the repo
           fetch-depth: 0
       - name: 'Change base'


### PR DESCRIPTION
- An error occurs with collaborators without access to secrets and cannot access JENKINS_PAT.
- Try to avoid this secret by defining permission scope to the workflow and us the generated GITHUB_TOKEN