### PR TITLE
README: correct cachix target for K

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,26 +235,7 @@ This is needed to expose the Nix 2.0 CLI and flakes support that are hidden behi
 By default, Nix will build the project and its transitive dependencies from
 source, which can take up to an hour. We recommend setting up
 [the binary cache](https://app.cachix.org/cache/k-framework) to speed up the build
-process significantly. You will also need to add the following sections to `/etc/nix/nix.conf` or, if you are a trusted user, `~/.config/nix/nix.conf` (if you don't know what a "trusted user" is, you probably want to do the former):
-
-```
-trusted-public-keys = ... hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-substituters = ... https://cache.iog.io
-```
-
-i.e. if the file was originally
-
-```
-substituters = https://cache.nixos.org
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-```
-
-it will now read
-
-```
-substituters = https://cache.nixos.org https://cache.iog.io
-trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
-```
+process significantly.
 
 To build the K Framework itself, run:
 

--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ This is needed to expose the Nix 2.0 CLI and flakes support that are hidden behi
 
 By default, Nix will build the project and its transitive dependencies from
 source, which can take up to an hour. We recommend setting up
-[the binary cache](https://app.cachix.org/cache/kore) to speed up the build
+[the binary cache](https://app.cachix.org/cache/k-framework) to speed up the build
 process significantly. You will also need to add the following sections to `/etc/nix/nix.conf` or, if you are a trusted user, `~/.config/nix/nix.conf` (if you don't know what a "trusted user" is, you probably want to do the former):
 
 ```


### PR DESCRIPTION
As pointed out by @nishantjr , we have an outdated Cachix instructions in the README, which this corrects. See: https://runtimeverification.slack.com/archives/C06L0RWQ2V9/p1742794416788669