### PR TITLE
Remove unused options from cterm_symbolic function

### DIFF
--- a/pyk/src/pyk/cterm/symbolic.py
+++ b/pyk/src/pyk/cterm/symbolic.py
@@ -17,7 +17,6 @@ from ..kore.rpc import (
     SatResult,
     SmtSolverError,
     StopReason,
-    TransportType,
     UnknownResult,
     UnsatResult,
     kore_server,
@@ -307,7 +306,6 @@ def cterm_symbolic(
     log_succ_rewrites: bool = True,
     log_fail_rewrites: bool = False,
     start_server: bool = True,
-    maude_port: int | None = None,
     fallback_on: Iterable[FallbackReason] | None = None,
     interim_simplification: int | None = None,
     no_post_exec_simplify: bool = False,
@@ -338,18 +336,7 @@ def cterm_symbolic(
     else:
         if port is None:
             raise ValueError('Missing port with start_server=False')
-        if maude_port is None:
-            dispatch = None
-        else:
-            dispatch = {
-                'execute': [('localhost', maude_port, TransportType.HTTP)],
-                'simplify': [('localhost', maude_port, TransportType.HTTP)],
-                'add-module': [
-                    ('localhost', maude_port, TransportType.HTTP),
-                    ('localhost', port, TransportType.SINGLE_SOCKET),
-                ],
-            }
-        with KoreClient('localhost', port, bug_report=bug_report, bug_report_id=id, dispatch=dispatch) as client:
+        with KoreClient('localhost', port, bug_report=bug_report, bug_report_id=id) as client:
             yield CTermSymbolic(
                 client, definition, log_succ_rewrites=log_succ_rewrites, log_fail_rewrites=log_fail_rewrites
             )

--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -265,9 +265,6 @@ class JsonRpcClient(ContextManager['JsonRpcClient']):
         bug_report_id: str | None = None,
         transport: TransportType = TransportType.SINGLE_SOCKET,
     ):
-        if (bug_report is None) != (bug_report_id is None):
-            raise ValueError('bug_report and bug_report_id must be passed together.')
-
         self._transport = self._create_transport(transport, host=host, port=port, timeout=timeout)
         self._req_id = 1
         self._bug_report_id = bug_report_id


### PR DESCRIPTION
None of the downstream semantics use the `maude_port` functionality and extra dispatch functionality of the `cterm_symbolic` at this point, so it's removed.

We also remove a check that `bug_report_id` is set, because it's only used in one place, and in that spot we anyway handle the case where it's unset:  https://github.com/runtimeverification/k/blob/32359773218dd79bc6f2c73dc973e571b3b89e1a/pyk/src/pyk/kore/rpc.py#L308