### PR TITLE
Update nix maven hash

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -84,7 +84,7 @@
 
             mk-k-framework = { haskell-backend-bins, llvm-kompile-libs }:
               prev.callPackage ./nix/k.nix {
-                mvnHash = "sha256-uHhx3L2ma9/N5fbagpXMbE3boL7RNfkRy5vzPmKOfU8=";
+                mvnHash = "sha256-v/6tVTx3UgIn95r1KUeYTRbLnDlaNI/B9+g8NSPDx34=";
                 manualMvnArtifacts = [
                   "org.scala-lang:scala-compiler:2.13.13"
                   "ant-contrib:ant-contrib:1.0b3"


### PR DESCRIPTION
The nix derivation for k started failing due to a hash mismatch in the maven nix derivation. This is probably due to maven dependencies being changed upstream, outside of our control. This happened for the first time last week, see [here](https://github.com/runtimeverification/k/pull/4790/commits/22d49bc06b4aef3116fde839dd07fd6421ca4a66), and has now occurred a second time.

Currently this issue is blocking other pull requests due to [failing CI](https://github.com/runtimeverification/k/actions/runs/14641493584/job/41098410643?pr=4782#step:6:10121).

I'll investigate this further and post updates of the investigation here or create an issue. I'd be a problem if this starts happening more frequently instead of only once.