### PR TITLE
Added method to create claim from APRProof

### DIFF
--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -11,7 +11,7 @@ from pyk.kore.rpc import LogEntry
 from ..cterm.cterm import remove_useless_constraints
 from ..kast.inner import KInner, Subst
 from ..kast.manip import flatten_label, free_vars, ml_pred_to_bool
-from ..kast.outer import KFlatModule, KImport, KRule
+from ..kast.outer import KClaim, KFlatModule, KImport, KRule
 from ..kcfg import KCFG, KCFGStore
 from ..kcfg.exploration import KCFGExploration
 from ..ktool.claim_index import ClaimIndex
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Final, TypeVar
 
-    from ..kast.outer import KClaim, KDefinition, KFlatModuleList, KRuleLike
+    from ..kast.outer import KDefinition, KFlatModuleList, KRuleLike
     from ..kcfg import KCFGExplore
     from ..kcfg.explore import KCFGExtendResult
     from ..kcfg.kcfg import CSubst, NodeIdLike
@@ -460,6 +460,12 @@ class APRProof(Proof[APRProofStep, APRProofResult], KCFGExploration):
         _rule = _edge.to_rule(self.rule_id, priority=priority)
         assert type(_rule) is KRule
         return _rule
+
+    def as_claim(self) -> KClaim:
+        _edge = KCFG.Edge(self.kcfg.node(self.init), self.kcfg.node(self.target), depth=0, rules=())
+        _claim = _edge.to_rule(self.rule_id, claim=True)
+        assert type(_claim) is KClaim
+        return _claim
 
     @staticmethod
     def from_spec_modules(


### PR DESCRIPTION
KMIR is increasing automation of generating specs and running proofs. We currently parse  Stable MIR JSON into a generated K claim and then parse that again into the APRProver. Instead, we can directly parse the Stable MIR JSON / claim into the APRProver and have that optionally print the claim. 