### PR TITLE
Make cachix builds from CI/CD match CLI/flake inputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -53,6 +53,8 @@
                   "haskell-backend/src/main/native/haskell-backend/*"
                   "llvm-backend/src/main/native/llvm-backend/*"
                   "k-distribution/tests/regression-new"
+                  # do not include submodule directories that might be initilized empty or non-existent
+                  "/web/k-web-theme"
                 ] ./.);
               dontBuild = true;
               installPhase = ''


### PR DESCRIPTION
This pull request fixes the same kind of issue that I already observed and fixed in `evm-semantics` and `kontrol`, see [evm-semantics#2739](https://github.com/runtimeverification/evm-semantics/pull/2739), [evm-semantics#2745](https://github.com/runtimeverification/evm-semantics/pull/2745), and [kontrol#1013](https://github.com/runtimeverification/kontrol/pull/1013).

The CI/CD pipeline for k releases builds and publishes kontrol to the [nix build cache k-framework-binary](https://app.cachix.org/cache/k-framework-binary). In the respective GitHub action job, the nix derivation is built by cloning the repository and building the derivation locally. When building the nix project locally with a cloned git repository, nix does not include and consider empty submodule directories included by git for building the project. On the other hand, when the repository is referenced in a flake input or built by specifying a github URL in a nix CLI command, the empty submodule directories are included. This causes the package requested by kup, nix CLI, or nix flake inputs to not match the package built by CI/CD that is pushed to the build cache.

As a consequence, k is built on the local machine instead of fetched from the binary cache. Though typically the requested version/hash is still available in the cache, as it is pushed to the cache by cache pushing jobs of other runtime verification repositories.

This pull request fixes this issue such that the same version/hash of the derivation is always built for the cache and requested by flake inputs/CLI/kup.
