### PR TITLE
Use relative imports inside the pyk library

### DIFF
--- a/pyk/src/pyk/kcfg/exploration.py
+++ b/pyk/src/pyk/kcfg/exploration.py
@@ -2,15 +2,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from pyk.kcfg.kcfg import KCFG, NodeAttr
-from pyk.kcfg.minimize import KCFGMinimizer
+from .kcfg import KCFG, NodeAttr
+from .minimize import KCFGMinimizer
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from typing import Any
 
-    from pyk.kcfg.kcfg import NodeIdLike
-    from pyk.kcfg.semantics import KCFGSemantics
+    from .kcfg import NodeIdLike
+    from .semantics import KCFGSemantics
 
 
 class KCFGExplorationNodeAttr(NodeAttr):

--- a/pyk/src/pyk/kcfg/kcfg.py
+++ b/pyk/src/pyk/kcfg/kcfg.py
@@ -30,11 +30,10 @@ if TYPE_CHECKING:
     from types import TracebackType
     from typing import Any
 
-    from pyk.kore.rpc import LogEntry
-
     from ..kast import KAtt
     from ..kast.inner import KInner
     from ..kast.outer import KClaim, KDefinition, KImport, KRuleLike
+    from ..kore.rpc import LogEntry
 
 
 NodeIdLike = int | str

--- a/pyk/src/pyk/kcfg/minimize.py
+++ b/pyk/src/pyk/kcfg/minimize.py
@@ -3,16 +3,14 @@ from __future__ import annotations
 from functools import reduce
 from typing import TYPE_CHECKING
 
-from pyk.cterm.cterm import cterms_anti_unify
-from pyk.utils import partition, single
-
+from ..cterm.cterm import cterms_anti_unify
+from ..utils import partition, single
 from .semantics import DefaultSemantics
 
 if TYPE_CHECKING:
     from collections.abc import Callable
 
-    from pyk.kast.outer import KDefinition
-
+    from ..kast.outer import KDefinition
     from .kcfg import KCFG, NodeIdLike
     from .semantics import KCFGSemantics
 

--- a/pyk/src/pyk/kdist/__main__.py
+++ b/pyk/src/pyk/kdist/__main__.py
@@ -5,9 +5,8 @@ import logging
 from argparse import ArgumentParser
 from typing import TYPE_CHECKING
 
-from pyk.cli.args import KCLIArgs
-from pyk.cli.utils import loglevel
-
+from ..cli.args import KCLIArgs
+from ..cli.utils import loglevel
 from ..kdist import kdist, target_ids
 from .utils import LOG_FORMAT
 

--- a/pyk/src/pyk/kdist/utils.py
+++ b/pyk/src/pyk/kdist/utils.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pyk.utils import check_dir_path
+from ..utils import check_dir_path
 
 if TYPE_CHECKING:
     from collections.abc import Iterator

--- a/pyk/src/pyk/klean/__main__.py
+++ b/pyk/src/pyk/klean/__main__.py
@@ -5,8 +5,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from pyk.cli.utils import dir_path
-from pyk.kore.internal import KoreDefn
+from ..cli.utils import dir_path
+from ..kore.internal import KoreDefn
 
 if TYPE_CHECKING:
     from argparse import Namespace
@@ -23,7 +23,7 @@ def main() -> None:
     import logging
     import sys
 
-    from pyk.cli.utils import LOG_FORMAT
+    from ..cli.utils import LOG_FORMAT
 
     args = sys.argv
     level, args = _extract_log_level(args)
@@ -41,8 +41,8 @@ def main() -> None:
 
 
 def _extract_log_level(args: list[str]) -> tuple[int, list[str]]:
-    from pyk.cli.args import KCLIArgs
-    from pyk.cli.utils import loglevel
+    from ..cli.args import KCLIArgs
+    from ..cli.utils import loglevel
 
     parser = KCLIArgs().logging_args
     ns, rest = parser.parse_known_args(args)

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -6,8 +6,6 @@ import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
-from pyk.kore.rpc import LogEntry
-
 from ..cterm.cterm import remove_useless_constraints
 from ..kast.inner import KInner, Subst
 from ..kast.manip import flatten_label, free_vars, ml_pred_to_bool
@@ -15,6 +13,7 @@ from ..kast.outer import KClaim, KFlatModule, KImport, KRule
 from ..kast.prelude.ml import mlAnd, mlTop
 from ..kcfg import KCFG, KCFGStore
 from ..kcfg.exploration import KCFGExploration
+from ..kore.rpc import LogEntry
 from ..ktool.claim_index import ClaimIndex
 from ..utils import FrozenDict, ensure_dir_path, hash_str, shorten_hashes, single
 from .implies import ProofSummary, Prover, RefutationProof

--- a/pyk/src/pyk/testing/_kompiler.py
+++ b/pyk/src/pyk/testing/_kompiler.py
@@ -8,8 +8,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from pyk.proof.reachability import APRProver
-
 from ..cterm import CTermSymbolic
 from ..kast.outer import read_kast_definition
 from ..kcfg import KCFGExplore
@@ -23,6 +21,7 @@ from ..ktool.kompile import DefinitionInfo, Kompile, LLVMKompileType
 from ..ktool.kprint import KPrint
 from ..ktool.kprove import KProve
 from ..ktool.krun import KRun
+from ..proof.reachability import APRProver
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Iterable, Iterator


### PR DESCRIPTION
As a style choice a while ago we decided to use relative imports when possible inside the `pyk` library. This is not enforced though, so some snuck through. This fixes them.