### PR TITLE
Small changes in preparation for CTermShow

### DIFF
--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -113,16 +113,11 @@ def exec_print(options: PrintOptions) -> None:
         _LOGGER.info(f'Wrote file: {options.output_file.name}')
     else:
         if options.minimize:
-            if options.omit_labels is not None and options.keep_cells is not None:
-                raise ValueError('You cannot use both --omit-labels and --keep-cells.')
-
-            abstract_labels = options.omit_labels.split(',') if options.omit_labels is not None else []
-            keep_cells = options.keep_cells.split(',') if options.keep_cells is not None else []
             minimized_disjuncts = []
 
             for disjunct in flatten_label('#Or', term):
                 try:
-                    minimized = minimize_term(disjunct, abstract_labels=abstract_labels, keep_cells=keep_cells)
+                    minimized = minimize_term(disjunct)
                     config, constraint = split_config_and_constraints(minimized)
                 except ValueError as err:
                     raise ValueError('The minimized term does not contain a config cell.') from err

--- a/pyk/src/pyk/cli/pyk.py
+++ b/pyk/src/pyk/cli/pyk.py
@@ -209,15 +209,11 @@ class PrintOptions(DefinitionOptions, OutputFileOptions, DisplayOptions, Logging
     term: IO[Any]
     input: PrintInput
     minimize: bool
-    omit_labels: str | None
-    keep_cells: str | None
 
     @staticmethod
     def default() -> dict[str, Any]:
         return {
             'input': PrintInput.KAST_JSON,
-            'omit_labels': None,
-            'keep_cells': None,
         }
 
     @staticmethod
@@ -402,8 +398,6 @@ def create_argument_parser() -> ArgumentParser:
     print_args.add_argument('definition_dir', type=dir_path, help='Path to definition directory.')
     print_args.add_argument('term', type=FileType('r'), help='Input term (in format specified with --input).')
     print_args.add_argument('--input', type=PrintInput, choices=list(PrintInput))
-    print_args.add_argument('--omit-labels', nargs='?', help='List of labels to omit from output.')
-    print_args.add_argument('--keep-cells', nargs='?', help='List of cells with primitive values to keep in output.')
     print_args.add_argument('--output-file', type=FileType('w'))
 
     rpc_print_args = pyk_args_command.add_parser(

--- a/pyk/src/pyk/cterm/cterm.py
+++ b/pyk/src/pyk/cterm/cterm.py
@@ -125,6 +125,11 @@ class CTerm:
         return mlAnd(self, GENERATED_TOP_CELL)
 
     @cached_property
+    def constraint(self) -> KInner:
+        """Return the unstructured bare `KInner` representation of the constraints."""
+        return mlAnd(self.constraints, GENERATED_TOP_CELL)
+
+    @cached_property
     def free_vars(self) -> frozenset[str]:
         """Return the set of free variable names contained in this `CTerm`."""
         return frozenset(free_vars(self.kast))

--- a/pyk/src/pyk/kast/manip.py
+++ b/pyk/src/pyk/kast/manip.py
@@ -506,9 +506,7 @@ def on_attributes(kast: W, f: Callable[[KAtt], KAtt]) -> W:
     return kast
 
 
-def minimize_term(
-    term: KInner, keep_vars: Iterable[str] = (), abstract_labels: Collection[str] = (), keep_cells: Collection[str] = ()
-) -> KInner:
+def minimize_term(term: KInner, keep_vars: Iterable[str] = ()) -> KInner:
     """Minimize a K term for pretty-printing.
 
     - Variables only used once will be removed.
@@ -524,14 +522,7 @@ def minimize_term(
     term = inline_cell_maps(term)
     term = remove_semantic_casts(term)
     term = useless_vars_to_dots(term, keep_vars=keep_vars)
-
-    if keep_cells:
-        term = extract_cells(term, keep_cells)
-    else:
-        term = labels_to_dots(term, abstract_labels)
-
     term = collapse_dots(term)
-
     return term
 
 

--- a/pyk/src/pyk/kcfg/show.py
+++ b/pyk/src/pyk/kcfg/show.py
@@ -127,25 +127,18 @@ class KCFGShow:
         processed_nodes: list[KCFG.Node] = []
         ret_lines: list[tuple[str, list[str]]] = []
 
-        def _multi_line_print(
-            label: str, lines: list[str], default: str = 'None', indent: int = 4, max_width: int | None = None
-        ) -> list[str]:
+        def _multi_line_print(label: str, lines: list[str], default: str = 'None', indent: int = 4) -> list[str]:
             ret_lines = []
             if len(lines) == 0:
                 ret_lines.append(f'{label}: {default}')
             else:
                 ret_lines.append(f'{label}:')
                 ret_lines.extend([f'{indent * " "}{line}' for line in lines])
-            if max_width is not None:
-                ret_lines = [
-                    ret_line if len(ret_line) <= max_width else ret_line[0:max_width] + '...' for ret_line in ret_lines
-                ]
             return ret_lines
 
         def _print_csubst(
             csubst: CSubst, subst_first: bool = False, indent: int = 4, minimize: bool = False
         ) -> list[str]:
-            max_width = 78 if minimize else None
             _constraint_strs = [
                 self.kprint.pretty_print(ml_pred_to_bool(constraint, unsafe=True)) for constraint in csubst.constraints
             ]
@@ -158,7 +151,7 @@ class KCFGShow:
                     for k, v in csubst.subst.minimize().items()
                     for line in f'{k} <- {self.kprint.pretty_print(v)}'.split('\n')
                 ]
-                subst_strs = _multi_line_print('subst', _subst_strs, '.Subst', max_width=max_width)
+                subst_strs = _multi_line_print('subst', _subst_strs, '.Subst')
             if subst_first:
                 return subst_strs + constraint_strs
             return constraint_strs + subst_strs

--- a/pyk/src/tests/unit/kast/test_manip.py
+++ b/pyk/src/tests/unit/kast/test_manip.py
@@ -63,17 +63,15 @@ def test_push_down_rewrites(term: KInner, expected: KInner) -> None:
 
 STATE: Final = KLabel('<state>')
 PC: Final = KLabel('<pc>')
-MINIMIZE_TERM_TEST_DATA: Final[tuple[tuple[KInner, list[str], list[str], KInner], ...]] = (
-    (f(k(a), STATE(a), PC(a)), [], [], f(k(a), STATE(a), PC(a))),
-    (f(k(a), STATE(a), PC(a)), ['<k>'], [], f(STATE(a), PC(a), DOTS)),
-    (f(k(a), STATE(a), PC(a)), [], ['<state>'], f(STATE(a), DOTS)),
+MINIMIZE_TERM_TEST_DATA: Final[tuple[tuple[KInner, KInner], ...]] = (
+    (f(k(a), STATE(a), PC(a)), f(k(a), STATE(a), PC(a))),
 )
 
 
-@pytest.mark.parametrize('term,abstract_labels,keep_cells,expected', MINIMIZE_TERM_TEST_DATA, ids=count())
-def test_minimize_term(term: KInner, abstract_labels: list[str], keep_cells: list[str], expected: KInner) -> None:
+@pytest.mark.parametrize('term,expected', MINIMIZE_TERM_TEST_DATA, ids=count())
+def test_minimize_term(term: KInner, expected: KInner) -> None:
     # When
-    actual = minimize_term(term, abstract_labels=abstract_labels, keep_cells=keep_cells)
+    actual = minimize_term(term)
 
     # Then
     assert actual == expected


### PR DESCRIPTION
These are several changes pulled out of https://github.com/runtimeverification/k/pull/4808 in order to make the delta there more manageable. These changes should not have significant breakages downstream (if any).

- `minimize_term` loses the options `abstract_labels` and `keep_cells`, which were not used downstream anyway. The `pyk print ...` command loses the corresponding options too. Test data is updated as well.
- `CTerm.constraint` is added, which returns a conjunct of all the constraints.
- The `KCFGShow` class no longer has an option for wrapping/truncating lines for you. Instead, that's left to the call-site, which can process the output how it needs.