### PR TITLE
Fix Dockerfiles for release workflows

### DIFF
--- a/.github/actions/with-k-docker/Dockerfile
+++ b/.github/actions/with-k-docker/Dockerfile
@@ -32,8 +32,8 @@ RUN rm /kframework.deb
 
 ARG USER_ID=9876
 ARG GROUP_ID=9876
-RUN    groupadd -g ${GROUP_ID} user \
-&& useradd -m -u ${USER_ID} -s /bin/sh -g user user
+RUN    groupadd -g ${GROUP_ID} user                     \
+    && useradd -m -u ${USER_ID} -s /bin/sh -g user user
 
 USER user
 WORKDIR /home/user

--- a/.github/actions/with-k-docker/Dockerfile
+++ b/.github/actions/with-k-docker/Dockerfile
@@ -29,18 +29,20 @@ RUN apt-get -y clean
 RUN rm /llvm-backend.deb
 RUN rm /kframework.deb
 
-ENV PATH=/usr/bin:${PATH}
-ARG UV_VERSION
-RUN    curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | env UV_INSTALL_DIR="/usr/bin" sh \
-    && uv --version
 
 ARG USER_ID=9876
 ARG GROUP_ID=9876
 RUN    groupadd -g ${GROUP_ID} user \
-    && useradd -m -u ${USER_ID} -s /bin/sh -g user user
+&& useradd -m -u ${USER_ID} -s /bin/sh -g user user
 
 USER user
 WORKDIR /home/user
+
+ENV PATH=/home/user/.local/bin:${PATH}
+
+ARG UV_VERSION
+RUN    curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
+    && uv --version
 
 ENV PATH=/home/user/.elan/bin:${PATH}
 RUN    curl -O https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \

--- a/.github/actions/with-k-docker/Dockerfile
+++ b/.github/actions/with-k-docker/Dockerfile
@@ -29,6 +29,11 @@ RUN apt-get -y clean
 RUN rm /llvm-backend.deb
 RUN rm /kframework.deb
 
+ENV PATH=/usr/bin:${PATH}
+ARG UV_VERSION
+RUN    curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | env UV_INSTALL_DIR="/usr/bin" sh \
+    && uv --version
+
 ARG USER_ID=9876
 ARG GROUP_ID=9876
 RUN    groupadd -g ${GROUP_ID} user \
@@ -36,11 +41,6 @@ RUN    groupadd -g ${GROUP_ID} user \
 
 USER user
 WORKDIR /home/user
-
-ENV PATH=/home/user/.local/bin:${PATH}
-ARG UV_VERSION
-RUN    curl -LsSf https://astral.sh/uv/${UV_VERSION}/install.sh | sh \
-    && uv --version
 
 ENV PATH=/home/user/.elan/bin:${PATH}
 RUN    curl -O https://raw.githubusercontent.com/leanprover/elan/master/elan-init.sh \

--- a/.github/actions/with-k-docker/action.yml
+++ b/.github/actions/with-k-docker/action.yml
@@ -43,6 +43,7 @@ runs:
       K_DEB_PATH=${{ inputs.k-deb-path }}
       LLVM_BACKEND_DEB_PATH=llvm-backend.deb
       HASKELL_BACKEND_DEB_PATH=haskell-backend.deb
+      UV_VERSION=$(cat deps/uv_release)
 
       gh release download                           \
         --repo runtimeverification/llvm-backend     \
@@ -63,6 +64,7 @@ runs:
         --build-arg K_DEB_PATH=${K_DEB_PATH}                        \
         --build-arg INSTALL_BACKEND_DEBS=${INSTALL_BACKEND_DEBS}    \
         --build-arg LLVM_BACKEND_DEB_PATH=${LLVM_BACKEND_DEB_PATH}  \
+        --build-arg "UV_VERSION=${UV_VERSION}"                      \
         --build-arg HASKELL_BACKEND_DEB_PATH=${HASKELL_BACKEND_DEB_PATH}
 
   - name: 'Run Docker container'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,7 @@ jobs:
   pyk-build-wheel:
     name: 'Pyk: Build Python wheel'
     runs-on: ubuntu-24.04
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: 'Get uv release'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,10 +86,36 @@ jobs:
             export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
             kup publish --verbose k-framework-binary .#k --keep-days 180
             kup publish --verbose k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
-      
+
+  test-package-kframework-wheel:
+    name: 'K: Python wheel'
+    runs-on: [self-hosted, linux, normal]
+    steps:
+      - uses: actions/checkout@v4
+      - name: 'Get uv release'
+        id: uv_release
+        run: |
+          echo uv_version=$(cat deps/uv_release) >> "${GITHUB_OUTPUT}"
+      - name: 'Install uv'
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: ${{ steps.uv_release.outputs.uv_version }}
+      - name: 'Build kframework wheel'
+        run: |
+          uv build --project pyk
+          cp pyk/dist/kframework-*.whl ./
+      - name: 'Upload kframework package wheel as artifact to the Summary Page'
+        uses: actions/upload-artifact@v4
+        with:
+          name: kframework.whl
+          path: kframework-*.whl
+          if-no-files-found: error
+          retention-days: 1
+
   ubuntu-noble:
     name: 'K Ubuntu Noble Package'
     runs-on: [self-hosted, linux, normal]
+    needs: 'test-package-kframework-wheel'
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -118,6 +144,10 @@ jobs:
           version=$(cat package/version)
           cp kframework_amd64_ubuntu_noble.deb "kframework_${version}_amd64_ubuntu_noble.deb"
           gh release upload --repo runtimeverification/k --clobber "v${version}" "kframework_${version}_amd64_ubuntu_noble.deb"
+      - name: 'Download kframework.whl'
+        uses: actions/download-artifact@v4
+        with:
+          name: kframework.whl
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -127,9 +157,8 @@ jobs:
           set -euxo pipefail
           version=$(cat package/version)
           version_tag=ubuntu-noble-${version}
-          UV_VERSION=$(cat deps/uv_release)
           docker login --username rvdockerhub --password "${DOCKERHUB_PASSWORD}"
-          docker image build . --file package/docker/Dockerfile.ubuntu-noble --tag "${DOCKERHUB_REPO}:${version_tag}" --build-arg "UV_VERSION=${UV_VERSION}"
+          docker image build . --file package/docker/Dockerfile.ubuntu-noble --tag "${DOCKERHUB_REPO}:${version_tag}"
           docker run --name "k-package-docker-test-noble-${GITHUB_SHA}" --rm -it --detach "${DOCKERHUB_REPO}:${version_tag}"
           docker exec -t "k-package-docker-test-noble-${GITHUB_SHA}" bash -c 'cd ~ && echo "module TEST imports BOOL endmodule" > test.k'
           docker exec -t "k-package-docker-test-noble-${GITHUB_SHA}" bash -c 'cd ~ && kompile test.k --backend llvm'
@@ -152,6 +181,7 @@ jobs:
   ubuntu-jammy:
     name: 'K Ubuntu Jammy Package'
     runs-on: [self-hosted, linux, normal]
+    needs: 'test-package-kframework-wheel'
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -179,6 +209,10 @@ jobs:
           version=$(cat package/version)
           cp kframework_amd64_ubuntu_jammy.deb "kframework_${version}_amd64_ubuntu_jammy.deb"
           gh release upload --repo runtimeverification/k --clobber "v${version}" "kframework_${version}_amd64_ubuntu_jammy.deb"
+      - name: 'Download kframework.whl'
+        uses: actions/download-artifact@v4
+        with:
+          name: kframework.whl
       - name: 'Build, Test, and Push Dockerhub Image'
         shell: bash {0}
         env:
@@ -188,9 +222,8 @@ jobs:
           set -euxo pipefail
           version=$(cat package/version)
           version_tag=ubuntu-jammy-${version}
-          UV_VERSION=$(cat deps/uv_release)
           docker login --username rvdockerhub --password "${DOCKERHUB_PASSWORD}"
-          docker image build . --file package/docker/Dockerfile.ubuntu-jammy --tag "${DOCKERHUB_REPO}:${version_tag}" --build-arg "UV_VERSION=${UV_VERSION}"
+          docker image build . --file package/docker/Dockerfile.ubuntu-jammy --tag "${DOCKERHUB_REPO}:${version_tag}"
           docker run --name "k-package-docker-test-jammy-${GITHUB_SHA}" --rm -it --detach "${DOCKERHUB_REPO}:${version_tag}"
           docker exec -t "k-package-docker-test-jammy-${GITHUB_SHA}" bash -c 'cd ~ && echo "module TEST imports BOOL endmodule" > test.k'
           docker exec -t "k-package-docker-test-jammy-${GITHUB_SHA}" bash -c 'cd ~ && kompile test.k --backend llvm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       - name: 'Get uv release'
         id: uv_release
         run: |
-          echo uv_version=$(cat deps/uv_release) >> "${GITHUB_OUTPUT}"
+          echo "uv_version=$(cat deps/uv_release)" >> "${GITHUB_OUTPUT}"
       - name: 'Install uv'
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,9 +87,9 @@ jobs:
             kup publish --verbose k-framework-binary .#k --keep-days 180
             kup publish --verbose k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
 
-  test-package-kframework-wheel:
-    name: 'K: Python wheel'
-    runs-on: [self-hosted, linux, normal]
+  pyk-build-wheel:
+    name: 'Pyk: Build Python wheel'
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: 'Get uv release'
@@ -115,7 +115,7 @@ jobs:
   ubuntu-noble:
     name: 'K Ubuntu Noble Package'
     runs-on: [self-hosted, linux, normal]
-    needs: 'test-package-kframework-wheel'
+    needs: 'pyk-build-wheel'
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4
@@ -181,7 +181,7 @@ jobs:
   ubuntu-jammy:
     name: 'K Ubuntu Jammy Package'
     runs-on: [self-hosted, linux, normal]
-    needs: 'test-package-kframework-wheel'
+    needs: 'pyk-build-wheel'
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v4

--- a/package/docker/Dockerfile.ubuntu-jammy
+++ b/package/docker/Dockerfile.ubuntu-jammy
@@ -18,16 +18,9 @@ RUN    apt-get update                                                           
     && apt-get upgrade --yes                                                            \
     && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_jammy.deb
 
-ARG UV_VERSION
-RUN    curl -LsSf https://astral.sh/uv/$UV_VERSION/install.sh | sh \
-    && uv --version
-
-COPY pyk /pyk
-RUN pipx ensurepath           \
-    && . /root/.profile       \
-    && cd /pyk                \
-    && make build             \
-    && pip install dist/*.whl \
-    && rm -rf /pyk
-
-RUN rm -rf /kframework_amd64_ubuntu_jammy.deb
+COPY kframework-*.whl ./
+RUN    pipx ensurepath                              \
+    && . /root/.profile                          \
+    && pip install /kframework-*.whl             \
+    && rm -rf /kframework-*                      \
+    && rm -rf /kframework_amd64_ubuntu_jammy.deb

--- a/package/docker/Dockerfile.ubuntu-jammy
+++ b/package/docker/Dockerfile.ubuntu-jammy
@@ -16,11 +16,11 @@ RUN    apt-get update                   \
 COPY kframework_amd64_ubuntu_jammy.deb /kframework_amd64_ubuntu_jammy.deb
 RUN    apt-get update                                                                   \
     && apt-get upgrade --yes                                                            \
-    && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_jammy.deb
+    && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_jammy.deb \
+    && rm /kframework_amd64_ubuntu_jammy.deb
 
 COPY kframework-*.whl ./
-RUN    pipx ensurepath                              \
-    && . /root/.profile                          \
-    && pip install /kframework-*.whl             \
-    && rm -rf /kframework-*                      \
-    && rm -rf /kframework_amd64_ubuntu_jammy.deb
+RUN    pipx ensurepath               \
+    && . /root/.profile              \
+    && pip install /kframework-*.whl \
+    && rm /kframework-*.whl

--- a/package/docker/Dockerfile.ubuntu-noble
+++ b/package/docker/Dockerfile.ubuntu-noble
@@ -16,11 +16,11 @@ RUN    apt-get update                   \
 COPY kframework_amd64_ubuntu_noble.deb /kframework_amd64_ubuntu_noble.deb
 RUN    apt-get update                                                                   \
     && apt-get upgrade --yes                                                            \
-    && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_noble.deb
+    && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_noble.deb \
+    && rm /kframework_amd64_ubuntu_noble.deb
 
 COPY kframework-*.whl ./
-RUN    pipx ensurepath                                          \
+RUN    pipx ensurepath                                       \
     && . /root/.profile                                      \
     && pip install /kframework-*.whl --break-system-packages \
-    && rm -rf /kframework-*                                  \
-    && rm -rf /kframework_amd64_ubuntu_noble.deb
+    && rm /kframework-*.whl

--- a/package/docker/Dockerfile.ubuntu-noble
+++ b/package/docker/Dockerfile.ubuntu-noble
@@ -18,16 +18,9 @@ RUN    apt-get update                                                           
     && apt-get upgrade --yes                                                            \
     && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_noble.deb
 
-ARG UV_VERSION
-RUN    curl -LsSf https://astral.sh/uv/$UV_VERSION/install.sh | sh \
-    && uv --version
-
-COPY pyk /pyk
-RUN pipx ensurepath                                   \
-    && . /root/.profile                               \
-    && cd /pyk                                        \
-    && make build                                     \
-    && pip install dist/*.whl --break-system-packages \
-    && rm -rf /pyk
-
-RUN rm -rf /kframework_amd64_ubuntu_noble.deb
+COPY kframework-*.whl ./
+RUN    pipx ensurepath                                          \
+    && . /root/.profile                                      \
+    && pip install /kframework-*.whl --break-system-packages \
+    && rm -rf /kframework-*                                  \
+    && rm -rf /kframework_amd64_ubuntu_noble.deb


### PR DESCRIPTION
The `poetry` to `uv` migration pull request #4831 causes the Dockerfile builds in release workflows [on CI to fail](https://github.com/runtimeverification/k/actions/runs/15757039533/job/44414666887). This is due to `uv` not being found at runtime as the underlying `bin` directory is missing in the PATH variable. This pull request fixes this by introducing a non-root user whose local bin directory `/home/${USER}/.local/bin` is added to the PATH variable.

I tested that the Dockerfiles successfully build on my local machine.

In addition, this pull request sets the `UV_VERSION` argument for the Dockerfile in the `with-k-docker` GitHub action that was missing before, which caused the resulting uv version that was installed to be of the latest version instead of a fixed specified version.