### PR TITLE
Update nix lock file and check in CI that nix lock file is in sync with nix flake

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -219,7 +219,7 @@ jobs:
           nix --version
           JQ=$(nix-build '<nixpkgs>' -A jq --no-link)/bin/jq
           export JQ
-          k=$(nix build . --print-build-logs --json | $JQ -r '.[].outputs | to_entries[].value')
+          k=$(nix build . --print-build-logs --json --no-update-lock-file | $JQ -r '.[].outputs | to_entries[].value')
           drv=$(nix-store --query --deriver "$k")
           nix-store --query --requisites "$drv" | cachix push k-framework
       - name: 'Smoke test K'

--- a/flake.lock
+++ b/flake.lock
@@ -165,8 +165,8 @@
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
+        "owner": "runtimeverification",
+        "ref": "libmatch",
         "repo": "nixpkgs",
         "type": "github"
       }


### PR DESCRIPTION
Recently, the nix flake was updated in a pull request without fully updating the respective nix lock file. This causes issues when trying to install a nix derivation from CLI, i.e. with `nix` or `kup`, without cloning the repository, as the checked out source is placed in the read-only nix store. Therefore, the nix lock file must always stay perfectly in sync with the nix flake.

This pull request updates the nix lock file to be in sync again. Additionally, the flag `--no-update-lock-file` was added to CI when building the nix derivation to check that the nix lock file is actually in sync. Otherwise, CI would silently update the nix lockfile without reflecting that change in a commit. This additional sanity check could also be added to other RV repositories with CI that use nix.