### PR TITLE
Change `ehildenb` to `palinatolmach` as default reviewer on protected files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-/k-distribution/include/kframework/builtin/* @ehildenb @tothtamas28
+/k-distribution/include/kframework/builtin/* @palinatolmach @tothtamas28
 /.github/workflows/* @runtimeverification/admin
-/package/version @ehildenb @rv-jenkins @F-WRunTime @tothtamas28
+/package/version @palinatolmach @rv-jenkins @F-WRunTime @tothtamas28


### PR DESCRIPTION
This PR changes @ehildenb to myself as one of the default reviewers on protected files in the K repository, as discussed yesterday with @ehildenb and @Robertorosmaninho.