### PR TITLE
Add fixture `load_kllvm`

### DIFF
--- a/pyk/src/pyk/testing/_kompiler.py
+++ b/pyk/src/pyk/testing/_kompiler.py
@@ -352,7 +352,7 @@ class RuntimeTest(KompiledTest):
     KOMPILE_BACKEND = 'llvm'
 
     @pytest.fixture(scope='class')
-    def runtime(self, definition_dir: Path) -> Runtime:
+    def runtime(self, load_kllvm: None, definition_dir: Path) -> Runtime:
         compile_runtime(definition_dir)
         return import_runtime(definition_dir)
 

--- a/pyk/src/pyk/testing/plugin.py
+++ b/pyk/src/pyk/testing/plugin.py
@@ -60,3 +60,13 @@ def profile(tmp_path: Path) -> Profiler:
 @pytest.fixture(scope='session')
 def kompile(tmp_path_factory: TempPathFactory) -> Kompiler:
     return Kompiler(tmp_path_factory)
+
+
+@pytest.fixture(scope='session')
+def load_kllvm(tmp_path_factory: TempPathFactory) -> None:
+    from ..kllvm.compiler import compile_kllvm
+    from ..kllvm.importer import import_kllvm
+
+    tmp_dir = tmp_path_factory.mktemp('kllvm')
+    module_file = compile_kllvm(tmp_dir)
+    import_kllvm(module_file)

--- a/pyk/src/pyk/testing/plugin.py
+++ b/pyk/src/pyk/testing/plugin.py
@@ -64,6 +64,21 @@ def kompile(tmp_path_factory: TempPathFactory) -> Kompiler:
 
 @pytest.fixture(scope='session')
 def load_kllvm(tmp_path_factory: TempPathFactory) -> None:
+    """Generate and import the ``_kllvm`` bindings module.
+
+    Use this fixture in all tests that import from ``pyk.kllvm``.
+    It ensures transitive imports of ``_kllvm`` are successful.
+
+    Example:
+        .. code-block:: python
+
+            def test_symbol_name(load_kllvm: None) -> None:
+                from pyk.kllvm.ast import Symbol
+
+                name = "Lbl'UndsPlus'Int'Unds'"
+                symbol = Symbol(name)
+                assert symbol.name == name
+    """
     from ..kllvm.compiler import compile_kllvm
     from ..kllvm.importer import import_kllvm
 

--- a/pyk/src/tests/integration/kllvm/test_convert.py
+++ b/pyk/src/tests/integration/kllvm/test_convert.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.convert import definition_to_llvm, llvm_to_definition, llvm_to_pattern, pattern_to_llvm
 from pyk.kore.parser import KoreParser
 
 if TYPE_CHECKING:
@@ -66,7 +64,9 @@ DEF_TEST_DATA: Final = (
 
 
 @pytest.mark.parametrize('test_id,kore_text', PAT_TEST_DATA, ids=[test_id for test_id, *_ in PAT_TEST_DATA])
-def test_pattern_to_llvm(test_id: str, kore_text: str) -> None:
+def test_pattern_to_llvm(load_kllvm: None, test_id: str, kore_text: str) -> None:
+    from pyk.kllvm.convert import llvm_to_pattern, pattern_to_llvm
+
     # Given
     expected = KoreParser(kore_text).pattern()
 
@@ -85,7 +85,9 @@ def test_pattern_to_llvm(test_id: str, kore_text: str) -> None:
 
 
 @pytest.mark.parametrize('test_id,kore_text', DEF_TEST_DATA, ids=[test_id for test_id, *_ in DEF_TEST_DATA])
-def test_definition_to_llvm(test_id: str, kore_text: str) -> None:
+def test_definition_to_llvm(load_kllvm: None, test_id: str, kore_text: str) -> None:
+    from pyk.kllvm.convert import definition_to_llvm, llvm_to_definition
+
     # Given
     expected = KoreParser(kore_text).definition()
 

--- a/pyk/src/tests/integration/kllvm/test_desugar_associative.py
+++ b/pyk/src/tests/integration/kllvm/test_desugar_associative.py
@@ -5,8 +5,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.convert import pattern_to_llvm
 from pyk.kore.parser import KoreParser
 
 if TYPE_CHECKING:
@@ -37,7 +35,9 @@ TEST_DATA: Final = (
 
 
 @pytest.mark.parametrize('kore_text,expected_text', TEST_DATA, ids=count())
-def test_desugar_associative(kore_text: str, expected_text: str) -> None:
+def test_desugar_associative(load_kllvm: None, kore_text: str, expected_text: str) -> None:
+    from pyk.kllvm.convert import pattern_to_llvm
+
     # Given
     kore = pattern_to_llvm(KoreParser(kore_text).pattern())
     expected = pattern_to_llvm(KoreParser(expected_text).pattern())

--- a/pyk/src/tests/integration/kllvm/test_evaluate.py
+++ b/pyk/src/tests/integration/kllvm/test_evaluate.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm import parser
 from pyk.testing import RuntimeTest
 
 from ..utils import K_FILES
@@ -39,6 +37,8 @@ class TestEvaluate(RuntimeTest):
         ids=[test_id for test_id, *_ in EVALUATE_TEST_DATA],
     )
     def test_simplify(self, runtime: Runtime, test_id: str, pattern_text: str, expected: str) -> None:
+        from pyk.kllvm import parser
+
         # Given
         pattern = parser.parse_pattern(pattern_text)
 

--- a/pyk/src/tests/integration/kllvm/test_internal_term.py
+++ b/pyk/src/tests/integration/kllvm/test_internal_term.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.parser import Parser
 from pyk.testing import RuntimeTest
 
 from ..utils import K_FILES
@@ -21,15 +19,18 @@ if TYPE_CHECKING:
 class TestInternalTerm(RuntimeTest):
     KOMPILE_MAIN_FILE = K_FILES / 'imp.k'
 
-    def test_str_llvm_backend_issue_724(self, runtime: Runtime) -> None:
+    def test_str_llvm_backend_issue_724(self, runtime: Runtime, start_pattern: Pattern) -> None:
         for _ in range(10000):
-            term = runtime._module.InternalTerm(start_pattern())
+            term = runtime._module.InternalTerm(start_pattern)
             term.step(-1)
             # just checking that str doesn't crash
             str(term)
 
 
-def start_pattern() -> Pattern:
+@pytest.fixture
+def start_pattern(load_kllvm: None) -> Pattern:
+    from pyk.kllvm.parser import Parser
+
     """
     <k> int x ; x = 1 </k>
     """

--- a/pyk/src/tests/integration/kllvm/test_load.py
+++ b/pyk/src/tests/integration/kllvm/test_load.py
@@ -2,15 +2,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pyk.kllvm.load  # noqa: F401
-import pyk.kllvm.load_static  # noqa: F401
-from pyk.kllvm.compiler import compile_kllvm
-
 if TYPE_CHECKING:
     from typing import Final
 
 
 def test_kllvm_module() -> None:
+    import pyk.kllvm.load  # noqa: F401
+    import pyk.kllvm.load_static  # noqa: F401
+    from pyk.kllvm.compiler import compile_kllvm
 
     # Given
     kllvm_module_dir: Final = pyk.kllvm.load.KLLVM_MODULE_DIR

--- a/pyk/src/tests/integration/kllvm/test_parser.py
+++ b/pyk/src/tests/integration/kllvm/test_parser.py
@@ -2,14 +2,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm import parser
-
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-def test_parse_pattern_file(tmp_path: Path) -> None:
+def test_parse_pattern_file(load_kllvm: None, tmp_path: Path) -> None:
+    from pyk.kllvm import parser
+
     # Given
     kore_text = 'A{}(B{}(),C{}())'
     kore_file = tmp_path / 'test.kore'
@@ -22,7 +21,9 @@ def test_parse_pattern_file(tmp_path: Path) -> None:
     assert str(actual) == kore_text
 
 
-def test_parse_pattern() -> None:
+def test_parse_pattern(load_kllvm: None) -> None:
+    from pyk.kllvm import parser
+
     # Given
     kore_text = 'A{}(X : S,Y : Z,Int{}())'
 
@@ -33,7 +34,9 @@ def test_parse_pattern() -> None:
     assert str(actual) == kore_text
 
 
-def test_parse_sort_file(tmp_path: Path) -> None:
+def test_parse_sort_file(load_kllvm: None, tmp_path: Path) -> None:
+    from pyk.kllvm import parser
+
     # Given
     kore_text = 'Foo{Bar,Baz}'
     kore_file = tmp_path / 'test.kore'
@@ -46,7 +49,9 @@ def test_parse_sort_file(tmp_path: Path) -> None:
     assert str(actual) == kore_text
 
 
-def test_parse_sort() -> None:
+def test_parse_sort(load_kllvm: None) -> None:
+    from pyk.kllvm import parser
+
     # Given
     kore_text = 'Foo{Bar,Baz}'
 
@@ -57,9 +62,10 @@ def test_parse_sort() -> None:
     assert str(actual) == kore_text
 
 
-def test_parse_definition_file(tmp_path: Path) -> None:
-    # Given
+def test_parse_definition_file(load_kllvm: None, tmp_path: Path) -> None:
+    from pyk.kllvm import parser
 
+    # Given
     # fmt: off
     kore_text = (
         '[]\n'
@@ -81,10 +87,10 @@ def test_parse_definition_file(tmp_path: Path) -> None:
     assert str(actual) == kore_text
 
 
-def test_parse_definition() -> None:
-    # Given
+def test_parse_definition(load_kllvm: None) -> None:
+    from pyk.kllvm import parser
 
-    # fmt: off
+    # Given
     kore_text = (
         '[]\n'
         '\n'
@@ -93,7 +99,6 @@ def test_parse_definition() -> None:
         'endmodule\n'
         '[concrete{}()]\n'
     )
-    # fmt: on
 
     # When
     actual = parser.parse_definition(kore_text)

--- a/pyk/src/tests/integration/kllvm/test_patterns.py
+++ b/pyk/src/tests/integration/kllvm/test_patterns.py
@@ -4,9 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.ast import CompositePattern, CompositeSort, Pattern, StringPattern, VariablePattern
-
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -19,7 +16,9 @@ if TYPE_CHECKING:
         'XYZ : ABC',
     ),
 )
-def test_file_load(tmp_path: Path, kore_text: str) -> None:
+def test_file_load(load_kllvm: None, tmp_path: Path, kore_text: str) -> None:
+    from pyk.kllvm.ast import Pattern
+
     # Given
     kore_file = tmp_path / 'test.kore'
     kore_file.write_text(kore_text)
@@ -31,7 +30,9 @@ def test_file_load(tmp_path: Path, kore_text: str) -> None:
     assert str(actual) == kore_text
 
 
-def test_composite() -> None:
+def test_composite(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositePattern, CompositeSort, VariablePattern
+
     # Given
     pattern = CompositePattern('F')
     pattern.add_argument(CompositePattern('A'))
@@ -44,7 +45,9 @@ def test_composite() -> None:
     assert str(actual) == 'F{}(A{}(),B{}())'
 
 
-def test_string() -> None:
+def test_string(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import StringPattern
+
     # Given
     pattern = StringPattern('abc')
 
@@ -53,7 +56,9 @@ def test_string() -> None:
     assert pattern.contents.decode('latin-1') == 'abc'
 
 
-def test_variable() -> None:
+def test_variable(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositePattern, CompositeSort, VariablePattern
+
     # Given
     pattern = VariablePattern('X', CompositeSort('S'))
 

--- a/pyk/src/tests/integration/kllvm/test_serialize.py
+++ b/pyk/src/tests/integration/kllvm/test_serialize.py
@@ -4,10 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm import parser
-from pyk.kllvm.ast import Pattern
-from pyk.kllvm.convert import pattern_to_llvm
 from pyk.kore.parser import KoreParser
 from pyk.testing import RuntimeTest
 
@@ -31,7 +27,10 @@ TEST_DATA = (
 
 
 @pytest.mark.parametrize('kore_text', TEST_DATA)
-def test_serialize(kore_text: str) -> None:
+def test_serialize(load_kllvm: None, kore_text: str) -> None:
+    from pyk.kllvm.ast import Pattern
+    from pyk.kllvm.convert import pattern_to_llvm
+
     # Given
     _pattern = KoreParser(kore_text).pattern()
     pattern = pattern_to_llvm(_pattern)
@@ -49,6 +48,9 @@ class TestSerializeRaw(RuntimeTest):
     KOMPILE_MAIN_FILE = K_FILES / 'imp.k'
 
     def test_serialize_raw(self, runtime: Runtime, tmp_path: Path) -> None:
+        from pyk.kllvm import parser
+        from pyk.kllvm.ast import Pattern
+
         # Given
         kore_text = r"""Lbl'UndsPlus'Int'Unds'{}(\dv{SortInt{}}("1"),\dv{SortInt{}}("2"))"""
         pattern = parser.parse_pattern(kore_text)

--- a/pyk/src/tests/integration/kllvm/test_simplify.py
+++ b/pyk/src/tests/integration/kllvm/test_simplify.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm import parser
 from pyk.testing import RuntimeTest
 
 from ..utils import K_FILES
@@ -40,6 +38,8 @@ class TestSimplify(RuntimeTest):
         ids=[test_id for test_id, *_ in SIMPLIFY_TEST_DATA],
     )
     def test_simplify(self, runtime: Runtime, test_id: str, pattern_text: str, expected: str) -> None:
+        from pyk.kllvm import parser
+
         # Given
         pattern = parser.parse_pattern(pattern_text)
         sort = parser.parse_sort('SortInt{}')
@@ -56,6 +56,8 @@ class TestSimplify(RuntimeTest):
         ids=[test_id for test_id, *_ in SIMPLIFY_BOOL_TEST_DATA],
     )
     def test_simplify_bool(self, runtime: Runtime, test_id: str, pattern_text: str, expected: bool) -> None:
+        from pyk.kllvm import parser
+
         # Given
         pattern = parser.parse_pattern(pattern_text)
 

--- a/pyk/src/tests/integration/kllvm/test_sorts.py
+++ b/pyk/src/tests/integration/kllvm/test_sorts.py
@@ -1,33 +1,35 @@
-from __future__ import annotations
+def test_is_concrete(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort
 
-from typing import TYPE_CHECKING
+    # Given
+    sort = CompositeSort('A')
 
-import pytest
-
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.ast import CompositeSort, SortVariable
-
-if TYPE_CHECKING:
-    from pyk.kllvm.ast import Sort
-
-
-@pytest.mark.parametrize(
-    'sort,expected',
-    (
-        (CompositeSort('A'), True),
-        (SortVariable('B'), False),
-    ),
-)
-def test_is_concrete(sort: Sort, expected: bool) -> None:
     # When
     actual = sort.is_concrete
 
     # Then
-    assert actual == expected
+    assert actual
 
 
-@pytest.mark.parametrize('name', ('A', 'SortInt', ''))
-def test_name(name: str) -> None:
+def test_is_not_concrete(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import SortVariable
+
+    # Given
+    sort = SortVariable('B')
+
+    # When
+    actual = sort.is_concrete
+
+    # Then
+    assert not actual
+
+
+def test_name(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort
+
+    # Given
+    name = 'SortInt'
+
     # When
     sort = CompositeSort(name)
 
@@ -35,22 +37,31 @@ def test_name(name: str) -> None:
     assert sort.name == name
 
 
-@pytest.mark.parametrize(
-    'sort,expected',
-    (
-        (CompositeSort('A'), 'A{}'),
-        (SortVariable('B'), 'B'),
-    ),
-)
-def test_str(sort: Sort, expected: str) -> None:
+def test_str(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort, SortVariable
+
+    # Given
+    s1 = CompositeSort('A')
+
     # When
-    actual = str(sort)
+    s1_str = str(s1)
 
     # Then
-    assert actual == expected
+    assert s1_str == 'A{}'
+
+    # And given
+    s2 = SortVariable('B')
+
+    # When
+    s2_str = str(s2)
+
+    # Then
+    assert s2_str == 'B'
 
 
-def test_add_argument() -> None:
+def test_add_argument(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort, SortVariable
+
     # Given
     f = CompositeSort('F')
     a = CompositeSort('A')
@@ -64,7 +75,9 @@ def test_add_argument() -> None:
     assert str(f) == 'F{A{},B}'
 
 
-def test_substitution_1() -> None:
+def test_substitution_1(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort, SortVariable
+
     # Given
     x = SortVariable('X')
     a = CompositeSort('A')
@@ -77,7 +90,9 @@ def test_substitution_1() -> None:
     assert actual == expected
 
 
-def test_substitution_2() -> None:
+def test_substitution_2(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort, SortVariable
+
     x = SortVariable('X')
     y = SortVariable('Y')
     a = CompositeSort('A')
@@ -113,7 +128,9 @@ def test_substitution_2() -> None:
     assert actual == expected
 
 
-def test_equality() -> None:
+def test_equality(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort, SortVariable
+
     # Given
     a1 = CompositeSort('A')
     a2 = CompositeSort('A')

--- a/pyk/src/tests/integration/kllvm/test_step.py
+++ b/pyk/src/tests/integration/kllvm/test_step.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.parser import parse_pattern
+import pytest
+
 from pyk.testing import RuntimeTest
 
 if TYPE_CHECKING:
@@ -23,8 +23,8 @@ class TestStep(RuntimeTest):
     KOMPILE_MAIN_MODULE = 'STEPS'
     KOMPILE_ARGS = {'syntax_module': 'STEPS'}
 
-    def test_steps_1(self, runtime: Runtime) -> None:
-        term = runtime.term(start_pattern())
+    def test_steps_1(self, runtime: Runtime, start_pattern: Pattern) -> None:
+        term = runtime.term(start_pattern)
         term.step(0)
         assert str(term) == foo_output(0)
         term.step()
@@ -33,27 +33,30 @@ class TestStep(RuntimeTest):
         term.step(200)
         assert str(term) == bar_output()
 
-    def test_steps_2(self, runtime: Runtime) -> None:
-        term = runtime.term(start_pattern())
+    def test_steps_2(self, runtime: Runtime, start_pattern: Pattern) -> None:
+        term = runtime.term(start_pattern)
         assert str(term) == foo_output(0)
         term.step(50)
         assert str(term) == foo_output(50)
         term.step(-1)
         assert str(term) == bar_output()
 
-    def test_steps_3(self, runtime: Runtime) -> None:
-        term = runtime.term(start_pattern())
+    def test_steps_3(self, runtime: Runtime, start_pattern: Pattern) -> None:
+        term = runtime.term(start_pattern)
         term.run()
         assert str(term) == bar_output()
 
-    def test_steps_to_pattern(self, runtime: Runtime) -> None:
-        term = runtime.term(start_pattern())
+    def test_steps_to_pattern(self, runtime: Runtime, start_pattern: Pattern) -> None:
+        term = runtime.term(start_pattern)
         term.run()
         pattern = term.pattern
         assert str(pattern) == bar_output()
 
 
-def start_pattern() -> Pattern:
+@pytest.fixture
+def start_pattern(load_kllvm: None) -> Pattern:
+    from pyk.kllvm.parser import parse_pattern
+
     """
     <k> foo(100) </k>
     """

--- a/pyk/src/tests/integration/kllvm/test_symbols.py
+++ b/pyk/src/tests/integration/kllvm/test_symbols.py
@@ -1,35 +1,29 @@
-from __future__ import annotations
+def test_str(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import CompositeSort, Symbol
 
-from typing import TYPE_CHECKING
+    # Given
+    s1 = Symbol("Lbl'Plus")
 
-import pytest
-
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.ast import CompositeSort, Symbol, Variable
-
-if TYPE_CHECKING:
-    from typing import Final
-
-s1 = Symbol("Lbl'Plus")
-s2 = Symbol("Lbl'Plus")
-s2.add_formal_argument(CompositeSort('A'))
-
-STR_TEST_DATA: Final = (
-    (s1, "Lbl'Plus{}"),
-    (s2, "Lbl'Plus{A{}}"),
-)
-
-
-@pytest.mark.parametrize('symbol,expected', STR_TEST_DATA, ids=[expected for _, expected in STR_TEST_DATA])
-def test_str(symbol: Symbol, expected: str) -> None:
     # When
-    actual = str(symbol)
+    s1_str = str(s1)
 
     # Then
-    assert actual == expected
+    assert s1_str == "Lbl'Plus{}"
+
+    # And given
+    s2 = Symbol("Lbl'Plus")
+    s2.add_formal_argument(CompositeSort('A'))
+
+    # When
+    s2_str = str(s2)
+
+    # Then
+    assert s2_str == "Lbl'Plus{A{}}"
 
 
-def test_equal() -> None:
+def test_equal(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import Symbol
+
     # Given
     a1 = Symbol('A')
     a2 = Symbol('A')
@@ -41,7 +35,9 @@ def test_equal() -> None:
     assert a1 != b
 
 
-def test_variable() -> None:
+def test_variable(load_kllvm: None) -> None:
+    from pyk.kllvm.ast import Variable
+
     # When
     a = Variable('A')
 

--- a/pyk/src/tests/integration/kllvm/test_term.py
+++ b/pyk/src/tests/integration/kllvm/test_term.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.ast import CompositePattern
 from pyk.testing import RuntimeTest
 
 if TYPE_CHECKING:
@@ -25,6 +23,8 @@ class TestTerm(RuntimeTest):
 
     @pytest.mark.parametrize('ctor', ('one', 'two', 'three'))
     def test_construct(self, runtime: Runtime, ctor: str) -> None:
+        from pyk.kllvm.ast import CompositePattern
+
         # Given
         label = f"Lbl{ctor}'LParRParUnds'CTOR'Unds'Foo"
         pattern = CompositePattern(label)

--- a/pyk/src/tests/integration/kllvm/test_utils.py
+++ b/pyk/src/tests/integration/kllvm/test_utils.py
@@ -4,8 +4,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-import pyk.kllvm.load  # noqa: F401
-from pyk.kllvm.utils import get_requires
 from pyk.kore.parser import KoreParser
 
 if TYPE_CHECKING:
@@ -28,7 +26,9 @@ AXIOM_TEST_DATA: Final = (
 @pytest.mark.parametrize(
     'test_id,kore_requires,kore_axiom', AXIOM_TEST_DATA, ids=[test_id for test_id, *_ in AXIOM_TEST_DATA]
 )
-def test_get_requires(test_id: str, kore_requires: str, kore_axiom: str) -> None:
+def test_get_requires(load_kllvm: None, test_id: str, kore_requires: str, kore_axiom: str) -> None:
+    from pyk.kllvm.utils import get_requires
+
     # Given
     axiom = KoreParser(kore_axiom).axiom()
 

--- a/pyk/src/tests/integration/test_bytes.py
+++ b/pyk/src/tests/integration/test_bytes.py
@@ -88,9 +88,7 @@ def definition_dir(request: FixtureRequest, backend: str) -> Path:
 
 
 @pytest.fixture(scope='module')
-def runtime(llvm_dir: Path) -> Runtime:
-    import pyk.kllvm.load  # noqa: F401
-
+def runtime(load_kllvm: None, llvm_dir: Path) -> Runtime:
     compile_runtime(llvm_dir)
     return import_runtime(llvm_dir)
 

--- a/pyk/src/tests/integration/test_string.py
+++ b/pyk/src/tests/integration/test_string.py
@@ -91,9 +91,7 @@ def definition_dir(request: FixtureRequest, backend: str) -> Path:
 
 
 @pytest.fixture(scope='module')
-def runtime(llvm_dir: Path) -> Runtime:
-    import pyk.kllvm.load  # noqa: F401
-
+def runtime(load_kllvm: None, llvm_dir: Path) -> Runtime:
     compile_runtime(llvm_dir)
     return import_runtime(llvm_dir)
 


### PR DESCRIPTION
Direct imports of `pyk.kllvm.load` are removed by relying on the fixture where needed. This eliminates the 5-10s startup delay in the integration test harness, as the `kllvm` Python module is now generated during test execution rather than at test collection.