### PR TITLE
Disable markup parsing in TUI

### DIFF
--- a/pyk/src/pyk/kcfg/tui.py
+++ b/pyk/src/pyk/kcfg/tui.py
@@ -79,10 +79,10 @@ class NavWidget(ScrollableContainer, can_focus=True):
         self.text = text
 
     def compose(self) -> ComposeResult:
-        yield Static(self.text)
+        yield Static(self.text, markup=False)
 
     def watch_text(self) -> None:
-        self.query_one(Static).update(self.text, markup=False)
+        self.query_one(Static).update(self.text)
 
 
 class Info(Widget, can_focus=False):
@@ -95,10 +95,10 @@ class Info(Widget, can_focus=False):
         self.text = text
 
     def compose(self) -> ComposeResult:
-        yield Static(self.text)
+        yield Static(self.text, markup=False)
 
     def watch_text(self) -> None:
-        self.query_one(Static).update(self.text, markup=False)
+        self.query_one(Static).update(self.text)
 
 
 class Status(NavWidget):

--- a/pyk/src/pyk/kcfg/tui.py
+++ b/pyk/src/pyk/kcfg/tui.py
@@ -82,7 +82,7 @@ class NavWidget(ScrollableContainer, can_focus=True):
         yield Static(self.text)
 
     def watch_text(self) -> None:
-        self.query_one(Static).update(self.text)
+        self.query_one(Static).update(self.text, markup=False)
 
 
 class Info(Widget, can_focus=False):
@@ -98,7 +98,7 @@ class Info(Widget, can_focus=False):
         yield Static(self.text)
 
     def watch_text(self) -> None:
-        self.query_one(Static).update(self.text)
+        self.query_one(Static).update(self.text, markup=False)
 
 
 class Status(NavWidget):


### PR DESCRIPTION
Closes https://github.com/runtimeverification/k/issues/4839.

This PR adds `markup=False` to `Static` widget creation, fixing an issue where TUI (e.g., invoked by `kontrol view-kcfg`) is crashing when clicking on a node since bytecode literal is being interpreted as markup.