### PR TITLE
Fix Noble Dockerfile, Nix release errors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,9 @@ jobs:
 
       - name: 'Install Nix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.5.1
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://hydra.iohk.io
@@ -105,9 +105,9 @@ jobs:
 
       - name: 'Install Nix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.5.1
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
           extra_nix_config: |
             access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
             substituters = http://cache.nixos.org https://hydra.iohk.io

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -162,9 +162,9 @@ jobs:
       - name: 'Check out code'
         uses: actions/checkout@v4
       - name: 'Install Nix'
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.5.1
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
           extra_nix_config: |
             substituters = http://cache.nixos.org https://hydra.iohk.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=
@@ -198,9 +198,9 @@ jobs:
         run: brew install bash
       - name: 'Install Nix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v22
+        uses: cachix/install-nix-action@v31.5.1
         with:
-          install_url: https://releases.nixos.org/nix/nix-2.13.3/install
+          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
           extra_nix_config: |
             substituters = http://cache.nixos.org https://hydra.iohk.io
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY= hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ=

--- a/package/docker/Dockerfile.ubuntu-jammy
+++ b/package/docker/Dockerfile.ubuntu-jammy
@@ -19,8 +19,6 @@ RUN    apt-get update                                                           
     && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_jammy.deb \
     && rm /kframework_amd64_ubuntu_jammy.deb
 
+ENV PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin
 COPY kframework-*.whl ./
-RUN    pipx ensurepath               \
-    && . /root/.profile              \
-    && pip install /kframework-*.whl \
-    && rm /kframework-*.whl
+RUN pipx install /kframework-*.whl && rm /kframework-*.whl

--- a/package/docker/Dockerfile.ubuntu-noble
+++ b/package/docker/Dockerfile.ubuntu-noble
@@ -19,8 +19,6 @@ RUN    apt-get update                                                           
     && apt-get install --yes --no-install-recommends /kframework_amd64_ubuntu_noble.deb \
     && rm /kframework_amd64_ubuntu_noble.deb
 
+ENV PIPX_HOME=/opt/pipx PIPX_BIN_DIR=/usr/local/bin
 COPY kframework-*.whl ./
-RUN    pipx ensurepath                                       \
-    && . /root/.profile                                      \
-    && pipx install /kframework-*.whl                        \
-    && rm /kframework-*.whl
+RUN pipx install /kframework-*.whl && rm /kframework-*.whl

--- a/package/docker/Dockerfile.ubuntu-noble
+++ b/package/docker/Dockerfile.ubuntu-noble
@@ -22,5 +22,5 @@ RUN    apt-get update                                                           
 COPY kframework-*.whl ./
 RUN    pipx ensurepath                                       \
     && . /root/.profile                                      \
-    && pipx install /kframework-*.whl --break-system-packages \
+    && pipx install /kframework-*.whl                        \
     && rm /kframework-*.whl

--- a/package/docker/Dockerfile.ubuntu-noble
+++ b/package/docker/Dockerfile.ubuntu-noble
@@ -22,5 +22,5 @@ RUN    apt-get update                                                           
 COPY kframework-*.whl ./
 RUN    pipx ensurepath                                       \
     && . /root/.profile                                      \
-    && pip install /kframework-*.whl --break-system-packages \
+    && pip install /kframework-*.whl --break-system-packages --force-reinstall \
     && rm /kframework-*.whl

--- a/package/docker/Dockerfile.ubuntu-noble
+++ b/package/docker/Dockerfile.ubuntu-noble
@@ -22,5 +22,5 @@ RUN    apt-get update                                                           
 COPY kframework-*.whl ./
 RUN    pipx ensurepath                                       \
     && . /root/.profile                                      \
-    && pip install /kframework-*.whl --break-system-packages --force-reinstall \
+    && pipx install /kframework-*.whl --break-system-packages \
     && rm /kframework-*.whl


### PR DESCRIPTION
This PR fixes the issues preventing K releases from going through. Specifically, it
- switches from `pip install` to `pipx install` in Ubuntu Jammy and Ubuntu Noble (to prevent package versioning issues as seen [here](https://github.com/runtimeverification/k/actions/runs/16967898838/job/48096671362#step:8:687))
- updates the Nix version to `2.30.1` in all CI workflows (to prevent Nix version conflicts as seen [here](https://github.com/runtimeverification/k/actions/runs/17239588825/job/48912830345))

The release job is passing now, as demonstrated by this run: https://github.com/runtimeverification/k/actions/runs/17242935221.