### PR TITLE
Uninstall pre-installed cmake prior to building with brew in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -347,6 +347,9 @@ jobs:
           # shellcheck disable=SC2162
           brew list -1 | grep python | while read formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
 
+          # uninstall pre-installed cmake
+          brew uninstall cmake
+
       - name: Build brew bottle
         id: build
         env:


### PR DESCRIPTION
The release workflow in CI started to break, see [here](https://github.com/runtimeverification/k/actions/runs/17381082425/job/49338586227#step:7:1363) due to brew and cmake.

This workflow uses a MacOS image provided by this [GitHub action](https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20250825.1763). While the version of cmake stayed the same, I assume that the image has switched from a non-brew cmake to a brew-provided cmake, causing a conflict when building K with brew.

This pull request fixes this issue by uninstalling cmake beforehand.