### PR TITLE
Fix macos release followup

### DIFF
--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -178,6 +178,7 @@ jobs:
           # explicitly instead.
           JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+          HOMEBREW_INTERNAL_ALLOW_PACKAGES_FROM_PATHS: 1
         run: |
           # The macOS public runners are prone to flakiness when running this
           # test suite, so the PL-tutorial is disabled for now.

--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -178,7 +178,7 @@ jobs:
           # explicitly instead.
           JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
-          HOMEBREW_INTERNAL_ALLOW_PACKAGES_FROM_PATHS: 1
+          HOMEBREW_FORBID_PACKAGES_FROM_PATHS: 0
         run: |
           # The macOS public runners are prone to flakiness when running this
           # test suite, so the PL-tutorial is disabled for now.

--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -1,0 +1,202 @@
+name: 'Release (for debugging)'
+run-name: K Framework Release (for debugging) ${{ github.ref_name }}
+on:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+    branches:
+      - 'develop'
+concurrency:
+  group: ${{ github.workflow }}
+
+jobs:
+  source-tarball:
+    name: 'Create source tarball'
+    runs-on: ubuntu-24.04
+    environment: production
+    steps:
+      - name: 'Check out code'
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - name: 'Create source tarball'
+        env:
+          GITHUB_TOKEN: ${{ secrets.JENKINS_GITHUB_PAT }}
+        run: |
+          set -x
+          version=$(cat package/version)
+          tarball=kframework-${version}-src.tar.gz
+          # shellcheck disable=SC2038
+          find . -name .git | xargs rm -r
+          CURDIR=$(pwd)
+          cd ..
+          tar czvf "${tarball}" "$(basename "${CURDIR}")"
+          mv "${tarball}" "${CURDIR}/"
+          cd "${CURDIR}"
+          gh release upload --repo runtimeverification/k --clobber "v${version}" "${tarball}"
+
+  macos-build:
+    name: 'Build MacOS Package'
+    runs-on: macos-14
+    timeout-minutes: 120
+    environment: production
+    needs: [source-tarball]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          path: kframework
+
+      - name: Check out matching homebrew repo branch
+        uses: actions/checkout@v4
+        id: checkout
+        with:
+          repository: runtimeverification/homebrew-k
+          path: homebrew-k
+          ref: staging
+        continue-on-error: true
+
+      - name: Check out homebrew repo master branch
+        uses: actions/checkout@v4
+        if: ${{ steps.checkout.outcome == 'failure' }}
+        with:
+          repository: runtimeverification/homebrew-k
+          path: homebrew-k
+
+      - name: Cache maven
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}-
+          restore-keys: |
+            ${{ runner.os }}-maven-
+
+      - name: Mac Dependencies
+        run: |
+          # Via: https://github.com/ledger/ledger/commit/1eec9f86667cad3b0bbafb82a83739a0d30ca09f
+          # Unlink and re-link to prevent errors when github mac runner images
+          # install python outside of brew, for example:
+          # https://github.com/orgs/Homebrew/discussions/3895
+          # https://github.com/actions/setup-python/issues/577
+          # https://github.com/actions/runner-images/issues/6459
+          # https://github.com/actions/runner-images/issues/6507
+          # https://github.com/actions/runner-images/issues/2322
+
+          # shellcheck disable=SC2162
+          brew list -1 | grep python | while read formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
+
+          # uninstall pre-installed cmake
+          brew uninstall cmake
+
+      - name: Build brew bottle
+        id: build
+        env:
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+          MAVEN_OPTS: >-
+              -Dhttp.keepAlive=false
+              -Dmaven.wagon.http.pool=false
+              -Dmaven.wagon.httpconnectionManager.ttlSeconds=30
+        run: |
+          PACKAGE=kframework
+          VERSION=$(cat kframework/package/version)
+          ROOT_URL='https://github.com/runtimeverification/k/releases/download'
+          wget "$ROOT_URL/v${VERSION}/kframework-${VERSION}-src.tar.gz"
+          cd homebrew-k
+          ../kframework/package/macos/brew-update-to-local "${PACKAGE}" "${VERSION}"
+          git commit "Formula/$PACKAGE.rb" -m "Update ${PACKAGE} to ${VERSION}: part 1"
+          ../kframework/package/macos/brew-build-and-update-to-local-bottle "${PACKAGE}" "${VERSION}" "${ROOT_URL}"
+          git reset HEAD^
+          LOCAL_BOTTLE_NAME=$(basename "$(find . -name "kframework--${VERSION}.arm64_sonoma.bottle*.tar.gz")")
+          # shellcheck disable=2001
+          BOTTLE_NAME=$(echo "${LOCAL_BOTTLE_NAME#./}" | sed 's!kframework--!kframework-!')
+          ../kframework/package/macos/brew-update-to-final "${PACKAGE}" "${VERSION}" "${ROOT_URL}"
+          echo "path=${LOCAL_BOTTLE_NAME}" >> "${GITHUB_OUTPUT}"
+          echo "path_remote=${BOTTLE_NAME}" >> "${GITHUB_OUTPUT}"
+
+      - name: Upload bottle
+        uses: actions/upload-artifact@v4
+        with:
+          name: homebrew
+          path: homebrew-k
+
+    outputs:
+      bottle_path: ${{ steps.build.outputs.path }}
+      bottle_path_remote: ${{ steps.build.outputs.path_remote }}
+
+  macos-test:
+    name: 'Test MacOS Package'
+    runs-on: macos-14
+    timeout-minutes: 60
+    environment: production
+    needs: [macos-build]
+    steps:
+      - name: 'Check out matching homebrew repo branch'
+        uses: actions/checkout@v4
+        id: checkout
+        with:
+          repository: runtimeverification/homebrew-k
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
+          path: homebrew-k
+          ref: staging
+        continue-on-error: true
+
+      - name: 'Check out homebrew repo master branch'
+        uses: actions/checkout@v4
+        if: ${{ steps.checkout.outcome == 'failure' }}
+        with:
+          repository: runtimeverification/homebrew-k
+          token: ${{ secrets.JENKINS_GITHUB_PAT }}
+          path: homebrew-k
+
+      - name: 'Download bottle'
+        uses: actions/download-artifact@v4
+        with:
+          name: homebrew
+          path: homebrew-k-old
+
+      - name: Mac Dependencies
+        run: |
+          # Via: https://github.com/ledger/ledger/commit/1eec9f86667cad3b0bbafb82a83739a0d30ca09f
+          # Unlink and re-link to prevent errors when github mac runner images
+          # install python outside of brew, for example:
+          # https://github.com/orgs/Homebrew/discussions/3895
+          # https://github.com/actions/setup-python/issues/577
+          # https://github.com/actions/runner-images/issues/6459
+          # https://github.com/actions/runner-images/issues/6507
+          # https://github.com/actions/runner-images/issues/2322
+
+          # shellcheck disable=SC2162
+          brew list -1 | grep python | while read formula; do brew unlink "$formula"; brew link --overwrite "$formula"; done
+
+      - name: 'Test brew bottle'
+        id: test
+        env:
+          # github actions sets the JAVA_HOME variable to Java 8 explicitly for
+          # some reason. There doesn't seem to be a way to tell it to unset the
+          # variable, so instead we just have to tell it to use Java 17
+          # explicitly instead.
+          JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
+        run: |
+          # The macOS public runners are prone to flakiness when running this
+          # test suite, so the PL-tutorial is disabled for now.
+          #   - https://github.com/runtimeverification/k/issues/3705
+          cd homebrew-k-old
+          # brew tap expects a git repository, so we initialise the current folder as a dummy repo
+          git init
+          brew tap runtimeverification/k "file:///$(pwd)"
+          brew install ${{ needs.macos-build.outputs.bottle_path }} -v
+          # cp -R /usr/local/share/kframework/pl-tutorial ~
+          # WD=`pwd`
+          # cd
+          # echo 'Starting kserver...'
+          # spawn-kserver $WD/kserver.log
+          # cd pl-tutorial
+          # echo 'Testing tutorial in user environment...'
+          # make -j`sysctl -n hw.ncpu` ${MAKE_EXTRA_ARGS}
+          # cd ~
+          echo 'module TEST imports BOOL endmodule' > test.k
+          kompile test.k --backend llvm
+          kompile test.k --backend haskell
+

--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -187,7 +187,7 @@ jobs:
           # brew tap expects a git repository, so we initialise the current folder as a dummy repo
           git init
           brew tap runtimeverification/k "file:///$(pwd)"
-          brew install ${{ needs.macos-build.outputs.bottle_path }} -v
+          brew install ${{ needs.macos-build.outputs.bottle_path }}
           # cp -R /usr/local/share/kframework/pl-tutorial ~
           # WD=`pwd`
           # cd

--- a/.github/workflows/release-debug.yml
+++ b/.github/workflows/release-debug.yml
@@ -178,7 +178,7 @@ jobs:
           # explicitly instead.
           JAVA_HOME: ${{ env.JAVA_HOME_17_X64 }}
           HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
-          HOMEBREW_FORBID_PACKAGES_FROM_PATHS: 0
+          HOMEBREW_DEVELOPER: 1
         run: |
           # The macOS public runners are prone to flakiness when running this
           # test suite, so the PL-tutorial is disabled for now.


### PR DESCRIPTION
The previous pull request #4852 succesfully fixed an error that made the homebrew build of k not build in CI.

It turns out that there is another unrelated error during testing of that homebrew build, see [logs](https://github.com/runtimeverification/k/actions/runs/17402621638/job/49401283081#step:6:46). brew cannot find the local bottle (brew package) when trying to install.