### PR TITLE
Allow publishing releases without macos-tests

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -511,7 +511,7 @@ jobs:
     name: 'Publish Release'
     runs-on: [self-hosted, linux, normal]
     environment: production
-    needs: [cachix-release, cachix-release-dependencies, macos-test, source-tarball, ubuntu-jammy, ubuntu-noble, set-release-id]
+    needs: [cachix-release, cachix-release-dependencies, source-tarball, ubuntu-jammy, ubuntu-noble, set-release-id]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
This PR allows bypassing the `macos-test` CI job to publish new K releases.

The release workflow started failing in the `macos-build` job as of this PR:
https://github.com/runtimeverification/k/pull/4850
The failure seems unrelated to the changes introduced by the PR and looks more like a flakiness issue in the CI due to non-deterministic dependency resolution.

A follow-up PR fixed the `macos-build` job:
https://github.com/runtimeverification/k/pull/4851

Unfortunately, the workflow is now failing in the `macos-test` job.
https://github.com/runtimeverification/k/pull/4852 is an attempt to debug and fix the tests.

The inability to publish new K-releases is currently blocking important updates on Simbolik.
 


