### PR TITLE
Introduce pyproject-nix overlay in nix flake

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -251,7 +251,7 @@
                 patchShebangs tests/regression-new/*
                 substituteInPlace tests/regression-new/append/kparse-twice \
                   --replace '"$(dirname "$0")/../../../bin/kparse"' '"${k}/bin/kparse"'
-              '';        inherit (pkgs) kontrol-pyk-debug;
+              '';
 
               buildFlags = [
                 "K_BIN=${k}/bin"

--- a/nix/pyk-pyproject/default.nix
+++ b/nix/pyk-pyproject/default.nix
@@ -1,0 +1,29 @@
+{
+  lib,
+  callPackage,
+  nix-gitignore,
+
+  uv2nix,
+}:
+let
+  # load a uv workspace from a workspace root
+  workspace = uv2nix.lib.workspace.loadWorkspace {
+    workspaceRoot = lib.cleanSource (nix-gitignore.gitignoreSourcePure [
+        ../../.gitignore
+        ".github/"
+        "result*"
+        "/deps/"
+        # do not include submodule directories that might be initilized empty or non-existent
+      ] ../../pyk/.
+    );
+  };
+
+  # create overlay
+  lockFileOverlay = workspace.mkPyprojectOverlay {
+    # prefer "wheel" over "sdist" due to maintance overhead
+    # there is no bundled set of overlays for "sdist" in uv2nix, in contrast to poetry2nix
+    sourcePreference = "wheel";
+  };
+in {
+  inherit lockFileOverlay workspace;
+}


### PR DESCRIPTION
In the past, when we were using poetry2nix, we used additional overlays in nix to ensure that nix flake overrides, e.g. `nix build --override-input kevm/k-framework v1.0.0`, do not only override the nix flake but also the python package that was locked in `poetry.lock`.

With the migration to `uv2nix`, this overlay was removed, causing confusion and overhead when wanting to override python code using nix flake overrides. This PR re-introduces these overlays that can be used in dependent nix flakes to re-establish this behaviour. Due to `uv2nix` using the newer nix python packaging tooling `pyproject-nix`, this code adds more complexity in comparison to `poetry2nix`, though it nonetheless achieves the same result.

There will be similar PRs in other repositories introducing and using these pyproject-nix overlays.