### PR TITLE
Streaming support for JsonRpcServer

### DIFF
--- a/pyk/src/pyk/rpc/rpc.py
+++ b/pyk/src/pyk/rpc/rpc.py
@@ -6,8 +6,7 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from functools import partial
 from http.server import BaseHTTPRequestHandler, HTTPServer
-from typing import TYPE_CHECKING, Any, Final, NamedTuple
-
+from typing import TYPE_CHECKING, NamedTuple
 from typing_extensions import Protocol
 
 from ..cli.cli import Options
@@ -15,6 +14,7 @@ from ..cli.cli import Options
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
+    from typing import Any, Final, Iterator
 
 
 _LOGGER: Final = logging.getLogger(__name__)
@@ -86,7 +86,8 @@ class JsonRpcBatchRequest(NamedTuple):
 class JsonRpcResult(ABC):
 
     @abstractmethod
-    def encode(self) -> bytes: ...
+    def encode(self) -> Iterator[bytes]:
+        ...
 
 
 @dataclass(frozen=True)
@@ -96,7 +97,7 @@ class JsonRpcError(JsonRpcResult):
     message: str
     id: str | int | None
 
-    def to_json(self) -> dict[str, Any]:
+    def wrap_response(self) -> dict[str, Any]:
         return {
             'jsonrpc': JsonRpcServer.JSONRPC_VERSION,
             'error': {
@@ -106,8 +107,8 @@ class JsonRpcError(JsonRpcResult):
             'id': self.id,
         }
 
-    def encode(self) -> bytes:
-        return json.dumps(self.to_json()).encode('ascii')
+    def encode(self) -> Iterator[bytes]:
+        yield json.dumps(self.wrap_response()).encode('ascii')
 
 
 @dataclass(frozen=True)
@@ -115,23 +116,31 @@ class JsonRpcSuccess(JsonRpcResult):
     payload: Any
     id: Any
 
-    def to_json(self) -> dict[str, Any]:
-        return {
-            'jsonrpc': JsonRpcServer.JSONRPC_VERSION,
-            'result': self.payload,
-            'id': self.id,
-        }
-
-    def encode(self) -> bytes:
-        return json.dumps(self.to_json()).encode('ascii')
+    def encode(self) -> Iterator[bytes]:
+        yield f'{{"jsonrpc":"2.0", "id": {self.id}, "result": '.encode('ascii')
+        if isinstance(self.payload, Iterator):
+            for chunk in self.payload:
+                yield chunk.encode('ascii')
+        else:
+            yield json.dumps(self.payload).encode('ascii')
+        yield b'}'
 
 
 @dataclass(frozen=True)
 class JsonRpcBatchResult(JsonRpcResult):
     results: tuple[JsonRpcError | JsonRpcSuccess, ...]
 
-    def encode(self) -> bytes:
-        return json.dumps([result.to_json() for result in self.results]).encode('ascii')
+    def encode(self) -> Iterator[bytes]:
+        yield b'['
+        first = True
+        for result in self.results:
+            if not first:
+                yield b','
+            else:
+                first = False
+            for chunk in result.encode():
+                yield chunk
+        yield b']'
 
 
 class JsonRpcRequestHandler(BaseHTTPRequestHandler):
@@ -143,8 +152,10 @@ class JsonRpcRequestHandler(BaseHTTPRequestHandler):
 
     def _send_response(self, response: JsonRpcResult) -> None:
         self.send_response_headers()
-        response_bytes = response.encode()
-        self.wfile.write(response_bytes)
+        response_body = response.encode()
+        for chunk in response_body:
+            self.wfile.write(chunk)
+        self.wfile.flush()
 
     def send_response_headers(self) -> None:
         self.send_response(200)

--- a/pyk/src/pyk/rpc/rpc.py
+++ b/pyk/src/pyk/rpc/rpc.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import json
 import logging
 from abc import ABC, abstractmethod
+from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import partial
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from typing import TYPE_CHECKING, NamedTuple
+
 from typing_extensions import Protocol
 
 from ..cli.cli import Options
@@ -14,7 +16,7 @@ from ..cli.cli import Options
 if TYPE_CHECKING:
     from collections.abc import Callable
     from pathlib import Path
-    from typing import Any, Final, Iterator
+    from typing import Any, Final
 
 
 _LOGGER: Final = logging.getLogger(__name__)
@@ -86,8 +88,7 @@ class JsonRpcBatchRequest(NamedTuple):
 class JsonRpcResult(ABC):
 
     @abstractmethod
-    def encode(self) -> Iterator[bytes]:
-        ...
+    def encode(self) -> Iterator[bytes]: ...
 
 
 @dataclass(frozen=True)
@@ -138,8 +139,7 @@ class JsonRpcBatchResult(JsonRpcResult):
                 yield b','
             else:
                 first = False
-            for chunk in result.encode():
-                yield chunk
+            yield from result.encode()
         yield b']'
 
 

--- a/pyk/src/tests/integration/test_json_rpc.py
+++ b/pyk/src/tests/integration/test_json_rpc.py
@@ -1,11 +1,10 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
 import json
 from http.client import HTTPConnection
 from threading import Thread
 from time import sleep
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING
 
 from pyk.cterm import CTerm
 from pyk.kast.inner import KApply, KSequence, KSort, KToken
@@ -16,6 +15,7 @@ from pyk.rpc.rpc import JsonRpcServer, ServeRpcOptions
 from pyk.testing import KRunTest
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from typing import Any
 
 
@@ -171,7 +171,7 @@ class StatefulJsonRpcServer(JsonRpcServer):
 
     def exec_add(self) -> int:
         return self.x + self.y
-    
+
     def exec_streaming(self) -> Iterator[bytes]:
         yield b'{'
         yield b'"foo": "bar"'


### PR DESCRIPTION
This PR extends the JsonRpcServer with support for streaming.
JsonRpcMethods can now return a stream of bytes (Iterator[bytes]) instead of a JSON-serializable value.
The method must ensure that the produced stream is already JSON-encoded, as no extra validation is performed.
This allows us to transfer large responses without buffering the entire response in memory.

This is needed by the kontrol-node, when transferring large execution traces.