### PR TITLE
Update `cachix` in CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
 
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework-binary
 
@@ -115,7 +115,7 @@ jobs:
 
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework-binary
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -169,7 +169,7 @@ jobs:
             substituters = http://cache.nixos.org
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework
           skipPush: true
@@ -206,7 +206,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
       - name: 'Install Cachix'
         if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'

--- a/.github/workflows/update-deps.yml
+++ b/.github/workflows/update-deps.yml
@@ -39,7 +39,7 @@ jobs:
             trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 
       - name: 'Install Cachix'
-        uses: cachix/cachix-action@v14
+        uses: cachix/cachix-action@v16
         with:
           name: k-framework
           authToken: '${{ secrets.CACHIX_PUBLIC_TOKEN }}'


### PR DESCRIPTION
The release workflows are failing in [k](https://github.com/runtimeverification/k/actions/runs/20188437031/job/58002015566#step:5:328), [evm-semantics](https://github.com/runtimeverification/evm-semantics/actions/runs/20228922478/job/58066919452#step:5:68), and possibly in other repositories on MacOS machines when pushing to a nix cache.

The exception means that the peer, cachix, closed the HTTP connection:
```
(InternalException Network.Socket.recvBuf: resource vanished (Connection reset by peer))
```

This PR is an attempt to fix this by updating cachix in CI from version 14 (Jan 12, 2024) to version 16 (Mar 10, 2025). 