### PR TITLE
Github WF update missed moving off a private runner to a public runner.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,8 +103,8 @@ jobs:
         include:
           - runner: ubuntu-24.04
             os: ubuntu-24.04
-          - runner: self-macos-latest
-            os: self-macos-latest
+          - runner: macos-latest
+            os: macos-15
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     steps:


### PR DESCRIPTION
Missed a swap to public macos runner to fix the release job. 