### PR TITLE
Fixing Cachix Push / Pin

### DIFF
--- a/.github/scripts/check-cachix-pin.sh
+++ b/.github/scripts/check-cachix-pin.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Kup relies on cachix registry k-framework-binary.
+CACHE="k-framework-binary"
+OWNER_REPO="${OWNER_REPO:-$(git remote get-url origin | sed -E 's#(git@github.com:|https://github.com/)##; s#\.git$##')}"
+REV="${REV:-${GITHUB_SHA:-$(git rev-parse HEAD)}}"
+UNAME_S="$(uname -s)"
+UNAME_M="$(uname -m)"
+case "${UNAME_S}-${UNAME_M}" in
+  Linux-x86_64) SYSTEM="x86_64-linux" ;;
+  Linux-aarch64 | Linux-arm64) SYSTEM="aarch64-linux" ;;
+  Darwin-x86_64) SYSTEM="x86_64-darwin" ;;
+  Darwin-arm64) SYSTEM="aarch64-darwin" ;;
+  *)
+    echo "Unsupported platform: ${UNAME_S}-${UNAME_M}" >&2
+    exit 1
+    ;;
+esac
+PIN_API_URL="https://app.cachix.org/api/v1/cache/${CACHE}/pin"
+# Must match every attribute passed to `kup publish … .#…` for this cache.
+CHECK_PACKAGES=(k k.openssl.secp256k1 k.openssl.procps.secp256k1)
+
+SUMMARY="${GITHUB_STEP_SUMMARY:-/dev/stdout}"
+
+{
+  echo "## Cachix publish pin check"
+  echo "CACHE: $CACHE"
+  echo "OWNER_REPO: $OWNER_REPO"
+  echo "REV: $REV"
+  echo "SYSTEM: $SYSTEM"
+  echo "PACKAGES: ${CHECK_PACKAGES[*]}"
+} >> "$SUMMARY"
+
+PIN_VISIBILITY_TIMEOUT_SECONDS=120
+PIN_VISIBILITY_INTERVAL_SECONDS=5
+PIN_VISIBILITY_ATTEMPTS=$((PIN_VISIBILITY_TIMEOUT_SECONDS / PIN_VISIBILITY_INTERVAL_SECONDS))
+for i in $(seq 1 "$PIN_VISIBILITY_ATTEMPTS"); do
+  PIN_JSON="$(curl -fsSL "${PIN_API_URL}?q=${REV}")"
+  ALL_OK=1
+
+  for PKG in "${CHECK_PACKAGES[@]}"; do
+    KEY="github:${OWNER_REPO}/${REV}#packages.${SYSTEM}.${PKG}"
+    STORE_PATH="$(
+      echo "$PIN_JSON" \
+        | jq -r --arg k "$KEY" 'map(select(.name == $k)) | first | (.lastRevision.storePath // .storePath // .store_path // .path // "")'
+    )"
+    if [ -z "$STORE_PATH" ]; then
+      PIN_STATUS="pin-missing"
+      PUSH_STATUS="000"
+      ALL_OK=0
+      {
+        echo "key-${PKG}: ${KEY}"
+        echo "pin-status-${PKG}: ${PIN_STATUS}"
+        echo "push-http-${PKG}: ${PUSH_STATUS}"
+      }
+      continue
+    fi
+
+    PIN_STATUS="pin-ok"
+    HASH="$(basename "$STORE_PATH" | cut -d- -f1)"
+    PUSH_NARINFO_URL="https://${CACHE}.cachix.org/${HASH}.narinfo"
+    PUSH_STATUS="$(curl -sS -o /dev/null -w '%{http_code}' "$PUSH_NARINFO_URL")" || PUSH_STATUS="000"
+    if [ "$PUSH_STATUS" != "200" ]; then
+      ALL_OK=0
+    fi
+
+    {
+      echo "key-${PKG}: ${KEY}"
+      echo "store-path-${PKG}: ${STORE_PATH}"
+      echo "pin-status-${PKG}: ${PIN_STATUS}"
+      echo "push-http-${PKG}: ${PUSH_STATUS}"
+    }
+  done
+
+  if [ "$ALL_OK" = "1" ]; then
+    echo "cachix-status: push-and-pin-ok-for-all-packages" >> "$SUMMARY"
+    exit 0
+  fi
+
+  echo "cachix-check-attempt-${i}: not-ready, retrying in ${PIN_VISIBILITY_INTERVAL_SECONDS}s"
+  sleep "$PIN_VISIBILITY_INTERVAL_SECONDS"
+done
+
+echo "cachix-status: push-or-pin-missing-after-${PIN_VISIBILITY_TIMEOUT_SECONDS}s-for-at-least-one-package" >> "$SUMMARY"
+exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,6 +84,8 @@ jobs:
         env:
           CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_KFB_TOKEN }}'
           GC_DONT_GC: '1'
+          OWNER_REPO: ${{ github.repository }}
+          REV: ${{ github.sha }}
         with:
           packages: jq
           script: |
@@ -95,6 +97,9 @@ jobs:
             kup publish --verbose k-framework-binary .#k --keep-days 180
             kup publish --verbose k-framework-binary .#k.openssl.secp256k1 --keep-days 180
             kup publish --verbose k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
+
+            # kup/cachix pin visibility can be flaky; verify pins and narinfo via public API
+            bash .github/scripts/check-cachix-pin.sh
 
   cachix-release-dependencies:
     name: 'k-framework cachix release'

--- a/package/debian/build-package
+++ b/package/debian/build-package
@@ -19,4 +19,16 @@ mv package/debian/${subdir}/rules.${base_distro}    debian/rules
 
 dpkg-buildpackage
 
-mv ../${subdir}_$(cat package/version)_amd64.deb ${pkg_name}
+# The .deb filename uses the Debian package version from debian/changelog, which can
+# differ from package/version; glob the artifact dpkg actually produced.
+shopt -s nullglob
+matches=(../"${subdir}"_*_amd64.deb)
+if [ "${#matches[@]}" -eq 0 ]; then
+  echo "error: no ../${subdir}_*_amd64.deb after dpkg-buildpackage" >&2
+  exit 1
+fi
+if [ "${#matches[@]}" -gt 1 ]; then
+  echo "error: expected one ../${subdir}_*_amd64.deb, got: ${matches[*]}" >&2
+  exit 1
+fi
+mv "${matches[0]}" "${pkg_name}"


### PR DESCRIPTION
Fixing cachix push and pin functionality broken by their cloudflare going unresponsive when using push and pin.


Similar issue pushed to [mir-semantics](https://github.com/runtimeverification/mir-semantics/pull/951/changes#diff-59cd4bfedd5e699e84dab588cd4c5bf931e01b112053cead0f7ce3d708d651d6). 

Cachix has an unresponsive cloudflare instance we can't seem to rely on them fixing. Our requests to push and pin get processed but we don't get a response. We can check if it worked through the provided script in this PR. 