### PR TITLE
Fix/cachix pin no response - follow up

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,9 +94,9 @@ jobs:
             
             # Publish all three package variants using kup publish
             # Using public macOS runner has proven reliable for large file uploads
-            kup publish --verbose k-framework-binary .#k --keep-days 180
-            kup publish --verbose k-framework-binary .#k.openssl.secp256k1 --keep-days 180
-            kup publish --verbose k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180
+            kup publish --verbose k-framework-binary .#k --keep-days 180 || true
+            kup publish --verbose k-framework-binary .#k.openssl.secp256k1 --keep-days 180 || true
+            kup publish --verbose k-framework-binary .#k.openssl.procps.secp256k1 --keep-days 180 || true
 
             # kup/cachix pin visibility can be flaky; verify pins and narinfo via public API
             bash .github/scripts/check-cachix-pin.sh


### PR DESCRIPTION
https://github.com/runtimeverification/k/pull/4906 introduced a fix for the cachix flakiness we observe in CI. However, that PR missed a crucial `|| true` at the end of `kup publish` that can be found, e.g., in the respective fix added to mir-semantics: https://github.com/runtimeverification/mir-semantics/pull/950/changes#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R174 .

Without that fix, CI is still failing during release, see https://github.com/runtimeverification/k/actions/runs/24207323412/job/70666525084 .