### PR TITLE
Support Claude as developer, add `--top-cell` flag to `pyk kompile`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,124 @@
+# K Framework — Agent Guide
+
+## Project Overview
+
+The K Framework is a language-agnostic formal specification and verification framework developed by Runtime Verification.
+It lets you define programming language semantics in `.k` files and then automatically derives an interpreter, model checker, and deductive verifier from that definition.
+
+The repository is a monorepo with two independent technology stacks:
+
+- **Java/Scala** — the K compiler toolchain (`kompile`, `krun`, `kprove`, etc.)
+- **Python** (`pyk/`) — the `kframework` Python SDK for programmatically interacting with the K toolchain
+
+## Repository Structure
+
+```
+k-frontend/                  K language parser and frontend (Java/Scala)
+k-distribution/              Main distribution bundle
+  bin/, lib/                   Symlinks into target/release/k/
+  include/kframework/          Shared Makefile infrastructure (ktest.mak, ktest-group.mak)
+  tests/regression-new/        Java-backend regression suite (229 test subdirs)
+haskell-backend/             Haskell-based symbolic backend
+llvm-backend/                LLVM-based concrete execution backend
+pyk/                         Python SDK sub-project (self-contained)
+  src/pyk/                     Package source (cli, kast, kore, proof, kcfg, kdist, …)
+  src/tests/                   pytest test suite (unit/, integration/)
+  regression-new/              Python-backend regression suite (213 test subdirs)
+  pyproject.toml               Build & tool config (hatchling, black, mypy, flake8, …)
+  Makefile                     All pyk make targets
+k-tutorial/                  Tutorial K definitions
+```
+
+## Build
+
+### Java (compile only, skip tests)
+
+```
+mvn package -DskipTests
+```
+
+This compiles all Maven modules (`k-frontend`, `k-distribution`, `haskell-backend`, `llvm-backend`) and produces JARs under each module's `target/` directory.
+Java 17 and Scala 2.13 are required.
+
+### Python
+
+The `pyk/` sub-project uses `hatchling` as its build backend and `uv` as its package manager.
+No explicit build step is needed before running lint or tests — the make targets handle installation.
+
+## Lint
+
+Python only (there is no lint target for Java):
+
+```
+make -C pyk check
+```
+
+This runs, in order: `black --check`, `isort --check`, `autoflake --check`, `flake8`, `mypy`, `pydocstyle`.
+
+To auto-apply all formatters:
+
+```
+make -C pyk format
+```
+
+Key style settings (from `pyk/pyproject.toml`):
+- `black`: line-length 120, skip-string-normalization
+- `isort`: black profile, line-length 120
+- `mypy`: `disallow_untyped_defs = true`
+- `pydocstyle`: Google convention
+
+## Tests
+
+There are four distinct test surfaces.
+
+### 1. Java unit tests
+
+```
+mvn verify
+```
+
+Runs all JUnit 4 tests across `k-frontend` and `k-distribution` via Maven Surefire.
+Tests run with `LC_NUMERIC=en_US.UTF-8`.
+
+### 2. Python unit + integration tests
+
+```
+make -C pyk test
+```
+
+Runs `src/tests/unit/` and `src/tests/integration/` with 4 parallel workers (pytest-xdist, worksteal).
+Unit tests only (faster, no K toolchain required):
+
+```
+make -C pyk test-unit
+```
+
+### 3. Java regression tests
+
+```
+make -C k-distribution/tests/regression-new
+```
+
+229 subdirectory test cases.
+Each test compiles a `.k` definition with `kompile` and executes it with `krun` or `kprove`, comparing output against `.out` baseline files.
+The shared test infrastructure lives in `k-distribution/include/kframework/ktest.mak`.
+
+### 4. Python regression tests
+
+```
+make -C pyk/regression-new
+```
+
+213 subdirectory test cases; 113 are currently skipped (listed in `pyk/regression-new/skipped`).
+Same test infrastructure as the Java regression suite but exercises pyk-specific code paths.
+
+## Updating Regression Baselines
+
+If a change intentionally alters K program output, regenerate the `.out` files:
+
+```
+make -C k-distribution/tests/regression-new update-results
+make -C pyk/regression-new update-results
+```
+
+Commit the updated baseline files in a dedicated commit after the logic change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,16 @@ No explicit build step is needed before running lint or tests — the make targe
 
 ## Lint
 
-Python only (there is no lint target for Java):
+### Java
+
+```
+mvn spotless:apply
+```
+
+This auto-formats all Java/Scala sources (Google Java Format + Scalafmt).
+Run it after every Java change; commits must pass `mvn spotless:check`.
+
+### Python
 
 ```
 make -C pyk check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,5 @@
+copyright: Copyright (c) Runtime Verification, Inc. All Rights Reserved.
+
 # K Framework — Agent Guide
 
 ## Project Overview

--- a/pyk/docs/pipeline.md
+++ b/pyk/docs/pipeline.md
@@ -1,0 +1,154 @@
+# K Compilation Pipeline — Developer Reference
+
+This document describes the K compilation pipeline, where pyk already participates, and the integration points for moving more of the pipeline from Java to Python.
+
+## Overview
+
+The pipeline has five logical stages:
+
+```
+Outer parsing → Inner parsing → 32 compilation passes → Kore emission → Backend compilation
+```
+
+The first four stages produce `definition.kore`.
+The fifth stage (LLVM/Haskell backend compilation) consumes `definition.kore` and is inherently backend-specific.
+
+## Stage 1: Outer Parsing
+
+**What it does**: Reads `.k` and `.md` files, resolves `require` statements, and produces a `KDefinition` (a set of `KFlatModule`s with import edges but with rule bodies still as unparsed "bubbles").
+
+**Java implementation**: JavaCC grammar at `k-frontend/src/main/javacc/Outer.jj`; entry point `DefinitionParsing.parseDefinition()`.
+
+**Python implementation**: `pyk/src/pyk/kast/outer_parser.py` + `outer_lexer.py`; entry point `pyk.kast.utils.parse_outer()`.
+
+**Pipeline seam**: Java `kompile` accepts `--outer-parsed-json`, which reads a pre-parsed `KDefinition` JSON from a file and skips the Java outer parsing stage entirely.
+The JSON format is `{"format": "KAST", "version": 3, "term": <KDefinition.to_dict()>}`.
+
+**`kompilex` command** (`pyk/src/pyk/__main__.py:exec_kompilex`):
+1. Calls `parse_outer()` (Python outer parser)
+2. Merges any `--pre-parsed-prelude` modules
+3. Serialises the result to a temp JSON file
+4. Calls Java `kompile --outer-parsed-json <tempfile>` for the remaining stages
+
+## Stage 2: Inner Parsing (Bubble Resolution)
+
+**What it does**: Parses the rule bodies ("bubbles") using the grammar generated from the user's syntax declarations.
+Each bubble is a rule LHS/RHS/requires/ensures that was left as a raw token stream by the outer parser.
+
+**Java implementation**: `k-frontend/src/main/java/org/kframework/parser/inner/` + `RuleGrammarGenerator`.
+This stage runs after `--outer-parsed-json` injection, so there is currently no way to skip it from Python.
+
+**Python implementation**: `pyk/src/pyk/kast/parser.py` + `lexer.py`.
+The Python inner parser exists but is not yet wired into the pipeline as a bypass.
+
+## Stage 3: Compilation Passes (Java)
+
+32 ordered passes, each a pure `Definition → Definition` transformation.
+They are named and can be selected individually via `--kore-backend-steps` in `KoreBackend.java`.
+
+The full ordered list (from `KoreBackend.steps()`, lines 274–306):
+
+| # | Pass name | What it does | External I/O? |
+|---|-----------|--------------|---------------|
+| 1 | `resolveComm` | Resolve commutative simplification rules | None |
+| 2 | `resolveIO` | Resolve I/O stream configuration cells | None |
+| 3 | `resolveFun` | Resolve `#fun` applications | None |
+| 4 | `resolveFunctionWithConfig` | Resolve function calls that reference the configuration | None |
+| 5 | `resolveStrict` | Expand `strict`/`seqstrict` attributes into heating/cooling rules | None |
+| 6 | `resolveAnonVars` | Replace `_` anonymous variables with fresh names | None |
+| 7 | `resolveContexts` | Resolve context holes and rewrites | None |
+| 8 | `numberSentences1` | Assign unique integer IDs to all sentences | None |
+| 9 | `resolveHeatCoolAttribute` | Expand `heat`/`cool` attributes into rules | None |
+| 10 | `resolveSemanticCasts` | Resolve `#` cast operations | None |
+| 11 | `subsortKItem1` | Add subsort productions: every sort is a subsort of `KItem` | None |
+| 12 | `constantFolding` | Fold constant expressions (via Java-reflection-based built-in hooks) | None |
+| 13 | `propagateMacroToRules` | Propagate `macro` label from production to its rules | None |
+| 14 | `guardOrs` | Transform or-patterns into guarded alternatives | None |
+| 15 | `resolveFreshConfigConstants` | Resolve `!Var` fresh constants in the configuration | None |
+| 16 | `generateSortPredicateSyntax1` | Generate `isSort(...)` predicate productions (pass 1) | None |
+| 17 | `generateSortProjections1` | Generate sort projection functions (pass 1) | None |
+| 18 | `expandMacros` | Expand macro rules | Optional coverage file write |
+| 19 | `addImplicitComputationCell` | Add implicit `<k>` computation cell to rules that lack it | None |
+| 20 | `resolveFreshConstants` | Resolve `!Var` fresh constants in rules | None |
+| 21 | `generateSortPredicateSyntax2` | Generate sort predicate productions (pass 2) | None |
+| 22 | `generateSortProjections2` | Generate sort projections (pass 2) | None |
+| 23 | `checkSimplificationRules` | Validate that simplification rule LHS has a function symbol | Error output |
+| 24 | `subsortKItem2` | Subsort to `KItem` (pass 2) | None |
+| 25 | `concretizeCells` | Concretize cell structure: `AddTopCellToRules` → `AddParentCells` → `CloseCells` → `SortCells` | None |
+| 26 | `genCoverage` | Write coverage instrumentation data | Optional file write |
+| 27 | `addSemanticsModule` | Add synthetic `LANGUAGE-PARSING` module | None |
+| 28 | `resolveConfigVar` | Add configuration variables to rule LHS | None |
+| 29 | `addCoolLikeAtt` | Add `cool-like` attribute to rules | None |
+| 30 | `removeAnywhereRules` | Filter `anywhere` rules (Haskell backend only) | Warning log |
+| 31 | `generateSortPredicateRules` | Generate rules implementing sort predicates | None |
+| 32 | `numberSentences2` | Re-number sentences (pass 2) | None |
+
+26 of 32 passes are completely pure (no I/O).
+The remaining 6 have conditional or minor I/O that can be trivially gated.
+
+**Output**: Java writes the post-pipeline KAST to `<kompiled-dir>/compiled.json` (and `compiled.txt`).
+This is the **second pipeline seam**: Python can read `compiled.json` and take over from here.
+
+## Stage 4: Kore Emission
+
+**What it does**: Converts the compiled KAST (`compiled.json`) into Kore syntax and writes `definition.kore` and `syntaxDefinition.kore`.
+
+**Java implementation**: `k-frontend/src/main/java/org/kframework/backend/kore/ModuleToKORE.java`.
+Uses `StringBuilder` string concatenation throughout; no intermediate structured Kore AST.
+
+**Python implementation** (partially complete):
+
+- `pyk/src/pyk/konvert/_module_to_kore.py` — `module_to_kore(definition)` generates:
+  - Sort declarations
+  - Symbol declarations
+  - Structural axioms: subsort, assoc, idem, unit, functional, no-confusion, no-junk, overload
+  - **Not yet**: rule axioms, macro rule separation, `Definition` wrapper, prelude imports, top-cell initializer
+
+- `pyk/src/pyk/konvert/_kast_to_kore.py` — `krule_to_kore(definition, krule)` converts a single K rule to a Kore `Axiom`.
+  This exists but is not yet called from `module_to_kore()`.
+
+**Gaps to close for full Python Kore emission**:
+1. Call `krule_to_kore()` inside `module_to_kore()` to emit rule axioms
+2. Separate macro rules into their own section (matching Java's output structure)
+3. Add a `kdef_to_kore(definition)` wrapper that produces a `Definition` with prelude modules (BASIC-K, KSEQ, INJ, K) and the top-cell initializer attribute
+4. Write the result to `definition.kore` and `syntaxDefinition.kore`
+
+## Stage 5: Backend Compilation
+
+LLVM or Haskell compilation of `definition.kore` into a binary or compiled artifact.
+This is inherently backend-specific and will remain in the respective backend tools.
+
+## What pyk Currently Wires Together
+
+| Mechanism | What it does |
+|-----------|-------------|
+| `pyk kompile` | Thin wrapper — delegates entirely to Java `kompile` |
+| `pyk kompilex` | Python outer parse → JSON → Java `kompile --outer-parsed-json` |
+| `pyk/regression-new/include/ktest.mak` | Uses `pyk kompile` (not yet `kompilex`) |
+
+## Planned Integration Points
+
+1. **Outer parsing**: switch `pyk/regression-new/include/ktest.mak` from `pyk kompile` to `pyk kompilex` so all regression tests exercise Python outer parsing.
+
+2. **Kore emission**: extend `_module_to_kore.py` with rule emission, add `kdef_to_kore()` wrapper, add a validation tool (`pyk emit-kore`) that reads `compiled.json` and diffs against `definition.kore`, then wire into `kompilex`.
+
+3. **Compilation passes**: once outer parsing and Kore emission are in Python, individual passes can be ported one at a time, replacing Java sub-steps without changing the overall pipeline interface.
+
+## Key Files
+
+| Path | Role |
+|------|------|
+| `k-frontend/src/main/javacc/Outer.jj` | Java outer parser grammar |
+| `k-frontend/src/main/java/org/kframework/kompile/KompileOptions.java` | `--outer-parsed-json` flag |
+| `k-frontend/src/main/java/org/kframework/kompile/DefinitionParsing.java:305` | Outer parsing bypass entry point |
+| `k-frontend/src/main/java/org/kframework/backend/kore/KoreBackend.java:122` | `steps()` — ordered pass list |
+| `k-frontend/src/main/java/org/kframework/backend/kore/ModuleToKORE.java` | Java Kore emission |
+| `pyk/src/pyk/kast/outer_parser.py` | Python outer parser |
+| `pyk/src/pyk/kast/utils.py` | `parse_outer()` — outer parse entry point |
+| `pyk/src/pyk/__main__.py:exec_kompilex` | `kompilex` pipeline driver |
+| `pyk/src/pyk/ktool/kompile.py` | `kompile()` — Java subprocess wrapper |
+| `pyk/src/pyk/konvert/_module_to_kore.py` | `module_to_kore()` — partial Kore emission |
+| `pyk/src/pyk/konvert/_kast_to_kore.py` | `krule_to_kore()` — rule → Kore axiom |
+| `pyk/src/pyk/kore/syntax.py` | Kore AST types |
+| `pyk/regression-new/include/ktest.mak` | Regression test kompile invocation |
+| `pyk/regression-new/skipped` | 113 currently skipped tests |

--- a/pyk/docs/regression-triage.md
+++ b/pyk/docs/regression-triage.md
@@ -94,17 +94,18 @@ or map the common ones explicitly.
 
 **Fix**: Add these as pass-through or explicit options in `pyk kompile`.
 
-## Category G — `<generatedCounter>` cell shown in output (≈6+ tests)
+## Category G — `<generatedCounter>` / `<generatedTop>` cells in output (≈6+ tests)
 
-Java `krun` strips the synthetic `<generatedCounter>` cell from output.
-`pyk run` (`KRun.pretty_print`) does not strip it.
-Tests whose K definitions use `generatedCounter` produce output that differs from baseline.
+Java `krun` strips the synthetic `<generatedCounter>` and `<generatedTop>` cells from output.
+`pyk run` intentionally retains them — this is a design decision in the pyk rewrite.
+Tests whose K definitions use these cells produce output that differs from the Java-generated baselines.
 
 Observed in: `context-alias`, `issue-1263`, `issue-1528`, `or-llvm`, `rand`, `rangemap-tests-llvm`
 (possibly more — not all tests were run).
 
-**Fix**: Strip `<generatedCounter>` from `KRun.pretty_print` output, matching Java `krun` behaviour.
-Then regenerate `.out` baselines with `make update-results`.
+**Fix**: Run `make update-results` in each affected test directory to regenerate `.out` baselines
+to match pyk's output (which includes these cells).
+Do not strip these cells from `pyk run` output — that is intentional behaviour.
 
 ## Category H — Output format differences
 

--- a/pyk/docs/regression-triage.md
+++ b/pyk/docs/regression-triage.md
@@ -1,0 +1,165 @@
+# pyk/regression-new — Skipped Test Triage
+
+This document categorises the 113 skipped tests in `pyk/regression-new/skipped` by root cause,
+lists the tests in each category, and identifies quick-win opportunities.
+
+## Category A — Haskell backend (≈39 tests)
+
+These tests set `KOMPILE_BACKEND=haskell`.
+They require the Haskell symbolic execution backend which is not the primary focus of the pyk test suite.
+
+```
+cell-sort-haskell, checkClaimError, concrete-function, concrete-function-cache,
+concrete-haskell, context-alias-2, context-labels, domains-lemmas-no-smt,
+imp-haskell, issue-1175, issue-1436, issue-1489-claimLoc, issue-1676-koreBytes,
+issue-1682-korePrettyPrint, issue-1683-cfgVarsWarns, issue-2142-markConcrete,
+issue-2174-kprovexParseError, issue-2287-simpl-rules-in-kprovex,
+issue-2321-kprovexCrash, issue-2356-koreDecode, ite-bug, kast-kore-input,
+kprove-append, kprove-branchingAllowed, kprove-error-status, kprove-java,
+kprove-markdown, kprove-var-equals, map-symbolic-tests-haskell, markdownSelectors,
+or-haskell, poly-sort, poly-unparsing, profile, quadratic-poly-unparsing,
+set-symbolic-tests, set_unification, spec-rule-application, unification-lemmas
+```
+
+Not addressable without Haskell backend support.
+
+## Category B — GLR / Bison parser generation (≈16 tests)
+
+These tests pass `--gen-glr-bison-parser` or `--gen-bison-parser` to `kompile`.
+They require C compilation and bison integration that is not available in pyk.
+
+```
+bison-parser-library, glr, glr2, glr3, glr4, imp++-llvm, issue-1602,
+kast-bison, kast-bison-bytes, llvm-krun, locations, locations2, locations3,
+parse-c, parseNonPgm, proof-instrumentation
+```
+
+Not addressable without bison integration.
+
+## Category C — kore backend (4 tests)
+
+These tests use `KOMPILE_BACKEND=kore` (the bytecode interpreter backend).
+
+```
+fresh1, fresh2, imp-kore, kore-brackets
+```
+
+Not addressable without kore backend support.
+
+## Category D — `pyk parse` subcommand missing (≈10 tests)
+
+The `ktest.mak` infrastructure sets `KAST=$(UV_RUN) pyk parse`, but `pyk parse` is not a
+valid subcommand in the current pyk CLI (valid commands: print, rpc-print, rpc-kast,
+prove-legacy, kompile, kompilex, run, prove, show, graph-imports, coverage,
+kore-to-json, json-to-kore, parse-outer).
+
+These tests exercise the KAST parsing / pretty-printing pipeline.
+
+```
+equals-formatting, issue-2273, issue-3647-debugTokens, issue-3672-debugParse,
+json-input, kast-default-output, kast-input, kast-rule
+```
+
+Also: `issue-1088` (uses `KAST_FLAGS=--output kast --output-file`).
+
+**Fix**: Add a `pyk parse` (or `pyk kast`) CLI subcommand that wraps the Java `kast` binary
+(similar to how `pyk kompile` wraps `kompile`), or wire pyk's inner-parsing infrastructure
+into a CLI command.
+
+## Category E — Missing `pyk run` flags
+
+`pyk run` (`exec_run` in `__main__.py`) is a thin wrapper that only accepts `pgm_file` and
+`--definition`.
+Several tests require flags that pass-through to the underlying Java `krun`:
+
+- `-cVAR=VALUE` (cell configuration override): `doubleinj`
+- `--output program`: `issue-1145`
+- `--parser <script>`: `issue-582`, `star-multiplicity`
+- `--search`, `--search-final`, `--no-pattern`, `--bound`, `--depth`: `context-alias-2`,
+  `no-pattern`, `search-bound`, `issue-3520-freshConfig`
+- `--io off`: `issue-1436` (also haskell)
+- `--output kore`: `issue-1676-koreBytes` (also haskell)
+
+**Fix**: Extend `pyk run` to pass unrecognised flags through to the underlying `krun` binary,
+or map the common ones explicitly.
+
+## Category F — Missing `pyk kompile` flags
+
+`pyk kompile` doesn't expose all Java `kompile` flags:
+
+- `--top-cell`: `issue-2075-2`
+- `--profile-rule-parsing`: `profile` (also haskell)
+- `--llvm-proof-hint-instrumentation`: `proof-instrumentation` (also bison)
+- `--llvm-kompile-type library`: `llvm-kompile-type`
+
+**Fix**: Add these as pass-through or explicit options in `pyk kompile`.
+
+## Category G — `<generatedCounter>` cell shown in output (≈6+ tests)
+
+Java `krun` strips the synthetic `<generatedCounter>` cell from output.
+`pyk run` (`KRun.pretty_print`) does not strip it.
+Tests whose K definitions use `generatedCounter` produce output that differs from baseline.
+
+Observed in: `context-alias`, `issue-1263`, `issue-1528`, `or-llvm`, `rand`, `rangemap-tests-llvm`
+(possibly more — not all tests were run).
+
+**Fix**: Strip `<generatedCounter>` from `KRun.pretty_print` output, matching Java `krun` behaviour.
+Then regenerate `.out` baselines with `make update-results`.
+
+## Category H — Output format differences
+
+Some tests have `.out` baselines that predate the current pyk pretty-printer formatting.
+These are likely fixable by running `make update-results` after verifying the actual output
+is correct.
+
+Observed patterns:
+- Inline collection items vs. one-per-line (e.g. `rand`: `ListItem(1) ListItem(2)` vs.
+  `ListItem(1)\nListItem(2)`)
+- Different argument ordering in error messages (e.g. `checks`)
+- Extra `[ERROR] Running process failed...` line in `pyk kompile` failure messages
+  (e.g. `nonexhaustive`) — not emitted by Java `kompile`
+
+## Category I — Special tool dependencies
+
+Tests that require infrastructure beyond pyk's CLI:
+
+- `append`: requires custom `./kparse-twice` script
+- `bad-flags`: tests `kompile --badflag` error output (argument-order mismatch in baseline)
+- `help`: tests `--help` and `--version` output for many K tools (`kserver`, `kparse-gen`, etc.)
+- `io-llvm`: requires `./prepare.sh` script
+- `issue-582`, `star-multiplicity`: require `./test-parser` script
+- `issue-946`: calls `pyk run` without a `pgm_file` (uses `--definition` only — not supported)
+- `issue-1169`: uses `kompile -E` (preprocessor mode)
+- `issue-1844-noPGM`, `issue-2812-kprove-filter-claims`, `issue-2909-allow-anywhere-haskell`,
+  `itp`, `kdep-options`, `mutable-bytes`, `non-executable`, `pl-tutorial`, `proof-tests`,
+  `rat`, `boundary-cells-opt`: group tests (SUBDIRS) — skip reason inherited from sub-tests
+
+## Category J — Likely quick wins not yet investigated
+
+These look like standard LLVM tests with no obviously missing features but have not been
+run yet:
+
+```
+configuration-formatting (output format diff — generatedTop)
+doubleinj (needs -c flag in pyk run)
+issue-1098 (no special flags — needs running)
+issue-2273 (kast, needs pyk parse)
+pattern-macro (output format diff — generatedTop)
+pattern-macro-productions (similar)
+```
+
+## Summary Table
+
+| Category | Count | Fix complexity |
+|----------|-------|---------------|
+| A — Haskell backend | ~39 | High (needs Haskell) |
+| B — GLR/Bison | ~16 | High (needs C bison) |
+| C — kore backend | 4 | Medium |
+| D — `pyk parse` missing | ~10 | Medium (add CLI command) |
+| E — Missing `pyk run` flags | ~8 | Low–Medium (pass-through flags) |
+| F — Missing `pyk kompile` flags | ~4 | Low (add flags) |
+| G — `<generatedCounter>` stripping | ~6+ | Low (strip in pretty_print) |
+| H — Output format differences | ~5 | Low (update-results) |
+| I — Special tool deps | ~15 | Varies |
+
+**Recommended priority**: G → E → D → F → H, then revisit per-test

--- a/pyk/regression-new/.gitignore
+++ b/pyk/regression-new/.gitignore
@@ -1,0 +1,1 @@
+*-kompiled/

--- a/pyk/regression-new/issue-2075-2/1.test.out
+++ b/pyk/regression-new/issue-2075-2/1.test.out
@@ -1,5 +1,10 @@
-<k>
-  <bar>
-    1
-  </bar> ~> .K
-</k>
+<generatedTop>
+  <k>
+    <bar>
+      1
+    </bar> ~> .K
+  </k>
+  <generatedCounter>
+    0
+  </generatedCounter>
+</generatedTop>

--- a/pyk/regression-new/skipped
+++ b/pyk/regression-new/skipped
@@ -42,7 +42,6 @@ issue-1676-koreBytes
 issue-1682-korePrettyPrint
 issue-1683-cfgVarsWarns
 issue-1844-noPGM
-issue-2075-2
 issue-2142-markConcrete
 issue-2174-kprovexParseError
 issue-2273

--- a/pyk/regression-new/skipped
+++ b/pyk/regression-new/skipped
@@ -110,4 +110,3 @@ star-multiplicity
 trace
 unification-lemmas
 useless
-werrorCategory

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -314,6 +314,7 @@ def exec_kompile(options: KompileCommandOptions) -> None:
         'gen_glr_bison_parser': options.gen_glr_bison_parser,
         'bison_lists': options.bison_lists,
         'outer_parsed_json': options.outer_parsed_json,
+        'top_cell': options.top_cell,
     }
     if options.backend == KompileBackend.LLVM:
         kompile_dict['ccopts'] = options.ccopts

--- a/pyk/src/pyk/cli/args.py
+++ b/pyk/src/pyk/cli/args.py
@@ -208,6 +208,7 @@ class KompileOptions(Options):
     bison_lists: bool
     no_exc_wrap: bool
     outer_parsed_json: bool
+    top_cell: str | None
     ignore_warnings: list[str]
 
     @staticmethod
@@ -235,6 +236,7 @@ class KompileOptions(Options):
             'bison_lists': False,
             'no_exc_wrap': False,
             'outer_parsed_json': False,
+            'top_cell': None,
             'ignore_warnings': [],
         }
 
@@ -499,6 +501,7 @@ class KCLIArgs:
         args.add_argument(
             '--ignore-warnings', '-Wno', dest='ignore_warnings', action='append', help='Ignore provided warnings'
         )
+        args.add_argument('--top-cell', dest='top_cell', default=None, help='Set the top cell for the definition.')
         return args
 
     @cached_property

--- a/pyk/src/pyk/ktool/kompile.py
+++ b/pyk/src/pyk/ktool/kompile.py
@@ -543,6 +543,7 @@ class KompileArgs:
     coverage: bool
     bison_lists: bool
     outer_parsed_json: bool
+    top_cell: str | None
 
     def __init__(
         self,
@@ -562,6 +563,7 @@ class KompileArgs:
         coverage: bool = False,
         bison_lists: bool = False,
         outer_parsed_json: bool = False,
+        top_cell: str | None = None,
     ):
         main_file = Path(main_file)
         include_dirs = tuple(sorted(Path(include_dir) for include_dir in include_dirs))
@@ -582,6 +584,7 @@ class KompileArgs:
         object.__setattr__(self, 'coverage', coverage)
         object.__setattr__(self, 'bison_lists', bison_lists)
         object.__setattr__(self, 'outer_parsed_json', outer_parsed_json)
+        object.__setattr__(self, 'top_cell', top_cell)
 
     def args(self) -> list[str]:
         args = [str(self.main_file)]
@@ -627,6 +630,9 @@ class KompileArgs:
 
         if self.outer_parsed_json:
             args += ['--outer-parsed-json']
+
+        if self.top_cell:
+            args += ['--top-cell', self.top_cell]
 
         return args
 


### PR DESCRIPTION
After a Claude analysis of the tests skipped in pyk/regression-new, I have made some small progress on supporting more tests in that test-suite with pyk. In particular:

- Add a `CLAUDE.md` for helping with Claude development.
- Add some to `.gitignore` for ignoring generated `*-kompiled` directories.
- Add some design document/context files to `pyk/docs/...` for the discovery of the remaining processes to be done for supporting the entire kompilation pipeline in Python directly.
- Add the flag `--top-cell` to `pyk kompile` and thread it htrough appropriately, uncomment one test that passes now.