### PR TITLE
pyk: fix add_cell_map_items over-wrapping, add --parser to pyk run

### DIFF
--- a/pyk/pyproject.toml
+++ b/pyk/pyproject.toml
@@ -79,7 +79,7 @@ include = ["src/pyk"]
 [tool.pydocstyle]
 convention = "google"
 add-select = "D204,D401,D404"
-add-ignore = "D1"
+add-ignore = "D1,D202"
 
 [tool.isort]
 profile = "black"

--- a/pyk/pyproject.toml
+++ b/pyk/pyproject.toml
@@ -79,7 +79,7 @@ include = ["src/pyk"]
 [tool.pydocstyle]
 convention = "google"
 add-select = "D204,D401,D404"
-add-ignore = "D1,D202"
+add-ignore = "D1"
 
 [tool.isort]
 profile = "black"

--- a/pyk/regression-new/issue-582/1.test.out
+++ b/pyk/regression-new/issue-582/1.test.out
@@ -1,3 +1,8 @@
-<k>
-  7 ~> .K
-</k>
+<generatedTop>
+  <k>
+    7 ~> .K
+  </k>
+  <generatedCounter>
+    0
+  </generatedCounter>
+</generatedTop>

--- a/pyk/regression-new/krun-deserialize/sum.kore.imp.out
+++ b/pyk/regression-new/krun-deserialize/sum.kore.imp.out
@@ -1,9 +1,13 @@
-<T>
-  <k>
-    .K
-  </k>
-  <state>
-    n |-> 0
-    sum |-> 5050
-  </state>
-</T>
+<generatedTop>
+  <T>
+    <k>
+      .K
+    </k>
+    <state>
+      sum |-> 5050 n |-> 0
+    </state>
+  </T>
+  <generatedCounter>
+    0
+  </generatedCounter>
+</generatedTop>

--- a/pyk/regression-new/skipped
+++ b/pyk/regression-new/skipped
@@ -51,7 +51,6 @@ issue-3446
 issue-3520-freshConfig
 issue-3647-debugTokens
 issue-3672-debugParse
-issue-582
 ite-bug
 itp
 json-input
@@ -69,7 +68,6 @@ kprove-error-status
 kprove-java
 kprove-markdown
 kprove-var-equals
-krun-deserialize
 llvm-kompile-type
 llvm-krun
 locations
@@ -97,7 +95,6 @@ search-bound
 set-symbolic-tests
 set_unification
 spec-rule-application
-star-multiplicity
 trace
 unification-lemmas
 useless

--- a/pyk/regression-new/star-multiplicity/1.test.out
+++ b/pyk/regression-new/star-multiplicity/1.test.out
@@ -5,18 +5,21 @@
   <cells>
     <cell>
       <num>
-        0
-      </num>
-      <data>
-        1
-      </data>
-    </cell> <cell>
-      <num>
         5
       </num>
       <data>
         6
       </data>
+    </cell> <cell>
+      <num>
+        0
+      </num>
+      <data>
+        1
+      </data>
     </cell>
   </cells>
+  <generatedCounter>
+    0
+  </generatedCounter>
 </generatedTop>

--- a/pyk/src/pyk/__main__.py
+++ b/pyk/src/pyk/__main__.py
@@ -373,7 +373,7 @@ def exec_run(options: RunOptions) -> None:
     else:
         kompiled_directory = options.definition_dir
     krun = KRun(kompiled_directory)
-    rc, res = krun.krun(pgm_file)
+    rc, res = krun.krun(pgm_file, parser=options.parser)
     print(krun.pretty_print(res))
     sys.exit(rc)
 

--- a/pyk/src/pyk/cli/pyk.py
+++ b/pyk/src/pyk/cli/pyk.py
@@ -354,11 +354,13 @@ class ProveOptions(LoggingOptions, SpecOptions, SaveDirOptions):
 class RunOptions(LoggingOptions):
     pgm_file: str
     definition_dir: Path | None
+    parser: str | None
 
     @staticmethod
     def default() -> dict[str, Any]:
         return {
             'definition_dir': None,
+            'parser': None,
         }
 
     @staticmethod
@@ -481,6 +483,7 @@ def create_argument_parser() -> ArgumentParser:
     )
     run_args.add_argument('pgm_file', type=str, help='File program to run in it.')
     run_args.add_argument('--definition', type=dir_path, dest='definition_dir', help='Path to definition to use.')
+    run_args.add_argument('--parser', type=str, help='Command to use as a custom parser.')
 
     prove_args = pyk_args_command.add_parser(
         'prove',

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1139,12 +1139,12 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
     def cell_map_item_info(self) -> dict[str, tuple[str, KSort]]:
         """Map from cell label to (element-constructor label, cell-map sort).
 
-        Derived from cell-collection productions that carry both ELEMENT and WRAP_ELEMENT
-        attributes and whose element constructor is a known symbol.
+        Derived from cell-collection productions that carry both ``ELEMENT`` and ``WRAP_ELEMENT`` attributes and whose element constructor is a known symbol.
+
+        Example:
+            syntax AccountCellMap [cellCollection, hook(MAP.Map)]
+            syntax AccountCellMap ::= AccountCellMap AccountCellMap [assoc, avoid, cellCollection, comm, element(AccountCellMapItem), function, hook(MAP.concat), unit(.AccountCellMap), wrapElement(<account>)]
         """
-        # example:
-        # syntax AccountCellMap [cellCollection, hook(MAP.Map)]
-        # syntax AccountCellMap ::= AccountCellMap AccountCellMap [assoc, avoid, cellCollection, comm, element(AccountCellMapItem), function, hook(MAP.concat), unit(.AccountCellMap), wrapElement(<account>)]
         result: dict[str, tuple[str, KSort]] = {}
         for ccp in self.cell_collection_productions:
             if Atts.ELEMENT in ccp.att and Atts.WRAP_ELEMENT in ccp.att:
@@ -1529,12 +1529,18 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         return bottom_up(_add_sort_params, kast)
 
     def add_cell_map_items(self, kast: KInner) -> KInner:
-        """Wrap cell-map items in the syntactical wrapper that the frontend generates for them (see `KDefinition.remove_cell_map_items`)."""
+        """Wrap cell-map items in the syntactical wrapper that the frontend generates for them.
 
-        # Wrapping is correct only when the parent production expects the cell MAP sort (e.g.
-        # EntryCellMap), not when it expects the individual cell element sort (e.g. EntryCell).
-        # For example, EntryCellMapKey(<entry>(...)) takes EntryCell — the <entry> must NOT be
-        # wrapped, whereas _EntryCellMap_(<entry>(...), ...) expects EntryCellMap — wrapping is needed.
+        See :func:`KDefinition.remove_cell_map_items`.
+
+        Note:
+            Wrapping is correct only when the parent production expects the cell MAP sort (e.g. ``EntryCellMap``), not when it expects the individual cell element sort (e.g. ``EntryCell``).
+
+        Example:
+            ``EntryCellMapKey(<entry>(...))``: takes ``EntryCell``, ``<entry>`` must NOT be wrapped
+            ``_EntryCellMap_(<entry>(...), ...)``: expects ``EntryCellMap``, wrapping is needed
+        """
+
         def _wrap_elements(_k: KInner) -> KInner:
             if not isinstance(_k, KApply) or _k.label.name not in self.symbols:
                 return _k

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1560,7 +1560,7 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         """Remove cell-map syntactical wrapper items that the frontend generates (see `KDefinition.add_cell_map_items`)."""
         cell_wrappers = {ctor: label for label, (ctor, _) in self.cell_map_item_info.items()}
 
-        def _wrap_elements(_k: KInner) -> KInner:
+        def _unwrap_elements(_k: KInner) -> KInner:
             if (
                 type(_k) is KApply
                 and _k.label.name in cell_wrappers
@@ -1571,7 +1571,7 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
                 return _k.args[1]
             return _k
 
-        return bottom_up(_wrap_elements, kast)
+        return bottom_up(_unwrap_elements, kast)
 
     def empty_config(self, sort: KSort) -> KInner:
         """Given a cell-sort, compute an "empty" configuration for it (all the constructor structure of the configuration in place, but variables in cell positions)."""

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1535,24 +1535,22 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         # EntryCellMap), not when it expects the individual cell element sort (e.g. EntryCell).
         # For example, EntryCellMapKey(<entry>(...)) takes EntryCell — the <entry> must NOT be
         # wrapped, whereas _EntryCellMap_(<entry>(...), ...) expects EntryCellMap — wrapping is needed.
-        cell_wrappers = self.cell_map_item_info
-
         def _wrap_elements(_k: KInner) -> KInner:
             if not isinstance(_k, KApply) or _k.label.name not in self.symbols:
                 return _k
-            prod = self.symbols[_k.label.name]
-            arg_sorts = prod.argument_sorts
-            if not arg_sorts or len(arg_sorts) != _k.arity:
+            arg_sorts = self.symbols[_k.label.name].argument_sorts
+            if not any(isinstance(arg, KApply) and arg.label.name in self.cell_map_item_info for arg in _k.args):
                 return _k
-            new_args: list[KInner] = list(_k.args)
-            changed = False
-            for i, (arg_sort, arg) in enumerate(zip(arg_sorts, _k.args, strict=True)):
-                if isinstance(arg, KApply) and arg.label.name in cell_wrappers:
-                    element_ctor, cell_map_sort = cell_wrappers[arg.label.name]
-                    if arg_sort == cell_map_sort:
-                        new_args[i] = KApply(element_ctor, [arg.args[0], arg])
-                        changed = True
-            return _k.let(args=new_args) if changed else _k
+            new_args: list[KInner] = []
+            for arg_sort, arg in zip(arg_sorts, _k.args, strict=True):
+                new_arg = arg
+                if isinstance(arg, KApply):
+                    if arg.label.name in self.cell_map_item_info:
+                        element_ctor, element_ctor_sort = self.cell_map_item_info[arg.label.name]
+                        if arg_sort == element_ctor_sort:
+                            new_arg = KApply(element_ctor, [arg.args[0], arg])
+                new_args.append(new_arg)
+            return _k.let(args=new_args)
 
         # To ensure we don't get duplicate wrappers.
         _kast = self.remove_cell_map_items(kast)

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1515,15 +1515,35 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         # syntax AccountCellMap [cellCollection, hook(MAP.Map)]
         # syntax AccountCellMap ::= AccountCellMap AccountCellMap [assoc, avoid, cellCollection, comm, element(AccountCellMapItem), function, hook(MAP.concat), unit(.AccountCellMap), wrapElement(<account>)]
 
-        cell_wrappers = {}
+        # Maps cell label -> (element_constructor, cell_map_sort).
+        # Wrapping is correct only when the parent production expects the cell MAP sort (e.g.
+        # EntryCellMap), not when it expects the individual cell element sort (e.g. EntryCell).
+        # For example, EntryCellMapKey(<entry>(...)) takes EntryCell — the <entry> must NOT be
+        # wrapped, whereas _EntryCellMap_(<entry>(...), ...) expects EntryCellMap — wrapping is needed.
+        cell_wrappers: dict[str, tuple[str, KSort]] = {}
         for ccp in self.cell_collection_productions:
             if Atts.ELEMENT in ccp.att and Atts.WRAP_ELEMENT in ccp.att:
-                cell_wrappers[ccp.att[Atts.WRAP_ELEMENT]] = ccp.att[Atts.ELEMENT]
+                cell_label = ccp.att[Atts.WRAP_ELEMENT]
+                element_ctor = ccp.att[Atts.ELEMENT]
+                if element_ctor in self.symbols:
+                    cell_wrappers[cell_label] = (element_ctor, self.symbols[element_ctor].sort)
 
         def _wrap_elements(_k: KInner) -> KInner:
-            if type(_k) is KApply and _k.label.name in cell_wrappers:
-                return KApply(cell_wrappers[_k.label.name], [_k.args[0], _k])
-            return _k
+            if not isinstance(_k, KApply) or _k.label.name not in self.symbols:
+                return _k
+            prod = self.symbols[_k.label.name]
+            arg_sorts = prod.argument_sorts
+            if not arg_sorts or len(arg_sorts) != _k.arity:
+                return _k
+            new_args: list[KInner] = list(_k.args)
+            changed = False
+            for i, (arg_sort, arg) in enumerate(zip(arg_sorts, _k.args, strict=True)):
+                if isinstance(arg, KApply) and arg.label.name in cell_wrappers:
+                    element_ctor, cell_map_sort = cell_wrappers[arg.label.name]
+                    if arg_sort == cell_map_sort:
+                        new_args[i] = KApply(element_ctor, [arg.args[0], arg])
+                        changed = True
+            return _k.let(args=new_args) if changed else _k
 
         # To ensure we don't get duplicate wrappers.
         _kast = self.remove_cell_map_items(kast)

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1136,6 +1136,22 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         return tuple(prod for module in self.modules for prod in module.cell_collection_productions)
 
     @cached_property
+    def cell_map_item_info(self) -> dict[str, tuple[str, KSort]]:
+        """Map from cell label to (element-constructor label, cell-map sort).
+
+        Derived from cell-collection productions that carry both ELEMENT and WRAP_ELEMENT
+        attributes and whose element constructor is a known symbol.
+        """
+        result: dict[str, tuple[str, KSort]] = {}
+        for ccp in self.cell_collection_productions:
+            if Atts.ELEMENT in ccp.att and Atts.WRAP_ELEMENT in ccp.att:
+                cell_label = ccp.att[Atts.WRAP_ELEMENT]
+                element_ctor = ccp.att[Atts.ELEMENT]
+                if element_ctor in self.symbols:
+                    result[cell_label] = (element_ctor, self.symbols[element_ctor].sort)
+        return result
+
+    @cached_property
     def rules(self) -> tuple[KRule, ...]:
         """Returns the `KRule` sentences transitively imported by the main module of this definition."""
         return tuple(rule for module in self.modules for rule in module.rules)
@@ -1515,18 +1531,11 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         # syntax AccountCellMap [cellCollection, hook(MAP.Map)]
         # syntax AccountCellMap ::= AccountCellMap AccountCellMap [assoc, avoid, cellCollection, comm, element(AccountCellMapItem), function, hook(MAP.concat), unit(.AccountCellMap), wrapElement(<account>)]
 
-        # Maps cell label -> (element_constructor, cell_map_sort).
         # Wrapping is correct only when the parent production expects the cell MAP sort (e.g.
         # EntryCellMap), not when it expects the individual cell element sort (e.g. EntryCell).
         # For example, EntryCellMapKey(<entry>(...)) takes EntryCell — the <entry> must NOT be
         # wrapped, whereas _EntryCellMap_(<entry>(...), ...) expects EntryCellMap — wrapping is needed.
-        cell_wrappers: dict[str, tuple[str, KSort]] = {}
-        for ccp in self.cell_collection_productions:
-            if Atts.ELEMENT in ccp.att and Atts.WRAP_ELEMENT in ccp.att:
-                cell_label = ccp.att[Atts.WRAP_ELEMENT]
-                element_ctor = ccp.att[Atts.ELEMENT]
-                if element_ctor in self.symbols:
-                    cell_wrappers[cell_label] = (element_ctor, self.symbols[element_ctor].sort)
+        cell_wrappers = self.cell_map_item_info
 
         def _wrap_elements(_k: KInner) -> KInner:
             if not isinstance(_k, KApply) or _k.label.name not in self.symbols:
@@ -1551,14 +1560,7 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
 
     def remove_cell_map_items(self, kast: KInner) -> KInner:
         """Remove cell-map syntactical wrapper items that the frontend generates (see `KDefinition.add_cell_map_items`)."""
-        # example:
-        # syntax AccountCellMap [cellCollection, hook(MAP.Map)]
-        # syntax AccountCellMap ::= AccountCellMap AccountCellMap [assoc, avoid, cellCollection, comm, element(AccountCellMapItem), function, hook(MAP.concat), unit(.AccountCellMap), wrapElement(<account>)]
-
-        cell_wrappers = {}
-        for ccp in self.cell_collection_productions:
-            if Atts.ELEMENT in ccp.att and Atts.WRAP_ELEMENT in ccp.att:
-                cell_wrappers[ccp.att[Atts.ELEMENT]] = ccp.att[Atts.WRAP_ELEMENT]
+        cell_wrappers = {ctor: label for label, (ctor, _) in self.cell_map_item_info.items()}
 
         def _wrap_elements(_k: KInner) -> KInner:
             if (

--- a/pyk/src/pyk/kast/outer.py
+++ b/pyk/src/pyk/kast/outer.py
@@ -1142,6 +1142,9 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
         Derived from cell-collection productions that carry both ELEMENT and WRAP_ELEMENT
         attributes and whose element constructor is a known symbol.
         """
+        # example:
+        # syntax AccountCellMap [cellCollection, hook(MAP.Map)]
+        # syntax AccountCellMap ::= AccountCellMap AccountCellMap [assoc, avoid, cellCollection, comm, element(AccountCellMapItem), function, hook(MAP.concat), unit(.AccountCellMap), wrapElement(<account>)]
         result: dict[str, tuple[str, KSort]] = {}
         for ccp in self.cell_collection_productions:
             if Atts.ELEMENT in ccp.att and Atts.WRAP_ELEMENT in ccp.att:
@@ -1527,9 +1530,6 @@ class KDefinition(KOuter, WithKAtt, Iterable[KFlatModule]):
 
     def add_cell_map_items(self, kast: KInner) -> KInner:
         """Wrap cell-map items in the syntactical wrapper that the frontend generates for them (see `KDefinition.remove_cell_map_items`)."""
-        # example:
-        # syntax AccountCellMap [cellCollection, hook(MAP.Map)]
-        # syntax AccountCellMap ::= AccountCellMap AccountCellMap [assoc, avoid, cellCollection, comm, element(AccountCellMapItem), function, hook(MAP.concat), unit(.AccountCellMap), wrapElement(<account>)]
 
         # Wrapping is correct only when the parent production expects the cell MAP sort (e.g.
         # EntryCellMap), not when it expects the individual cell element sort (e.g. EntryCell).

--- a/pyk/src/pyk/ktool/krun.py
+++ b/pyk/src/pyk/ktool/krun.py
@@ -294,8 +294,8 @@ class KRun(KPrint):
         assert parser.eof
         return res
 
-    def krun(self, input_file: Path) -> tuple[int, KInner]:
-        result = _krun(input_file=input_file, definition_dir=self.definition_dir, output=KRunOutput.KORE)
+    def krun(self, input_file: Path, parser: str | None = None) -> tuple[int, KInner]:
+        result = _krun(input_file=input_file, definition_dir=self.definition_dir, output=KRunOutput.KORE, parser=parser)
         kore = KoreParser(result.stdout).pattern()
         kast = self.kore_to_kast(kore)
         return (result.returncode, kast)

--- a/pyk/src/tests/unit/kast/test_definition.py
+++ b/pyk/src/tests/unit/kast/test_definition.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from pyk.kast.att import Atts, KAtt
+from pyk.kast.inner import KApply, KAs, KLabel, KSequence, KSort, KToken, KVariable
+from pyk.kast.outer import KDefinition, KFlatModule, KNonTerminal, KProduction, KTerminal
+
+if TYPE_CHECKING:
+    from typing import Final
+
+    from pyk.kast.inner import KInner
+
+
+# ---------------------------------------------------------------------------
+# Minimal test definition
+#
+# bar: syntax N       ::= bar(N)        -- result sort is the param directly
+# foo: syntax MInt{N} ::= foo(MInt{N})  -- result/arg sorts nest the param
+# #Equals: syntax S2  ::= #Equals{S1,S2}(S1, S1)  -- ML pred, result sort context-dependent
+#
+# Cell map fragment:
+#   AccountCellMap ::= AccountCellMap AccountCellMap  [cellCollection, element(AccountCellMapItem), wrapElement(<account>)]
+#   AccountCellMap ::= AccountCellMapItem(Int, AccountCell)
+#   AccountCell    ::= <account>(Int, Int)
+#   AccountCell    ::= getEntry(AccountCell)           -- takes element sort, NOT map sort
+# ---------------------------------------------------------------------------
+
+INT: Final = KSort('Int')
+N: Final = KSort('N')
+S1: Final = KSort('S1')
+S2: Final = KSort('S2')
+MINT_N: Final = KSort('MInt', (N,))
+MINT_INT: Final = KSort('MInt', (INT,))
+SORT_PARAM: Final = KSort('#SortParam')
+ACCOUNT_CELL_MAP: Final = KSort('AccountCellMap')
+ACCOUNT_CELL: Final = KSort('AccountCell')
+
+_BAR_PROD: Final = KProduction(
+    sort=N,
+    items=[KTerminal('bar'), KTerminal('('), KNonTerminal(N), KTerminal(')')],
+    params=[N],
+    klabel='bar',
+)
+
+_FOO_PROD: Final = KProduction(
+    sort=MINT_N,
+    items=[KTerminal('foo'), KTerminal('('), KNonTerminal(MINT_N), KTerminal(')')],
+    params=[N],
+    klabel='foo',
+)
+
+_EQUALS_PROD: Final = KProduction(
+    sort=S2,
+    items=[KNonTerminal(S1), KNonTerminal(S1)],
+    params=[S1, S2],
+    klabel='#Equals',
+)
+
+_ACCT_MAP_CONCAT: Final = KProduction(
+    sort=ACCOUNT_CELL_MAP,
+    items=[KNonTerminal(ACCOUNT_CELL_MAP), KNonTerminal(ACCOUNT_CELL_MAP)],
+    klabel='_AccountCellMap_',
+    att=KAtt(entries=[Atts.CELL_COLLECTION(None), Atts.ELEMENT('AccountCellMapItem'), Atts.WRAP_ELEMENT('<account>')]),
+)
+
+_ACCT_MAP_ITEM: Final = KProduction(
+    sort=ACCOUNT_CELL_MAP,
+    items=[
+        KTerminal('AccountCellMapItem'),
+        KTerminal('('),
+        KNonTerminal(INT),
+        KTerminal(','),
+        KNonTerminal(ACCOUNT_CELL),
+        KTerminal(')'),
+    ],
+    klabel='AccountCellMapItem',
+)
+
+_ACCOUNT_CELL: Final = KProduction(
+    sort=ACCOUNT_CELL,
+    items=[
+        KTerminal('<account>'),
+        KTerminal('('),
+        KNonTerminal(INT),
+        KTerminal(','),
+        KNonTerminal(INT),
+        KTerminal(')'),
+    ],
+    klabel='<account>',
+)
+
+_GET_ENTRY: Final = KProduction(
+    sort=ACCOUNT_CELL,
+    items=[KTerminal('getEntry'), KTerminal('('), KNonTerminal(ACCOUNT_CELL), KTerminal(')')],
+    klabel='getEntry',
+)
+
+DEFN: Final = KDefinition(
+    'TEST',
+    [
+        KFlatModule(
+            'TEST', [_BAR_PROD, _FOO_PROD, _EQUALS_PROD, _ACCT_MAP_CONCAT, _ACCT_MAP_ITEM, _ACCOUNT_CELL, _GET_ENTRY]
+        )
+    ],
+)
+
+
+# ---------------------------------------------------------------------------
+# KDefinition.sort
+# ---------------------------------------------------------------------------
+
+SORT_DATA: Final = (
+    # Basic leaf terms
+    ('ktoken', KToken('42', INT), INT),
+    ('kvariable_with_sort', KVariable('X', sort=INT), INT),
+    ('ksequence', KSequence([]), KSort('K')),
+    # KApply: result sort substituted directly from param
+    ('kapply_direct_result', KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]), INT),
+    # KApply: result sort nests the param (MInt{N} with N→Int → MInt{Int})
+    ('kapply_nested_result', KApply(KLabel('foo', [INT]), [KVariable('X', sort=MINT_INT)]), MINT_INT),
+    # KApply with unfilled sort params: sort() returns None rather than raising
+    ('kapply_unfilled_params', KApply(KLabel('foo'), [KVariable('X', sort=MINT_INT)]), None),
+    # KApply with unknown label: KeyError from symbols lookup → None
+    ('kapply_unknown_label', KApply(KLabel('nonexistent'), []), None),
+    # KAs: sort of the alias variable
+    ('kas_sorted_alias', KAs(KVariable('X', sort=MINT_INT), KVariable('Y', sort=MINT_INT)), MINT_INT),
+    # KAs whose alias has no sort annotation: returns None
+    ('kas_unsorted_alias', KAs(KVariable('X', sort=MINT_INT), KVariable('Y')), None),
+)
+
+
+@pytest.mark.parametrize(
+    'test_id,term,expected',
+    SORT_DATA,
+    ids=[test_id for test_id, *_ in SORT_DATA],
+)
+def test_sort(test_id: str, term: KInner, expected: KSort | None) -> None:
+    assert DEFN.sort(term) == expected
+
+
+# ---------------------------------------------------------------------------
+# KDefinition.resolve_sorts
+# ---------------------------------------------------------------------------
+
+RESOLVE_SORTS_DATA: Final = (
+    # Direct substitution: result sort IS the param (N → Int)
+    ('direct_bar', KLabel('bar', [INT]), INT, (INT,)),
+    # Recursive substitution: result/arg sort nests the param (MInt{N} with N → Int → MInt{Int})
+    ('nested_foo', KLabel('foo', [INT]), MINT_INT, (MINT_INT,)),
+)
+
+
+@pytest.mark.parametrize(
+    'test_id,label,expected_result,expected_args',
+    RESOLVE_SORTS_DATA,
+    ids=[test_id for test_id, *_ in RESOLVE_SORTS_DATA],
+)
+def test_resolve_sorts(test_id: str, label: KLabel, expected_result: KSort, expected_args: tuple[KSort, ...]) -> None:
+    result, args = DEFN.resolve_sorts(label)
+    assert result == expected_result
+    assert args == expected_args
+
+
+# ---------------------------------------------------------------------------
+# KDefinition.add_sort_params
+# ---------------------------------------------------------------------------
+
+ADD_SORT_PARAMS_DATA: Final = (
+    # Label already has params filled: leave unchanged
+    (
+        'already_filled',
+        KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]),
+        KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]),
+    ),
+    # Direct sort param: psort IS the param (N ~ Int → N=Int)
+    (
+        'direct_param',
+        KApply(KLabel('bar'), [KVariable('X', sort=INT)]),
+        KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]),
+    ),
+    # Nested sort param: psort = MInt{N}, asort = MInt{Int} → N=Int via unification
+    (
+        'nested_param',
+        KApply(KLabel('foo'), [KVariable('X', sort=MINT_INT)]),
+        KApply(KLabel('foo', [INT]), [KVariable('X', sort=MINT_INT)]),
+    ),
+    # ML pred: S1 inferred from args, S2 (result sort) filled with #SortParam sentinel
+    (
+        'ml_pred_sentinel',
+        KApply('#Equals', [KVariable('X', sort=INT), KVariable('Y', sort=INT)]),
+        KApply(KLabel('#Equals', [INT, SORT_PARAM]), [KVariable('X', sort=INT), KVariable('Y', sort=INT)]),
+    ),
+    # Unsortable argument (no sort annotation): cannot fill params, term returned unchanged
+    (
+        'unsortable_arg_unchanged',
+        KApply(KLabel('foo'), [KVariable('X')]),
+        KApply(KLabel('foo'), [KVariable('X')]),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    'test_id,term,expected',
+    ADD_SORT_PARAMS_DATA,
+    ids=[test_id for test_id, *_ in ADD_SORT_PARAMS_DATA],
+)
+def test_add_sort_params(test_id: str, term: KInner, expected: KInner) -> None:
+    assert DEFN.add_sort_params(term) == expected
+
+
+# ---------------------------------------------------------------------------
+# KDefinition.add_cell_map_items
+# ---------------------------------------------------------------------------
+
+_ACCT_1: Final = KApply('<account>', [KVariable('X', sort=INT), KVariable('Y', sort=INT)])
+_ACCT_2: Final = KApply('<account>', [KVariable('A', sort=INT), KVariable('B', sort=INT)])
+
+ADD_CELL_MAP_ITEMS_DATA: Final = (
+    # Parent expects AccountCellMap (the map sort) — children are wrapped in AccountCellMapItem.
+    (
+        'wraps_when_parent_expects_cell_map_sort',
+        KApply('_AccountCellMap_', [_ACCT_1, _ACCT_2]),
+        KApply(
+            '_AccountCellMap_',
+            [
+                KApply('AccountCellMapItem', [KVariable('X', sort=INT), _ACCT_1]),
+                KApply('AccountCellMapItem', [KVariable('A', sort=INT), _ACCT_2]),
+            ],
+        ),
+    ),
+    # Parent expects AccountCell (the element sort) — the <account> child must NOT be wrapped.
+    # Before the guard fix, _wrap_elements would incorrectly wrap here too.
+    (
+        'no_wrap_when_parent_expects_cell_element_sort',
+        KApply('getEntry', [_ACCT_1]),
+        KApply('getEntry', [_ACCT_1]),
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    'test_id,term,expected',
+    ADD_CELL_MAP_ITEMS_DATA,
+    ids=[test_id for test_id, *_ in ADD_CELL_MAP_ITEMS_DATA],
+)
+def test_add_cell_map_items(test_id: str, term: KInner, expected: KInner) -> None:
+    assert DEFN.add_cell_map_items(term) == expected

--- a/pyk/src/tests/unit/kast/test_definition.py
+++ b/pyk/src/tests/unit/kast/test_definition.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 import pytest
 
 from pyk.kast.att import Atts, KAtt
-from pyk.kast.inner import KApply, KAs, KLabel, KSequence, KSort, KToken, KVariable
+from pyk.kast.inner import KApply, KSort, KVariable
 from pyk.kast.outer import KDefinition, KFlatModule, KNonTerminal, KProduction, KTerminal
 
 if TYPE_CHECKING:
@@ -17,10 +17,6 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Minimal test definition
 #
-# bar: syntax N       ::= bar(N)        -- result sort is the param directly
-# foo: syntax MInt{N} ::= foo(MInt{N})  -- result/arg sorts nest the param
-# #Equals: syntax S2  ::= #Equals{S1,S2}(S1, S1)  -- ML pred, result sort context-dependent
-#
 # Cell map fragment:
 #   AccountCellMap ::= AccountCellMap AccountCellMap  [cellCollection, element(AccountCellMapItem), wrapElement(<account>)]
 #   AccountCellMap ::= AccountCellMapItem(Int, AccountCell)
@@ -29,35 +25,8 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 
 INT: Final = KSort('Int')
-N: Final = KSort('N')
-S1: Final = KSort('S1')
-S2: Final = KSort('S2')
-MINT_N: Final = KSort('MInt', (N,))
-MINT_INT: Final = KSort('MInt', (INT,))
-SORT_PARAM: Final = KSort('#SortParam')
 ACCOUNT_CELL_MAP: Final = KSort('AccountCellMap')
 ACCOUNT_CELL: Final = KSort('AccountCell')
-
-_BAR_PROD: Final = KProduction(
-    sort=N,
-    items=[KTerminal('bar'), KTerminal('('), KNonTerminal(N), KTerminal(')')],
-    params=[N],
-    klabel='bar',
-)
-
-_FOO_PROD: Final = KProduction(
-    sort=MINT_N,
-    items=[KTerminal('foo'), KTerminal('('), KNonTerminal(MINT_N), KTerminal(')')],
-    params=[N],
-    klabel='foo',
-)
-
-_EQUALS_PROD: Final = KProduction(
-    sort=S2,
-    items=[KNonTerminal(S1), KNonTerminal(S1)],
-    params=[S1, S2],
-    klabel='#Equals',
-)
 
 _ACCT_MAP_CONCAT: Final = KProduction(
     sort=ACCOUNT_CELL_MAP,
@@ -100,116 +69,8 @@ _GET_ENTRY: Final = KProduction(
 
 DEFN: Final = KDefinition(
     'TEST',
-    [
-        KFlatModule(
-            'TEST', [_BAR_PROD, _FOO_PROD, _EQUALS_PROD, _ACCT_MAP_CONCAT, _ACCT_MAP_ITEM, _ACCOUNT_CELL, _GET_ENTRY]
-        )
-    ],
+    [KFlatModule('TEST', [_ACCT_MAP_CONCAT, _ACCT_MAP_ITEM, _ACCOUNT_CELL, _GET_ENTRY])],
 )
-
-
-# ---------------------------------------------------------------------------
-# KDefinition.sort
-# ---------------------------------------------------------------------------
-
-SORT_DATA: Final = (
-    # Basic leaf terms
-    ('ktoken', KToken('42', INT), INT),
-    ('kvariable_with_sort', KVariable('X', sort=INT), INT),
-    ('ksequence', KSequence([]), KSort('K')),
-    # KApply: result sort substituted directly from param
-    ('kapply_direct_result', KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]), INT),
-    # KApply: result sort nests the param (MInt{N} with N→Int → MInt{Int})
-    ('kapply_nested_result', KApply(KLabel('foo', [INT]), [KVariable('X', sort=MINT_INT)]), MINT_INT),
-    # KApply with unfilled sort params: sort() returns None rather than raising
-    ('kapply_unfilled_params', KApply(KLabel('foo'), [KVariable('X', sort=MINT_INT)]), None),
-    # KApply with unknown label: KeyError from symbols lookup → None
-    ('kapply_unknown_label', KApply(KLabel('nonexistent'), []), None),
-    # KAs: sort of the alias variable
-    ('kas_sorted_alias', KAs(KVariable('X', sort=MINT_INT), KVariable('Y', sort=MINT_INT)), MINT_INT),
-    # KAs whose alias has no sort annotation: returns None
-    ('kas_unsorted_alias', KAs(KVariable('X', sort=MINT_INT), KVariable('Y')), None),
-)
-
-
-@pytest.mark.parametrize(
-    'test_id,term,expected',
-    SORT_DATA,
-    ids=[test_id for test_id, *_ in SORT_DATA],
-)
-def test_sort(test_id: str, term: KInner, expected: KSort | None) -> None:
-    assert DEFN.sort(term) == expected
-
-
-# ---------------------------------------------------------------------------
-# KDefinition.resolve_sorts
-# ---------------------------------------------------------------------------
-
-RESOLVE_SORTS_DATA: Final = (
-    # Direct substitution: result sort IS the param (N → Int)
-    ('direct_bar', KLabel('bar', [INT]), INT, (INT,)),
-    # Recursive substitution: result/arg sort nests the param (MInt{N} with N → Int → MInt{Int})
-    ('nested_foo', KLabel('foo', [INT]), MINT_INT, (MINT_INT,)),
-)
-
-
-@pytest.mark.parametrize(
-    'test_id,label,expected_result,expected_args',
-    RESOLVE_SORTS_DATA,
-    ids=[test_id for test_id, *_ in RESOLVE_SORTS_DATA],
-)
-def test_resolve_sorts(test_id: str, label: KLabel, expected_result: KSort, expected_args: tuple[KSort, ...]) -> None:
-    result, args = DEFN.resolve_sorts(label)
-    assert result == expected_result
-    assert args == expected_args
-
-
-# ---------------------------------------------------------------------------
-# KDefinition.add_sort_params
-# ---------------------------------------------------------------------------
-
-ADD_SORT_PARAMS_DATA: Final = (
-    # Label already has params filled: leave unchanged
-    (
-        'already_filled',
-        KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]),
-        KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]),
-    ),
-    # Direct sort param: psort IS the param (N ~ Int → N=Int)
-    (
-        'direct_param',
-        KApply(KLabel('bar'), [KVariable('X', sort=INT)]),
-        KApply(KLabel('bar', [INT]), [KVariable('X', sort=INT)]),
-    ),
-    # Nested sort param: psort = MInt{N}, asort = MInt{Int} → N=Int via unification
-    (
-        'nested_param',
-        KApply(KLabel('foo'), [KVariable('X', sort=MINT_INT)]),
-        KApply(KLabel('foo', [INT]), [KVariable('X', sort=MINT_INT)]),
-    ),
-    # ML pred: S1 inferred from args, S2 (result sort) filled with #SortParam sentinel
-    (
-        'ml_pred_sentinel',
-        KApply('#Equals', [KVariable('X', sort=INT), KVariable('Y', sort=INT)]),
-        KApply(KLabel('#Equals', [INT, SORT_PARAM]), [KVariable('X', sort=INT), KVariable('Y', sort=INT)]),
-    ),
-    # Unsortable argument (no sort annotation): cannot fill params, term returned unchanged
-    (
-        'unsortable_arg_unchanged',
-        KApply(KLabel('foo'), [KVariable('X')]),
-        KApply(KLabel('foo'), [KVariable('X')]),
-    ),
-)
-
-
-@pytest.mark.parametrize(
-    'test_id,term,expected',
-    ADD_SORT_PARAMS_DATA,
-    ids=[test_id for test_id, *_ in ADD_SORT_PARAMS_DATA],
-)
-def test_add_sort_params(test_id: str, term: KInner, expected: KInner) -> None:
-    assert DEFN.add_sort_params(term) == expected
-
 
 # ---------------------------------------------------------------------------
 # KDefinition.add_cell_map_items


### PR DESCRIPTION
`add_cell_map_items` was wrapping element-sort constructors in their cell-map item wrapper unconditionally. This caused incorrect KAST for productions like `getEntry(AccountCell)` where the argument expects the element sort `AccountCell`, not the collection sort `AccountCellMap`. The fix tracks the expected sort for each argument position and only wraps when the parent expects the map sort.

While investigating which regression tests this unblocks, pyk run was also missing `--parser`, which is used by several test cases to supply a custom input parser. This is now wired through from the CLI down to `_krun`.

Changes:
- `KDefinition.cell_map_item_info`: added cached property to `KDefinition` for extracting not only the element constructor for a given cell collection production, but also the sort of that constructor, and uses this factored out method in both of `KDefinition.{add_cell_map_items,remove_cell_map_items}`.
- `KDefinition.add_cell_map_items`: guard wrapping behind a check that the parent argument sort matches the cell map sort
- pyk run / `KRun.krun`: add `--parser` flag support
- Remove star-multiplicity, issue-582, krun-deserialize from regression-new/skipped; update their baselines to current compiler output

Validation:
- New unit tests in test_definition.py cover both the wrapping case (`_AccountCellMap_`) and the no-wrap case (`getEntry`)
- All three re-enabled regression tests pass end-to-end against the LLVM backend