### PR TITLE
Add progressive depth-halving policy to Prover.advance_proof

### DIFF
--- a/pyk/src/pyk/cterm/symbolic.py
+++ b/pyk/src/pyk/cterm/symbolic.py
@@ -93,6 +93,10 @@ class CTermSymbolic:
     def kore_to_kast(self, pattern: Pattern) -> KInner:
         return kore_to_kast(self._definition, pattern)
 
+    def interrupt(self) -> None:
+        """Abort a backend request currently in flight on another thread; see `KoreClient.interrupt`."""
+        self._kore_client.interrupt()
+
     def execute(
         self,
         cterm: CTerm,

--- a/pyk/src/pyk/kcfg/explore.py
+++ b/pyk/src/pyk/kcfg/explore.py
@@ -59,6 +59,10 @@ class KCFGExplore:
     def pretty_print(self, kinner: KInner) -> str:
         return self._pretty_printer.print(kinner)
 
+    def interrupt(self) -> None:
+        """Abort a backend request currently in flight on another thread; see `KoreClient.interrupt`."""
+        self.cterm_symbolic.interrupt()
+
     def _extract_rule_labels(self, _logs: tuple[LogEntry, ...]) -> list[str]:
         _rule_lines = []
         for node_log in _logs:

--- a/pyk/src/pyk/kore/rpc.py
+++ b/pyk/src/pyk/kore/rpc.py
@@ -76,6 +76,15 @@ class Transport(ContextManager['Transport'], ABC):
     @abstractmethod
     def close(self) -> None: ...
 
+    def interrupt(self) -> None:
+        """Abort a request that is currently in flight on another thread.
+
+        After `interrupt()` returns, a thread blocked in `request()` must raise promptly and
+        the transport must remain usable for subsequent requests. The default implementation
+        does nothing; transports backed by an interruptible connection should override it.
+        """
+        ...
+
     @abstractmethod
     def _request(self, req: str) -> str: ...
 
@@ -92,6 +101,7 @@ class TransportType(Enum):
 class SingleSocketTransport(Transport):
     _host: str
     _port: int
+    _timeout: int | None
     _sock: socket.socket
     _file: IO[str]
 
@@ -104,6 +114,7 @@ class SingleSocketTransport(Transport):
     ):
         self._host = host
         self._port = port
+        self._timeout = timeout
         self._sock = self._create_connection(host, port, timeout)
         self._file = self._sock.makefile('r')
 
@@ -130,6 +141,23 @@ class SingleSocketTransport(Transport):
     def close(self) -> None:
         self._file.close()
         self._sock.close()
+
+    def interrupt(self) -> None:
+        # Shutting down the socket unblocks a thread currently blocked in `readline`, causing
+        # its read to raise. We then reconnect so the transport stays usable for later requests.
+        # The old socket is closed; the old file object is left to be reclaimed by the garbage
+        # collector to avoid racing a `close()` against the unwinding reader thread.
+        old_sock = self._sock
+        try:
+            old_sock.shutdown(socket.SHUT_RDWR)
+        except OSError:
+            pass
+        self._sock = self._create_connection(self._host, self._port, self._timeout)
+        self._file = self._sock.makefile('r')
+        try:
+            old_sock.close()
+        except OSError:
+            pass
 
     def _request(self, req: str) -> str:
         self._sock.sendall(req.encode())
@@ -235,6 +263,12 @@ class JsonRpcClientFacade(ContextManager['JsonRpcClientFacade']):
             for client in clients:
                 client.close()
 
+    def interrupt(self) -> None:
+        self._default_client.interrupt()
+        for clients in self._clients.values():
+            for client in clients:
+                client.interrupt()
+
     def request(self, method: str, **params: Any) -> dict[str, Any]:
         if method in self._clients:
             for client in self._clients[method]:
@@ -288,6 +322,9 @@ class JsonRpcClient(ContextManager['JsonRpcClient']):
 
     def close(self) -> None:
         self._transport.close()
+
+    def interrupt(self) -> None:
+        self._transport.interrupt()
 
     def request(self, method: str, **params: Any) -> dict[str, Any]:
         req_id = f'{id(self)}-{self._req_id:03}'
@@ -917,6 +954,15 @@ class KoreClient(ContextManager['KoreClient']):
 
     def close(self) -> None:
         self._client.close()
+
+    def interrupt(self) -> None:
+        """Abort an `execute`/`simplify`/… request currently in flight on another thread.
+
+        After this returns the interrupted call raises and the client stays usable. Only
+        effective for the single-socket transport; a no-op for transports that cannot abort
+        an in-flight request.
+        """
+        self._client.interrupt()
 
     def _request(self, method: str, **params: Any) -> dict[str, Any]:
         try:

--- a/pyk/src/pyk/proof/proof.py
+++ b/pyk/src/pyk/proof/proof.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import json
 import logging
 from abc import ABC, abstractmethod
-from concurrent.futures import ThreadPoolExecutor, wait
+from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import TimeoutError as FuturesTimeoutError
+from concurrent.futures import wait
 from dataclasses import dataclass
 from enum import Enum
 from itertools import chain
@@ -499,6 +501,30 @@ class Prover(ContextManager['Prover'], Generic[P, PS, SR]):
         """
         ...
 
+    def get_step_depth(self) -> int | None:
+        """Return the current per-step exploration depth, if this prover exposes a tunable one.
+
+        Returning `None` (the default) opts the prover out of the progressive depth-halving
+        policy in `advance_proof`. Provers with a tunable execution depth (e.g. `APRProver`)
+        should override this together with `set_step_depth`.
+        """
+        return None
+
+    def set_step_depth(self, depth: int) -> None:
+        """Set the per-step exploration depth. No-op by default; see `get_step_depth`."""
+        ...
+
+    def interrupt(self) -> None:
+        """Abort a `step_proof` call currently running on another thread, as quickly as possible.
+
+        Used by the progressive depth-halving policy in `advance_proof` to abandon a step that
+        has exhausted its stall window. After this returns, a thread blocked in `step_proof` must
+        raise promptly and the prover must remain usable for subsequent steps. The default
+        implementation does nothing; provers backed by an interruptible resource (e.g. a Kore RPC
+        connection) should override it.
+        """
+        ...
+
     def advance_proof(
         self,
         proof: P,
@@ -506,6 +532,7 @@ class Prover(ContextManager['Prover'], Generic[P, PS, SR]):
         fail_fast: bool = False,
         callback: Callable[[P], None] = (lambda x: None),
         maintenance_rate: int = 1,
+        per_depth_timeout: float | None = None,
     ) -> None:
         """Advance a proof.
 
@@ -518,29 +545,74 @@ class Prover(ContextManager['Prover'], Generic[P, PS, SR]):
               halt execution even if there are still available steps.
             callback: Callable to run in between each completed step, useful for getting real-time information about the proof.
             maintenance_rate: Number of iterations between proof maintenance (writing to disk and executing callback).
+            per_depth_timeout (optional): Enables progressive depth halving when set to a positive value.
+              Each step is given a stall window of `current_depth * per_depth_timeout` seconds (where
+              `current_depth` is the prover's `get_step_depth()`) to commit its result. If a step does not
+              finish within its window, it is interrupted, the step depth is halved (down to a floor of 1),
+              and the step is retried at the shallower depth. Has no effect for provers whose
+              `get_step_depth()` returns `None`.
         """
         iterations = 0
         _LOGGER.info(f'Initializing proof: {proof.id}')
         self.init_proof(proof)
-        while True:
-            steps = list(proof.get_steps())
-            _LOGGER.info(f'Found {len(steps)} next steps for proof: {proof.id}')
-            if len(steps) == 0:
-                break
-            for step in steps:
-                if fail_fast and proof.failed:
-                    _LOGGER.warning(f'Terminating proof early because fail_fast is set: {proof.id}')
-                    proof.failure_info = self.failure_info(proof)
-                    return
-                if max_iterations is not None and max_iterations <= iterations:
-                    return
-                iterations += 1
-                results = self.step_proof(step)
-                for result in results:
-                    proof.commit(result)
-                if iterations % maintenance_rate == 0:
-                    proof.write_proof_data()
-                    callback(proof)
+
+        progressive = per_depth_timeout is not None and per_depth_timeout > 0 and self.get_step_depth() is not None
+        executor = ThreadPoolExecutor(max_workers=1) if progressive else None
+        try:
+            while True:
+                steps = list(proof.get_steps())
+                _LOGGER.info(f'Found {len(steps)} next steps for proof: {proof.id}')
+                if len(steps) == 0:
+                    break
+                halved_depth = False
+                for step in steps:
+                    if fail_fast and proof.failed:
+                        _LOGGER.warning(f'Terminating proof early because fail_fast is set: {proof.id}')
+                        proof.failure_info = self.failure_info(proof)
+                        return
+                    if max_iterations is not None and max_iterations <= iterations:
+                        return
+                    if progressive:
+                        assert executor is not None
+                        assert per_depth_timeout is not None
+                        depth = self.get_step_depth()
+                        assert depth is not None
+                        window = max(depth, 1) * per_depth_timeout
+                        future = executor.submit(self.step_proof, step)
+                        try:
+                            results = future.result(timeout=window)
+                        except FuturesTimeoutError:
+                            # The step exhausted its stall window: interrupt it, halve the depth,
+                            # and re-fetch steps so the same node is retried at the shallower depth.
+                            self.interrupt()
+                            wait([future])
+                            new_depth = max(1, depth // 2)
+                            if new_depth >= depth:
+                                _LOGGER.warning(
+                                    f'Proof {proof.id}: step exhausted {window}s stall window at minimum '
+                                    f'depth {depth}; stopping.'
+                                )
+                                return
+                            _LOGGER.warning(
+                                f'Proof {proof.id}: step exhausted {window}s stall window at depth {depth}; '
+                                f'halving to {new_depth}.'
+                            )
+                            self.set_step_depth(new_depth)
+                            halved_depth = True
+                            break
+                    else:
+                        results = self.step_proof(step)
+                    iterations += 1
+                    for result in results:
+                        proof.commit(result)
+                    if iterations % maintenance_rate == 0:
+                        proof.write_proof_data()
+                        callback(proof)
+                if halved_depth:
+                    continue
+        finally:
+            if executor is not None:
+                executor.shutdown(wait=False)
 
         if proof.failed:
             proof.failure_info = self.failure_info(proof)

--- a/pyk/src/pyk/proof/reachability.py
+++ b/pyk/src/pyk/proof/reachability.py
@@ -755,6 +755,15 @@ class APRProver(Prover[APRProof, APRProofStep, APRProofResult]):
     def close(self) -> None:
         self.kcfg_explore.cterm_symbolic._kore_client.close()
 
+    def get_step_depth(self) -> int | None:
+        return self.execute_depth
+
+    def set_step_depth(self, depth: int) -> None:
+        self.execute_depth = depth
+
+    def interrupt(self) -> None:
+        self.kcfg_explore.interrupt()
+
     def init_proof(self, proof: APRProof) -> None:
         main_module_name = self.main_module_name
         if self.extra_module:

--- a/pyk/src/tests/unit/test_advance_proof.py
+++ b/pyk/src/tests/unit/test_advance_proof.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from threading import Event
+from typing import TYPE_CHECKING
+
+from pyk.proof.proof import Proof, ProofStatus, Prover
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+    from typing import Any
+
+
+class _StepInterrupted(Exception):
+    """Raised inside `step_proof` when the prover is interrupted, mimicking a backend abort."""
+
+
+class CountingProof(Proof[int, int]):
+    """Minimal proof that needs `target` committed steps to pass."""
+
+    target: int
+    committed: int
+
+    def __init__(self, id: str, target: int) -> None:
+        super().__init__(id)
+        self.target = target
+        self.committed = 0
+
+    def commit(self, result: int) -> None:
+        self.committed += result
+
+    @property
+    def own_status(self) -> ProofStatus:
+        return ProofStatus.PASSED if self.committed >= self.target else ProofStatus.PENDING
+
+    @property
+    def can_progress(self) -> bool:
+        return self.committed < self.target
+
+    @classmethod
+    def from_dict(cls: type[CountingProof], dct: Mapping[str, Any], proof_dir: Path | None = None) -> CountingProof:
+        raise NotImplementedError
+
+    def write_proof_data(self) -> None: ...
+
+    def get_steps(self) -> list[int]:
+        return [self.committed] if self.can_progress else []
+
+
+class CountingProver(Prover[CountingProof, int, int]):
+    """Prover whose `step_proof` stalls (blocks until interrupted) while `depth` exceeds `quick_at_depth`.
+
+    Tracks the number of interruptions so tests can assert how many times the depth was halved.
+    """
+
+    depth: int
+    quick_at_depth: int
+    interrupt_count: int
+    _interrupt_event: Event
+
+    def __init__(self, depth: int, quick_at_depth: int) -> None:
+        self.depth = depth
+        self.quick_at_depth = quick_at_depth
+        self.interrupt_count = 0
+        self._interrupt_event = Event()
+
+    def close(self) -> None: ...
+
+    def failure_info(self, proof: CountingProof) -> Any:
+        return None
+
+    def init_proof(self, proof: CountingProof) -> None: ...
+
+    def get_step_depth(self) -> int | None:
+        return self.depth
+
+    def set_step_depth(self, depth: int) -> None:
+        self.depth = depth
+
+    def interrupt(self) -> None:
+        self.interrupt_count += 1
+        self._interrupt_event.set()
+
+    def step_proof(self, step: int) -> list[int]:
+        self._interrupt_event.clear()
+        if self.depth > self.quick_at_depth:
+            # Stall until `advance_proof` interrupts us once the stall window elapses.
+            if self._interrupt_event.wait(timeout=10.0):
+                raise _StepInterrupted()
+            raise AssertionError('step_proof was not interrupted within 10s')
+        return [1]
+
+
+PER_DEPTH_TIMEOUT = 0.02
+
+
+def test_advance_proof_halves_depth_until_progress() -> None:
+    # Given: depth 8 stalls, but a step completes once depth drops to <= 2.
+    proof = CountingProof('counting', target=1)
+    prover = CountingProver(depth=8, quick_at_depth=2)
+
+    # When
+    prover.advance_proof(proof, per_depth_timeout=PER_DEPTH_TIMEOUT)
+
+    # Then: 8 -> 4 -> 2 (two halvings, two interrupts), then a step commits and the proof passes.
+    assert proof.status == ProofStatus.PASSED
+    assert prover.depth == 2
+    assert prover.interrupt_count == 2
+
+
+def test_advance_proof_stops_at_minimum_depth_when_never_progressing() -> None:
+    # Given: every step stalls regardless of depth.
+    proof = CountingProof('counting', target=1)
+    prover = CountingProver(depth=4, quick_at_depth=0)
+
+    # When
+    prover.advance_proof(proof, per_depth_timeout=PER_DEPTH_TIMEOUT)
+
+    # Then: depth halves 4 -> 2 -> 1, then stops at the floor; the proof stays pending.
+    assert proof.status == ProofStatus.PENDING
+    assert proof.committed == 0
+    assert prover.depth == 1
+    assert prover.interrupt_count == 3
+
+
+def test_advance_proof_no_halving_when_steps_are_fast() -> None:
+    # Given: progressive policy enabled but steps always complete in time.
+    proof = CountingProof('counting', target=3)
+    prover = CountingProver(depth=8, quick_at_depth=8)
+
+    # When
+    prover.advance_proof(proof, per_depth_timeout=PER_DEPTH_TIMEOUT)
+
+    # Then: no interruptions, depth untouched, proof passes.
+    assert proof.status == ProofStatus.PASSED
+    assert prover.depth == 8
+    assert prover.interrupt_count == 0
+
+
+def test_advance_proof_without_per_depth_timeout_is_unaffected() -> None:
+    # Given: no per_depth_timeout -> classic in-loop behavior, no watchdog thread.
+    proof = CountingProof('counting', target=2)
+    prover = CountingProver(depth=8, quick_at_depth=8)
+
+    # When
+    prover.advance_proof(proof)
+
+    # Then
+    assert proof.status == ProofStatus.PASSED
+    assert prover.depth == 8
+    assert prover.interrupt_count == 0


### PR DESCRIPTION
Closes #4924.

Factors kontrol's [`--per-depth-timeout`](https://github.com/runtimeverification/kontrol/pull/1141) mechanism out of tool-specific code and into a generic policy in `Prover.advance_proof`, as suggested by @ehildenb in [this review comment](https://github.com/runtimeverification/kontrol/pull/1141#issuecomment-4575606818).

## What it does

`advance_proof` gains an optional `per_depth_timeout: float | None = None`. When set to a positive value (and the prover exposes a tunable step depth), each `step_proof` runs under a stall window of `current_depth * per_depth_timeout` seconds:

- **Step finishes in time** → committed as usual.
- **Step exceeds its window** → it is interrupted, the step depth is halved (floor of 1), and the same (uncommitted) node is retried at the shallower depth.
- **At the minimum depth and still stalling** → the proof stops and stays pending.

This mirrors the kontrol behavior (`--max-depth 1000 --per-depth-timeout 0.5` → 500s window, then 250s at depth 500, … down to depth 1) but as a reusable, in-process policy rather than a forked-subprocess kill loop.

## How it stays generic

The policy lives entirely in the base `Prover` and is driven by three new hooks with safe no-op defaults:

- `get_step_depth() -> int | None` — return `None` (default) to opt out of the policy entirely.
- `set_step_depth(depth)` — no-op default.
- `interrupt()` — abort an in-flight `step_proof` on another thread; no-op default.

`APRProver` overrides them to read/write `execute_depth` and to call `kcfg_explore.interrupt()`. Provers without a tunable depth are unaffected, and the code path when `per_depth_timeout` is unset is unchanged.

To actually abort an in-flight Kore RPC call, `interrupt()` is threaded through `KCFGExplore` → `CTermSymbolic` → `KoreClient` → `JsonRpcClientFacade`/`JsonRpcClient` → `Transport`. `SingleSocketTransport.interrupt()` shuts down the blocked socket (unblocking the reader thread) and reconnects so the prover stays usable; `HttpTransport.interrupt()` is a documented no-op.

## Testing

- New `pyk/src/tests/unit/test_advance_proof.py` (in-memory fake prover, no backend): covers halving-until-progress, stop-at-minimum-depth, no-halving-when-fast, and the disabled (no `per_depth_timeout`) path.
- `make -C pyk check` passes (flake8, mypy, autoflake, isort, pydocstyle, black).
- Full pyk unit suite passes.

## Notes / follow-up

Client-side `interrupt()` reconnects to the **same** `KoreServer` (preserving added modules), but an abandoned computation may keep running server-side until it notices the dropped connection — unlike kontrol's full process-group kill. The shallower retry still proceeds correctly; a fully faithful server-restart variant would require the prover to own the server handle and is left as a follow-up.

CLI flag plumbing remains on the tool side (e.g. kontrol); this PR only provides the generic capability.