### PR TITLE
Optimize Nix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           gh release upload --repo runtimeverification/k --clobber "v${version}" "${tarball}"
 
   cachix-release:
-    name: 'Cachix release (binary cache + dependency closure)'
+    name: 'Cachix release (binary cache `k-framework-binary` + dependency cache `k-framework`)'
     strategy:
       matrix:
         include:
@@ -79,17 +79,11 @@ jobs:
         with:
           name: k-framework-binary
 
-      # The binary publish and the dependency-closure publish build the same three
-      # derivations.  Running them as sequential steps on one runner means the build
-      # happens once: the first step populates the local Nix store, so the second
-      # step's `nix build` is an instant store hit rather than a full recompile.
-      #
-      # The two publishes target different caches with different tokens (private
-      # `k-framework-binary` via kup vs. public `k-framework` via cachix), so they are
-      # kept independent: `continue-on-error` plus `if: always()` ensures a flaky
-      # upload to one cache neither blocks nor masks the other, and the final guard
-      # re-fails the job if either push failed — preserving the release gate that the
-      # two separate jobs used to provide.
+      # Both publishes build the same three derivations, so they run as sequential
+      # steps on one runner: the first populates the local Nix store and the second is
+      # a store hit. They run independently (continue-on-error) so a flaky upload to
+      # one cache neither blocks nor masks the other, and a final guard fails the job
+      # if either push failed.
       - name: 'Publish K to k-framework-binary cache (private)'
         id: binary
         continue-on-error: true
@@ -116,7 +110,6 @@ jobs:
 
       - name: 'Build and cache K and K dependencies (public)'
         id: dependencies
-        if: always()
         continue-on-error: true
         uses: workflow/nix-shell-action@v3
         env:
@@ -138,7 +131,6 @@ jobs:
             nix-store --query --requisites --include-outputs ${DRV_K_OPENSSL_PROCPS_SECP256K1} | cachix push k-framework
 
       - name: 'Fail if either cachix publish failed'
-        if: always()
         run: |
           binary='${{ steps.binary.outcome }}'
           dependencies='${{ steps.dependencies.outcome }}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
           gh release upload --repo runtimeverification/k --clobber "v${version}" "${tarball}"
 
   cachix-release:
-    name: 'k-framework-binary cachix release'
+    name: 'Cachix release (binary cache + dependency closure)'
     strategy:
       matrix:
         include:
@@ -79,7 +79,20 @@ jobs:
         with:
           name: k-framework-binary
 
-      - name: 'Publish K to k-framework-binary cache'
+      # The binary publish and the dependency-closure publish build the same three
+      # derivations.  Running them as sequential steps on one runner means the build
+      # happens once: the first step populates the local Nix store, so the second
+      # step's `nix build` is an instant store hit rather than a full recompile.
+      #
+      # The two publishes target different caches with different tokens (private
+      # `k-framework-binary` via kup vs. public `k-framework` via cachix), so they are
+      # kept independent: `continue-on-error` plus `if: always()` ensures a flaky
+      # upload to one cache neither blocks nor masks the other, and the final guard
+      # re-fails the job if either push failed — preserving the release gate that the
+      # two separate jobs used to provide.
+      - name: 'Publish K to k-framework-binary cache (private)'
+        id: binary
+        continue-on-error: true
         uses: workflow/nix-shell-action@v3.3.2
         env:
           CACHIX_AUTH_TOKEN: '${{ secrets.CACHIX_PRIVATE_KFB_TOKEN }}'
@@ -91,7 +104,7 @@ jobs:
           script: |
             # Install kup
             export PATH="$(nix build github:runtimeverification/kup --no-link --json | jq -r '.[].outputs | to_entries[].value')/bin:$PATH"
-            
+
             # Publish all three package variants using kup publish
             # Using public macOS runner has proven reliable for large file uploads
             kup publish --verbose k-framework-binary .#k --keep-days 180 || true
@@ -101,38 +114,10 @@ jobs:
             # kup/cachix pin visibility can be flaky; verify pins and narinfo via public API
             bash .github/scripts/check-cachix-pin.sh
 
-  cachix-release-dependencies:
-    name: 'k-framework cachix release'
-    strategy:
-      matrix:
-        include:
-          - runner: ubuntu-24.04
-            os: ubuntu-24.04
-          - runner: macos-latest
-            os: macos-15
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: 120
-    steps:
-      - name: 'Check out code'
-        uses: actions/checkout@v4
-
-      - name: 'Install Nix'
-        if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/install-nix-action@v31.5.1
-        with:
-          install_url: https://releases.nixos.org/nix/nix-2.30.1/install
-          extra_nix_config: |
-            access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-            substituters = http://cache.nixos.org
-            trusted-public-keys = cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-
-      - name: 'Install Cachix'
-        if: ${{ !startsWith(matrix.os, 'self') }}
-        uses: cachix/cachix-action@v14
-        with:
-          name: k-framework-binary
-
-      - name: 'Build and cache K and K dependencies'
+      - name: 'Build and cache K and K dependencies (public)'
+        id: dependencies
+        if: always()
+        continue-on-error: true
         uses: workflow/nix-shell-action@v3
         env:
           GC_DONT_GC: 1
@@ -151,6 +136,15 @@ jobs:
             K_OPENSSL_PROCPS_SECP256K1=$(nix build --extra-experimental-features 'nix-command flakes' .#k.openssl.procps.secp256k1 --json | jq -r '.[].outputs | to_entries[].value')
             DRV_K_OPENSSL_PROCPS_SECP256K1=$(nix-store --query --deriver ${K_OPENSSL_PROCPS_SECP256K1})
             nix-store --query --requisites --include-outputs ${DRV_K_OPENSSL_PROCPS_SECP256K1} | cachix push k-framework
+
+      - name: 'Fail if either cachix publish failed'
+        if: always()
+        run: |
+          binary='${{ steps.binary.outcome }}'
+          dependencies='${{ steps.dependencies.outcome }}'
+          echo "binary publish:       ${binary}"
+          echo "dependencies publish: ${dependencies}"
+          [ "${binary}" = 'success' ] && [ "${dependencies}" = 'success' ]
 
   pyk-build-wheel:
     name: 'Pyk: Build Python wheel'
@@ -313,7 +307,7 @@ jobs:
     name: 'Publish Release'
     runs-on: [self-hosted, linux, normal]
     environment: production
-    needs: [cachix-release, cachix-release-dependencies, source-tarball, ubuntu-jammy, ubuntu-noble, set-release-id]
+    needs: [cachix-release, source-tarball, ubuntu-jammy, ubuntu-noble, set-release-id]
     steps:
       - name: 'Check out code'
         uses: actions/checkout@v4


### PR DESCRIPTION
The k-framework-binary (private, via kup) and k-framework (public, via cachix) publishes built the same three derivations on separate runners, recompiling K four times (2 jobs x 2 OS) for work that needs two builds. Fold them into one matrix job: the first publish populates the local Nix store so the second's nix build is an instant store hit. The two publishes stay independent (continue-on-error + if: always()) so a flaky upload to one cache neither blocks nor masks the other, and a final guard re-fails the job if either push failed, preserving the release gate the two separate jobs provided. Drop the removed cachix-release-dependencies from the release job's needs.